### PR TITLE
[release/1.6] ci: bump Go 1.23.11, 1.24.5

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.23.10"
+    default: "1.23.11"
     description: "Go version to install"
 
 runs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022]
-        go-version: ["1.23.10", "1.24.4"]
+        go-version: ["1.23.11", "1.24.5"]
     steps:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Containerd Release
 
 env:
-  GO_VERSION: "1.23.10"
+  GO_VERSION: "1.23.11"
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -103,7 +103,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.23.10",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.23.11",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.23.10
+ARG GOLANG_VERSION=1.23.11
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.10"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.11"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
> go1.24.5 (released 2025-07-08) includes security fixes to the go command, as well as bug fixes to the compiler, the linker, the runtime, and the go command. See the [Go 1.24.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.5+label%3ACherryPickApproved) on our issue tracker for details.

full diff: https://github.com/golang/go/compare/go1.24.4...go1.24.5

> go1.23.11 (released 2025-07-08) includes security fixes to the go command, as well as bug fixes to the compiler, the linker, and the runtime. See the [Go 1.23.11 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.11+label%3ACherryPickApproved) on our issue tracker for details.

full diff: https://github.com/golang/go/compare/go1.23.10...go1.23.11

(cherry picked from commit c5ad254a3a18ca2e318f3827ae08e9b49937ae25)