### PR TITLE
blockfile: Ensure required options are always set

### DIFF
--- a/plugins/snapshots/blockfile/blockfile.go
+++ b/plugins/snapshots/blockfile/blockfile.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -158,6 +159,10 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 
 	if config.mountOptions == nil {
 		config.mountOptions = []string{"loop"}
+	}
+
+	if !slices.Contains(config.mountOptions, "loop") {
+		config.mountOptions = append(config.mountOptions, "loop")
 	}
 
 	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"))


### PR DESCRIPTION
When using blockfile snapshotter and passing specific filesystem mount options, the users may be caught by surprise by the fact that some options are required but not documented anywhere.

The easiest way to solve this is by ensuring that the "loop" required option is always added to the mount options.