### PR TITLE
gha: use relative path for install-go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,8 +226,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: src/github.com/containerd/containerd
-
-      - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
+      - uses: ./.github/actions/install-go
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
All other places in this file used the relative path; my IDE didn't like the absolute path as it considered it didn't exist.