### PR TITLE
Handle pod network teardown more carefully when setup failed.

### DIFF
--- a/internal/cri/server/cni_conf_syncer.go
+++ b/internal/cri/server/cni_conf_syncer.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,10 @@ import (
 	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 	"github.com/fsnotify/fsnotify"
+)
+
+var (
+	ErrCNIConfigNotInitialized = errors.New("cni config not initialized")
 )
 
 // cniNetConfSyncer is used to reload cni network conf triggered by fs change

--- a/internal/cri/server/sandbox_stop.go
+++ b/internal/cri/server/sandbox_stop.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -114,10 +113,8 @@ func (c *criService) stopPodSandbox(ctx context.Context, sandbox sandboxstore.Sa
 		} else if closed {
 			sandbox.NetNSPath = ""
 		}
-		if sandbox.CNIResult != nil {
-			if err := c.teardownPodNetwork(ctx, sandbox); err != nil {
-				return fmt.Errorf("failed to destroy network for sandbox %q: %w", id, err)
-			}
+		if err := c.teardownPodNetwork(ctx, sandbox); err != nil {
+			return fmt.Errorf("failed to destroy network for sandbox %q: %w", id, err)
 		}
 		if err := sandbox.NetNS.Remove(); err != nil {
 			return fmt.Errorf("failed to remove network namespace for sandbox %q: %w", id, err)
@@ -153,7 +150,7 @@ func (c *criService) waitSandboxStop(ctx context.Context, sandbox sandboxstore.S
 func (c *criService) teardownPodNetwork(ctx context.Context, sandbox sandboxstore.Sandbox) error {
 	netPlugin := c.getNetworkPlugin(sandbox.RuntimeHandler)
 	if netPlugin == nil {
-		return errors.New("cni config not initialized")
+		return ErrCNIConfigNotInitialized
 	}
 
 	var (


### PR DESCRIPTION
This is a follow up of both #10744 and #10839, where `teardownPodNetwork` may be skipped if setup networks failed in the first place.

In the situation illustrated on #12130, for chained CNI pattern the skipping logic may be problematic and leads to network resource leakage (e.g. Pod IP).

This PR attempts to make the sandbox network handling more robust by conditionally skipping the teardown network only when error is related to CNI initialization, while allowing teardown retry to happen if setup already allocated network resoruce partially.

/cc @sameersaeed @mikebrow @aojea 