### PR TITLE
Make signal notifications work on Windows

### DIFF
--- a/cmd/containerd/command/main_windows.go
+++ b/cmd/containerd/command/main_windows.go
@@ -33,10 +33,7 @@ import (
 )
 
 var (
-	handledSignals = []os.Signal{
-		windows.SIGTERM,
-		windows.SIGINT,
-	}
+	handledSignals = []os.Signal{os.Interrupt}
 )
 
 func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *server.Server, cancel func()) chan struct{} {


### PR DESCRIPTION
On Windows, the Go runtime will only ever notify `os.Interrupt` or `syscall.SIGINT`. Using `windows.SIGINT`, even if it wraps the same integer value as `syscall.SIGINT`, will have no effect.

A simple proof: Executing the below program produces an instant panic:

<details>
<summary>main.go (broken)</summary>

```go
package main

import (
	"fmt"
	"os"
	"os/signal"

	"golang.org/x/sys/windows"
)

func main() {
	sigs := make(chan os.Signal, 1)
	signal.Notify(sigs, windows.SIGINT, windows.SIGTERM)

	fmt.Println("Waiting for signal...")
	sig := <-sigs
	fmt.Println("Received signal:", sig)
}
```
</details>

```text
Waiting for signal...
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan receive]:
main.main()
        C:/Users/tom/foobar/main.go:16 +0xbe
exit status 2
```

A program using `os.Interrupt` works as intended:

<details>
<summary>main.go (works)</summary>

```go
package main

import (
	"fmt"
	"os"
	"os/signal"
)

func main() {
	sigs := make(chan os.Signal, 1)
	signal.Notify(sigs, os.Interrupt)

	fmt.Println("Waiting for signal...")
	sig := <-sigs
	fmt.Println("Received signal:", sig)
}
```
</details>

```text
Waiting for signal...
<<< Hitting Ctrl+C >>
Received signal: interrupt
```

