### PR TITLE
Remove WS2025 from CIs due to test failures

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -9,7 +9,7 @@ on:
       azure_windows_image_id:
         description: Windows image URN to deploy
         required: true
-        default: MicrosoftWindowsServer:WindowsServer:2025-datacenter:latest
+        default: MicrosoftWindowsServer:WindowsServer:2022-datacenter:latest
       azure_vm_size:
         description: Windows image builder VM size
         required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022, windows-2025]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022]
         go-version: ["1.24.4"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -214,7 +214,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2025, windows-2022]
+        os: [windows-2022]
         cgroup_driver: [cgroupfs]
 
     defaults:

--- a/.github/workflows/windows-hyperv-periodic.yml
+++ b/.github/workflows/windows-hyperv-periodic.yml
@@ -43,16 +43,12 @@ jobs:
       # (e.g. hitting resource limits in the `AZTestVMCreate` task)
       fail-fast: false
       matrix:
-        win_ver: [ltsc2022, ltsc2025]
+        win_ver: [ltsc2022]
         include:
         - win_ver: ltsc2022
           AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:latest"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2022-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2022-hyperv/"
-        - win_ver: ltsc2025
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2025-Datacenter:latest"
-          AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2025-${{ github.run_id }}
-          GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2025-hyperv/"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -42,16 +42,12 @@ jobs:
       # (e.g. hitting resource limits in the `AZTestVMCreate` task)
       fail-fast: false
       matrix:
-        win_ver: [ltsc2022, ltsc2025]
+        win_ver: [ltsc2022]
         include:
         - win_ver: ltsc2022
           AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:latest"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2022-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2022/"
-        - win_ver: ltsc2025
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2025-Datacenter:latest"
-          AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2025-${{ github.run_id }}
-          GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2025/"
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:

--- a/integration/images/volume-copy-up/Makefile
+++ b/integration/images/volume-copy-up/Makefile
@@ -33,8 +33,8 @@ endif
 OS ?= linux
 # Architectures supported: amd64, arm64
 ARCH ?= amd64
-# OS Version for the Windows images: ltsc2022, ltsc2025
-OSVERSION ?= ltsc2022
+# OS Version for the Windows images: 1809, 20H2, ltsc2022
+OSVERSION ?= 1809
 
 # The output type could either be docker (local), or registry.
 # If it is registry, it will also allow us to push the Windows images.
@@ -46,7 +46,7 @@ ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 
 ifneq ($(REMOTE_DOCKER_URL),)
 ALL_OS += windows
-ALL_OSVERSIONS.windows := ltsc2022 ltsc2025
+ALL_OSVERSIONS.windows := 1809 20H2 ltsc2022
 ALL_OS_ARCH.windows = $(foreach osversion, ${ALL_OSVERSIONS.windows}, windows-amd64-${osversion})
 BASE.windows := mcr.microsoft.com/windows/nanoserver
 endif

--- a/integration/images/volume-ownership/Makefile
+++ b/integration/images/volume-ownership/Makefile
@@ -33,8 +33,8 @@ endif
 OS ?= linux
 # Architectures supported: amd64, arm64
 ARCH ?= amd64
-# OS Version for the Windows images: ltsc2022, lts2025
-OSVERSION ?= ltsc2022
+# OS Version for the Windows images: 1809, 20H2, ltsc2022
+OSVERSION ?= 1809
 
 # The output type could either be docker (local), or registry.
 # If it is registry, it will also allow us to push the Windows images.
@@ -46,7 +46,7 @@ ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 
 ifneq ($(REMOTE_DOCKER_URL),)
 ALL_OS += windows
-ALL_OSVERSIONS.windows := ltsc2022 ltsc2025
+ALL_OSVERSIONS.windows := 1809 20H2 ltsc2022
 ALL_OS_ARCH.windows = $(foreach osversion, ${ALL_OSVERSIONS.windows}, windows-amd64-${osversion})
 BASE.windows := mcr.microsoft.com/windows/nanoserver
 endif


### PR DESCRIPTION
TestCRISuite on WS2025 seems to have regressed. There are other sig-windows failures on test grid as well https://testgrid.k8s.io/sig-windows-signal#capz-windows-master-2025. Removing WS2025 temporarily while we continue to look into the failures to unblock merge queue.