### PR TITLE
Update win documentation for command prompt users

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -140,6 +140,32 @@ containerd.exe --register-service
 Start-Service containerd
 ```
 
+From an elevated PowerShell session (_running as Admin_) run the following commands:
+
+```bat
+:: Download and extract desired containerd Windows binaries
+set Version="1.7.13"	& :: update to your preferred version
+set Arch="amd64"	& :: arm64 also available
+curl.exe -LO https://github.com/containerd/containerd/releases/download/v%Version%/containerd-%Version%-windows-%Arch%.tar.gz
+tar.exe xvf .\containerd-%Version%-windows-%Arch%.tar.gz
+
+:: Copy
+xcopy .\bin "%ProgramFiles%\containerd" /E /I /H /Y
+
+:: Add the binaries (containerd.exe, ctr.exe) to the system PATH
+setx PATH "%PATH%;%ProgramFiles%\containerd" /M
+
+:: Configure containerd
+"%ProgramFiles%\containerd\containerd.exe" config default > "%ProgramFiles%\containerd\config.toml"
+
+:: Review the configuration (optional, as you can open the file manually)
+:: type "%ProgramFiles%\containerd\config.toml"
+
+:: Register and start service
+"%ProgramFiles%\containerd\containerd.exe" --register-service
+net start containerd
+```
+
 > **Tip for Running `containerd` Service on Windows:**
 >
 > `containerd` logs are not persisted when we start it as a service

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -140,29 +140,34 @@ containerd.exe --register-service
 Start-Service containerd
 ```
 
-From an elevated PowerShell session (_running as Admin_) run the following commands:
+For an **Administrator command prompt** run the following commands:
 
 ```bat
+:: If containerd previously installed run:
+net stop containerd
+
 :: Download and extract desired containerd Windows binaries
-set Version="1.7.13"	& :: update to your preferred version
-set Arch="amd64"	& :: arm64 also available
-curl.exe -LO https://github.com/containerd/containerd/releases/download/v%Version%/containerd-%Version%-windows-%Arch%.tar.gz
+set "Version=1.7.13"	& :: update to your preferred version
+set "Arch=amd64"	& :: arm64 also available
+curl.exe -LO "https://github.com/containerd/containerd/releases/download/v%Version%/containerd-%Version%-windows-%Arch%.tar.gz"
 tar.exe xvf .\containerd-%Version%-windows-%Arch%.tar.gz
 
 :: Copy
 xcopy .\bin "%ProgramFiles%\containerd" /E /I /H /Y
 
-:: Add the binaries (containerd.exe, ctr.exe) to the system PATH
-setx PATH "%PATH%;%ProgramFiles%\containerd" /M
+:: Add the binaries (containerd.exe, ctr.exe) to the system PATH (environment variables) by copying the output of the below command
+echo %ProgramFiles%\containerd
 
 :: Configure containerd
 "%ProgramFiles%\containerd\containerd.exe" config default > "%ProgramFiles%\containerd\config.toml"
 
-:: Review the configuration (optional, as you can open the file manually)
-:: type "%ProgramFiles%\containerd\config.toml"
+:: Review the configuration (optional)
+type "%ProgramFiles%\containerd\config.toml"
 
 :: Register and start service
 "%ProgramFiles%\containerd\containerd.exe" --register-service
+
+:: Start the containerd service
 net start containerd
 ```
 


### PR DESCRIPTION
Updated the documentation for windows command prompt. By default **cmd** writes config.toml with `utf-8`  encoding whereas **PowerShell** outputs in `utf-16`

**PoweShell**
```PowerShell
containerd.exe config default | Out-File $Env:ProgramFiles\containerd\config.toml -Encoding ascii
```

**Command Prompt**
```bat
"%ProgramFiles%\containerd\containerd.exe" config default > "%ProgramFiles%\containerd\config.toml"
```