### PR TITLE
[release/1.6] ci: use fedora 39 archive

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,13 @@ Vagrant.configure("2") do |config|
   config.vm.box = ENV["BOX"] ? ENV["BOX"].split("@")[0] : "fedora/39-cloud-base"
   # BOX_VERSION is deprecated. Use "BOX=<BOX>@<BOX_VERSION>".
   config.vm.box_version = ENV["BOX_VERSION"] || (ENV["BOX"].split("@")[1] if ENV["BOX"])
+
+  # Set box_url for archive boxes
+  # Workaround for https://github.com/containerd/containerd/issues/12124
+  if config.vm.box.include?("fedora/39-cloud-base")
+    config.vm.box_url = "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-39-1.5.x86_64.vagrant-libvirt.box"
+  end
+
   memory = 4096
   cpus = 2
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
Workaround for https://github.com/containerd/containerd/issues/12124

Fedora 39 cloud image is now available on archive. i.e. https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/x86_64/images/