### PR TITLE
erofs-snapshotter: make IMMUTABLE_FL optional to recover performance

### DIFF
--- a/plugins/snapshots/erofs/plugin/plugin_linux.go
+++ b/plugins/snapshots/erofs/plugin/plugin_linux.go
@@ -36,6 +36,9 @@ type Config struct {
 
 	// EnableFsverity enables fsverity for EROFS layers
 	EnableFsverity bool `toml:"enable_fsverity"`
+
+	// If `SetImmutable` is enabled, IMMUTABLE_FL will be set on layer blobs.
+	SetImmutable bool `toml:"set_immutable"`
 }
 
 func init() {
@@ -63,6 +66,10 @@ func init() {
 
 			if config.EnableFsverity {
 				opts = append(opts, erofs.WithFsverity())
+			}
+
+			if config.SetImmutable {
+				opts = append(opts, erofs.WithImmutable())
 			}
 
 			ic.Meta.Exports[plugins.SnapshotterRootDir] = root


### PR DESCRIPTION
Enabling the IMMUTABLE_FL file attribute causes dirty data to be flushed synchronously at least on EXT4[1], which can greatly impact container launch performance.  In contrast, the overlayfs snapshotter does not use `syncfs` by default.

Most users may not need IMMUTABLE_FL, let's make IMMUTABLE_FL optional to align with the behavior of the overlayfs snapshotter and recover the original performance.

0. containerd toml file:
``` toml
  [plugins."io.containerd.differ.v1.erofs"]
    mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
```

1. tensorflow image
Test commands:
``` sh
$ nerdctl image pull --snapshotter=X --unpack="false" tensorflow/tensorflow:2.19.0
$ time nerdctl container --snapshotter=X run -d tensorflow/tensorflow:2.19.0 /bin/sh
```

Results:
```
 overlayfs                 | 0m18.748s
 erofs (no IMMUTABLE_FL)   | 0m10.090s
 erofs (with IMMUTABLE_FL) | 0m21.074s
```

2. ubuntu 22.04 image
Test commands:
``` sh
$ nerdctl image pull --snapshotter=X --unpack="false" ubuntu:22.04
$ time nerdctl container --snapshotter=X run -d ubuntu:22.04 /bin/sh
```

Results:
```
 overlayfs                 | 0m1.147s
 erofs (no IMMUTABLE_FL)   | 0m0.795s
 erofs (with IMMUTABLE_FL) | 0m1.094s
```

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/ext4/ioctl.c?h=v6.15#n636