### PR TITLE
Update 1.6 timeline to add an extended period

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -127,7 +127,7 @@ to all committers.
 | [1.3](https://github.com/containerd/containerd/releases/tag/v1.3.10) | End of Life   | September 26, 2019             | March 4, 2021                  |                        |
 | [1.4](https://github.com/containerd/containerd/releases/tag/v1.4.13) | End of Life   | August 17, 2020                | March 3, 2022                  |                        |
 | [1.5](https://github.com/containerd/containerd/releases/tag/v1.5.18) | End of Life   | May 3, 2021                    | February 28, 2023              |                        |
-| [1.6](https://github.com/containerd/containerd/releases/tag/v1.6.0)  | LTS           | February 15, 2022              | July 23, 2025                  | @containerd/committers |
+| [1.6](https://github.com/containerd/containerd/releases/tag/v1.6.0)  | Extended      | February 15, 2022              | August 23, 2025                | @containerd/committers |
 | [1.7](https://github.com/containerd/containerd/releases/tag/v1.7.0)  | LTS           | March 10, 2023                 | March 10, 2026                 | @containerd/committers |
 | [2.0](https://github.com/containerd/containerd/releases/tag/v2.0.0)  | Active        | November 5, 2024               | November 7, 2025               | @containerd/committers |
 | [2.1](https://github.com/containerd/containerd/releases/tag/v2.1.0)  | Active        | May 7, 2025                    | May 5, 2026 (_tentative_)      | @containerd/committers |


### PR DESCRIPTION
The 1.6.39 was just released and the original end of life is scheduled for July 23rd. I propose we add one month of extended support for any security patches based on the last release. 1.6.39 will be the last non-security release.