### PR TITLE
nri: enable otel traces in NRI.

### DIFF
--- a/internal/nri/config.go
+++ b/internal/nri/config.go
@@ -19,6 +19,8 @@ package nri
 import (
 	"github.com/containerd/containerd/v2/internal/tomlext"
 	nri "github.com/containerd/nri/pkg/adaptation"
+	"github.com/containerd/otelttrpc"
+	"github.com/containerd/ttrpc"
 )
 
 // Config data for NRI.
@@ -67,6 +69,21 @@ func (c *Config) toOptions() []nri.Option {
 	if c.DisableConnections {
 		opts = append(opts, nri.WithDisabledExternalConnections())
 	}
+	opts = append(opts,
+		nri.WithTTRPCOptions(
+			[]ttrpc.ClientOpts{
+				ttrpc.WithUnaryClientInterceptor(
+					otelttrpc.UnaryClientInterceptor(),
+				),
+			},
+			[]ttrpc.ServerOpt{
+				ttrpc.WithUnaryServerInterceptor(
+					otelttrpc.UnaryServerInterceptor(),
+				),
+			},
+		),
+	)
+
 	return opts
 }
 


### PR DESCRIPTION
Set up NRI for producing otel trace spans.