### PR TITLE
ci: enable usetesting linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,10 +5,14 @@ linters:
     - depguard # Checks for dependencies that should not be (re)introduced. See "settings" for further details.
     - dupword # Checks for duplicate words in the source code
     - gosec
+    - govet
+    - ineffassign
     - misspell
     - nolintlint
     - revive
+    - staticcheck
     - unconvert
+    - unused
     - usetesting
   disable:
     - errcheck
@@ -40,21 +44,19 @@ linters:
         - G301
         - G302
         - G304
-    staticcheck:
-      checks:
-        - all
-        - -QF1008 # Excludes QF1008 from staticcheck
-        - -ST1000
-        - -ST1020
-        - -ST1021
+    nolintlint:
+      allow-unused: true
     revive:
       rules:
         - name: package-comments
-          severity: warning
           disabled: true
-          exclude: [ "" ]
-    nolintlint:
-      allow-unused: true
+    staticcheck:
+      checks:
+        - all
+        - -QF1008 # Omit embedded fields from selector expression
+        - -ST1000 # Incorrect or missing package comment
+        - -ST1020 # The documentation of an exported function should start with the function’s name
+        - -ST1021 # The documentation of an exported type should start with type’s name
   exclusions:
     generated: lax
     rules:
@@ -96,6 +98,8 @@ linters:
       - docs/man
       - releases
       - test
+    # Log a warning if an exclusion rule is unused.
+    warn-unused: true
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -45,8 +45,7 @@ func init() {
 }
 
 func testContext(t testing.TB) (context.Context, context.CancelFunc) {
-	// This needs work to convert from context.Background() to t.Context().
-	ctx, cancel := context.WithCancel(context.Background())  //nolint:all
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:usetesting // This needs work to convert from context.Background() to t.Context().
 	ctx = namespaces.WithNamespace(ctx, testNamespace)
 	if t != nil {
 		ctx = logtest.WithT(ctx, t)


### PR DESCRIPTION
#### Description

Following https://github.com/containerd/containerd/pull/11623#discussion_r2126517928 , this restore the list of enabled linters even if they are enabled by default to make them visible.

This also sort linters settings alphabetically and update some comments.

It adds usetesting as a replacement for tenv