### PR TITLE
[release/2.1] backport: update go-md2man binary to v2.0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-go
-      - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.2
+      - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.7
       - run: make man
 
   # Make sure binaries compile with other minor platforms.

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -22,7 +22,7 @@ set -eu -o pipefail
 # install `protobuild` and other commands
 go install github.com/containerd/protobuild@v0.3.0
 go install github.com/containerd/protobuild/cmd/go-fix-acronym@v0.3.0
-go install github.com/cpuguy83/go-md2man/v2@v2.0.2
+go install github.com/cpuguy83/go-md2man/v2@v2.0.7
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0


### PR DESCRIPTION
We updated the vendored dependency, but the binary was still left on an older version.

full diff: https://github.com/cpuguy83/go-md2man/compare/v2.0.2...v2.0.7

Cherry pick #12070 
(cherry picked from commit 62bbdce7f537fb16f4359312f8b38c5ec57fc3c2)