### PR TITLE
ci: enable testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - misspell
     - nolintlint
     - revive
+    - testifylint
     - unconvert
     - usetesting
   disable:
@@ -55,6 +56,8 @@ linters:
           exclude: [ "" ]
     nolintlint:
       allow-unused: true
+    testifylint:
+      enable-all: true
   exclusions:
     generated: lax
     rules:

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/log/logtest"
@@ -63,7 +64,7 @@ func TestMergeConfigs(t *testing.T) {
 	}
 
 	err := mergeConfig(a, b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 2, a.Version)
 	assert.Equal(t, "new_root", a.Root)
@@ -79,13 +80,13 @@ func TestMergeConfigs(t *testing.T) {
 	a = &Config{Version: 2, OOMScore: 1}
 	b = &Config{Version: 2, OOMScore: 0} // OOMScore "not set / default"
 	err = mergeConfig(a, b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, a.OOMScore)
 
 	a = &Config{Version: 2, OOMScore: 1}
 	b = &Config{Version: 2, OOMScore: 0} // OOMScore "not set / default"
 	err = mergeConfig(a, b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, a.OOMScore)
 }
 
@@ -94,7 +95,7 @@ func TestResolveImports(t *testing.T) {
 
 	for _, filename := range []string{"config_1.toml", "config_2.toml", "test.toml"} {
 		err := os.WriteFile(filepath.Join(tempDir, filename), []byte(""), 0o600)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	imports, err := resolveImports(filepath.Join(tempDir, "root.toml"), []string{
@@ -102,24 +103,24 @@ func TestResolveImports(t *testing.T) {
 		filepath.Join(tempDir, "./test.toml"),   // Path clean up
 		"current.toml",                          // Resolve current working dir
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, imports, []string{
+	assert.Equal(t, []string{
 		filepath.Join(tempDir, "config_1.toml"),
 		filepath.Join(tempDir, "config_2.toml"),
 		filepath.Join(tempDir, "test.toml"),
 		filepath.Join(tempDir, "current.toml"),
-	})
+	}, imports)
 
 	t.Run("GlobRelativePath", func(t *testing.T) {
 		imports, err := resolveImports(filepath.Join(tempDir, "root.toml"), []string{
 			"config_*.toml", // Glob files from working dir
 		})
-		assert.NoError(t, err)
-		assert.Equal(t, imports, []string{
+		require.NoError(t, err)
+		assert.Equal(t, []string{
 			filepath.Join(tempDir, "config_1.toml"),
 			filepath.Join(tempDir, "config_2.toml"),
-		})
+		}, imports)
 	})
 }
 
@@ -137,11 +138,11 @@ root = "/var/lib/containerd"
 
 	path := filepath.Join(tempDir, "config.toml")
 	err := os.WriteFile(path, []byte(data), 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var out Config
 	err = LoadConfig(context.Background(), path, &out)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 2, out.Version)
 	assert.Equal(t, "/var/lib/containerd", out.Root)
 	assert.Equal(t, map[string]StreamProcessor{
@@ -166,14 +167,14 @@ disabled_plugins = ["io.containerd.v1.xyz"]
 	tempDir := t.TempDir()
 
 	err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(data1), 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = os.WriteFile(filepath.Join(tempDir, "data2.toml"), []byte(data2), 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var out Config
 	err = LoadConfig(context.Background(), filepath.Join(tempDir, "data1.toml"), &out)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 2, out.Version)
 	assert.Equal(t, "/var/lib/containerd", out.Root)
@@ -194,14 +195,14 @@ imports = ["data1.toml", "data2.toml"]
 	tempDir := t.TempDir()
 
 	err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(data1), 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = os.WriteFile(filepath.Join(tempDir, "data2.toml"), []byte(data2), 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var out Config
 	err = LoadConfig(context.Background(), filepath.Join(tempDir, "data1.toml"), &out)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 2, out.Version)
 	assert.Equal(t, "/var/lib/containerd", out.Root)
@@ -222,12 +223,12 @@ disabled_plugins=["cri"]
 	tempDir := t.TempDir()
 
 	err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(data1), 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var out Config
 	out.Version = version.ConfigVersion
 	err = LoadConfig(context.Background(), filepath.Join(tempDir, "data1.toml"), &out)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, version.ConfigVersion, out.Version)
 	assert.Equal(t, []string{"io.containerd.grpc.v1.cri"}, out.DisabledPlugins)
@@ -245,15 +246,15 @@ version = 2
 
 	path := filepath.Join(tempDir, "config.toml")
 	err := os.WriteFile(path, []byte(data), 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var out Config
 	err = LoadConfig(context.Background(), path, &out)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	pluginConfig := map[string]interface{}{}
 	_, err = out.Decode(ctx, "io.containerd.runtime.v2.task", &pluginConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, true, pluginConfig["shim_debug"])
 }
 
@@ -268,20 +269,20 @@ func TestDecodePluginInV1Config(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), "config.toml")
 	err := os.WriteFile(path, []byte(data), 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var out Config
 	err = LoadConfig(context.Background(), path, &out)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 0, out.Version)
 
 	err = out.MigrateConfig(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 3, out.Version)
 
 	pluginConfig := map[string]interface{}{}
 	_, err = out.Decode(ctx, "io.containerd.runtime.v2.task", &pluginConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, true, pluginConfig["shim_debug"])
 }
 
@@ -425,17 +426,17 @@ func testMergeConfig(t *testing.T, inputs []string, expected string, comparePlug
 		filename := fmt.Sprintf("data%d.toml", i+1)
 		filepath := filepath.Join(tempDir, filename)
 		err := os.WriteFile(filepath, []byte(data), 0600)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		var tempOut Config
 		err = LoadConfig(context.Background(), filepath, &tempOut)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		if i == 0 {
 			result = tempOut
 		} else {
 			err = mergeConfig(&result, &tempOut)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}
 

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestCleanProfileName(t *testing.T) {
-	assert.Equal(t, cleanProfileName(""), "unconfined")
-	assert.Equal(t, cleanProfileName("unconfined"), "unconfined")
-	assert.Equal(t, cleanProfileName("unconfined (enforce)"), "unconfined")
-	assert.Equal(t, cleanProfileName("docker-default"), "docker-default")
-	assert.Equal(t, cleanProfileName("foo"), "foo")
-	assert.Equal(t, cleanProfileName("foo (enforce)"), "foo")
+	assert.Equal(t, "unconfined", cleanProfileName(""))
+	assert.Equal(t, "unconfined", cleanProfileName("unconfined"))
+	assert.Equal(t, "unconfined", cleanProfileName("unconfined (enforce)"))
+	assert.Equal(t, "docker-default", cleanProfileName("docker-default"))
+	assert.Equal(t, "foo", cleanProfileName("foo"))
+	assert.Equal(t, "foo", cleanProfileName("foo (enforce)"))
 }

--- a/core/content/helpers_test.go
+++ b/core/content/helpers_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type copySource struct {
@@ -185,7 +186,7 @@ func TestCopy(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, testcase.source.digest, testcase.writer.committedDigest)
 			assert.Equal(t, testcase.expected, testcase.writer.String())
 		})

--- a/core/content/testsuite/testsuite.go
+++ b/core/content/testsuite/testsuite.go
@@ -34,7 +34,7 @@ import (
 	"github.com/containerd/log/logtest"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -283,7 +283,7 @@ func checkResumeWriter(ctx context.Context, t *testing.T, cs content.Store) {
 	}
 
 	checkStatus(t, w1, expected, dgstFirst, preStart, postStart, preUpdate, postUpdate)
-	assert.Nil(t, w1.Close(), "close first writer")
+	require.NoError(t, w1.Close(), "close first writer")
 
 	w2, err := content.OpenWriter(ctx, cs, content.WithRef(ref), content.WithDescriptor(ocispec.Descriptor{Size: 256, Digest: dgst}))
 	if err != nil {
@@ -307,7 +307,7 @@ func checkResumeWriter(ctx context.Context, t *testing.T, cs content.Store) {
 	}
 	postCommit := time.Now()
 
-	assert.Nil(t, w2.Close(), "close second writer")
+	require.NoError(t, w2.Close(), "close second writer")
 	info := content.Info{
 		Digest: dgst,
 		Size:   256,

--- a/core/images/image_test.go
+++ b/core/images/image_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,9 +45,9 @@ func TestValidateMediaType(t *testing.T) {
 
 			err = validateMediaType(b, tc.mt)
 			if tc.index {
-				assert.Error(t, err, "manifest should not be a valid index")
+				require.Error(t, err, "manifest should not be a valid index")
 			} else {
-				assert.NoError(t, err, "manifest should be valid")
+				require.NoError(t, err, "manifest should be valid")
 			}
 		})
 		t.Run("index-"+tc.mt, func(t *testing.T) {
@@ -60,9 +59,9 @@ func TestValidateMediaType(t *testing.T) {
 
 			err = validateMediaType(b, tc.mt)
 			if tc.index {
-				assert.NoError(t, err, "index should be valid")
+				require.NoError(t, err, "index should be valid")
 			} else {
-				assert.Error(t, err, "index should not be a valid manifest")
+				require.Error(t, err, "index should not be a valid manifest")
 			}
 		})
 	}
@@ -98,7 +97,7 @@ func TestValidateMediaType(t *testing.T) {
 				require.NoError(t, err, "failed to marshal document")
 
 				err = validateMediaType(b, tc.mt)
-				assert.NoError(t, err, "document should be valid")
+				require.NoError(t, err, "document should be valid")
 			})
 		}
 		for _, iv := range tc.invalid {
@@ -110,7 +109,7 @@ func TestValidateMediaType(t *testing.T) {
 				require.NoError(t, err, "failed to marshal document")
 
 				err = validateMediaType(b, tc.mt)
-				assert.Error(t, err, "document should not be valid")
+				require.Error(t, err, "document should not be valid")
 			})
 		}
 	}
@@ -122,6 +121,6 @@ func TestValidateMediaType(t *testing.T) {
 		require.NoError(t, err, "failed to marshal document")
 
 		err = validateMediaType(b, "")
-		assert.Error(t, err, "document should not be valid")
+		require.Error(t, err, "document should not be valid")
 	})
 }

--- a/core/leases/lease_test.go
+++ b/core/leases/lease_test.go
@@ -61,7 +61,7 @@ func TestWithLabels(t *testing.T) {
 			lease := newLease(tc.initialLabels)
 			err := WithLabels(tc.labels)(lease)
 			require.NoError(t, err)
-			assert.Equal(t, lease.Labels, tc.expected)
+			assert.Equal(t, tc.expected, lease.Labels)
 		})
 	}
 	for _, tc := range testcases {
@@ -71,7 +71,7 @@ func TestWithLabels(t *testing.T) {
 				err := WithLabel(k, v)(lease)
 				require.NoError(t, err)
 			}
-			assert.Equal(t, lease.Labels, tc.expected)
+			assert.Equal(t, tc.expected, lease.Labels)
 		})
 	}
 }

--- a/core/metadata/containers_test.go
+++ b/core/metadata/containers_test.go
@@ -714,7 +714,7 @@ func testEnv(t *testing.T) (context.Context, *bolt.DB) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		assert.NoError(t, db.Close())
+		require.NoError(t, db.Close())
 		cancel()
 	})
 

--- a/core/metadata/db_test.go
+++ b/core/metadata/db_test.go
@@ -101,7 +101,7 @@ func testDB(t *testing.T, opt ...testOpt) (context.Context, *DB) {
 	require.NoError(t, db.Init(ctx))
 
 	t.Cleanup(func() {
-		assert.NoError(t, bdb.Close())
+		require.NoError(t, bdb.Close())
 		cancel()
 	})
 
@@ -115,7 +115,7 @@ func TestInit(t *testing.T) {
 
 	version, err := readDBVersion(db, bucketKeyVersion)
 	require.NoError(t, err)
-	assert.EqualValues(t, version, dbVersion, "unexpected version %d, expected %d", version, dbVersion)
+	assert.Equal(t, dbVersion, version, "unexpected version %d, expected %d", version, dbVersion)
 }
 
 func TestMigrations(t *testing.T) {

--- a/core/metadata/gc_test.go
+++ b/core/metadata/gc_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/containerd/log/logtest"
 	"github.com/opencontainers/go-digest"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 
@@ -684,7 +683,7 @@ func newDatabase(t testing.TB) (*bolt.DB, error) {
 	}
 
 	t.Cleanup(func() {
-		assert.NoError(t, db.Close())
+		require.NoError(t, db.Close())
 	})
 
 	return db, nil

--- a/core/metadata/namespaces_test.go
+++ b/core/metadata/namespaces_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
 )
@@ -67,8 +66,7 @@ func TestCreateDelete(t *testing.T) {
 				})
 			},
 			validate: func(t *testing.T, err error) {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), `still has containers, snapshots on "testss" snapshotter`)
+				require.ErrorContains(t, err, `still has containers, snapshots on "testss" snapshotter`)
 			},
 		},
 	}

--- a/core/mount/lookup_linux_test.go
+++ b/core/mount/lookup_linux_test.go
@@ -29,12 +29,13 @@ import (
 	"github.com/containerd/continuity/testutil"
 	"github.com/containerd/continuity/testutil/loopback"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func checkLookup(t *testing.T, fsType, mntPoint, dir string) {
 	t.Helper()
 	info, err := Lookup(dir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, fsType, info.FSType)
 	assert.Equal(t, mntPoint, info.Mountpoint)
 }
@@ -105,11 +106,11 @@ func TestLookupWithOverlay(t *testing.T) {
 
 	testdir := filepath.Join(overlay, "testdir")
 	err := os.Mkdir(testdir, 0777)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testfile := filepath.Join(overlay, "testfile")
 	_, err = os.Create(testfile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	checkLookup(t, "overlay", overlay, testdir)
 	checkLookup(t, "overlay", overlay, testfile)

--- a/core/mount/mount_idmapped_linux_test.go
+++ b/core/mount/mount_idmapped_linux_test.go
@@ -202,17 +202,17 @@ func initIDMappedChecker(t *testing.T, uidMaps, gidMaps []syscall.SysProcIDMap, 
 
 	srcDir := t.TempDir()
 
-	require.Equal(t, len(uidMaps), len(gidMaps))
+	require.Len(t, gidMaps, len(uidMaps))
 	for idx := range uidMaps {
 		file := filepath.Join(srcDir, fmt.Sprintf("%v", idx))
 
 		f, err := os.Create(file)
-		require.NoError(t, err, fmt.Sprintf("create file %s", file))
+		require.NoError(t, err, "create file %s", file)
 		defer f.Close()
 
 		uid, gid := uidMaps[idx].ContainerID, gidMaps[idx].ContainerID
 		err = f.Chown(uid, gid)
-		require.NoError(t, err, fmt.Sprintf("chown %v:%v for file %s", uid, gid, file))
+		require.NoError(t, err, "chown %v:%v for file %s", uid, gid, file)
 	}
 
 	writableDir := filepath.Join(srcDir, "write-test")
@@ -225,17 +225,17 @@ func initIDMappedChecker(t *testing.T, uidMaps, gidMaps []syscall.SysProcIDMap, 
 			file := filepath.Join(destDir, fmt.Sprintf("%v", idx))
 
 			f, err := os.Open(file)
-			require.NoError(t, err, fmt.Sprintf("open file %s", file))
+			require.NoError(t, err, "open file %s", file)
 			defer f.Close()
 
 			stat, err := f.Stat()
-			require.NoError(t, err, fmt.Sprintf("stat file %s", file))
+			require.NoError(t, err, "stat file %s", file)
 
 			sysStat := stat.Sys().(*syscall.Stat_t)
 
 			uid, gid := uidMaps[idx].HostID, gidMaps[idx].HostID
-			require.Equal(t, uint32(uid), sysStat.Uid, fmt.Sprintf("check file %s uid", file))
-			require.Equal(t, uint32(gid), sysStat.Gid, fmt.Sprintf("check file %s gid", file))
+			require.Equal(t, uint32(uid), sysStat.Uid, "check file %s uid", file)
+			require.Equal(t, uint32(gid), sysStat.Gid, "check file %s gid", file)
 			t.Logf("IDMapped File %s uid=%v, gid=%v", file, uid, gid)
 		}
 

--- a/core/mount/mount_linux_test.go
+++ b/core/mount/mount_linux_test.go
@@ -381,7 +381,7 @@ func TestDoPrepareIDMappedOverlay(t *testing.T) {
 
 			if tc.injectUmountFault {
 				// We should have failed to remove the remounts location if the unmount failed.
-				assert.Error(t, err, "expected remove to fail (dir not empty), expected remount child locations to still exist after unmount failure")
+				require.Error(t, err, "expected remove to fail (dir not empty), expected remount child locations to still exist after unmount failure")
 			} else {
 				assert.NoError(t, err, "expected remove to work (dir empty), the child directory should be unmounted and removed")
 			}

--- a/core/remotes/docker/auth/parse_test.go
+++ b/core/remotes/docker/auth/parse_test.go
@@ -79,7 +79,7 @@ func TestParseAuthHeader(t *testing.T) {
 
 	actual, ok := challenge[0].Parameters["empty"]
 	assert.True(t, ok)
-	assert.Equal(t, "", actual)
+	assert.Empty(t, actual)
 
 	actual, ok = challenge[0].Parameters["service"]
 	assert.True(t, ok)

--- a/core/remotes/docker/config/hosts_resolver_test.go
+++ b/core/remotes/docker/config/hosts_resolver_test.go
@@ -36,6 +36,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 )
@@ -162,9 +163,9 @@ server = "%s"
 		hostFilePath = filepath.Join(hostDir, "hosts.toml")
 
 		err := os.MkdirAll(hostDir, 0755)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = os.WriteFile(hostFilePath, []byte(hostTOML), 0644)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		hostOptions := HostOptions{
 			HostDir: HostDirFromRoot(dir),

--- a/core/remotes/docker/fetcher_test.go
+++ b/core/remotes/docker/fetcher_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/containerd/containerd/v2/core/transfer"
@@ -161,7 +162,7 @@ func TestFetcherOpenParallel(t *testing.T) {
 		if errors.Is(err, errNoOverlap) {
 			err = nil
 		}
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if ignoreContentRange {
 			rng = nil
 		}
@@ -234,7 +235,7 @@ func TestFetcherOpenParallel(t *testing.T) {
 				return
 			}
 		}
-		assert.NoError(t, rc.Close())
+		require.NoError(t, rc.Close())
 	}
 
 	cfgConcurency(10, 1*1024*1024)
@@ -273,16 +274,16 @@ func TestFetcherOpenParallel(t *testing.T) {
 	failAfter = 1
 	forceRange = []httpRange{{start: 20}}
 	_, err = f.open(ctx, req, "", 20, true)
-	assert.ErrorContains(t, err, "unexpected status")
+	require.ErrorContains(t, err, "unexpected status")
 	forceRange = nil
 	failAfter = 0
 
 	// test a case when a subsequent request fails and shouldn't have
 	failAfter = 1 * 1024 * 1024
 	body, err := f.open(ctx, req, "", 0, true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = io.ReadAll(body)
-	assert.Error(t, err, "this should have failed")
+	require.Error(t, err, "this should have failed")
 }
 
 func TestContentEncoding(t *testing.T) {
@@ -586,11 +587,11 @@ func TestDockerFetcherOpenLimiterDeadlock(t *testing.T) {
 
 	req := f.request(host, http.MethodGet)
 	_, err = f.open(context.Background(), req, "", 0, true)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// verify that the limiter Release has been successfully called when the last open error occurred
 	_, err = f.open(context.Background(), req, "", 0, true)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // httpRange specifies the byte range to be sent to the client.

--- a/core/remotes/docker/pusher_test.go
+++ b/core/remotes/docker/pusher_test.go
@@ -162,19 +162,19 @@ func TestPusherErrReset(t *testing.T) {
 	}
 
 	w, err := p.push(context.Background(), desc, remotes.MakeRefKey(context.Background(), desc), false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// first push should fail with ErrReset
 	_, err = w.Write(ct)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = w.Commit(context.Background(), desc.Size, desc.Digest)
 	assert.Equal(t, content.ErrReset, err)
 
 	// second push should succeed
 	_, err = w.Write(ct)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = w.Commit(context.Background(), desc.Size, desc.Digest)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestPusherInvalidAuthorizationOnMount(t *testing.T) {
@@ -279,9 +279,9 @@ func TestPusherInvalidAuthorizationOnMount(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = w.Write(ct)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = w.Commit(context.Background(), desc.Size, desc.Digest)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.True(t, triggered.Load(), "error return was not triggered")
 		})
@@ -684,7 +684,7 @@ func Test_dockerPusher_push(t *testing.T) {
 
 			if test.wantStatus != nil {
 				status, err := tracker.GetStatus(test.args.ref)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, *test.wantStatus, status.PushStatus)
 			}
 
@@ -698,7 +698,7 @@ func Test_dockerPusher_push(t *testing.T) {
 
 			pw, ok := got.(*pushWriter)
 			if !ok {
-				assert.Errorf(t, errors.New("unable to cast content.Writer to pushWriter"), "got %v instead of pushwriter", got)
+				require.Errorf(t, errors.New("unable to cast content.Writer to pushWriter"), "got %v instead of pushwriter", got)
 			}
 
 			// test whether a proper response has been received after the push operation

--- a/core/remotes/docker/scope_test.go
+++ b/core/remotes/docker/scope_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containerd/containerd/v2/pkg/reference"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRepositoryScope(t *testing.T) {
@@ -50,7 +51,7 @@ func TestRepositoryScope(t *testing.T) {
 	for _, x := range testCases {
 		t.Run(x.refspec.String(), func(t *testing.T) {
 			actual, err := RepositoryScope(x.refspec, x.push)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, x.expected, actual)
 		})
 	}

--- a/core/runtime/restart/restart_test.go
+++ b/core/runtime/restart/restart_test.go
@@ -216,6 +216,6 @@ func TestRestartPolicyReconcile(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		result := Reconcile(testCase.status, testCase.labels)
-		assert.Equal(t, testCase.want, result, testCase)
+		assert.Equal(t, testCase.want, result, "%+v", testCase)
 	}
 }

--- a/core/runtime/v2/bundle_linux_test.go
+++ b/core/runtime/v2/bundle_linux_test.go
@@ -67,7 +67,7 @@ func TestNewBundle(t *testing.T) {
 			require.NotNil(t, b, "bundle should not be nil")
 
 			fi, err := os.Stat(b.Path)
-			assert.NoError(t, err, "should be able to stat bundle path")
+			require.NoError(t, err, "should be able to stat bundle path")
 			if tc.userns {
 				assert.Equal(t, os.ModeDir|0710, fi.Mode(), "bundle path should be a directory with perm 0710")
 			} else {
@@ -136,7 +136,7 @@ func TestRemappedGID(t *testing.T) {
 			s, err := json.Marshal(tc.spec)
 			require.NoError(t, err, "failed to marshal spec")
 			gid, err := remappedGID(s)
-			assert.NoError(t, err, "should unmarshal successfully")
+			require.NoError(t, err, "should unmarshal successfully")
 			assert.Equal(t, tc.gid, gid, "expected GID to match")
 		})
 	}

--- a/core/runtime/v2/shim_test.go
+++ b/core/runtime/v2/shim_test.go
@@ -115,10 +115,10 @@ func TestRestoreBootstrapParams(t *testing.T) {
 		Protocol: "ttrpc",
 	}
 
-	require.EqualValues(t, expected, restored)
+	require.Equal(t, expected, restored)
 
 	loaded, err := readBootstrapParams(filepath.Join(bundlePath, "bootstrap.json"))
 
 	require.NoError(t, err)
-	require.EqualValues(t, expected, loaded)
+	require.Equal(t, expected, loaded)
 }

--- a/core/sandbox/store_test.go
+++ b/core/sandbox/store_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/containerd/typeurl/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddExtension(t *testing.T) {
@@ -31,10 +32,10 @@ func TestAddExtension(t *testing.T) {
 	typeurl.Register(&test{})
 
 	var in = test{Name: "test"}
-	assert.NoError(t, sb.AddExtension("test", &in))
+	require.NoError(t, sb.AddExtension("test", &in))
 
 	var out test
 	err := sb.GetExtension("test", &out)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", out.Name)
 }

--- a/core/snapshots/benchsuite/benchmark_test.go
+++ b/core/snapshots/benchsuite/benchmark_test.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/containerd/continuity/fs/fstest"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -65,14 +65,14 @@ func BenchmarkNative(b *testing.B) {
 	}
 
 	snapshotter, err := native.NewSnapshotter(nativeRootPath)
-	assert.Nil(b, err)
+	require.NoError(b, err)
 
 	defer func() {
 		err = snapshotter.Close()
-		assert.Nil(b, err)
+		require.NoError(b, err)
 
 		err = os.RemoveAll(nativeRootPath)
-		assert.Nil(b, err)
+		require.NoError(b, err)
 	}()
 
 	benchmarkSnapshotter(b, snapshotter)
@@ -84,14 +84,14 @@ func BenchmarkOverlay(b *testing.B) {
 	}
 
 	snapshotter, err := overlay.NewSnapshotter(overlayRootPath)
-	assert.Nil(b, err, "failed to create overlay snapshotter")
+	require.NoError(b, err, "failed to create overlay snapshotter")
 
 	defer func() {
 		err = snapshotter.Close()
-		assert.Nil(b, err)
+		require.NoError(b, err)
 
 		err = os.RemoveAll(overlayRootPath)
-		assert.Nil(b, err)
+		require.NoError(b, err)
 	}()
 
 	benchmarkSnapshotter(b, snapshotter)
@@ -115,17 +115,17 @@ func BenchmarkDeviceMapper(b *testing.B) {
 	ctx := context.Background()
 
 	snapshotter, err := devmapper.NewSnapshotter(ctx, config)
-	assert.Nil(b, err)
+	require.NoError(b, err)
 
 	defer func() {
 		err := snapshotter.ResetPool(ctx)
-		assert.Nil(b, err)
+		require.NoError(b, err)
 
 		err = snapshotter.Close()
-		assert.Nil(b, err)
+		require.NoError(b, err)
 
 		err = os.RemoveAll(dmRootPath)
-		assert.Nil(b, err)
+		require.NoError(b, err)
 	}()
 
 	benchmarkSnapshotter(b, snapshotter)
@@ -185,19 +185,19 @@ func benchmarkSnapshotter(b *testing.B, snapshotter snapshots.Snapshotter) {
 
 				timer = time.Now()
 				mounts, err := snapshotter.Prepare(ctx, current, parent)
-				assert.Nil(b, err)
+				require.NoError(b, err)
 				prepareDuration += time.Since(timer)
 
 				timer = time.Now()
 				err = mount.WithTempMount(ctx, mounts, layers[l].Apply)
-				assert.Nil(b, err)
+				require.NoError(b, err)
 				writeDuration += time.Since(timer)
 
 				parent = fmt.Sprintf("committed-%d", layerIndex.Add(1))
 
 				timer = time.Now()
 				err = snapshotter.Commit(ctx, parent, current)
-				assert.Nil(b, err)
+				require.NoError(b, err)
 				commitDuration += time.Since(timer)
 			}
 		}

--- a/core/snapshots/storage/metastore_test.go
+++ b/core/snapshots/storage/metastore_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testFunc func(context.Context, *testing.T, *MetaStore)
@@ -234,7 +235,7 @@ func assertExist(t *testing.T, err error) {
 func testGetInfo(ctx context.Context, t *testing.T, _ *MetaStore) {
 	for key, expected := range baseInfo {
 		_, info, _, err := GetInfo(ctx, key)
-		assert.Nil(t, err, "on key %v", key)
+		require.NoError(t, err, "on key %v", key)
 		assert.Truef(t, cmp.Equal(expected, info, cmpSnapshotInfo), "on key %v", key)
 	}
 }
@@ -275,7 +276,7 @@ func testWalk(ctx context.Context, t *testing.T, _ *MetaStore) {
 		found[info.Name] = info
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, cmp.Equal(baseInfo, found, cmpSnapshotInfo))
 }
 
@@ -325,7 +326,7 @@ func testGetSnapshot(ctx context.Context, t *testing.T, ms *MetaStore) {
 	test := func(ctx context.Context, t *testing.T, ms *MetaStore) {
 		for key, expected := range snapshotMap {
 			s, err := GetSnapshot(ctx, key)
-			assert.Nil(t, err, "failed to get snapshot %s", key)
+			require.NoError(t, err, "failed to get snapshot %s", key)
 			assert.Equalf(t, expected, s, "on key %s", key)
 		}
 	}

--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -122,7 +122,7 @@ func TestAdditionalGids(t *testing.T) {
 
 			t.Log("Search additional groups in container log")
 			content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Contains(t, string(content), tc.expected+"\n")
 		})
 	}

--- a/integration/client/client_ttrpc_test.go
+++ b/integration/client/client_ttrpc_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/ttrpcutil"
 	"github.com/containerd/ttrpc"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientTTRPC_New(t *testing.T) {
@@ -36,10 +37,10 @@ func TestClientTTRPC_New(t *testing.T) {
 		t.Skip()
 	}
 	client, err := ttrpcutil.NewClient(address + ".ttrpc")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = client.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestClientTTRPC_Reconnect(t *testing.T) {
@@ -47,13 +48,13 @@ func TestClientTTRPC_Reconnect(t *testing.T) {
 		t.Skip()
 	}
 	client, err := ttrpcutil.NewClient(address + ".ttrpc")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = client.Reconnect()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	service, err := client.EventsService()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Send test request to make sure its alive after reconnect
 	_, err = service.Forward(context.Background(), &v1.ForwardRequest{
@@ -64,10 +65,10 @@ func TestClientTTRPC_Reconnect(t *testing.T) {
 			Event:     &types.Any{},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = client.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestClientTTRPC_Close(t *testing.T) {
@@ -75,17 +76,17 @@ func TestClientTTRPC_Close(t *testing.T) {
 		t.Skip()
 	}
 	client, err := ttrpcutil.NewClient(address + ".ttrpc")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	service, err := client.EventsService()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = client.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = service.Forward(context.Background(), &v1.ForwardRequest{Envelope: &apitypes.Envelope{}})
 	assert.Equal(t, err, ttrpc.ErrClosed)
 
 	err = client.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -1723,7 +1723,7 @@ func TestIssue10589(t *testing.T) {
 		defer close(exec1done)
 		t.Log("Starting exec1")
 		err := exec1.Start(ctx)
-		assert.Error(t, err, "start exec1")
+		require.Error(t, err, "start exec1")
 		t.Logf("error starting exec1: %s", err)
 	}()
 
@@ -1763,7 +1763,7 @@ func TestIssue10589(t *testing.T) {
 		defer close(exec2done)
 		t.Log("Starting exec2")
 		err := exec2.Start(ctx)
-		assert.Error(t, err, "start exec2")
+		require.Error(t, err, "start exec2")
 		t.Logf("error starting exec2: %s", err)
 	}()
 
@@ -1783,7 +1783,7 @@ func TestIssue10589(t *testing.T) {
 	// 7. Allow exec=1 to proceed
 	t.Log("7. Allow exec=1 to proceed")
 	err = exec1DelayFifo.Trigger()
-	assert.NoError(t, err, "trigger exec1 fifo")
+	require.NoError(t, err, "trigger exec1 fifo")
 	status, err = task.Status(ctx)
 	require.NoError(t, err, "container status")
 	t.Log("container status", status.Status)
@@ -1796,7 +1796,7 @@ func TestIssue10589(t *testing.T) {
 	if didExec2Run {
 		t.Log("8. Allow exec2 to proceed")
 		err = exec2DelayFifo.Trigger()
-		assert.NoError(t, err, "trigger exec2 fifo")
+		require.NoError(t, err, "trigger exec2 fifo")
 		status, err = task.Status(ctx)
 		require.NoError(t, err, "container status")
 		t.Log("container status", status.Status)

--- a/integration/client/convert_test.go
+++ b/integration/client/convert_test.go
@@ -71,7 +71,7 @@ func TestConvert(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Assert that the image does not have any extra arch.
-	assert.Equal(t, 1, len(plats))
+	assert.Len(t, plats, 1)
 	assert.True(t, defPlat.Match(plats[0]))
 
 	// Assert that the media type is converted to OCI and also uncompressed

--- a/integration/client/tracing.go
+++ b/integration/client/tracing.go
@@ -52,7 +52,7 @@ func validateRootSpan(t *testing.T, spanNameExpected string, spans []tracetest.S
 		//A span is root span if its parent SpanContext is invalid
 		if !span.Parent.IsValid() {
 			if span.Name == spanNameExpected {
-				assert.NotEqual(t, span.Status.Code, codes.Error)
+				assert.NotEqual(t, codes.Error, span.Status.Code)
 				return
 			}
 		}

--- a/integration/container_cgroup_writable_linux_test.go
+++ b/integration/container_cgroup_writable_linux_test.go
@@ -113,17 +113,17 @@ func TestContainerCgroupWritable(t *testing.T) {
 			cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
 			require.NoError(t, err)
 			defer func() {
-				assert.NoError(t, runtimeService.RemoveContainer(cn))
+				require.NoError(t, runtimeService.RemoveContainer(cn))
 			}()
 
 			require.NoError(t, runtimeService.StartContainer(cn))
 			defer func() {
-				assert.NoError(t, runtimeService.StopContainer(cn, 30))
+				require.NoError(t, runtimeService.StopContainer(cn, 30))
 			}()
 
 			status, err := runtimeService.ContainerStatus(cn)
 			require.NoError(t, err)
-			assert.Equal(t, status.GetState(), runtime.ContainerState_CONTAINER_RUNNING)
+			assert.Equal(t, runtime.ContainerState_CONTAINER_RUNNING, status.GetState())
 
 			// Execute a command to verify if cgroup is writable
 			_, stderr, err := runtimeService.ExecSync(cn, []string{"mkdir", "sys/fs/cgroup/dummy-group"}, 2)

--- a/integration/container_event_test.go
+++ b/integration/container_event_test.go
@@ -38,9 +38,9 @@ func TestContainerEvents(t *testing.T) {
 
 	t.Log("Set up container events streaming clients")
 	containerEventsStreamingClient1, err := runtimeService.GetContainerEvents(ctx, &runtime.GetEventsRequest{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	containerEventsStreamingClient2, err := runtimeService.GetContainerEvents(ctx, &runtime.GetEventsRequest{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	containerEventsChan1 := make(chan *runtime.ContainerEventResponse)
 	containerEventsChan2 := make(chan *runtime.ContainerEventResponse)
 
@@ -62,10 +62,10 @@ func TestContainerEvents(t *testing.T) {
 		expectedContainerStates := []runtime.ContainerState{}
 		expectedPodSandboxStatus := &runtime.PodSandboxStatus{State: runtime.PodSandboxState_SANDBOX_NOTREADY}
 		t.Logf("Step 6: StopPodSandbox and check events")
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		require.NoError(t, runtimeService.StopPodSandbox(sb))
 		checkContainerEventResponse(t, containerEventsChannels, runtime.ContainerEventType_CONTAINER_STOPPED_EVENT, expectedPodSandboxStatus, expectedContainerStates)
 		t.Logf("Step 7: RemovePodSandbox and check events")
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+		require.NoError(t, runtimeService.RemovePodSandbox(sb))
 		checkContainerEventResponse(t, containerEventsChannels, runtime.ContainerEventType_CONTAINER_DELETED_EVENT, nil, expectedContainerStates)
 	})
 
@@ -93,7 +93,7 @@ func TestContainerEvents(t *testing.T) {
 
 	t.Cleanup(func() {
 		t.Logf("Step 5: RemoveContainer and check events")
-		assert.NoError(t, runtimeService.RemoveContainer(cn))
+		require.NoError(t, runtimeService.RemoveContainer(cn))
 		// No container status after the container is removed
 		expectedContainerStates := []runtime.ContainerState{}
 		checkContainerEventResponse(t, containerEventsChannels, runtime.ContainerEventType_CONTAINER_DELETED_EVENT, expectedPodSandboxStatus, expectedContainerStates)
@@ -106,7 +106,7 @@ func TestContainerEvents(t *testing.T) {
 
 	t.Cleanup(func() {
 		t.Logf("Step 4: StopContainer and check events")
-		assert.NoError(t, runtimeService.StopContainer(cn, 10))
+		require.NoError(t, runtimeService.StopContainer(cn, 10))
 		expectedContainerStates := []runtime.ContainerState{runtime.ContainerState_CONTAINER_EXITED}
 		checkContainerEventResponse(t, containerEventsChannels, runtime.ContainerEventType_CONTAINER_STOPPED_EVENT, expectedPodSandboxStatus, expectedContainerStates)
 	})
@@ -123,7 +123,7 @@ func listenToEventChannel(ctx context.Context, t *testing.T, containerEventsChan
 			return
 		default:
 		}
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if resp != nil {
 			containerEventsChan <- resp
 		}

--- a/integration/container_exec_test.go
+++ b/integration/container_exec_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/containerd/containerd/v2/integration/images"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,13 +52,13 @@ func TestContainerDrainExecIOAfterExit(t *testing.T) {
 	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, runtimeService.RemoveContainer(cn))
+		require.NoError(t, runtimeService.RemoveContainer(cn))
 	}()
 
 	t.Log("Start the container")
 	require.NoError(t, runtimeService.StartContainer(cn))
 	defer func() {
-		assert.NoError(t, runtimeService.StopContainer(cn, 10))
+		require.NoError(t, runtimeService.StopContainer(cn, 10))
 	}()
 
 	t.Log("Exec in container")

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -73,7 +73,7 @@ func TestContainerLogWithoutTailingNewLine(t *testing.T) {
 
 	t.Log("Check container log")
 	content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	checkContainerLog(t, string(content), []string{
 		fmt.Sprintf("%s %s %s", runtime.Stdout, runtime.LogTagPartial, "abcd"),
 	})
@@ -128,7 +128,7 @@ func TestLongContainerLog(t *testing.T) {
 
 	t.Log("Check container log")
 	content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	checkContainerLog(t, string(content), []string{
 		fmt.Sprintf("%s %s %s", runtime.Stdout, runtime.LogTagFull, strings.Repeat("a", maxSize-1)),
 		fmt.Sprintf("%s %s %s", runtime.Stdout, runtime.LogTagFull, strings.Repeat("b", maxSize)),
@@ -144,7 +144,7 @@ func checkContainerLog(t *testing.T, log string, messages []string) {
 		ts, msg, ok := strings.Cut(line, " ")
 		require.True(t, ok)
 		_, err := time.Parse(time.RFC3339Nano, ts)
-		assert.NoError(t, err, "timestamp should be in RFC3339Nano format")
+		require.NoError(t, err, "timestamp should be in RFC3339Nano format")
 		assert.Equal(t, messages[i], msg, "log content should match")
 	}
 }

--- a/integration/container_restart_test.go
+++ b/integration/container_restart_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/integration/images"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,11 +41,11 @@ func TestContainerRestart(t *testing.T) {
 	cn, err := runtimeService.CreateContainer(sb, containerConfig, sbConfig)
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, runtimeService.RemoveContainer(cn))
+		require.NoError(t, runtimeService.RemoveContainer(cn))
 	}()
 	require.NoError(t, runtimeService.StartContainer(cn))
 	defer func() {
-		assert.NoError(t, runtimeService.StopContainer(cn, 10))
+		require.NoError(t, runtimeService.StopContainer(cn, 10))
 	}()
 
 	t.Logf("Restart the container with same config")
@@ -78,11 +77,11 @@ func TestFailedContainerRestart(t *testing.T) {
 	cn, err := runtimeService.CreateContainer(sb, containerConfig, sbConfig)
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, runtimeService.RemoveContainer(cn))
+		require.NoError(t, runtimeService.RemoveContainer(cn))
 	}()
 	require.Error(t, runtimeService.StartContainer(cn))
 	defer func() {
-		assert.NoError(t, runtimeService.StopContainer(cn, 10))
+		require.NoError(t, runtimeService.StopContainer(cn, 10))
 	}()
 
 	t.Logf("Create the container with a proper command")

--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -47,11 +47,11 @@ func TestContainerStats(t *testing.T) {
 	cn, err := runtimeService.CreateContainer(sb, containerConfig, sbConfig)
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, runtimeService.RemoveContainer(cn))
+		require.NoError(t, runtimeService.RemoveContainer(cn))
 	}()
 	require.NoError(t, runtimeService.StartContainer(cn))
 	defer func() {
-		assert.NoError(t, runtimeService.StopContainer(cn, 10))
+		require.NoError(t, runtimeService.StopContainer(cn, 10))
 	}()
 
 	t.Logf("Fetch stats for container")
@@ -89,11 +89,11 @@ func TestContainerConsumedStats(t *testing.T) {
 	cn, err := runtimeService.CreateContainer(sb, containerConfig, sbConfig)
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, runtimeService.RemoveContainer(cn))
+		require.NoError(t, runtimeService.RemoveContainer(cn))
 	}()
 	require.NoError(t, runtimeService.StartContainer(cn))
 	defer func() {
-		assert.NoError(t, runtimeService.StopContainer(cn, 10))
+		require.NoError(t, runtimeService.StopContainer(cn, 10))
 	}()
 
 	t.Logf("Fetch initial stats for container")
@@ -170,11 +170,11 @@ func TestContainerListStats(t *testing.T) {
 		require.NoError(t, err)
 		containerConfigMap[cn] = containerConfig
 		defer func() {
-			assert.NoError(t, runtimeService.RemoveContainer(cn))
+			require.NoError(t, runtimeService.RemoveContainer(cn))
 		}()
 		require.NoError(t, runtimeService.StartContainer(cn))
 		defer func() {
-			assert.NoError(t, runtimeService.StopContainer(cn, 10))
+			require.NoError(t, runtimeService.StopContainer(cn, 10))
 		}()
 	}
 
@@ -225,11 +225,11 @@ func TestContainerListStatsWithIdFilter(t *testing.T) {
 		containerConfigMap[cn] = containerConfig
 		require.NoError(t, err)
 		defer func() {
-			assert.NoError(t, runtimeService.RemoveContainer(cn))
+			require.NoError(t, runtimeService.RemoveContainer(cn))
 		}()
 		require.NoError(t, runtimeService.StartContainer(cn))
 		defer func() {
-			assert.NoError(t, runtimeService.StopContainer(cn, 10))
+			require.NoError(t, runtimeService.StopContainer(cn, 10))
 		}()
 	}
 
@@ -285,11 +285,11 @@ func TestContainerListStatsWithSandboxIdFilter(t *testing.T) {
 		containerConfigMap[cn] = containerConfig
 		require.NoError(t, err)
 		defer func() {
-			assert.NoError(t, runtimeService.RemoveContainer(cn))
+			require.NoError(t, runtimeService.RemoveContainer(cn))
 		}()
 		require.NoError(t, runtimeService.StartContainer(cn))
 		defer func() {
-			assert.NoError(t, runtimeService.StopContainer(cn, 10))
+			require.NoError(t, runtimeService.StopContainer(cn, 10))
 		}()
 	}
 
@@ -346,11 +346,11 @@ func TestContainerListStatsWithIdSandboxIdFilter(t *testing.T) {
 		containerConfigMap[cn] = containerConfig
 		require.NoError(t, err)
 		defer func() {
-			assert.NoError(t, runtimeService.RemoveContainer(cn))
+			require.NoError(t, runtimeService.RemoveContainer(cn))
 		}()
 		require.NoError(t, runtimeService.StartContainer(cn))
 		defer func() {
-			assert.NoError(t, runtimeService.StopContainer(cn, 10))
+			require.NoError(t, runtimeService.StopContainer(cn, 10))
 		}()
 	}
 	t.Logf("Fetch container stats for sandbox ID and container ID filter")
@@ -481,20 +481,20 @@ func TestContainerSysfsStatsWithPrivilegedPod(t *testing.T) {
 			)
 			cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
 			if test.expectedErr != "" && err != nil {
-				assert.Contains(t, err.Error(), test.expectedErr)
+				require.ErrorContains(t, err, test.expectedErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer func() {
 				if test.expectedErr == "" {
-					assert.NoError(t, runtimeService.RemoveContainer(cn))
+					require.NoError(t, runtimeService.RemoveContainer(cn))
 				}
 			}()
 
 			t.Log("Start the container")
 			require.NoError(t, runtimeService.StartContainer(cn))
 			defer func() {
-				assert.NoError(t, runtimeService.StopContainer(cn, 10))
+				require.NoError(t, runtimeService.StopContainer(cn, 10))
 			}()
 
 			t.Logf("Execute cmd in container by sync")
@@ -503,7 +503,7 @@ func TestContainerSysfsStatsWithPrivilegedPod(t *testing.T) {
 				"-c",
 				"mount |grep sysfs",
 			}, 10)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Contains(t, string(mountinfo), test.expectedSysfsOption)
 		})
 	}

--- a/integration/container_stop_test.go
+++ b/integration/container_stop_test.go
@@ -38,8 +38,8 @@ func TestSharedPidMultiProcessContainerStop(t *testing.T) {
 			sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
 			require.NoError(t, err)
 			defer func() {
-				assert.NoError(t, runtimeService.StopPodSandbox(sb))
-				assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+				require.NoError(t, runtimeService.StopPodSandbox(sb))
+				require.NoError(t, runtimeService.RemovePodSandbox(sb))
 			}()
 
 			var (
@@ -109,10 +109,10 @@ func TestContainerStopCancellation(t *testing.T) {
 		ContainerId: cn,
 		Timeout:     3,
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	t.Log("The container should still be running even after 5 seconds")
-	assert.NoError(t, Consistently(func() (bool, error) {
+	require.NoError(t, Consistently(func() (bool, error) {
 		s, err := runtimeService.ContainerStatus(cn)
 		if err != nil {
 			return false, err
@@ -121,7 +121,7 @@ func TestContainerStopCancellation(t *testing.T) {
 	}, 100*time.Millisecond, 5*time.Second))
 
 	t.Log("Stop the container with 1s timeout, without shorter context timeout")
-	assert.NoError(t, runtimeService.StopContainer(cn, 1))
+	require.NoError(t, runtimeService.StopContainer(cn, 1))
 
 	t.Log("The container state should be exited")
 	s, err := runtimeService.ContainerStatus(cn)

--- a/integration/container_volume_test.go
+++ b/integration/container_volume_test.go
@@ -138,7 +138,7 @@ func TestContainerSymlinkVolumes(t *testing.T) {
 			}, time.Second, 30*time.Second))
 
 			output, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Contains(t, string(output), content)
 		})

--- a/integration/container_without_image_ref_test.go
+++ b/integration/container_without_image_ref_test.go
@@ -48,7 +48,7 @@ func TestContainerLifecycleWithoutImageRef(t *testing.T) {
 	require.NoError(t, runtimeService.StartContainer(cn))
 
 	t.Log("Remove test image")
-	assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
+	require.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
 
 	t.Log("Container status should be running")
 	status, err := runtimeService.ContainerStatus(cn)
@@ -57,7 +57,7 @@ func TestContainerLifecycleWithoutImageRef(t *testing.T) {
 
 	t.Logf("Stop container")
 	err = runtimeService.StopContainer(cn, 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Log("Container status should be exited")
 	status, err = runtimeService.ContainerStatus(cn)

--- a/integration/image_volume_linux_test.go
+++ b/integration/image_volume_linux_test.go
@@ -137,7 +137,7 @@ func TestImageVolumeBasic(t *testing.T) {
 			podCtx, cnID, err := setupRunningContainerWithImageVolume(t, tc.selinuxLevel, tc.containerImage, tc.imageVolumeImage, tc.imageSubPath, tc.containerPath)
 			if err != nil {
 				require.NotEmpty(t, tc.createContainerError)
-				require.Contains(t, err.Error(), tc.createContainerError)
+				require.ErrorContains(t, err, tc.createContainerError)
 				return
 			}
 			require.Empty(t, tc.createContainerError)
@@ -174,13 +174,12 @@ func TestImageVolumeBasic(t *testing.T) {
 
 			stdout, stderr, err := runtimeService.ExecSync(cnID, tc.execSyncCommands, 0)
 			if tc.execSyncError != "" {
-				require.Error(t, err)
 				require.ErrorContains(t, err, tc.execSyncError)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Len(t, stderr, 0)
+			require.Empty(t, stderr)
 			require.Contains(t, string(stdout), tc.execSyncOutput)
 		})
 	}

--- a/integration/imagefs_info_test.go
+++ b/integration/imagefs_info_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/v2/integration/images"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -61,5 +60,5 @@ func TestImageFSInfo(t *testing.T) {
 
 	t.Logf("Image filesystem mountpath should exist")
 	_, err := os.Stat(info.GetFsId().GetMountpoint())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/integration/issue10244_loopback_linux_test.go
+++ b/integration/issue10244_loopback_linux_test.go
@@ -95,7 +95,7 @@ func checkLoopbackResult(t *testing.T, useInternalLoopback bool) bool {
 
 	t.Logf("Check loopback status - should be UP (not DOWN) when 'use_internal_loopback' is '%t'", useInternalLoopback)
 	stdout, _, err := podCtx.rSvc.ExecSync(cnID, []string{"/loopback-v2"}, 5*time.Second)
-	require.NoError(t, err, "")
+	require.NoError(t, err)
 	t.Logf("%s", stdout)
 
 	return assert.Contains(t, string(stdout), "UP")

--- a/integration/issue7496_linux_test.go
+++ b/integration/issue7496_linux_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/shim"
 	"github.com/containerd/ttrpc"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,7 +95,7 @@ func TestIssue7496(t *testing.T) {
 	select {
 	case <-time.After(15 * time.Second):
 		resp, err := shimCli.Connect(ctx, &apitask.ConnectRequest{})
-		assert.Error(t, err, "should failed to call shim connect API")
+		require.Error(t, err, "should failed to call shim connect API")
 
 		t.Errorf("Strace doesn't exit in time")
 
@@ -140,7 +139,7 @@ func injectDelayToUmount2(ctx context.Context, t *testing.T, shimCli apitask.TTR
 
 		bufReader := bufio.NewReader(pipeR)
 		_, err := bufReader.Peek(1)
-		assert.NoError(t, err, "failed to ensure that strace has attached to shim")
+		require.NoError(t, err, "failed to ensure that strace has attached to shim")
 
 		close(readyCh)
 		io.Copy(os.Stdout, bufReader)
@@ -149,7 +148,7 @@ func injectDelayToUmount2(ctx context.Context, t *testing.T, shimCli apitask.TTR
 
 	go func() {
 		defer pipeW.Close()
-		assert.NoError(t, cmd.Wait(), "strace should exit with zero code")
+		require.NoError(t, cmd.Wait(), "strace should exit with zero code")
 	}()
 
 	<-readyCh

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/opencontainers/selinux/go-selinux"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -280,8 +279,8 @@ func PodSandboxConfigWithCleanup(t *testing.T, name, ns string, opts ...PodSandb
 	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+		require.NoError(t, runtimeService.StopPodSandbox(sb))
+		require.NoError(t, runtimeService.RemovePodSandbox(sb))
 	})
 
 	return sb, sbConfig
@@ -794,7 +793,7 @@ func RestartContainerd(t *testing.T, signal syscall.Signal) {
 
 	// Use assert so that the 3rd wait always runs, this makes sure
 	// containerd is running before this function returns.
-	assert.NoError(t, Eventually(func() (bool, error) {
+	require.NoError(t, Eventually(func() (bool, error) {
 		pid, err := PidOf(*containerdBin)
 		if err != nil {
 			return false, err

--- a/integration/nri_linux_test.go
+++ b/integration/nri_linux_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/containerd/nri/pkg/api"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/vishvananda/netlink"
@@ -189,7 +188,7 @@ func TestNriPluginNetworkingLifecycle(t *testing.T) {
 		t.Fatalf("test timed out waiting for the RunPodSandbox hook to be executed")
 	}
 
-	assert.NoError(t, runtimeService.StopPodSandbox(podID))
+	require.NoError(t, runtimeService.StopPodSandbox(podID))
 	err = plugin.Wait(&Event{Pod: podID, Type: EventType(StopPodSandbox)}, time.After(pluginSyncTimeout))
 	require.NoError(t, err, "plugin sync wait")
 	select {
@@ -198,7 +197,7 @@ func TestNriPluginNetworkingLifecycle(t *testing.T) {
 		t.Fatalf("test timed out waiting for the StopPodSandbox hook to be executed")
 	}
 
-	assert.NoError(t, runtimeService.RemovePodSandbox(podID))
+	require.NoError(t, runtimeService.RemovePodSandbox(podID))
 	err = plugin.Wait(&Event{Pod: podID, Type: EventType(RemovePodSandbox)}, time.After(pluginSyncTimeout))
 	require.NoError(t, err, "plugin sync wait")
 	select {

--- a/integration/nri_test.go
+++ b/integration/nri_test.go
@@ -36,7 +36,6 @@ import (
 
 	cri "github.com/containerd/containerd/v2/integration/cri-api/pkg/apis"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/containerd/v2/integration/images"
@@ -676,14 +675,14 @@ func (tc *nriTest) startContainer(podID, name string, opts ...ContainerOpts) str
 	}
 
 	ctrID, err := tc.runtime.CreateContainer(podID, ctrCfg, podCfg)
-	assert.NoError(tc.t, err, "create container")
-	assert.NoError(tc.t, tc.runtime.StartContainer(ctrID), "start container")
+	require.NoError(tc.t, err, "create container")
+	require.NoError(tc.t, tc.runtime.StartContainer(ctrID), "start container")
 
 	tc.ctrs = append(tc.ctrs, ctrID)
 
 	tc.t.Cleanup(func() {
-		assert.NoError(tc.t, tc.runtime.StopContainer(ctrID, containerStopTimeout))
-		assert.NoError(tc.t, tc.runtime.RemoveContainer(ctrID))
+		require.NoError(tc.t, tc.runtime.StopContainer(ctrID, containerStopTimeout))
+		require.NoError(tc.t, tc.runtime.RemoveContainer(ctrID))
 	})
 
 	tc.t.Logf("created/started container %s/%s/%s with ID %s",

--- a/integration/pod_dualstack_test.go
+++ b/integration/pod_dualstack_test.go
@@ -76,7 +76,7 @@ func TestPodDualStack(t *testing.T) {
 	}, time.Second, 30*time.Second))
 
 	content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	status, err := runtimeService.PodSandboxStatus(sb)
 	require.NoError(t, err)
 	ip := status.GetNetwork().GetIp()
@@ -92,9 +92,9 @@ func TestPodDualStack(t *testing.T) {
 	}
 
 	ipv4Enabled, err := regexp.MatchString(ipv4Regex, string(content))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ipv6Enabled, err := regexp.MatchString(ipv6Regex, string(content))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	if ipv4Enabled && ipv6Enabled {
 		t.Log("Dualstack should be enabled")
@@ -103,7 +103,7 @@ func TestPodDualStack(t *testing.T) {
 		assert.Nil(t, net.ParseIP(additionalIps[0].GetIp()).To4())
 	} else {
 		t.Log("Dualstack should not be enabled")
-		assert.Len(t, additionalIps, 0)
+		assert.Empty(t, additionalIps)
 		assert.NotEmpty(t, ip)
 	}
 }

--- a/integration/pod_hostname_test.go
+++ b/integration/pod_hostname_test.go
@@ -79,8 +79,8 @@ func TestPodHostname(t *testing.T) {
 			}
 			// Make sure the sandbox is cleaned up.
 			defer func() {
-				assert.NoError(t, runtimeService.StopPodSandbox(sb))
-				assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+				require.NoError(t, runtimeService.StopPodSandbox(sb))
+				require.NoError(t, runtimeService.RemovePodSandbox(sb))
 			}()
 			if test.expectErr {
 				t.Fatalf("Expected RunPodSandbox to return error")
@@ -120,7 +120,7 @@ func TestPodHostname(t *testing.T) {
 			}, time.Second, 30*time.Second))
 
 			content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			t.Log("Search hostname env in container log")
 			if goruntime.GOOS == "windows" {

--- a/integration/pod_userns_linux_test.go
+++ b/integration/pod_userns_linux_test.go
@@ -254,8 +254,8 @@ func TestPodUserNS(t *testing.T) {
 			}
 			// Make sure the sandbox is cleaned up.
 			defer func() {
-				assert.NoError(t, runtimeService.StopPodSandbox(sb))
-				assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+				require.NoError(t, runtimeService.StopPodSandbox(sb))
+				require.NoError(t, runtimeService.RemovePodSandbox(sb))
 			}()
 			if test.expectErr {
 				t.Fatalf("Expected RunPodSandbox to return error")
@@ -296,7 +296,7 @@ func TestPodUserNS(t *testing.T) {
 			}, time.Second, 30*time.Second))
 
 			content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			t.Log("Running check function")
 			test.checkOutput(t, string(content))
@@ -359,8 +359,8 @@ func TestIssue10598(t *testing.T) {
 
 	// Make sure the sandbox is cleaned up.
 	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+		require.NoError(t, runtimeService.StopPodSandbox(sb))
+		require.NoError(t, runtimeService.RemovePodSandbox(sb))
 	}()
 
 	t.Log("Create a container for userns")

--- a/integration/release_upgrade_linux_test.go
+++ b/integration/release_upgrade_linux_test.go
@@ -299,7 +299,7 @@ func shouldRecoverAllThePodsAfterUpgrade(t *testing.T, taskVersion int,
 					PodSandboxId: pod.Id,
 				})
 				require.NoError(t, err)
-				require.Equal(t, 3, len(cntrs))
+				require.Len(t, cntrs, 3)
 
 				for _, cntr := range cntrs {
 					switch cntr.Id {
@@ -324,7 +324,7 @@ func shouldRecoverAllThePodsAfterUpgrade(t *testing.T, taskVersion int,
 					PodSandboxId: pod.Id,
 				})
 				require.NoError(t, err)
-				require.Equal(t, 1, len(cntrs))
+				require.Len(t, cntrs, 1)
 				assert.Equal(t, criruntime.ContainerState_CONTAINER_EXITED, cntrs[0].State)
 
 			default:
@@ -364,7 +364,7 @@ func execToExistingContainer(t *testing.T, _ int,
 			PodSandboxId: pods[0].Id,
 		})
 		require.NoError(t, err)
-		require.Equal(t, 1, len(cntrs))
+		require.Len(t, cntrs, 1)
 		assert.Equal(t, criruntime.ContainerState_CONTAINER_RUNNING, cntrs[0].State)
 		assert.Equal(t, cnID, cntrs[0].Id)
 
@@ -388,7 +388,7 @@ func execToExistingContainer(t *testing.T, _ int,
 		t.Log("Run ExecSync")
 		stdout, stderr, err := rSvc.ExecSync(cntrs[0].Id, []string{"echo", "-n", "true"}, 0)
 		require.NoError(t, err)
-		require.Len(t, stderr, 0)
+		require.Empty(t, stderr)
 		require.Equal(t, "true", string(stdout))
 	}
 	return []upgradeVerifyCaseFunc{verifyFunc}, nil
@@ -501,7 +501,7 @@ func shouldManipulateContainersInPodAfterUpgrade(runtimeHandler string) setupUpg
 			t.Logf("Containers data dir %s should be empty", cntrDataDir)
 			ents, err := os.ReadDir(cntrDataDir)
 			require.NoError(t, err)
-			require.Len(t, ents, 0, cntrDataDir)
+			require.Empty(t, ents, cntrDataDir)
 
 			t.Log("Creating new running container in new pod")
 			pod2Ctx := newPodTCtxWithRuntimeHandler(t, rSvc, "running-pod-2", "sandbox", runtimeHandler)
@@ -518,7 +518,7 @@ func shouldManipulateContainersInPodAfterUpgrade(runtimeHandler string) setupUpg
 			for _, shimCli := range shimConns {
 				t.Logf("Checking container %s's shim client", shimCli.cntrID)
 				_, err = shimCli.cli.Connect(context.Background(), &apitask.ConnectRequest{})
-				assert.ErrorContains(t, err, "ttrpc: closed", "should be closed after deleting pod")
+				require.ErrorContains(t, err, "ttrpc: closed", "should be closed after deleting pod")
 			}
 		}
 		return []upgradeVerifyCaseFunc{verifyFunc}, nil
@@ -618,7 +618,7 @@ done
 
 		// NOTE: Just in case that part of inactive cache has been reclaimed.
 		expectedBytes := uint64(fileSize * 2 / 3)
-		require.True(t, stats.GetMemory().GetUsageBytes().GetValue() > expectedBytes)
+		require.Greater(t, stats.GetMemory().GetUsageBytes().GetValue(), expectedBytes)
 	}
 	return []upgradeVerifyCaseFunc{verifyFunc}, nil
 }
@@ -834,8 +834,8 @@ func cleanupPods(t *testing.T, criRuntimeService cri.RuntimeService) {
 	require.NoError(t, err)
 
 	for _, pod := range pods {
-		assert.NoError(t, criRuntimeService.StopPodSandbox(pod.Id))
-		assert.NoError(t, criRuntimeService.RemovePodSandbox(pod.Id))
+		require.NoError(t, criRuntimeService.StopPodSandbox(pod.Id))
+		require.NoError(t, criRuntimeService.RemovePodSandbox(pod.Id))
 	}
 }
 
@@ -940,7 +940,7 @@ func newCtrdProc(t *testing.T, ctrdBin string, ctrdWorkDir string, envs []string
 		defer close(p.waitBlock)
 
 		require.NoError(t, p.cmd.Start(), "start containerd(%s)", ctrdBin)
-		assert.NoError(t, p.cmd.Wait())
+		require.NoError(t, p.cmd.Wait())
 	}()
 	return p
 }

--- a/integration/release_upgrade_utils_linux_test.go
+++ b/integration/release_upgrade_utils_linux_test.go
@@ -63,7 +63,7 @@ func downloadReleaseBinary(t *testing.T, targetDir string, ver string) {
 // previousReleaseVersion returns the latest version of previous release.
 func previousReleaseVersion(t *testing.T, version string) string {
 	tags := gitLsRemoteCtrdTags(t, fmt.Sprintf("refs/tags/v%s.*", version))
-	require.True(t, len(tags) >= 1)
+	require.GreaterOrEqual(t, len(tags), 1)
 
 	// sort them and get the latest version
 	semver.Sort(tags)
@@ -87,7 +87,7 @@ func gitLsRemoteCtrdTags(t *testing.T, pattern string) (_tags []string) {
 	// cec2382030533cf5797d63a4cdb2b255a9c3c7b6        refs/tags/v1.6.9
 	// 1c90a442489720eec95342e1789ee8a5e1b9536f        refs/tags/v1.6.9^{}
 	refTags := strings.Fields(string(out))
-	require.True(t, len(refTags)%2 == 0)
+	require.Equal(t, 0, len(refTags)%2)
 
 	tags := make([]string, 0, len(refTags)/2)
 	for i := 1; i < len(refTags); i += 2 {

--- a/integration/restart_linux_test.go
+++ b/integration/restart_linux_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -35,13 +36,13 @@ func TestContainerdRestartSandboxRecover(t *testing.T) {
 
 	sbReadyConfig := PodSandboxConfig("sandbox_ready", "sandbox_ready")
 	_, err := runtimeService.RunPodSandbox(sbReadyConfig, *runtimeHandler)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sbNotReadyConfig := PodSandboxConfig("sandbox_not_ready", "sandbox_not_ready")
 	notReadyID, err := runtimeService.RunPodSandbox(sbNotReadyConfig, *runtimeHandler)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = runtimeService.StopPodSandbox(notReadyID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Logf("Create a pod config with shim create delay")
 	sbUnknownConfig := PodSandboxConfig("sandbox_unknown", "sandbox_unknown_status")
@@ -57,10 +58,10 @@ func TestContainerdRestartSandboxRecover(t *testing.T) {
 	}()
 	t.Logf("Create a sandbox with shim create delay")
 	_, err = runtimeService.RunPodSandbox(sbUnknownConfig, failpointRuntimeHandler)
-	assert.Error(t, err)
+	require.Error(t, err)
 	<-waitCh
 	sbs, err := runtimeService.ListPodSandbox(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	foundUnkownSb := false
 	for _, sb := range sbs {
 		if sb.Metadata.Name == "sandbox_unknown" {
@@ -69,9 +70,9 @@ func TestContainerdRestartSandboxRecover(t *testing.T) {
 		if status, ok := sbStatuses[sb.Metadata.Name]; ok {
 			assert.Equal(t, status, sb.State)
 			err = runtimeService.StopPodSandbox(sb.Id)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = runtimeService.RemovePodSandbox(sb.Id)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}
 	assert.True(t, foundUnkownSb)

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -162,7 +162,7 @@ func TestContainerdRestart(t *testing.T) {
 		EnsureImageExists(t, image)
 	}
 	imagesBeforeRestart, err := imageService.ListImages(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Logf("Restart containerd")
 	RestartContainerd(t, syscall.SIGTERM)
@@ -210,14 +210,14 @@ func TestContainerdRestart(t *testing.T) {
 
 	t.Logf("Should be able to stop and remove sandbox after restart")
 	for _, s := range sandboxes {
-		assert.NoError(t, runtimeService.StopPodSandbox(s.id))
-		assert.NoError(t, runtimeService.RemovePodSandbox(s.id))
+		require.NoError(t, runtimeService.StopPodSandbox(s.id))
+		require.NoError(t, runtimeService.RemovePodSandbox(s.id))
 	}
 
 	t.Logf("Should recover all images")
 	imagesAfterRestart, err := imageService.ListImages(nil)
-	assert.NoError(t, err)
-	assert.Equal(t, len(imagesBeforeRestart), len(imagesAfterRestart))
+	require.NoError(t, err)
+	assert.Len(t, imagesAfterRestart, len(imagesBeforeRestart))
 	for _, i1 := range imagesBeforeRestart {
 		found := false
 		for _, i2 := range imagesAfterRestart {

--- a/integration/sandbox_clean_remove_test.go
+++ b/integration/sandbox_clean_remove_test.go
@@ -105,7 +105,7 @@ func TestSandboxRemoveWithoutIPLeakage(t *testing.T) {
 	assert.True(t, info.NetNSClosed)
 
 	t.Logf("Sandbox state should be NOTREADY")
-	assert.NoError(t, Eventually(func() (bool, error) {
+	require.NoError(t, Eventually(func() (bool, error) {
 		status, err := runtimeService.PodSandboxStatus(sb)
 		if err != nil {
 			return false, err
@@ -117,8 +117,8 @@ func TestSandboxRemoveWithoutIPLeakage(t *testing.T) {
 	assert.True(t, checkIP(ip))
 
 	t.Logf("Should be able to stop and remove the sandbox")
-	assert.NoError(t, runtimeService.StopPodSandbox(sb))
-	assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	require.NoError(t, runtimeService.StopPodSandbox(sb))
+	require.NoError(t, runtimeService.RemovePodSandbox(sb))
 
 	t.Logf("Should not be able to find the pod ip in host-local checkpoint")
 	assert.False(t, checkIP(ip))

--- a/integration/sandbox_clean_remove_windows_test.go
+++ b/integration/sandbox_clean_remove_windows_test.go
@@ -174,7 +174,7 @@ func TestSandboxRemoveWithoutIPLeakage(t *testing.T) {
 	assert.True(t, info.NetNSClosed)
 
 	t.Logf("Sandbox state should be NOTREADY")
-	assert.NoError(t, Eventually(func() (bool, error) {
+	require.NoError(t, Eventually(func() (bool, error) {
 		status, err := runtimeService.PodSandboxStatus(sb)
 		if err != nil {
 			return false, err
@@ -186,8 +186,8 @@ func TestSandboxRemoveWithoutIPLeakage(t *testing.T) {
 	assert.True(t, checkIP(ip))
 
 	t.Logf("Should be able to stop and remove the sandbox")
-	assert.NoError(t, runtimeService.StopPodSandbox(sb))
-	assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	require.NoError(t, runtimeService.StopPodSandbox(sb))
+	require.NoError(t, runtimeService.RemovePodSandbox(sb))
 
 	t.Logf("Should not be able to find the pod ip in host-local checkpoint")
 	assert.False(t, checkIP(ip), fmt.Sprintf("The IP: %s is still in use in azure-vnet-ipam.json", ip))

--- a/integration/truncindex_test.go
+++ b/integration/truncindex_test.go
@@ -62,9 +62,9 @@ func TestTruncIndex(t *testing.T) {
 	defer func() {
 		// The 2th StopPodSandbox will fail, the 2th RemovePodSandbox will success.
 		if !hasStoppedSandbox {
-			assert.NoError(t, runtimeService.StopPodSandbox(sbTruncIndex))
+			require.NoError(t, runtimeService.StopPodSandbox(sbTruncIndex))
 		}
-		assert.NoError(t, runtimeService.RemovePodSandbox(sbTruncIndex))
+		require.NoError(t, runtimeService.RemovePodSandbox(sbTruncIndex))
 	}()
 
 	t.Logf("Get sandbox status by truncindex")
@@ -74,7 +74,7 @@ func TestTruncIndex(t *testing.T) {
 
 	t.Logf("Forward port for sandbox by truncindex")
 	_, err = runtimeService.PortForward(&runtimeapi.PortForwardRequest{PodSandboxId: sbTruncIndex, Port: []int32{80}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// TODO(yanxuean): add test case for ListPodSandbox
 
@@ -89,7 +89,7 @@ func TestTruncIndex(t *testing.T) {
 	cnTruncIndex := genTruncIndex(cn)
 	defer func() {
 		// the 2th RemovePodSandbox will success.
-		assert.NoError(t, runtimeService.RemoveContainer(cnTruncIndex))
+		require.NoError(t, runtimeService.RemoveContainer(cnTruncIndex))
 	}()
 
 	t.Logf("Get container status by truncindex")
@@ -103,7 +103,7 @@ func TestTruncIndex(t *testing.T) {
 	defer func() {
 		// The 2th StopPodSandbox will fail
 		if !hasStoppedContainer {
-			assert.NoError(t, runtimeService.StopContainer(cnTruncIndex, 10))
+			require.NoError(t, runtimeService.StopContainer(cnTruncIndex, 10))
 		}
 	}()
 
@@ -117,12 +117,12 @@ func TestTruncIndex(t *testing.T) {
 		err = runtimeService.UpdateContainerResources(cnTruncIndex, &runtimeapi.LinuxContainerResources{
 			MemoryLimitInBytes: 50 * 1024 * 1024,
 		}, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	} else {
 		err = runtimeService.UpdateContainerResources(cnTruncIndex, nil, &runtimeapi.WindowsContainerResources{
 			MemoryLimitInBytes: 50 * 1024 * 1024,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	t.Logf("Execute cmd in container")
@@ -132,33 +132,33 @@ func TestTruncIndex(t *testing.T) {
 		Stdout:      true,
 	}
 	_, err = runtimeService.Exec(execReq)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Logf("Execute cmd in container by sync")
 	_, _, err = runtimeService.ExecSync(cnTruncIndex, []string{"pwd"}, 10)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// TODO(yanxuean): add test case for ListContainers
 
 	t.Logf("Get a non exist container status by truncindex")
 	err = runtimeService.StopContainer(cnTruncIndex, 10)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if err == nil {
 		hasStoppedContainer = true
 	}
 	_, err = runtimeService.ContainerStats(cnTruncIndex)
-	assert.Error(t, err)
-	assert.NoError(t, runtimeService.RemoveContainer(cnTruncIndex))
+	require.Error(t, err)
+	require.NoError(t, runtimeService.RemoveContainer(cnTruncIndex))
 	_, err = runtimeService.ContainerStatus(cnTruncIndex)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	t.Logf("Get a non exist sandbox status by truncindex")
 	err = runtimeService.StopPodSandbox(sbTruncIndex)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if err == nil {
 		hasStoppedSandbox = true
 	}
-	assert.NoError(t, runtimeService.RemovePodSandbox(sbTruncIndex))
+	require.NoError(t, runtimeService.RemovePodSandbox(sbTruncIndex))
 	_, err = runtimeService.PodSandboxStatus(sbTruncIndex)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/integration/volume_copy_up_test.go
+++ b/integration/volume_copy_up_test.go
@@ -127,7 +127,7 @@ func TestVolumeCopyUp(t *testing.T) {
 	t.Logf("Check host path of the volume")
 	for _, vol := range expectedVolumes {
 		_, ok := volumeMappings[vol.containerPath]
-		assert.Equalf(t, true, ok, "expected to find volume %s", vol.containerPath)
+		assert.Truef(t, ok, "expected to find volume %s", vol.containerPath)
 	}
 
 	// ghcr.io/containerd/volume-copy-up:2.2 contains 3 volumes on Linux and 2 volumes on Windows.
@@ -136,7 +136,7 @@ func TestVolumeCopyUp(t *testing.T) {
 	for _, vol := range expectedVolumes {
 		files, err := os.ReadDir(volumeMappings[vol.containerPath])
 		require.NoError(t, err)
-		assert.Equal(t, len(vol.files), len(files))
+		assert.Len(t, files, len(vol.files))
 
 		for _, file := range vol.files {
 			t.Logf("Check whether volume %s contains the test file %s", vol.containerPath, file.fileName)

--- a/integration/windows_device_test.go
+++ b/integration/windows_device_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/v2/integration/images"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -83,7 +82,7 @@ func TestWindowsDevice(t *testing.T) {
 
 	t.Log("Check container log")
 	content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	checkContainerLog(t, string(content), []string{
 		fmt.Sprintf("%s %s %s", runtime.Stdout, runtime.LogTagFull, "/Windows/System32/HostDriverStore/FileRepository"),
 	})

--- a/integration/windows_hostprocess_test.go
+++ b/integration/windows_hostprocess_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/containerd/containerd/v2/integration/images"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows/registry"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -111,7 +110,7 @@ func runHostProcess(t *testing.T, expectErr bool, image string, action hpcAction
 	cn, err := runtimeService.CreateContainer(sb, containerConfig, sbConfig)
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, runtimeService.RemoveContainer(cn))
+		require.NoError(t, runtimeService.RemoveContainer(cn))
 	}()
 	_, err = t, runtimeService.StartContainer(cn)
 	if err != nil {
@@ -121,7 +120,7 @@ func runHostProcess(t *testing.T, expectErr bool, image string, action hpcAction
 		return
 	}
 	defer func() {
-		assert.NoError(t, runtimeService.StopContainer(cn, 10))
+		require.NoError(t, runtimeService.StopContainer(cn, 10))
 	}()
 
 	action(t, cn, containerConfig)
@@ -175,8 +174,8 @@ func TestArgsEscapedImagesOnWindows(t *testing.T) {
 	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+		require.NoError(t, runtimeService.StopPodSandbox(sb))
+		require.NoError(t, runtimeService.RemovePodSandbox(sb))
 	})
 
 	EnsureImageExists(t, testImage)

--- a/integration/windows_rootfs_size_test.go
+++ b/integration/windows_rootfs_size_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/v2/integration/images"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -82,7 +81,7 @@ func TestWindowsRootfsSize(t *testing.T) {
 
 	t.Log("Check container log")
 	content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Format of output for dir /-C:
 	//

--- a/internal/cleanup/context_test.go
+++ b/internal/cleanup/context_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDo(t *testing.T) {
@@ -32,17 +33,17 @@ func TestDo(t *testing.T) {
 	v := "incontext"
 	ctx = context.WithValue(ctx, k, v) //nolint:staticcheck
 
-	assert.Nil(t, contextError(ctx))
+	require.NoError(t, contextError(ctx))
 	assert.Equal(t, ctx.Value(k), v)
 
 	cancel()
-	assert.Error(t, contextError(ctx))
+	require.Error(t, contextError(ctx))
 	assert.Equal(t, ctx.Value(k), v)
 
 	t.Run("with canceled context", func(t *testing.T) {
 		t.Parallel()
 		Do(ctx, func(ctx context.Context) {
-			assert.NoError(t, contextError(ctx))
+			require.NoError(t, contextError(ctx))
 			assert.Equal(t, ctx.Value(k), v)
 		})
 	})
@@ -52,7 +53,7 @@ func TestDo(t *testing.T) {
 		Do(ctx, func(ctx context.Context) {
 			ctx, cancelFn := context.WithCancel(ctx)
 			cancelFn()
-			assert.ErrorIs(t, contextError(ctx), context.Canceled)
+			require.ErrorIs(t, contextError(ctx), context.Canceled)
 			assert.Equal(t, ctx.Value(k), v)
 		})
 	})

--- a/internal/cri/config/config_kernel_linux_test.go
+++ b/internal/cri/config/config_kernel_linux_test.go
@@ -22,6 +22,7 @@ import (
 
 	kernel "github.com/containerd/containerd/v2/pkg/kernelversion"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateEnableUnprivileged(t *testing.T) {
@@ -95,9 +96,9 @@ func TestValidateEnableUnprivileged(t *testing.T) {
 			}
 			err := ValidateEnableUnprivileged(context.Background(), test.config)
 			if test.expectedErr != "" {
-				assert.Equal(t, err.Error(), test.expectedErr)
+				assert.Equal(t, test.expectedErr, err.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/cri/config/config_test.go
+++ b/internal/cri/config/config_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	criruntime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/internal/cri/opts"
@@ -303,10 +304,9 @@ func TestValidateConfig(t *testing.T) {
 			if test.runtimeConfig != nil {
 				w, err := ValidateRuntimeConfig(context.Background(), test.runtimeConfig)
 				if test.runtimeExpectedErr != "" {
-					assert.Error(t, err)
-					assert.Contains(t, err.Error(), test.runtimeExpectedErr)
+					require.ErrorContains(t, err, test.runtimeExpectedErr)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.Equal(t, test.runtimeExpected, test.runtimeConfig)
 				}
 				warnings = append(warnings, w...)
@@ -314,9 +314,9 @@ func TestValidateConfig(t *testing.T) {
 			if test.imageConfig != nil {
 				w, err := ValidateImageConfig(context.Background(), test.imageConfig)
 				if test.imageExpectedErr != "" {
-					assert.Contains(t, err.Error(), test.imageExpectedErr)
+					require.ErrorContains(t, err, test.imageExpectedErr)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.Equal(t, test.imageExpected, test.imageConfig)
 				}
 				warnings = append(warnings, w...)
@@ -324,9 +324,9 @@ func TestValidateConfig(t *testing.T) {
 			if test.serverConfig != nil {
 				w, err := ValidateServerConfig(context.Background(), test.serverConfig)
 				if test.serverExpectedErr != "" {
-					assert.Contains(t, err.Error(), test.serverExpectedErr)
+					require.ErrorContains(t, err, test.serverExpectedErr)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.Equal(t, test.serverExpected, test.serverConfig)
 				}
 				warnings = append(warnings, w...)
@@ -335,7 +335,7 @@ func TestValidateConfig(t *testing.T) {
 			if len(test.warnings) > 0 {
 				assert.ElementsMatch(t, test.warnings, warnings)
 			} else {
-				assert.Len(t, warnings, 0)
+				assert.Empty(t, warnings)
 			}
 		})
 	}

--- a/internal/cri/config/streaming_test.go
+++ b/internal/cri/config/streaming_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateStreamServer(t *testing.T) {
@@ -119,10 +120,10 @@ func TestValidateStreamServer(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			tlsMode, err := getStreamListenerMode(&test.config)
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.tlsMode, tlsMode)
 		})
 	}

--- a/internal/cri/io/logger_test.go
+++ b/internal/cri/io/logger_test.go
@@ -249,7 +249,7 @@ func TestRedirectLogs(t *testing.T) {
 				fields := strings.SplitN(lines[i], string([]byte{delimiter}), 4)
 				require.Len(t, fields, 4)
 				_, err := time.Parse(timestampFormat, fields[0])
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.EqualValues(t, test.stream, fields[1])
 				assert.Equal(t, string(test.tag[i]), fields[2])
 				assert.Equal(t, test.content[i], fields[3])

--- a/internal/cri/opts/spec_windows_test.go
+++ b/internal/cri/opts/spec_windows_test.go
@@ -193,7 +193,7 @@ func TestWithDevices(t *testing.T) {
 
 			spec, err := oci.GenerateSpecWithPlatform(ctx, nil, platform, c, specOpts...)
 			if tc.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}

--- a/internal/cri/server/container_create_test.go
+++ b/internal/cri/server/container_create_test.go
@@ -98,7 +98,7 @@ func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
 			desc:           "a passthrough annotation should be passed as an OCI annotation",
 			podAnnotations: []string{"c"},
 			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
-				assert.Equal(t, spec.Annotations["c"], "d")
+				assert.Equal(t, "d", spec.Annotations["c"])
 			},
 		},
 		{
@@ -108,7 +108,7 @@ func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
 			},
 			podAnnotations: []string{"c"},
 			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
-				assert.Equal(t, spec.Annotations["c"], "d")
+				assert.Equal(t, "d", spec.Annotations["c"])
 				_, ok := spec.Annotations["d"]
 				assert.False(t, ok)
 			},
@@ -125,9 +125,9 @@ func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
 			podAnnotations: []string{"t*", "z.*", "y.c*"},
 			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
 				t.Logf("%+v", spec.Annotations)
-				assert.Equal(t, spec.Annotations["t.f"], "j")
-				assert.Equal(t, spec.Annotations["z.g"], "o")
-				assert.Equal(t, spec.Annotations["y.ca"], "b")
+				assert.Equal(t, "j", spec.Annotations["t.f"])
+				assert.Equal(t, "o", spec.Annotations["z.g"])
+				assert.Equal(t, "b", spec.Annotations["y.ca"])
 				_, ok := spec.Annotations["y"]
 				assert.False(t, ok)
 				_, ok = spec.Annotations["z"]
@@ -147,7 +147,7 @@ func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
 			}
 			spec, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, "", testContainerName, testImageName,
 				containerConfig, sandboxConfig, imageConfig, nil, ociRuntime, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, spec)
 			specCheck(t, testID, testSandboxID, testPid, spec)
 			if test.specCheck != nil {
@@ -218,10 +218,10 @@ func TestContainerSpecCommand(t *testing.T) {
 			var spec runtimespec.Spec
 			err := opts.WithProcessArgs(config, imageConfig)(context.Background(), nil, nil, &spec)
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, spec.Process.Args, test.desc)
 		})
 	}
@@ -509,7 +509,7 @@ func TestContainerAnnotationPassthroughContainerSpec(t *testing.T) {
 			}
 			spec, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, "", testContainerName, testImageName,
 				containerConfig, sandboxConfig, imageConfig, nil, ociRuntime, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, spec)
 			specCheck(t, testID, testSandboxID, testPid, spec)
 			if test.specCheck != nil {
@@ -536,7 +536,7 @@ func TestBaseRuntimeSpec(t *testing.T) {
 		oci.WithHostname("new-host"),
 		oci.WithDomainname("new-domain"),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "1.0.2", out.Version)
 	assert.Equal(t, "new-host", out.Hostname)
@@ -544,9 +544,9 @@ func TestBaseRuntimeSpec(t *testing.T) {
 
 	// Make sure original base spec not changed
 	spec, err := c.LoadOCISpec("/etc/containerd/cri-base.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, out, spec)
-	assert.Equal(t, spec.Hostname, "old")
+	assert.Equal(t, "old", spec.Hostname)
 
 	assert.Equal(t, filepath.Join("/", constants.K8sContainerdNamespace, "id1"), out.Linux.CgroupsPath)
 }

--- a/internal/cri/server/container_create_windows_test.go
+++ b/internal/cri/server/container_create_windows_test.go
@@ -166,7 +166,7 @@ func TestContainerWindowsNetworkNamespace(t *testing.T) {
 
 	containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
 	spec, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, nsPath, testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, spec)
 	specCheck(t, testID, testSandboxID, testPid, spec)
 	assert.NotNil(t, spec.Windows)
@@ -188,7 +188,7 @@ func TestMountCleanPath(t *testing.T) {
 		HostPath:      "c:/test/host-path",
 	})
 	spec, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, nsPath, testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, spec)
 	specCheck(t, testID, testSandboxID, testPid, spec)
 	checkMount(t, spec.Mounts, "c:\\test\\host-path", "c:\\test\\container-path", "", []string{"rw"}, nil)
@@ -208,7 +208,7 @@ func TestMountNamedPipe(t *testing.T) {
 		HostPath:      `\\.\pipe\foo`,
 	})
 	spec, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, nsPath, testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, spec)
 	specCheck(t, testID, testSandboxID, testPid, spec)
 	checkMount(t, spec.Mounts, `\\.\pipe\foo`, `\\.\pipe\foo`, "", []string{"rw"}, nil)
@@ -260,9 +260,9 @@ func TestHostProcessRequirements(t *testing.T) {
 			}
 			_, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime, nil)
 			if test.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -356,7 +356,7 @@ func TestEntrypointAndCmdForArgsEscaped(t *testing.T) {
 				Windows: &runtime.WindowsContainerConfig{},
 			}
 			runtimeSpec, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, nsPath, testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{}, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, runtimeSpec)
 
 			// check the runtime spec for expected commandline and args

--- a/internal/cri/server/container_list_test.go
+++ b/internal/cri/server/container_list_test.go
@@ -60,7 +60,7 @@ func TestToCRIContainer(t *testing.T) {
 			},
 		),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expect := &runtime.Container{
 		Id:           "test-id",
 		PodSandboxId: "test-sandbox-id",
@@ -285,14 +285,14 @@ func TestListContainers(t *testing.T) {
 
 	// Inject test sandbox metadata
 	for _, sb := range sandboxesInStore {
-		assert.NoError(t, c.sandboxStore.Add(sb))
+		require.NoError(t, c.sandboxStore.Add(sb))
 	}
 
 	// Inject test container metadata
 	for _, cntr := range containersInStore {
 		container, err := cntr.toContainer()
-		assert.NoError(t, err)
-		assert.NoError(t, c.containerStore.Add(container))
+		require.NoError(t, err)
+		require.NoError(t, c.containerStore.Add(container))
 	}
 
 	for _, testdata := range []struct {
@@ -352,7 +352,7 @@ func TestListContainers(t *testing.T) {
 	} {
 		t.Run(testdata.desc, func(t *testing.T) {
 			resp, err := c.ListContainers(context.Background(), &runtime.ListContainersRequest{Filter: testdata.filter})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, resp)
 			containers := resp.GetContainers()
 			assert.Len(t, containers, len(testdata.expect))

--- a/internal/cri/server/container_remove_test.go
+++ b/internal/cri/server/container_remove_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 )
@@ -75,15 +76,15 @@ func TestSetContainerRemoving(t *testing.T) {
 				containerstore.Metadata{ID: testID},
 				containerstore.WithFakeStatus(test.status),
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = setContainerRemoving(container)
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, test.status, container.Status.Get(), "metadata should not be updated")
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.True(t, container.Status.Get().Removing, "removing should be set")
-				assert.NoError(t, resetContainerRemoving(container))
+				require.NoError(t, resetContainerRemoving(container))
 				assert.False(t, container.Status.Get().Removing, "removing should be reset")
 			}
 		})

--- a/internal/cri/server/container_start_test.go
+++ b/internal/cri/server/container_start_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 )
@@ -89,15 +90,15 @@ func TestSetContainerStarting(t *testing.T) {
 				containerstore.Metadata{ID: testID},
 				containerstore.WithFakeStatus(test.status),
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = setContainerStarting(container)
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, test.status, container.Status.Get(), "metadata should not be updated")
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.True(t, container.Status.Get().Starting, "starting should be set")
-				assert.NoError(t, resetContainerStarting(container))
+				require.NoError(t, resetContainerStarting(container))
 				assert.False(t, container.Status.Get().Starting, "starting should be reset")
 			}
 		})

--- a/internal/cri/server/container_stats_list_test.go
+++ b/internal/cri/server/container_stats_list_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/containerd/typeurl/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -72,26 +73,26 @@ func TestContainerMetricsCPUNanoCoreUsage(t *testing.T) {
 			container, err := containerstore.NewContainer(
 				containerstore.Metadata{ID: test.id},
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Nil(t, container.Stats)
 			err = c.containerStore.Add(container)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			cpuUsage, err := c.getUsageNanoCores(test.id, false, test.firstCPUValue, timestamp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			container, err = c.containerStore.Get(test.id)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, container.Stats)
 
 			assert.Equal(t, test.expectedNanoCoreUsageFirst, cpuUsage)
 
 			cpuUsage, err = c.getUsageNanoCores(test.id, false, test.secondCPUValue, tenSecondAftertimeStamp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expectedNanoCoreUsageSecond, cpuUsage)
 
 			container, err = c.containerStore.Get(test.id)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, container.Stats)
 		})
 	}
@@ -339,7 +340,7 @@ func TestContainerMetricsMemory(t *testing.T) {
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			got, err := c.memoryContainerStats("ID", test.metrics, timestamp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, got)
 		})
 	}
@@ -502,6 +503,6 @@ func platformBasedMetricsData(t *testing.T) *anypb.Any {
 	default:
 		t.Fail()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return data
 }

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/typeurl/v2"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
@@ -159,7 +160,7 @@ func TestToCRIContainerStatus(t *testing.T) {
 				containerstore.WithFakeStatus(*status),
 				containerstore.WithContainer(ctnr),
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Set expectation based on test case.
 			expected.Reason = test.expectedReason
 			expected.StartedAt = test.startedAt
@@ -171,7 +172,7 @@ func TestToCRIContainerStatus(t *testing.T) {
 				container,
 				expected.Image,
 				expected.ImageRef)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, containerStatus, test.desc)
 		})
 	}
@@ -184,12 +185,12 @@ func TestToCRIContainerInfo(t *testing.T) {
 		*metadata,
 		containerstore.WithFakeStatus(*status),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	info, err := toCRIContainerInfo(context.Background(),
 		container,
 		false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, info)
 }
 
@@ -251,18 +252,18 @@ func TestContainerStatus(t *testing.T) {
 				containerstore.WithFakeStatus(*status),
 				containerstore.WithContainer(ctnr),
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if test.exist {
-				assert.NoError(t, c.containerStore.Add(container))
+				require.NoError(t, c.containerStore.Add(container))
 			}
 			if test.imageExist {
 				imageStore, err := imagestore.NewFakeStore([]imagestore.Image{*image})
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				c.ImageService = &fakeImageService{imageStore: imageStore}
 			}
 			resp, err := c.ContainerStatus(context.Background(), &runtime.ContainerStatusRequest{ContainerId: container.ID})
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, resp)
 				return
 			}

--- a/internal/cri/server/container_stop_test.go
+++ b/internal/cri/server/container_stop_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 )
@@ -71,8 +72,8 @@ func TestWaitContainerStop(t *testing.T) {
 				containerstore.Metadata{ID: id},
 				containerstore.WithFakeStatus(*test.status),
 			)
-			assert.NoError(t, err)
-			assert.NoError(t, c.containerStore.Add(container))
+			require.NoError(t, err)
+			require.NoError(t, c.containerStore.Add(container))
 			ctx := context.Background()
 			if test.cancel {
 				cancelledCtx, cancel := context.WithCancel(ctx)

--- a/internal/cri/server/container_update_resources_linux_test.go
+++ b/internal/cri/server/container_update_resources_linux_test.go
@@ -22,6 +22,7 @@ import (
 
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -245,9 +246,9 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 			}
 			got, err := updateOCIResource(context.Background(), test.spec, test.request, config)
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, test.expected, got)
 		})

--- a/internal/cri/server/events/events_test.go
+++ b/internal/cri/server/events/events_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/typeurl/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestBackOff tests the logic of backOff struct.
@@ -75,23 +76,23 @@ func TestBackOff(t *testing.T) {
 			actual.enBackOff(k, event)
 		}
 	}
-	assert.Equal(t, actual.queuePool, expectedQueues)
+	assert.Equal(t, expectedQueues, actual.queuePool)
 
 	t.Logf("Should be able to check if the container is in backOff state")
 	for k, queue := range inputQueues {
 		for _, e := range queue.events {
 			evt, err := typeurl.MarshalAny(e)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			key, _, err := convertEvent(evt)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, k, key)
-			assert.Equal(t, actual.isInBackOff(key), true)
+			assert.True(t, actual.isInBackOff(key))
 		}
 	}
 
 	t.Logf("Should be able to check that a container isn't in backOff state")
 	notExistKey := "containerNotExist"
-	assert.Equal(t, actual.isInBackOff(notExistKey), false)
+	assert.False(t, actual.isInBackOff(notExistKey))
 
 	t.Logf("No containers should be expired")
 	assert.Empty(t, actual.getExpiredIDs())
@@ -99,7 +100,7 @@ func TestBackOff(t *testing.T) {
 	t.Logf("Should be able to get all keys which are expired for backOff")
 	testClock.Sleep(backOffInitDuration)
 	actKeyList := actual.getExpiredIDs()
-	assert.Equal(t, len(inputQueues), len(actKeyList))
+	assert.Len(t, actKeyList, len(inputQueues))
 	for k := range inputQueues {
 		assert.Contains(t, actKeyList, k)
 	}
@@ -131,6 +132,6 @@ func TestBackOff(t *testing.T) {
 			duration:   2 * queue.duration,
 			clock:      testClock,
 		}
-		assert.Equal(t, actQueue, expQueue)
+		assert.Equal(t, expQueue, actQueue)
 	}
 }

--- a/internal/cri/server/helpers_test.go
+++ b/internal/cri/server/helpers_test.go
@@ -149,7 +149,7 @@ systemd_cgroup = true
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			opts, err := criconfig.GenerateRuntimeOptions(test.r)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expectedOptions, opts)
 		})
 	}

--- a/internal/cri/server/images/image_list_test.go
+++ b/internal/cri/server/images/image_list_test.go
@@ -100,10 +100,10 @@ func TestListImages(t *testing.T) {
 
 	var err error
 	c.imageStore, err = imagestore.NewFakeStore(imagesInStore)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	resp, err := c.ListImages(context.Background(), &runtime.ListImagesRequest{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, resp)
 	images := resp.GetImages()
 	assert.Len(t, images, len(expect))

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/platforms"
@@ -278,7 +279,7 @@ func TestRegistryEndpoints(t *testing.T) {
 			c, _ := newTestCRIService()
 			c.config.Registry.Mirrors = test.mirrors
 			got, err := c.registryEndpoints(test.host)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, got)
 		})
 	}
@@ -431,7 +432,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 			snapshotter, err := cri.snapshotterFromPodSandboxConfig(context.Background(), "test-image", tt.podSandboxConfig)
 			assert.Equal(t, tt.expectedSnapshotter, snapshotter)
 			if tt.expectedErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			}
 		})
 	}

--- a/internal/cri/server/images/image_status_test.go
+++ b/internal/cri/server/images/image_status_test.go
@@ -57,18 +57,18 @@ func TestImageStatus(t *testing.T) {
 	resp, err := c.ImageStatus(context.Background(), &runtime.ImageStatusRequest{
 		Image: &runtime.ImageSpec{Image: testID},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Nil(t, resp.GetImage())
 
 	c.imageStore, err = imagestore.NewFakeStore([]imagestore.Image{image})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Logf("should return correct image status for exist image")
 	resp, err = g.ImageStatus(context.Background(), &runtime.ImageStatusRequest{
 		Image: &runtime.ImageSpec{Image: testID},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, expected, resp.GetImage())
 }

--- a/internal/cri/server/images/service_test.go
+++ b/internal/cri/server/images/service_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -68,7 +69,7 @@ func TestLocalResolve(t *testing.T) {
 	c, _ := newTestCRIService()
 	var err error
 	c.imageStore, err = imagestore.NewFakeStore([]imagestore.Image{image})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, ref := range []string{
 		"sha256:c75bebcdd211f41b3a460c7bf82970ed6c75acaab9cd4c9a4e125b03ca113799",
@@ -86,11 +87,11 @@ func TestLocalResolve(t *testing.T) {
 		"docker.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 	} {
 		img, err := c.LocalResolve(ref)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, image, img)
 	}
 	img, err := c.LocalResolve("randomid")
-	assert.Equal(t, errdefs.IsNotFound(err), true)
+	assert.True(t, errdefs.IsNotFound(err))
 	assert.Equal(t, imagestore.Image{}, img)
 }
 

--- a/internal/cri/server/podsandbox/controller_test.go
+++ b/internal/cri/server/podsandbox/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
@@ -62,7 +63,7 @@ func Test_Status(t *testing.T) {
 		CreatedAt: createdAt,
 	})
 	sb.Metadata = sandboxstore.Metadata{ID: sandboxID}
-	assert.NoError(t, controller.store.Save(sb))
+	require.NoError(t, controller.store.Save(sb))
 	s, err := controller.Status(context.Background(), sandboxID, false)
 	if err != nil {
 		t.Fatal(err)
@@ -71,7 +72,7 @@ func Test_Status(t *testing.T) {
 	assert.Equal(t, s.CreatedAt, createdAt)
 	assert.Equal(t, s.State, sandboxstore.StateReady.String())
 
-	assert.NoError(t, sb.Exit(exitStatus, exitedAt))
+	require.NoError(t, sb.Exit(exitStatus, exitedAt))
 
 	exit, err := controller.Wait(context.Background(), sandboxID)
 	if err != nil {

--- a/internal/cri/server/podsandbox/helpers_selinux_linux_test.go
+++ b/internal/cri/server/podsandbox/helpers_selinux_linux_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -89,7 +90,7 @@ func TestInitSelinuxOpts(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			processLabel, mountLabel, err := initLabelsFromOpt(test.selinuxOpt)
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				assert.Regexp(t, test.processLabel, processLabel)
 				assert.Regexp(t, test.mountLabel, mountLabel)
@@ -169,9 +170,9 @@ func TestCheckSelinuxLevel(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			err := checkSelinuxLevel(test.level)
 			if test.expectNoMatch {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/cri/server/podsandbox/recover_test.go
+++ b/internal/cri/server/podsandbox/recover_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/typeurl/v2"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/containerd/api/types"
 	containerd "github.com/containerd/containerd/v2/client"
@@ -403,7 +404,7 @@ func TestRecoverContainer(t *testing.T) {
 	for _, c := range containers {
 		cont := c.container
 		sb, err := controller.RecoverContainer(context.Background(), &cont)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		pSb := controller.store.Get(cont.ID())
 		assert.NotNil(t, pSb)

--- a/internal/cri/server/podsandbox/sandbox_run_linux_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux_test.go
@@ -68,35 +68,35 @@ func getRunPodSandboxTestData(criCfg criconfig.Config) (*runtime.PodSandboxConfi
 		assert.Equal(t, "test-hostname", spec.Hostname)
 		assert.Equal(t, getCgroupsPath("/test/cgroup/parent", id), spec.Linux.CgroupsPath)
 		assert.Equal(t, relativeRootfsPath, spec.Root.Path)
-		assert.Equal(t, true, spec.Root.Readonly)
+		assert.True(t, spec.Root.Readonly)
 		assert.Contains(t, spec.Process.Env, "a=b", "c=d")
 		assert.Equal(t, []string{"/pause", "forever"}, spec.Process.Args)
 		assert.Equal(t, "/workspace", spec.Process.Cwd)
-		assert.EqualValues(t, *spec.Linux.Resources.CPU.Shares, opts.DefaultSandboxCPUshares)
-		assert.EqualValues(t, *spec.Process.OOMScoreAdj, defaultSandboxOOMAdj)
+		assert.EqualValues(t, opts.DefaultSandboxCPUshares, *spec.Linux.Resources.CPU.Shares)
+		assert.Equal(t, defaultSandboxOOMAdj, *spec.Process.OOMScoreAdj)
 
 		t.Logf("Check PodSandbox annotations")
 		assert.Contains(t, spec.Annotations, annotations.SandboxID)
-		assert.EqualValues(t, spec.Annotations[annotations.SandboxID], id)
+		assert.Equal(t, spec.Annotations[annotations.SandboxID], id)
 
 		assert.Contains(t, spec.Annotations, annotations.ContainerType)
-		assert.EqualValues(t, spec.Annotations[annotations.ContainerType], annotations.ContainerTypeSandbox)
+		assert.Equal(t, annotations.ContainerTypeSandbox, spec.Annotations[annotations.ContainerType])
 
 		assert.Contains(t, spec.Annotations, annotations.SandboxNamespace)
-		assert.EqualValues(t, spec.Annotations[annotations.SandboxNamespace], "test-ns")
+		assert.Equal(t, "test-ns", spec.Annotations[annotations.SandboxNamespace])
 
 		assert.Contains(t, spec.Annotations, annotations.SandboxUID)
-		assert.EqualValues(t, spec.Annotations[annotations.SandboxUID], "test-uid")
+		assert.Equal(t, "test-uid", spec.Annotations[annotations.SandboxUID])
 
 		assert.Contains(t, spec.Annotations, annotations.SandboxName)
-		assert.EqualValues(t, spec.Annotations[annotations.SandboxName], "test-name")
+		assert.Equal(t, "test-name", spec.Annotations[annotations.SandboxName])
 
 		assert.Contains(t, spec.Annotations, annotations.SandboxLogDir)
-		assert.EqualValues(t, spec.Annotations[annotations.SandboxLogDir], "test-log-directory")
+		assert.Equal(t, "test-log-directory", spec.Annotations[annotations.SandboxLogDir])
 
 		if selinux.GetEnabled() {
-			assert.NotEqual(t, "", spec.Process.SelinuxLabel)
-			assert.NotEqual(t, "", spec.Linux.MountLabel)
+			assert.NotEmpty(t, spec.Process.SelinuxLabel)
+			assert.NotEmpty(t, spec.Linux.MountLabel)
 		}
 
 		assert.Contains(t, spec.Mounts, runtimespec.Mount{
@@ -128,7 +128,7 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 
 	netnsBasedir := t.TempDir()
 	t.Cleanup(func() {
-		assert.NoError(t, unmountRecursive(context.Background(), netnsBasedir))
+		require.NoError(t, unmountRecursive(context.Background(), netnsBasedir))
 	})
 
 	var netNs *netns.NetNS
@@ -243,8 +243,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 					Type: runtimespec.UserNamespace,
 					Path: filepath.Join(c.config.StateDir, "sandboxes", testID, "pinned-namespaces", "user"),
 				})
-				require.Equal(t, spec.Linux.UIDMappings, []runtimespec.LinuxIDMapping{expIDMap})
-				require.Equal(t, spec.Linux.GIDMappings, []runtimespec.LinuxIDMapping{expIDMap})
+				require.Equal(t, []runtimespec.LinuxIDMapping{expIDMap}, spec.Linux.UIDMappings)
+				require.Equal(t, []runtimespec.LinuxIDMapping{expIDMap}, spec.Linux.GIDMappings)
 
 			},
 		},
@@ -372,20 +372,20 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			specCheck: func(t *testing.T, _ *Controller, spec *runtimespec.Spec) {
 				value, ok := spec.Annotations[annotations.SandboxCPUPeriod]
 				assert.True(t, ok)
-				assert.EqualValues(t, strconv.FormatInt(100, 10), value)
-				assert.EqualValues(t, "100", value)
+				assert.Equal(t, strconv.FormatInt(100, 10), value)
+				assert.Equal(t, "100", value)
 
 				value, ok = spec.Annotations[annotations.SandboxCPUQuota]
 				assert.True(t, ok)
-				assert.EqualValues(t, "200", value)
+				assert.Equal(t, "200", value)
 
 				value, ok = spec.Annotations[annotations.SandboxCPUShares]
 				assert.True(t, ok)
-				assert.EqualValues(t, "5000", value)
+				assert.Equal(t, "5000", value)
 
 				value, ok = spec.Annotations[annotations.SandboxMem]
 				assert.True(t, ok)
-				assert.EqualValues(t, "1024", value)
+				assert.Equal(t, "1024", value)
 			},
 		},
 		{
@@ -409,16 +409,16 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			specCheck: func(t *testing.T, _ *Controller, spec *runtimespec.Spec) {
 				value, ok := spec.Annotations[annotations.SandboxCPUPeriod]
 				assert.True(t, ok)
-				assert.EqualValues(t, "0", value)
+				assert.Equal(t, "0", value)
 				value, ok = spec.Annotations[annotations.SandboxCPUQuota]
 				assert.True(t, ok)
-				assert.EqualValues(t, "0", value)
+				assert.Equal(t, "0", value)
 				value, ok = spec.Annotations[annotations.SandboxCPUShares]
 				assert.True(t, ok)
-				assert.EqualValues(t, "0", value)
+				assert.Equal(t, "0", value)
 				value, ok = spec.Annotations[annotations.SandboxMem]
 				assert.True(t, ok)
-				assert.EqualValues(t, "0", value)
+				assert.Equal(t, "0", value)
 			},
 		},
 	} {
@@ -428,7 +428,7 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			c.config.StateDir = t.TempDir()
 
 			defer func() {
-				assert.NoError(t, unmountRecursive(context.Background(), c.config.StateDir))
+				require.NoError(t, unmountRecursive(context.Background(), c.config.StateDir))
 			}()
 
 			c.config.EnableUnprivilegedICMP = true
@@ -440,11 +440,11 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			}
 			spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath, nil)
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, spec)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, spec)
 			specCheck(t, testID, spec)
 			if test.specCheck != nil {
@@ -779,11 +779,11 @@ options timeout:1
 		t.Run(test.desc, func(t *testing.T) {
 			resolvContent, err := parseDNSOptions(test.servers, test.searches, test.options)
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
-			assert.Equal(t, resolvContent, test.expectedContent)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedContent, resolvContent)
 		})
 	}
 }

--- a/internal/cri/server/podsandbox/sandbox_run_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_test.go
@@ -24,6 +24,7 @@ import (
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
@@ -64,7 +65,7 @@ func TestSandboxContainerSpec(t *testing.T) {
 			desc:           "a passthrough annotation should be passed as an OCI annotation",
 			podAnnotations: []string{"c"},
 			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
-				assert.Equal(t, spec.Annotations["c"], "d")
+				assert.Equal(t, "d", spec.Annotations["c"])
 			},
 		},
 		{
@@ -74,7 +75,7 @@ func TestSandboxContainerSpec(t *testing.T) {
 			},
 			podAnnotations: []string{"c"},
 			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
-				assert.Equal(t, spec.Annotations["c"], "d")
+				assert.Equal(t, "d", spec.Annotations["c"])
 				_, ok := spec.Annotations["d"]
 				assert.False(t, ok)
 			},
@@ -90,9 +91,9 @@ func TestSandboxContainerSpec(t *testing.T) {
 			},
 			podAnnotations: []string{"t*", "z.*", "y.c*"},
 			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
-				assert.Equal(t, spec.Annotations["t.f"], "j")
-				assert.Equal(t, spec.Annotations["z.g"], "o")
-				assert.Equal(t, spec.Annotations["y.ca"], "b")
+				assert.Equal(t, "j", spec.Annotations["t.f"])
+				assert.Equal(t, "o", spec.Annotations["z.g"])
+				assert.Equal(t, "b", spec.Annotations["y.ca"])
 				_, ok := spec.Annotations["y"]
 				assert.False(t, ok)
 				_, ok = spec.Annotations["z"]
@@ -113,11 +114,11 @@ func TestSandboxContainerSpec(t *testing.T) {
 			spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath,
 				test.podAnnotations)
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, spec)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, spec)
 			specCheck(t, testID, spec)
 			if test.specCheck != nil {
@@ -166,9 +167,9 @@ func TestTypeurlMarshalUnmarshalSandboxMeta(t *testing.T) {
 			}
 
 			md, err := typeurl.MarshalAny(meta)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			data, err := typeurl.UnmarshalAny(md)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.IsType(t, &sandboxstore.Metadata{}, data)
 			curMeta, ok := data.(*sandboxstore.Metadata)
 			assert.True(t, ok)

--- a/internal/cri/server/podsandbox/sandbox_run_windows_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_windows_test.go
@@ -22,6 +22,7 @@ import (
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
@@ -103,7 +104,7 @@ func TestSandboxWindowsNetworkNamespace(t *testing.T) {
 
 	config, imageConfig, specCheck := getRunPodSandboxTestData(c.config)
 	spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, spec)
 	specCheck(t, testID, spec)
 	assert.NotNil(t, spec.Windows)

--- a/internal/cri/server/runtime_config_linux_test.go
+++ b/internal/cri/server/runtime_config_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/systemd"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -97,7 +98,7 @@ func TestRuntimeConfig(t *testing.T) {
 			c.config.RuntimeConfig.ContainerdConfig.Runtimes = test.runtimes
 
 			resp, err := c.RuntimeConfig(context.TODO(), &runtime.RuntimeConfigRequest{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expectedCgroupDriver, resp.Linux.CgroupDriver, "got unexpected cgroup driver")
 		})
 	}

--- a/internal/cri/server/sandbox_list_test.go
+++ b/internal/cri/server/sandbox_list_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
@@ -158,7 +159,7 @@ func TestFilterSandboxes(t *testing.T) {
 
 	// Inject test sandbox metadata
 	for _, sb := range sandboxes {
-		assert.NoError(t, c.sandboxStore.Add(sb))
+		require.NoError(t, c.sandboxStore.Add(sb))
 	}
 
 	for _, test := range []struct {

--- a/internal/cri/server/sandbox_stats_windows_test.go
+++ b/internal/cri/server/sandbox_stats_windows_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/store/stats"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -53,13 +54,13 @@ func TestGetUsageNanoCores(t *testing.T) {
 			container, err := containerstore.NewContainer(
 				containerstore.Metadata{ID: ID},
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// calculate for first iteration
 			// first run so container stats will be nil
 			assert.Nil(t, container.Stats)
 			cpuUsage := getUsageNanoCores(test.firstCPUValue, container.Stats, timestamp.UnixNano())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expectedNanoCoreUsageFirst, cpuUsage)
 
 			// fill in the stats as if they now exist
@@ -70,7 +71,7 @@ func TestGetUsageNanoCores(t *testing.T) {
 
 			// calculate for second iteration
 			cpuUsage = getUsageNanoCores(test.secondCPUValue, container.Stats, secondAfterTimeStamp.UnixNano())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expectedNanoCoreUsageSecond, cpuUsage)
 		})
 	}

--- a/internal/cri/server/status_test.go
+++ b/internal/cri/server/status_test.go
@@ -27,6 +27,7 @@ import (
 	coreintrospection "github.com/containerd/containerd/v2/core/introspection"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -39,7 +40,7 @@ func TestRuntimeConditionContainerdHasNoDeprecationWarnings(t *testing.T) {
 	}
 
 	cond, err := runtimeConditionContainerdHasNoDeprecationWarnings(deprecations, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &runtime.RuntimeCondition{
 		Type:    ContainerdHasNoDeprecationWarnings,
 		Status:  false,
@@ -48,7 +49,7 @@ func TestRuntimeConditionContainerdHasNoDeprecationWarnings(t *testing.T) {
 	}, cond)
 
 	cond, err = runtimeConditionContainerdHasNoDeprecationWarnings(deprecations, []string{"io.containerd.deprecation/foo"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &runtime.RuntimeCondition{
 		Type:   ContainerdHasNoDeprecationWarnings,
 		Status: true,
@@ -118,11 +119,11 @@ func TestStatusRuntimeHandlersOrdering(t *testing.T) {
 
 	// Call Status() twice
 	resp1, err := c.Status(context.Background(), &runtime.StatusRequest{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, resp1.RuntimeHandlers, len(handlers), "Unexpected number of runtime handlers")
 
 	resp2, err := c.Status(context.Background(), &runtime.StatusRequest{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, resp2.RuntimeHandlers, len(handlers), "Unexpected number of runtime handlers")
 
 	// Check runtime handlers are in the same order

--- a/internal/cri/server/update_runtime_config_test.go
+++ b/internal/cri/server/update_runtime_config_test.go
@@ -128,14 +128,14 @@ func TestUpdateRuntimeConfig(t *testing.T) {
 				c.netPlugin[defaultNetworkPlugin].(*servertesting.FakeCNIPlugin).LoadErr = errors.New("random error")
 			}
 			_, err = c.UpdateRuntimeConfig(context.Background(), req)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if !test.expectCNIConfig {
 				_, err := os.Stat(confName)
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				got, err := os.ReadFile(confName)
-				assert.NoError(t, err)
-				assert.Equal(t, expected, string(got))
+				require.NoError(t, err)
+				assert.Equal(t, expected, string(got)) //nolint:testifylint //Can not use JSONEq
 			}
 		})
 	}

--- a/internal/cri/sputil/apparmor_linux_test.go
+++ b/internal/cri/sputil/apparmor_linux_test.go
@@ -22,6 +22,7 @@ import (
 
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/contrib/apparmor"
@@ -178,9 +179,9 @@ func TestGenerateApparmorSpecOpts(t *testing.T) {
 			csp, err := GenerateApparmorSecurityProfile(test.profile)
 			if err != nil {
 				if test.expectErr {
-					assert.Error(t, err)
+					require.Error(t, err)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 			} else {
 				if asp == nil {
@@ -188,9 +189,9 @@ func TestGenerateApparmorSpecOpts(t *testing.T) {
 				}
 				specOpts, err := GenerateApparmorSpecOpts(asp, test.privileged, !test.disable)
 				if test.expectErr {
-					assert.Error(t, err)
+					require.Error(t, err)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					if test.specOpts == nil && specOpts == nil {
 						return
 					}
@@ -206,7 +207,7 @@ func TestGenerateApparmorSpecOpts(t *testing.T) {
 					}
 					var actual runtimespec.Spec
 					err := util.DeepCopy(&actual, &expected)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 
 					test.specOpts(context.TODO(), nil, nil, &expected)
 					specOpts(context.TODO(), nil, nil, &actual)

--- a/internal/cri/sputil/seccomp_linux_test.go
+++ b/internal/cri/sputil/seccomp_linux_test.go
@@ -22,6 +22,7 @@ import (
 
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/contrib/seccomp"
@@ -167,9 +168,9 @@ func TestGenerateSeccompSecurityProfileSpecOpts(t *testing.T) {
 				test.defaultProfile)
 			if err != nil {
 				if test.expectErr {
-					assert.Error(t, err)
+					require.Error(t, err)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 			} else {
 				if ssp == nil {
@@ -177,9 +178,9 @@ func TestGenerateSeccompSecurityProfileSpecOpts(t *testing.T) {
 				}
 				specOpts, err := GenerateSeccompSpecOpts(ssp, test.privileged, !test.disable)
 				if test.expectErr {
-					assert.Error(t, err)
+					require.Error(t, err)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					if test.specOpts == nil && specOpts == nil {
 						return
 					}
@@ -216,7 +217,7 @@ func TestGenerateSeccompSecurityProfileSpecOpts(t *testing.T) {
 					}
 					var actual runtimespec.Spec
 					err := util.DeepCopy(&actual, &expected)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 
 					test.specOpts(context.TODO(), nil, nil, &expected)
 					specOpts(context.TODO(), nil, nil, &actual)

--- a/internal/cri/store/container/container_test.go
+++ b/internal/cri/store/container/container_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/opencontainers/selinux/go-selinux"
 	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -153,13 +154,14 @@ func TestContainerStore(t *testing.T) {
 		},
 	}
 	assert := assertlib.New(t)
+	require := require.New(t)
 	containers := map[string]Container{}
 	for id := range metadatas {
 		container, err := NewContainer(
 			metadatas[id],
 			WithFakeStatus(statuses[id]),
 		)
-		assert.NoError(err)
+		require.NoError(err)
 		containers[id] = container
 	}
 
@@ -174,14 +176,14 @@ func TestContainerStore(t *testing.T) {
 
 	t.Logf("should be able to add container")
 	for _, c := range containers {
-		assert.NoError(s.Add(c))
+		require.NoError(s.Add(c))
 	}
 
 	t.Logf("should be able to get container")
 	genTruncIndex := func(normalName string) string { return normalName[:(len(normalName)+1)/2] }
 	for id, c := range containers {
 		got, err := s.Get(genTruncIndex(id))
-		assert.NoError(err)
+		require.NoError(err)
 		assert.Equal(c, got)
 		assert.Nil(c.Stats)
 	}
@@ -193,7 +195,7 @@ func TestContainerStore(t *testing.T) {
 	t.Logf("should be able to update stats on container")
 	for id := range containers {
 		err := s.UpdateContainerStats(id, stats[id])
-		assert.NoError(err)
+		require.NoError(err)
 	}
 
 	// Validate stats were updated
@@ -266,9 +268,10 @@ func TestWithContainerIO(t *testing.T) {
 		Message:    "TestMessage-1",
 	}
 	assert := assertlib.New(t)
+	require := require.New(t)
 
 	c, err := NewContainer(meta, WithFakeStatus(status))
-	assert.NoError(err)
+	require.NoError(err)
 	assert.Nil(c.IO)
 
 	c, err = NewContainer(
@@ -276,6 +279,6 @@ func TestWithContainerIO(t *testing.T) {
 		WithFakeStatus(status),
 		WithContainerIO(&cio.ContainerIO{}),
 	)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.NotNil(c.IO)
 }

--- a/internal/cri/store/container/metadata_test.go
+++ b/internal/cri/store/container/metadata_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -40,35 +41,36 @@ func TestMetadataMarshalUnmarshal(t *testing.T) {
 	}
 
 	assert := assertlib.New(t)
+	require := require.New(t)
 	newMeta := &Metadata{}
 	newVerMeta := &versionedMetadata{}
 
 	t.Logf("should be able to do json.marshal")
 	data, err := json.Marshal(meta)
-	assert.NoError(err)
+	require.NoError(err)
 	data1, err := json.Marshal(&versionedMetadata{
 		Version:  metadataVersion,
 		Metadata: metadataInternal(*meta),
 	})
-	assert.NoError(err)
+	require.NoError(err)
 	assert.Equal(data, data1)
 
 	t.Logf("should be able to do MarshalJSON")
 	data, err = meta.MarshalJSON()
-	assert.NoError(err)
-	assert.NoError(newMeta.UnmarshalJSON(data))
+	require.NoError(err)
+	require.NoError(newMeta.UnmarshalJSON(data))
 	assert.Equal(meta, newMeta)
 
 	t.Logf("should be able to do MarshalJSON and json.Unmarshal")
 	data, err = meta.MarshalJSON()
-	assert.NoError(err)
-	assert.NoError(json.Unmarshal(data, newVerMeta))
-	assert.Equal(meta, (*Metadata)(&newVerMeta.Metadata))
+	require.NoError(err)
+	require.NoError(json.Unmarshal(data, newVerMeta))
+	assert.Equal((*Metadata)(&newVerMeta.Metadata), meta)
 
 	t.Logf("should be able to do json.Marshal and UnmarshalJSON")
 	data, err = json.Marshal(meta)
-	assert.NoError(err)
-	assert.NoError(newMeta.UnmarshalJSON(data))
+	require.NoError(err)
+	require.NoError(newMeta.UnmarshalJSON(data))
 	assert.Equal(meta, newMeta)
 
 	t.Logf("should json.Unmarshal fail for unsupported version")
@@ -76,6 +78,6 @@ func TestMetadataMarshalUnmarshal(t *testing.T) {
 		Version:  "random-test-version",
 		Metadata: metadataInternal(*meta),
 	})
-	assert.NoError(err)
-	assert.Error(json.Unmarshal(unsupported, &newMeta))
+	require.NoError(err)
+	require.Error(json.Unmarshal(unsupported, &newMeta))
 }

--- a/internal/cri/store/container/status_test.go
+++ b/internal/cri/store/container/status_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	requirelib "github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -85,10 +86,11 @@ func TestStatusEncodeDecode(t *testing.T) {
 		Unknown:    true,
 	}
 	assert := assertlib.New(t)
+	require := require.New(t)
 	data, err := s.encode()
-	assert.NoError(err)
+	require.NoError(err)
 	newS := &Status{}
-	assert.NoError(newS.decode(data))
+	require.NoError(newS.decode(data))
 	s.Removing = false // Removing should not be encoded.
 	s.Starting = false // Starting should not be encoded.
 	s.Unknown = false  // Unknown should not be encoded.
@@ -98,8 +100,8 @@ func TestStatusEncodeDecode(t *testing.T) {
 		Version: "random-test-version",
 		Status:  *s,
 	})
-	assert.NoError(err)
-	assert.Error(newS.decode(unsupported))
+	require.NoError(err)
+	require.Error(newS.decode(unsupported))
 }
 
 func TestStatus(t *testing.T) {
@@ -120,11 +122,11 @@ func TestStatus(t *testing.T) {
 
 	t.Logf("simple store and get")
 	s, err := StoreStatus(tempDir, testID, testStatus)
-	assert.NoError(err)
+	require.NoError(err)
 	old := s.Get()
 	assert.Equal(testStatus, old)
 	_, err = os.Stat(statusFile)
-	assert.NoError(err)
+	require.NoError(err)
 	loaded, err := LoadStatus(tempDir, testID)
 	require.NoError(err)
 	assert.Equal(testStatus, loaded)
@@ -143,13 +145,13 @@ func TestStatus(t *testing.T) {
 	err = s.Update(func(o Status) (Status, error) {
 		return updateStatus, nil
 	})
-	assert.NoError(err)
+	require.NoError(err)
 	assert.Equal(updateStatus, s.Get())
 	loaded, err = LoadStatus(tempDir, testID)
 	require.NoError(err)
 	assert.Equal(testStatus, loaded)
 	// Recover status.
-	assert.NoError(s.Update(func(o Status) (Status, error) {
+	require.NoError(s.Update(func(o Status) (Status, error) {
 		return testStatus, nil
 	}))
 
@@ -167,7 +169,7 @@ func TestStatus(t *testing.T) {
 	err = s.UpdateSync(func(o Status) (Status, error) {
 		return updateStatus, nil
 	})
-	assert.NoError(err)
+	require.NoError(err)
 	assert.Equal(updateStatus, s.Get())
 	loaded, err = LoadStatus(tempDir, testID)
 	require.NoError(err)
@@ -177,12 +179,12 @@ func TestStatus(t *testing.T) {
 	assert.Equal(testStatus, old)
 
 	t.Logf("delete status")
-	assert.NoError(s.Delete())
+	require.NoError(s.Delete())
 	_, err = LoadStatus(tempDir, testID)
-	assert.Error(err)
+	require.Error(err)
 	_, err = os.Stat(statusFile)
 	assert.True(os.IsNotExist(err))
 
 	t.Logf("delete status should be idempotent")
-	assert.NoError(s.Delete())
+	require.NoError(s.Delete())
 }

--- a/internal/cri/store/image/image_test.go
+++ b/internal/cri/store/image/image_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/opencontainers/go-digest/digestset"
 	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInternalStore(t *testing.T) {
@@ -56,6 +57,7 @@ func TestInternalStore(t *testing.T) {
 		},
 	}
 	assert := assertlib.New(t)
+	require := require.New(t)
 	genTruncIndex := func(normalName string) string { return normalName[:(len(normalName)+1)/2] }
 
 	s := &store{
@@ -67,14 +69,14 @@ func TestInternalStore(t *testing.T) {
 	t.Logf("should be able to add image")
 	for _, img := range images {
 		err := s.add(img)
-		assert.NoError(err)
+		require.NoError(err)
 	}
 
 	t.Logf("should be able to get image")
 	for _, v := range images {
 		truncID := genTruncIndex(v.ID)
 		got, err := s.get(truncID)
-		assert.NoError(err, "truncID:%s, fullID:%s", truncID, v.ID)
+		require.NoError(err, "truncID:%s, fullID:%s", truncID, v.ID)
 		assert.Equal(v, got)
 	}
 
@@ -82,7 +84,7 @@ func TestInternalStore(t *testing.T) {
 	for _, v := range images {
 		truncID := genTruncIndex(v.ID[strings.Index(v.ID, ":")+1:])
 		got, err := s.get(truncID)
-		assert.NoError(err, "truncID:%s, fullID:%s", truncID, v.ID)
+		require.NoError(err, "truncID:%s, fullID:%s", truncID, v.ID)
 		assert.Equal(v, got)
 	}
 
@@ -90,7 +92,7 @@ func TestInternalStore(t *testing.T) {
 	ambiguousPrefixs := []string{"sha256", "sha256:"}
 	for _, v := range ambiguousPrefixs {
 		_, err := s.get(v)
-		assert.NotEqual(nil, err)
+		require.Error(err)
 	}
 
 	t.Logf("should be able to list images")
@@ -107,24 +109,24 @@ func TestInternalStore(t *testing.T) {
 		newImg := v
 		newImg.References = []string{newRef}
 		err := s.add(newImg)
-		assert.NoError(err)
+		require.NoError(err)
 		got, err := s.get(truncID)
-		assert.NoError(err)
+		require.NoError(err)
 		assert.Len(got.References, 2)
 		assert.Contains(got.References, oldRef, newRef)
 
 		t.Logf("should not be able to add duplicated references")
 		err = s.add(newImg)
-		assert.NoError(err)
+		require.NoError(err)
 		got, err = s.get(truncID)
-		assert.NoError(err)
+		require.NoError(err)
 		assert.Len(got.References, 2)
 		assert.Contains(got.References, oldRef, newRef)
 
 		t.Logf("should be able to delete image references")
 		s.delete(truncID, oldRef)
 		got, err = s.get(truncID)
-		assert.NoError(err)
+		require.NoError(err)
 		assert.Equal([]string{newRef}, got.References)
 
 		t.Logf("should be able to delete image")
@@ -141,6 +143,7 @@ func TestInternalStore(t *testing.T) {
 
 func TestInternalStorePinnedImage(t *testing.T) {
 	assert := assertlib.New(t)
+	require := require.New(t)
 	s := &store{
 		images:     make(map[string]Image),
 		digestSet:  digestset.NewSet(),
@@ -156,9 +159,9 @@ func TestInternalStorePinnedImage(t *testing.T) {
 	}
 
 	t.Logf("add unpinned image ref, image should be unpinned")
-	assert.NoError(s.add(image))
+	require.NoError(s.add(image))
 	i, err := s.get(image.ID)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.False(i.Pinned)
 	assert.False(s.isPinned(image.ID, ref1))
 
@@ -166,42 +169,42 @@ func TestInternalStorePinnedImage(t *testing.T) {
 	ref2 := "containerd.io/ref-2"
 	image.References = []string{ref2}
 	image.Pinned = true
-	assert.NoError(s.add(image))
+	require.NoError(s.add(image))
 	i, err = s.get(image.ID)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.True(i.Pinned)
 	assert.False(s.isPinned(image.ID, ref1))
 	assert.True(s.isPinned(image.ID, ref2))
 
 	t.Logf("pin unpinned image ref, image should be pinned, all refs should be pinned")
-	assert.NoError(s.pin(image.ID, ref1))
+	require.NoError(s.pin(image.ID, ref1))
 	i, err = s.get(image.ID)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.True(i.Pinned)
 	assert.True(s.isPinned(image.ID, ref1))
 	assert.True(s.isPinned(image.ID, ref2))
 
 	t.Logf("unpin one of image refs, image should be pinned")
-	assert.NoError(s.unpin(image.ID, ref2))
+	require.NoError(s.unpin(image.ID, ref2))
 	i, err = s.get(image.ID)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.True(i.Pinned)
 	assert.True(s.isPinned(image.ID, ref1))
 	assert.False(s.isPinned(image.ID, ref2))
 
 	t.Logf("unpin the remaining one image ref, image should be unpinned")
-	assert.NoError(s.unpin(image.ID, ref1))
+	require.NoError(s.unpin(image.ID, ref1))
 	i, err = s.get(image.ID)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.False(i.Pinned)
 	assert.False(s.isPinned(image.ID, ref1))
 	assert.False(s.isPinned(image.ID, ref2))
 
 	t.Logf("pin one of image refs, then delete this, image should be unpinned")
-	assert.NoError(s.pin(image.ID, ref1))
+	require.NoError(s.pin(image.ID, ref1))
 	s.delete(image.ID, ref1)
 	i, err = s.get(image.ID)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.False(i.Pinned)
 	assert.False(s.isPinned(image.ID, ref2))
 }
@@ -216,6 +219,7 @@ func TestImageStore(t *testing.T) {
 		Size:       10,
 	}
 	assert := assertlib.New(t)
+	require := require.New(t)
 
 	equal := func(i1, i2 Image) {
 		sort.Strings(i1.References)
@@ -292,17 +296,17 @@ func TestImageStore(t *testing.T) {
 	} {
 		t.Run(desc, func(t *testing.T) {
 			s, err := NewFakeStore([]Image{image})
-			assert.NoError(err)
-			assert.NoError(s.update(test.ref, test.image))
+			require.NoError(err)
+			require.NoError(s.update(test.ref, test.image))
 
 			assert.Len(s.List(), len(test.expected))
 			for _, expect := range test.expected {
 				got, err := s.Get(expect.ID)
-				assert.NoError(err)
+				require.NoError(err)
 				equal(got, expect)
 				for _, ref := range expect.References {
 					id, err := s.Resolve(ref)
-					assert.NoError(err)
+					require.NoError(err)
 					assert.Equal(expect.ID, id)
 				}
 			}

--- a/internal/cri/store/label/label_test.go
+++ b/internal/cri/store/label/label_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddThenRemove(t *testing.T) {
@@ -29,6 +30,7 @@ func TestAddThenRemove(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	require := require.New(t)
 	store := NewStore()
 	releaseCount := 0
 	reserveCount := 0
@@ -44,11 +46,11 @@ func TestAddThenRemove(t *testing.T) {
 	}
 
 	t.Log("should count to two level")
-	assert.NoError(store.Reserve("junk:junk:junk:c1,c2"))
-	assert.NoError(store.Reserve("junk2:junk2:junk2:c1,c2"))
+	require.NoError(store.Reserve("junk:junk:junk:c1,c2"))
+	require.NoError(store.Reserve("junk2:junk2:junk2:c1,c2"))
 
 	t.Log("should have one item")
-	assert.Equal(1, len(store.levels))
+	assert.Len(store.levels, 1)
 
 	t.Log("c1,c2 count should be 2")
 	assert.Equal(2, store.levels["c1,c2"])
@@ -57,7 +59,7 @@ func TestAddThenRemove(t *testing.T) {
 	store.Release("junk2:junk2:junk2:c1,c2")
 
 	t.Log("should have 0 items")
-	assert.Equal(0, len(store.levels))
+	assert.Empty(store.levels)
 
 	t.Log("should have reserved")
 	assert.Equal(1, reserveCount)
@@ -72,6 +74,7 @@ func TestJunkData(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	require := require.New(t)
 	store := NewStore()
 	releaseCount := 0
 	store.Releaser = func(label string) {
@@ -83,34 +86,34 @@ func TestJunkData(t *testing.T) {
 	}
 
 	t.Log("should ignore empty label")
-	assert.NoError(store.Reserve(""))
-	assert.Equal(0, len(store.levels))
+	require.NoError(store.Reserve(""))
+	assert.Empty(store.levels)
 	store.Release("")
-	assert.Equal(0, len(store.levels))
+	assert.Empty(store.levels)
 	assert.Equal(0, releaseCount)
 	assert.Equal(0, reserveCount)
 
 	t.Log("should fail on bad label")
-	assert.Error(store.Reserve("junkjunkjunkc1c2"))
-	assert.Equal(0, len(store.levels))
+	require.Error(store.Reserve("junkjunkjunkc1c2"))
+	assert.Empty(store.levels)
 	store.Release("junkjunkjunkc1c2")
-	assert.Equal(0, len(store.levels))
+	assert.Empty(store.levels)
 	assert.Equal(0, releaseCount)
 	assert.Equal(0, reserveCount)
 
 	t.Log("should not release unknown label")
 	store.Release("junk2:junk2:junk2:c1,c2")
-	assert.Equal(0, len(store.levels))
+	assert.Empty(store.levels)
 	assert.Equal(0, releaseCount)
 	assert.Equal(0, reserveCount)
 
 	t.Log("should release once even if too many deletes")
-	assert.NoError(store.Reserve("junk2:junk2:junk2:c1,c2"))
-	assert.Equal(1, len(store.levels))
+	require.NoError(store.Reserve("junk2:junk2:junk2:c1,c2"))
+	assert.Len(store.levels, 1)
 	assert.Equal(1, store.levels["c1,c2"])
 	store.Release("junk2:junk2:junk2:c1,c2")
 	store.Release("junk2:junk2:junk2:c1,c2")
-	assert.Equal(0, len(store.levels))
+	assert.Empty(store.levels)
 	assert.Equal(1, releaseCount)
 	assert.Equal(1, reserveCount)
 }

--- a/internal/cri/store/sandbox/metadata_test.go
+++ b/internal/cri/store/sandbox/metadata_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -38,35 +39,36 @@ func TestMetadataMarshalUnmarshal(t *testing.T) {
 		},
 	}
 	assert := assertlib.New(t)
+	require := require.New(t)
 	newMeta := &Metadata{}
 	newVerMeta := &versionedMetadata{}
 
 	t.Logf("should be able to do json.marshal")
 	data, err := json.Marshal(meta)
-	assert.NoError(err)
+	require.NoError(err)
 	data1, err := json.Marshal(&versionedMetadata{
 		Version:  metadataVersion,
 		Metadata: metadataInternal(*meta),
 	})
-	assert.NoError(err)
+	require.NoError(err)
 	assert.Equal(data, data1)
 
 	t.Logf("should be able to do MarshalJSON")
 	data, err = meta.MarshalJSON()
-	assert.NoError(err)
-	assert.NoError(newMeta.UnmarshalJSON(data))
+	require.NoError(err)
+	require.NoError(newMeta.UnmarshalJSON(data))
 	assert.Equal(meta, newMeta)
 
 	t.Logf("should be able to do MarshalJSON and json.Unmarshal")
 	data, err = meta.MarshalJSON()
-	assert.NoError(err)
-	assert.NoError(json.Unmarshal(data, newVerMeta))
-	assert.Equal(meta, (*Metadata)(&newVerMeta.Metadata))
+	require.NoError(err)
+	require.NoError(json.Unmarshal(data, newVerMeta))
+	assert.Equal((*Metadata)(&newVerMeta.Metadata), meta)
 
 	t.Logf("should be able to do json.Marshal and UnmarshalJSON")
 	data, err = json.Marshal(meta)
-	assert.NoError(err)
-	assert.NoError(newMeta.UnmarshalJSON(data))
+	require.NoError(err)
+	require.NoError(newMeta.UnmarshalJSON(data))
 	assert.Equal(meta, newMeta)
 
 	t.Logf("should json.Unmarshal fail for unsupported version")
@@ -74,6 +76,6 @@ func TestMetadataMarshalUnmarshal(t *testing.T) {
 		Version:  "random-test-version",
 		Metadata: metadataInternal(*meta),
 	})
-	assert.NoError(err)
-	assert.Error(json.Unmarshal(unsupported, &newMeta))
+	require.NoError(err)
+	require.Error(json.Unmarshal(unsupported, &newMeta))
 }

--- a/internal/cri/store/sandbox/sandbox_test.go
+++ b/internal/cri/store/sandbox/sandbox_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/errdefs"
 
 	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -130,25 +131,26 @@ func TestSandboxStore(t *testing.T) {
 		},
 	}
 	assert := assertlib.New(t)
+	require := require.New(t)
 	s := NewStore(label.NewStore())
 
 	t.Logf("should be able to add sandbox")
 	for _, sb := range sandboxes {
-		assert.NoError(s.Add(sb))
+		require.NoError(s.Add(sb))
 	}
-	assert.NoError(s.Add(unknown))
+	require.NoError(s.Add(unknown))
 
 	t.Logf("should be able to get sandbox")
 	genTruncIndex := func(normalName string) string { return normalName[:(len(normalName)+1)/2] }
 	for id, sb := range sandboxes {
 		got, err := s.Get(genTruncIndex(id))
-		assert.NoError(err)
+		require.NoError(err)
 		assert.Equal(sb, got)
 	}
 
 	t.Logf("should be able to get sandbox in unknown state with Get")
 	got, err := s.Get(unknown.ID)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.Equal(unknown, got)
 
 	t.Logf("should be able to list sandboxes")
@@ -159,7 +161,7 @@ func TestSandboxStore(t *testing.T) {
 	t.Logf("should be able to update stats on container")
 	for id := range sandboxes {
 		err := s.UpdateContainerStats(id, stats[id])
-		assert.NoError(err)
+		require.NoError(err)
 	}
 
 	// Validate stats were updated

--- a/internal/cri/store/sandbox/status_test.go
+++ b/internal/cri/store/sandbox/status_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStatus(t *testing.T) {
@@ -37,6 +38,7 @@ func TestStatus(t *testing.T) {
 	}
 	updateErr := errors.New("update error")
 	assert := assertlib.New(t)
+	require := require.New(t)
 
 	t.Logf("simple store and get")
 	s := StoreStatus(testStatus)
@@ -54,7 +56,7 @@ func TestStatus(t *testing.T) {
 	err = s.Update(func(o Status) (Status, error) {
 		return updateStatus, nil
 	})
-	assert.NoError(err)
+	require.NoError(err)
 	assert.Equal(updateStatus, s.Get())
 }
 

--- a/internal/cri/store/snapshot/snapshot_test.go
+++ b/internal/cri/store/snapshot/snapshot_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/errdefs"
 
 	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSnapshotStore(t *testing.T) {
@@ -63,6 +64,7 @@ func TestSnapshotStore(t *testing.T) {
 		},
 	}
 	assert := assertlib.New(t)
+	require := require.New(t)
 
 	s := NewStore()
 
@@ -74,7 +76,7 @@ func TestSnapshotStore(t *testing.T) {
 	t.Logf("should be able to get snapshot")
 	for id, sn := range snapshots {
 		got, err := s.Get(id)
-		assert.NoError(err)
+		require.NoError(err)
 		assert.Equal(sn, got)
 	}
 

--- a/internal/cri/streamingserver/request_cache_test.go
+++ b/internal/cri/streamingserver/request_cache_test.go
@@ -83,7 +83,7 @@ func TestInsert(t *testing.T) {
 
 	// Insert again (should evict)
 	_, err = c.Insert(nextRequest())
-	assert.Error(t, err, "should reject further requests")
+	require.Error(t, err, "should reject further requests")
 	recorder := httptest.NewRecorder()
 	require.NoError(t, WriteError(err, recorder))
 	errResponse := recorder.Result()

--- a/internal/cri/streamingserver/server_test.go
+++ b/internal/cri/streamingserver/server_test.go
@@ -65,13 +65,13 @@ func TestGetExec(t *testing.T) {
 	serv, err := NewServer(Config{
 		Addr: testAddr,
 	}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tlsServer, err := NewServer(Config{
 		Addr:      testAddr,
 		TLSConfig: &tls.Config{},
 	}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	const pathPrefix = "cri/shim"
 	prefixServer, err := NewServer(Config{
@@ -82,7 +82,7 @@ func TestGetExec(t *testing.T) {
 			Path:   "/" + pathPrefix + "/",
 		},
 	}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assertRequestToken := func(expectedReq *runtimeapi.ExecRequest, cache *requestCache, token string) {
 		req, ok := cache.Consume(token)
@@ -97,7 +97,7 @@ func TestGetExec(t *testing.T) {
 	}
 	{ // Non-TLS
 		resp, err := serv.GetExec(request)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expectedURL := "http://" + testAddr + "/exec/"
 		assert.Contains(t, resp.Url, expectedURL)
 		token := strings.TrimPrefix(resp.Url, expectedURL)
@@ -106,7 +106,7 @@ func TestGetExec(t *testing.T) {
 
 	{ // TLS
 		resp, err := tlsServer.GetExec(request)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expectedURL := "https://" + testAddr + "/exec/"
 		assert.Contains(t, resp.Url, expectedURL)
 		token := strings.TrimPrefix(resp.Url, expectedURL)
@@ -115,7 +115,7 @@ func TestGetExec(t *testing.T) {
 
 	{ // Path prefix
 		resp, err := prefixServer.GetExec(request)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expectedURL := "http://" + testAddr + "/" + pathPrefix + "/exec/"
 		assert.Contains(t, resp.Url, expectedURL)
 		token := strings.TrimPrefix(resp.Url, expectedURL)
@@ -223,7 +223,7 @@ func TestGetAttach(t *testing.T) {
 	}
 	{ // Non-TLS
 		resp, err := serv.GetAttach(request)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expectedURL := "http://" + testAddr + "/attach/"
 		assert.Contains(t, resp.Url, expectedURL)
 		token := strings.TrimPrefix(resp.Url, expectedURL)
@@ -232,7 +232,7 @@ func TestGetAttach(t *testing.T) {
 
 	{ // TLS
 		resp, err := tlsServer.GetAttach(request)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expectedURL := "https://" + testAddr + "/attach/"
 		assert.Contains(t, resp.Url, expectedURL)
 		token := strings.TrimPrefix(resp.Url, expectedURL)
@@ -251,9 +251,9 @@ func TestGetPortForward(t *testing.T) {
 		serv, err := NewServer(Config{
 			Addr: testAddr,
 		}, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		resp, err := serv.GetPortForward(request)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expectedURL := "http://" + testAddr + "/portforward/"
 		assert.True(t, strings.HasPrefix(resp.Url, expectedURL))
 		token := strings.TrimPrefix(resp.Url, expectedURL)
@@ -267,9 +267,9 @@ func TestGetPortForward(t *testing.T) {
 			Addr:      testAddr,
 			TLSConfig: &tls.Config{},
 		}, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		resp, err := tlsServer.GetPortForward(request)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expectedURL := "https://" + testAddr + "/portforward/"
 		assert.True(t, strings.HasPrefix(resp.Url, expectedURL))
 		token := strings.TrimPrefix(resp.Url, expectedURL)
@@ -478,13 +478,13 @@ func doClientStreams(t *testing.T, prefix string, stdin io.Writer, stdout, stder
 func readExpected(t *testing.T, streamName string, r io.Reader, expected string) {
 	result := make([]byte, len(expected))
 	_, err := io.ReadAtLeast(r, result, len(expected))
-	assert.NoError(t, err, "stream %s", streamName)
+	require.NoError(t, err, "stream %s", streamName)
 	assert.Equal(t, expected, string(result), "stream %s", streamName)
 }
 
 // Write and verify success of the data over the stream.
 func writeExpected(t *testing.T, streamName string, w io.Writer, data string) {
 	n, err := io.WriteString(w, data)
-	assert.NoError(t, err, "stream %s", streamName)
+	require.NoError(t, err, "stream %s", streamName)
 	assert.Equal(t, len(data), n, "stream %s", streamName)
 }

--- a/internal/cri/util/deep_copy_test.go
+++ b/internal/cri/util/deep_copy_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type A struct {
@@ -58,6 +59,6 @@ func TestCopy(t *testing.T) {
 	}
 	assert.NotEqual(t, expected, dst)
 	err := DeepCopy(dst, src)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, dst)
 }

--- a/internal/cri/util/references_test.go
+++ b/internal/cri/util/references_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
@@ -63,7 +64,7 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			named, err := reference.ParseDockerRef(test.ref)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			repoDigest, repoTag := GetRepoDigestAndTag(named, digest)
 			assert.Equal(t, test.expectedRepoDigest, repoDigest)
 			assert.Equal(t, test.expectedRepoTag, repoTag)

--- a/internal/cri/util/util_test.go
+++ b/internal/cri/util/util_test.go
@@ -22,6 +22,7 @@ import (
 
 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -224,9 +225,9 @@ func TestGenerateUserString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r, err := GenerateUserString(tc.u, tc.uid, tc.gid)
 			if tc.expectedError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.result, r)
 		})

--- a/internal/registrar/registrar_test.go
+++ b/internal/registrar/registrar_test.go
@@ -19,25 +19,25 @@ package registrar
 import (
 	"testing"
 
-	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRegistrar(t *testing.T) {
 	r := NewRegistrar()
-	assert := assertlib.New(t)
+	require := require.New(t)
 
 	t.Logf("should be able to reserve a name<->key mapping")
-	assert.NoError(r.Reserve("test-name-1", "test-id-1"))
+	require.NoError(r.Reserve("test-name-1", "test-id-1"))
 
 	t.Logf("should be able to reserve a new name<->key mapping")
-	assert.NoError(r.Reserve("test-name-2", "test-id-2"))
+	require.NoError(r.Reserve("test-name-2", "test-id-2"))
 
 	t.Logf("should be able to reserve the same name<->key mapping")
-	assert.NoError(r.Reserve("test-name-1", "test-id-1"))
+	require.NoError(r.Reserve("test-name-1", "test-id-1"))
 
 	t.Logf("should not be able to reserve conflict name<->key mapping")
-	assert.Error(r.Reserve("test-name-1", "test-id-conflict"))
-	assert.Error(r.Reserve("test-name-conflict", "test-id-2"))
+	require.Error(r.Reserve("test-name-1", "test-id-conflict"))
+	require.Error(r.Reserve("test-name-conflict", "test-id-2"))
 
 	t.Logf("should be able to release name<->key mapping by key")
 	r.ReleaseByKey("test-id-1")
@@ -46,9 +46,9 @@ func TestRegistrar(t *testing.T) {
 	r.ReleaseByName("test-name-2")
 
 	t.Logf("should be able to reserve new name<->key mapping after release")
-	assert.NoError(r.Reserve("test-name-1", "test-id-new"))
-	assert.NoError(r.Reserve("test-name-new", "test-id-2"))
+	require.NoError(r.Reserve("test-name-1", "test-id-new"))
+	require.NoError(r.Reserve("test-name-new", "test-id-2"))
 
 	t.Logf("should be able to reserve same name/key name<->key")
-	assert.NoError(r.Reserve("same-name-id", "same-name-id"))
+	require.NoError(r.Reserve("same-name-id", "same-name-id"))
 }

--- a/internal/userns/idmap_test.go
+++ b/internal/userns/idmap_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRootPair(t *testing.T) {
@@ -172,9 +173,9 @@ func TestToHost(t *testing.T) {
 		r, err := idmap.ToHost(test.container)
 		assert.Equal(t, test.host, r)
 		if r == invalidUser {
-			assert.Error(t, err)
+			require.Error(t, err)
 		} else {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}
 }
@@ -296,7 +297,7 @@ func TestToHostOverflow(t *testing.T) {
 		},
 	} {
 		r, err := test.idmap.ToHost(test.user)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, r, invalidUser)
 	}
 }

--- a/pkg/atomicfile/file_test.go
+++ b/pkg/atomicfile/file_test.go
@@ -34,13 +34,13 @@ func TestFile(t *testing.T) {
 	f, err := New(path, 0o644)
 	require.NoError(t, err, "failed to create file")
 	n, err := fmt.Fprint(f, content)
-	assert.NoError(t, err, "failed to write content")
+	require.NoError(t, err, "failed to write content")
 	assert.Equal(t, len(content), n, "written bytes should be equal")
 	err = f.Close()
 	require.NoError(t, err, "failed to close file")
 
 	actual, err := os.ReadFile(path)
-	assert.NoError(t, err, "failed to read file")
+	require.NoError(t, err, "failed to read file")
 	assert.Equal(t, content, string(actual))
 }
 
@@ -56,22 +56,22 @@ func TestConcurrentWrites(t *testing.T) {
 	require.NoError(t, err, "failed to create file2")
 
 	n, err := fmt.Fprint(file1, content1)
-	assert.NoError(t, err, "failed to write content1")
+	require.NoError(t, err, "failed to write content1")
 	assert.Equal(t, len(content1), n, "written bytes should be equal")
 
 	n, err = fmt.Fprint(file2, content2)
-	assert.NoError(t, err, "failed to write content2")
+	require.NoError(t, err, "failed to write content2")
 	assert.Equal(t, len(content2), n, "written bytes should be equal")
 
 	err = file1.Close()
 	require.NoError(t, err, "failed to close file1")
 	actual, err := os.ReadFile(path)
-	assert.NoError(t, err, "failed to read file")
+	require.NoError(t, err, "failed to read file")
 	assert.Equal(t, content1, string(actual))
 
 	err = file2.Close()
 	require.NoError(t, err, "failed to close file2")
 	actual, err = os.ReadFile(path)
-	assert.NoError(t, err, "failed to read file")
+	require.NoError(t, err, "failed to read file")
 	assert.Equal(t, content2, string(actual))
 }

--- a/pkg/cap/cap_linux_test.go
+++ b/pkg/cap/cap_linux_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const procPIDStatus = `Name:   cat
@@ -91,9 +92,9 @@ func TestFromNumber(t *testing.T) {
 	assert.Equal(t, "CAP_CHOWN", FromNumber(0))
 	assert.Equal(t, "CAP_SYS_ADMIN", FromNumber(21))
 	assert.Equal(t, "CAP_CHECKPOINT_RESTORE", FromNumber(40))
-	assert.Equal(t, "", FromNumber(-1))
-	assert.Equal(t, "", FromNumber(63))
-	assert.Equal(t, "", FromNumber(255))
+	assert.Empty(t, FromNumber(-1))
+	assert.Empty(t, FromNumber(63))
+	assert.Empty(t, FromNumber(255))
 }
 
 func TestFromBitmap(t *testing.T) {
@@ -148,7 +149,7 @@ func TestFromBitmap(t *testing.T) {
 
 func TestParseProcPIDStatus(t *testing.T) {
 	res, err := ParseProcPIDStatus(strings.NewReader(procPIDStatus))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expected := map[Type]uint64{
 		Inheritable: 0,
 		Permitted:   0xffffffffff,
@@ -156,18 +157,18 @@ func TestParseProcPIDStatus(t *testing.T) {
 		Bounding:    0xffffffffff,
 		Ambient:     0,
 	}
-	assert.EqualValues(t, expected, res)
+	assert.Equal(t, expected, res)
 }
 
 func TestCurrent(t *testing.T) {
 	caps, err := Current()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Logf("verify the result manually: %+v", caps)
 }
 
 func TestKnown(t *testing.T) {
 	caps := Known()
-	assert.EqualValues(t, caps59, caps)
+	assert.Equal(t, caps59, caps)
 }
 
 func FuzzParseProcPIDStatus(f *testing.F) {

--- a/pkg/cio/io_test.go
+++ b/pkg/cio/io_test.go
@@ -59,7 +59,7 @@ func TestBinaryIOAbsolutePath(t *testing.T) {
 
 func TestBinaryIOFailOnRelativePath(t *testing.T) {
 	_, err := BinaryIO("./bin", nil)("!")
-	assert.Error(t, err, "absolute path needed")
+	require.Error(t, err, "absolute path needed")
 }
 
 func TestLogFileAbsolutePath(t *testing.T) {
@@ -71,14 +71,14 @@ func TestLogFileAbsolutePath(t *testing.T) {
 
 	// Test parse back
 	parsed, err := url.Parse(res.Config().Stdout)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "file", parsed.Scheme)
 	assert.Equal(t, urlPrefix+"/full/path/file.txt", parsed.Path)
 }
 
 func TestLogFileFailOnRelativePath(t *testing.T) {
 	_, err := LogFile("./file.txt")("!")
-	assert.Error(t, err, "absolute path needed")
+	require.Error(t, err, "absolute path needed")
 }
 
 type LogURIGeneratorTestCase struct {
@@ -98,10 +98,10 @@ func baseTestLogURIGenerator(t *testing.T, testCases []LogURIGeneratorTestCase) 
 	for _, tc := range testCases {
 		uri, err := LogURIGenerator(tc.scheme, tc.path, tc.args)
 		if tc.err != "" {
-			assert.ErrorContains(t, err, tc.err)
+			require.ErrorContains(t, err, tc.err)
 			continue
 		}
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expected, uri.String())
 	}
 }

--- a/pkg/imageverifier/bindir/bindir_test.go
+++ b/pkg/imageverifier/bindir/bindir_test.go
@@ -146,7 +146,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 			Size:        2048,
 			Annotations: map[string]string{"a": "b"},
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, j.OK)
 		assert.Equal(t, fmt.Sprintf("verifier-0%[1]v => Reason A line 1\nReason A line 2", exeIfWindows()), j.Reason)
 
@@ -156,7 +156,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 
 		b, err = os.ReadFile(data.StdinFile)
 		require.NoError(t, err)
-		assert.Equal(t, `{"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json","digest":"sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4","size":2048,"annotations":{"a":"b"}}`, strings.TrimSpace(string(b)))
+		assert.JSONEq(t, `{"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json","digest":"sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4","size":2048,"annotations":{"a":"b"}}`, string(b))
 	})
 
 	t.Run("large output is truncated", func(t *testing.T) {
@@ -188,7 +188,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, j.OK)
 		assert.NotEmpty(t, j.Reason)
 	})
@@ -201,7 +201,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, j.OK)
 		assert.NotEmpty(t, j.Reason)
 	})
@@ -218,7 +218,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, j.OK)
 		assert.Empty(t, j.Reason)
 	})
@@ -236,7 +236,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, j.OK)
 		assert.NotEmpty(t, j.Reason)
 	})
@@ -255,7 +255,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, j.OK)
 		assert.NotEmpty(t, j.Reason)
 	})
@@ -273,7 +273,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, j.OK)
 		assert.Equal(t, fmt.Sprintf("verifier-0%[1]v => Reason A, verifier-1%[1]v => Reason B, verifier-2%[1]v => Reason C", exeIfWindows()), j.Reason)
 	})
@@ -292,7 +292,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, j.OK)
 		assert.Equal(t, fmt.Sprintf("verifier verifier-2%[1]v rejected image (exit code 1): Reason D", exeIfWindows()), j.Reason)
 	})
@@ -311,7 +311,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, j.OK)
 		assert.Equal(t, fmt.Sprintf("verifier-0%[1]v => Reason A, verifier-1%[1]v => Reason B, verifier-2%[1]v => Reason C", exeIfWindows()), j.Reason)
 	})
@@ -330,7 +330,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, j.OK)
 		assert.Equal(t, fmt.Sprintf("verifier verifier-2%[1]v rejected image (exit code 1): Reason D", exeIfWindows()), j.Reason)
 	})
@@ -350,11 +350,11 @@ func TestBinDirVerifyImage(t *testing.T) {
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
 		if runtime.GOOS == "windows" {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.False(t, j.OK)
 			assert.Equal(t, "verifier verifier-2.exe rejected image (exit code 1): ", j.Reason)
 		} else {
-			assert.ErrorContains(t, err, "signal: killed")
+			require.ErrorContains(t, err, "signal: killed")
 			assert.Nil(t, j)
 		}
 
@@ -389,7 +389,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, j)
 	})
 
@@ -417,7 +417,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		// Should see a log like the following, but verification still succeeds:
 		// time="2023-09-05T11:15:50-04:00" level=warning msg="failed to completely write descriptor to stdin" error="write |1: broken pipe"
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, j.OK)
 		assert.NotEmpty(t, j.Reason)
 	})

--- a/pkg/ioutil/read_closer_test.go
+++ b/pkg/ioutil/read_closer_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWrapReadCloser(t *testing.T) {
@@ -31,12 +32,12 @@ func TestWrapReadCloser(t *testing.T) {
 	dst := make([]byte, 1)
 	n, err := rc.Read(dst)
 	assert.Equal(t, 1, n)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte("a"), dst)
 
 	n, err = rc.Read(dst)
 	assert.Equal(t, 1, n)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte("b"), dst)
 
 	rc.Close()

--- a/pkg/ioutil/write_closer_test.go
+++ b/pkg/ioutil/write_closer_test.go
@@ -37,7 +37,7 @@ func TestWriteCloseInformer(t *testing.T) {
 	n, err := wci.Write([]byte(data))
 	assert.Equal(t, len(data), n)
 	assert.Equal(t, data, original.buf.String())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	select {
 	case <-close:
@@ -83,7 +83,7 @@ func TestSerialWriteCloser(t *testing.T) {
 		for i := 0; i < goroutine; i++ {
 			go func(id int) {
 				n, err := wc.Write(testData[id])
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, dataLen+1, n)
 				wg.Done()
 			}(i)

--- a/pkg/ioutil/writer_group_test.go
+++ b/pkg/ioutil/writer_group_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type writeCloser struct {
@@ -40,7 +41,7 @@ func (wc *writeCloser) Close() error {
 func TestEmptyWriterGroup(t *testing.T) {
 	wg := NewWriterGroup()
 	_, err := wg.Write([]byte("test"))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestClosedWriterGroup(t *testing.T) {
@@ -53,7 +54,7 @@ func TestClosedWriterGroup(t *testing.T) {
 	n, err := wg.Write([]byte(data))
 	assert.Equal(t, len(data), n)
 	assert.Equal(t, data, wc.buf.String())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	wg.Close()
 	assert.True(t, wc.closed)
@@ -63,7 +64,7 @@ func TestClosedWriterGroup(t *testing.T) {
 	assert.True(t, newWC.closed)
 
 	_, err = wg.Write([]byte(data))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestAddGetRemoveWriter(t *testing.T) {
@@ -73,12 +74,12 @@ func TestAddGetRemoveWriter(t *testing.T) {
 
 	wg.Add(key1, wc1)
 	_, err := wg.Write([]byte("test data 1"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test data 1", wc1.buf.String())
 
 	wg.Add(key2, wc2)
 	_, err = wg.Write([]byte("test data 2"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test data 1test data 2", wc1.buf.String())
 	assert.Equal(t, "test data 2", wc2.buf.String())
 
@@ -86,11 +87,11 @@ func TestAddGetRemoveWriter(t *testing.T) {
 
 	wg.Remove(key1)
 	_, err = wg.Write([]byte("test data 3"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test data 1test data 2", wc1.buf.String())
 	assert.Equal(t, "test data 2test data 3", wc2.buf.String())
 
-	assert.Equal(t, nil, wg.Get(key1))
+	assert.Nil(t, wg.Get(key1))
 
 	wg.Close()
 }
@@ -102,12 +103,12 @@ func TestReplaceWriter(t *testing.T) {
 
 	wg.Add(key, wc1)
 	_, err := wg.Write([]byte("test data 1"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test data 1", wc1.buf.String())
 
 	wg.Add(key, wc2)
 	_, err = wg.Write([]byte("test data 2"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test data 1", wc1.buf.String())
 	assert.Equal(t, "test data 2", wc2.buf.String())
 

--- a/pkg/labels/validate_test.go
+++ b/pkg/labels/validate_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/containerd/errdefs"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidLabels(t *testing.T) {
@@ -58,23 +58,23 @@ func TestLongKey(t *testing.T) {
 	value := strings.Repeat("v", maxSize-len(key))
 
 	err := Validate(key, value)
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 
 	key = strings.Repeat("s", keyMaxLen+12)
 	value = strings.Repeat("v", maxSize-len(key)+1)
 
 	err = Validate(key, value)
-	assert.ErrorIs(t, err, errdefs.ErrInvalidArgument)
+	require.ErrorIs(t, err, errdefs.ErrInvalidArgument)
 
 	key = strings.Repeat("s", keyMaxLen-1)
 	value = strings.Repeat("v", maxSize-len(key))
 
 	err = Validate(key, value)
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 
 	key = strings.Repeat("s", keyMaxLen-1)
 	value = strings.Repeat("v", maxSize-len(key)-1)
 
 	err = Validate(key, value)
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 }

--- a/pkg/oci/spec_opts_linux_test.go
+++ b/pkg/oci/spec_opts_linux_test.go
@@ -117,7 +117,7 @@ guest:x:100:guest
 			}
 			err := WithUser(testCase.user)(context.Background(), nil, &c, &s)
 			if err != nil {
-				assert.EqualError(t, err, testCase.err)
+				require.EqualError(t, err, testCase.err)
 			}
 			assert.Equal(t, testCase.expectedUID, s.Process.User.UID)
 			assert.Equal(t, testCase.expectedGID, s.Process.User.GID)
@@ -173,7 +173,7 @@ guest:x:405:100:guest:/dev/null:/sbin/nologin
 				Linux: &specs.Linux{},
 			}
 			err := WithUserID(testCase.userID)(context.Background(), nil, &c, &s)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, testCase.expectedUID, s.Process.User.UID)
 			assert.Equal(t, testCase.expectedGID, s.Process.User.GID)
 		})
@@ -233,7 +233,7 @@ guest:x:405:100:guest:/dev/null:/sbin/nologin
 			}
 			err := WithUsername(testCase.user)(context.Background(), nil, &c, &s)
 			if err != nil {
-				assert.EqualError(t, err, testCase.err)
+				require.EqualError(t, err, testCase.err)
 			}
 			assert.Equal(t, testCase.expectedUID, s.Process.User.UID)
 			assert.Equal(t, testCase.expectedGID, s.Process.User.GID)
@@ -300,7 +300,7 @@ sys:x:3:root,bin,adm
 				},
 			}
 			err := WithAdditionalGIDs(testCase.user)(context.Background(), nil, &c, &s)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, testCase.expected, s.Process.User.AdditionalGids)
 		})
 	}
@@ -709,7 +709,7 @@ daemon:x:2:root,bin,daemon
 			}
 			err := WithAppendAdditionalGroups(testCase.groups...)(context.Background(), nil, &c, &s)
 			if err != nil {
-				assert.EqualError(t, err, testCase.err)
+				require.EqualError(t, err, testCase.err)
 			}
 			assert.Equal(t, testCase.expected, s.Process.User.AdditionalGids)
 		})
@@ -766,7 +766,7 @@ func TestWithAppendAdditionalGroupsNoEtcGroup(t *testing.T) {
 			}
 			err := WithAppendAdditionalGroups(testCase.groups...)(context.Background(), nil, &c, &s)
 			if err != nil {
-				assert.EqualError(t, err, testCase.err)
+				require.EqualError(t, err, testCase.err)
 			}
 			assert.Equal(t, testCase.expected, s.Process.User.AdditionalGids)
 		})
@@ -834,9 +834,9 @@ func TestWithLinuxDeviceFollowSymlinks(t *testing.T) {
 			for _, opt := range opts {
 				if err := opt(nil, nil, nil, &spec); err != nil {
 					if tc.expectError {
-						assert.Error(t, err)
+						require.Error(t, err)
 					} else {
-						assert.NoError(t, err)
+						require.NoError(t, err)
 					}
 				}
 			}

--- a/pkg/oci/spec_opts_test.go
+++ b/pkg/oci/spec_opts_test.go
@@ -221,19 +221,19 @@ func TestWithEnv(t *testing.T) {
 	}
 
 	err := WithEnv([]string{"env=1"})(context.Background(), nil, nil, &s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"DEFAULT=test", "env=1"}, s.Process.Env, "didn't append")
 
 	err = WithEnv([]string{"env2=1"})(context.Background(), nil, nil, &s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"DEFAULT=test", "env=1", "env2=1"}, s.Process.Env, "didn't append")
 
 	err = WithEnv([]string{"env2=2"})(context.Background(), nil, nil, &s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"DEFAULT=test", "env=1", "env2=2"}, s.Process.Env, "didn't update")
 
 	err = WithEnv([]string{"env2"})(context.Background(), nil, nil, &s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"DEFAULT=test", "env=1"}, s.Process.Env, "didn't update")
 }
 
@@ -256,7 +256,7 @@ func TestWithMounts(t *testing.T) {
 			Destination: "new-dest",
 		},
 	})(nil, nil, nil, &s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, s.Mounts, 2, "didn't append")
 	assert.Equal(t, "new-source", s.Mounts[1].Source, "invalid mount")
 	assert.Equal(t, "new-dest", s.Mounts[1].Destination, "invalid mount")
@@ -271,17 +271,17 @@ func TestWithDefaultSpec(t *testing.T) {
 	)
 
 	err := ApplyOpts(ctx, nil, &c, &s, WithDefaultSpec())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var expected Spec
 
 	switch runtime.GOOS {
 	case "windows":
-		assert.NoError(t, populateDefaultWindowsSpec(ctx, &expected, c.ID))
+		require.NoError(t, populateDefaultWindowsSpec(ctx, &expected, c.ID))
 	case "darwin":
-		assert.NoError(t, populateDefaultDarwinSpec(&expected))
+		require.NoError(t, populateDefaultDarwinSpec(&expected))
 	default:
-		assert.NoError(t, populateDefaultUnixSpec(ctx, &expected, c.ID))
+		require.NoError(t, populateDefaultUnixSpec(ctx, &expected, c.ID))
 	}
 
 	assert.NotEmpty(t, s)
@@ -297,17 +297,17 @@ func TestWithSpecFromFile(t *testing.T) {
 	)
 
 	expected, err := GenerateSpec(ctx, nil, &c)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	p, err := json.Marshal(expected)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	specFile := filepath.Join(t.TempDir(), "testwithdefaultspec.json")
 	err = os.WriteFile(specFile, p, 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = ApplyOpts(ctx, nil, &c, &s, WithSpecFromFile(specFile))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, s)
 	assert.Equal(t, expected, &s)
 }
@@ -375,7 +375,7 @@ func TestWithMemorySwap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			expected := int64(123)
 			err := WithMemorySwap(expected)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "linux" {
 				assert.Equal(t, expected, *spec.Linux.Resources.Memory.Swap)
 			} else {
@@ -390,7 +390,7 @@ func TestWithPidsLimit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			expected := int64(123)
 			err := WithPidsLimit(expected)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "linux" {
 				assert.Equal(t, expected, spec.Linux.Resources.Pids.Limit)
 			} else {
@@ -409,7 +409,7 @@ func TestWithBlockIO(t *testing.T) {
 				LeafWeight: &v,
 			}
 			err := WithBlockIO(expected)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "linux" {
 				assert.Equal(t, expected, spec.Linux.Resources.BlockIO)
 			} else {
@@ -424,7 +424,7 @@ func TestWithCPUShares(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			expected := uint64(123)
 			err := WithCPUShares(expected)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "linux" {
 				assert.Equal(t, expected, *spec.Linux.Resources.CPU.Shares)
 			} else {
@@ -439,7 +439,7 @@ func TestWithCPUs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			expected := "0,1"
 			err := WithCPUs(expected)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "linux" {
 				assert.Equal(t, expected, spec.Linux.Resources.CPU.Cpus)
 			} else {
@@ -454,7 +454,7 @@ func TestWithCPUsMems(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			expected := "0,1"
 			err := WithCPUsMems(expected)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "linux" {
 				assert.Equal(t, expected, spec.Linux.Resources.CPU.Mems)
 			} else {
@@ -469,7 +469,7 @@ func TestWithCPUBurst(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			expected := uint64(123)
 			err := WithCPUBurst(expected)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "linux" {
 				assert.Equal(t, expected, *spec.Linux.Resources.CPU.Burst)
 			} else {
@@ -484,7 +484,7 @@ func TestWithCPURT(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			expectedRT, expectedPeriod := int64(123), uint64(456)
 			err := WithCPURT(expectedRT, expectedPeriod)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "linux" {
 				assert.Equal(t, expectedRT, *spec.Linux.Resources.CPU.RealtimeRuntime)
 				assert.Equal(t, expectedPeriod, *spec.Linux.Resources.CPU.RealtimePeriod)
@@ -858,7 +858,7 @@ func TestWithWindowsDevice(t *testing.T) {
 			for _, opt := range opts {
 				if err := opt(nil, nil, nil, &spec); err != nil {
 					if tc.expectError {
-						assert.Error(t, err)
+						require.Error(t, err)
 					} else {
 						require.NoError(t, err)
 					}
@@ -881,7 +881,7 @@ func TestWithWindowsCPUCount(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			expected := uint64(123)
 			err := WithWindowsCPUCount(expected)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "windows" {
 				assert.Equal(t, expected, *spec.Windows.Resources.CPU.Count)
 			} else {
@@ -896,7 +896,7 @@ func TestWithWindowsCPUShares(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			expected := uint16(123)
 			err := WithWindowsCPUShares(expected)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "windows" {
 				assert.Equal(t, expected, *spec.Windows.Resources.CPU.Shares)
 			} else {
@@ -911,7 +911,7 @@ func TestWithWindowsCPUMaximum(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			expected := uint16(123)
 			err := WithWindowsCPUMaximum(expected)(nil, nil, nil, &spec)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if name == "windows" {
 				assert.Equal(t, expected, *spec.Windows.Resources.CPU.Maximum)
 			} else {

--- a/pkg/oci/utils_unix_test.go
+++ b/pkg/oci/utils_unix_test.go
@@ -111,7 +111,7 @@ func TestHostDevicesDeviceFromPathFailure(t *testing.T) {
 		t.Fatalf("Unexpected error %v, expected %v", err, testError)
 	}
 
-	assert.Equal(t, 0, len(d))
+	assert.Empty(t, d)
 }
 
 // Based on test from runc:
@@ -138,8 +138,8 @@ func TestHostDevicesDeviceFromPathFailureInUserNS(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("Unexpected error %v, expected %v", err, nil)
 	}
-	assert.Equal(t, 1, len(d))
-	assert.Equal(t, d[0].Path, "/dev/null")
+	assert.Len(t, d, 1)
+	assert.Equal(t, "/dev/null", d[0].Path)
 }
 
 func TestHostDevicesAllValid(t *testing.T) {

--- a/pkg/snapshotters/annotations_test.go
+++ b/pkg/snapshotters/annotations_test.go
@@ -25,12 +25,13 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImageLayersLabel(t *testing.T) {
 	sampleKey := "sampleKey"
 	sampleDigest, err := digest.Parse("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	sampleMaxSize := 300
 	sampleValidate := func(k, v string) error {
 		if (len(k) + len(v)) > sampleMaxSize {

--- a/pkg/sys/oom_linux_test.go
+++ b/pkg/sys/oom_linux_test.go
@@ -32,8 +32,8 @@ import (
 func TestSetPositiveOomScoreAdjustment(t *testing.T) {
 	// Setting a *positive* OOM score adjust does not require privileged
 	_, adjustment, err := adjustOom(123)
-	assert.NoError(t, err)
-	assert.EqualValues(t, adjustment, 123)
+	require.NoError(t, err)
+	assert.Equal(t, 123, adjustment)
 }
 
 func TestSetNegativeOomScoreAdjustmentWhenPrivileged(t *testing.T) {
@@ -43,8 +43,8 @@ func TestSetNegativeOomScoreAdjustmentWhenPrivileged(t *testing.T) {
 	}
 
 	_, adjustment, err := adjustOom(-123)
-	assert.NoError(t, err)
-	assert.EqualValues(t, adjustment, -123)
+	require.NoError(t, err)
+	assert.Equal(t, adjustment, -123)
 }
 
 func TestSetNegativeOomScoreAdjustmentWhenUnprivilegedHasNoEffect(t *testing.T) {
@@ -57,33 +57,31 @@ func TestSetNegativeOomScoreAdjustmentWhenUnprivilegedHasNoEffect(t *testing.T) 
 	}
 
 	initial, adjustment, err := adjustOom(-123)
-	assert.NoError(t, err)
-	assert.EqualValues(t, adjustment, initial)
+	require.NoError(t, err)
+	assert.Equal(t, adjustment, initial)
 }
 
 func TestSetOOMScoreBoundaries(t *testing.T) {
 	err := SetOOMScore(0, OOMScoreAdjMax+1)
-	require.NotNil(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf("value out of range (%d): OOM score must be between", OOMScoreAdjMax+1))
+	require.ErrorContains(t, err, fmt.Sprintf("value out of range (%d): OOM score must be between", OOMScoreAdjMax+1))
 
 	err = SetOOMScore(0, OOMScoreAdjMin-1)
-	require.NotNil(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf("value out of range (%d): OOM score must be between", OOMScoreAdjMin-1))
+	require.ErrorContains(t, err, fmt.Sprintf("value out of range (%d): OOM score must be between", OOMScoreAdjMin-1))
 
 	_, adjustment, err := adjustOom(OOMScoreAdjMax)
-	assert.NoError(t, err)
-	assert.EqualValues(t, adjustment, OOMScoreAdjMax)
+	require.NoError(t, err)
+	assert.Equal(t, OOMScoreAdjMax, adjustment)
 
 	score, err := GetOOMScoreAdj(os.Getpid())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if score == OOMScoreAdjMin {
 		// We won't be able to set the score lower than the parent process. This
 		// could also be tested if the parent process does not have a oom-score-adj
 		// set, but GetOOMScoreAdj does not distinguish between "not set" and
 		// "score is set, but zero".
 		_, adjustment, err = adjustOom(OOMScoreAdjMin)
-		assert.NoError(t, err)
-		assert.EqualValues(t, adjustment, OOMScoreAdjMin)
+		require.NoError(t, err)
+		assert.Equal(t, OOMScoreAdjMin, adjustment)
 	}
 }
 

--- a/pkg/sys/unshare_linux_test.go
+++ b/pkg/sys/unshare_linux_test.go
@@ -38,7 +38,6 @@ func TestUnshareAfterEnterUserns(t *testing.T) {
 	}
 
 	err = UnshareAfterEnterUserns("0:1000:1", "0:1000:1", syscall.CLONE_NEWUSER|syscall.CLONE_NEWIPC, nil)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "unshare flags should not include user namespace")
 
 	t.Run("should work", testUnshareAfterEnterUsernsShouldWork)
@@ -131,7 +130,6 @@ func testUnshareAfterEnterUsernsKillPid(t *testing.T) {
 
 		return nil
 	})
-	require.Error(t, uerr)
 	require.ErrorContains(t, uerr, "failed to ensure child process is alive: no such process")
 }
 
@@ -139,7 +137,6 @@ func testUnshareAfterEnterUsernsInvalidFlags(t *testing.T) {
 	t.Parallel()
 
 	uerr := UnshareAfterEnterUserns("0:1000:1", "0:1000:1", syscall.CLONE_IO, nil)
-	require.Error(t, uerr)
 	require.ErrorContains(t, uerr, "fork/exec /proc/self/exe: invalid argument")
 }
 

--- a/pkg/testutil/helpers.go
+++ b/pkg/testutil/helpers.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const umountflags int = 0
@@ -99,5 +99,5 @@ func DumpDirOnFailure(t *testing.T, root string) {
 func Unmount(t testing.TB, mountPoint string) {
 	t.Log("unmount", mountPoint)
 	err := mount.UnmountAll(mountPoint, umountflags)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/plugins/content/local/locks_test.go
+++ b/plugins/content/local/locks_test.go
@@ -19,7 +19,6 @@ package local
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,10 +26,9 @@ func TestTryLock(t *testing.T) {
 	s := &store{locks: map[string]*lock{}}
 
 	err := s.tryLock("testref")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer s.unlock("testref")
 
 	err = s.tryLock("testref")
-	require.NotNil(t, err)
-	assert.Contains(t, err.Error(), "ref testref locked for ")
+	require.ErrorContains(t, err, "ref testref locked for ")
 }

--- a/plugins/content/local/store_test.go
+++ b/plugins/content/local/store_test.go
@@ -42,7 +42,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type memoryLabelStore struct {
@@ -351,7 +351,7 @@ func checkWrite(ctx context.Context, t checker, cs content.Store, dgst digest.Di
 
 func TestWriterTruncateRecoversFromIncompleteWrite(t *testing.T) {
 	cs, err := NewStore(t.TempDir())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -362,26 +362,26 @@ func TestWriterTruncateRecoversFromIncompleteWrite(t *testing.T) {
 	setupIncompleteWrite(ctx, t, cs, ref, total)
 
 	writer, err := cs.Writer(ctx, content.WithRef(ref), content.WithDescriptor(ocispec.Descriptor{Size: total}))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Nil(t, writer.Truncate(0))
+	require.NoError(t, writer.Truncate(0))
 
 	_, err = writer.Write(contentB)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst := digest.FromBytes(contentB)
 	err = writer.Commit(ctx, total, dgst)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func setupIncompleteWrite(ctx context.Context, t *testing.T, cs content.Store, ref string, total int64) {
 	writer, err := cs.Writer(ctx, content.WithRef(ref), content.WithDescriptor(ocispec.Descriptor{Size: total}))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = writer.Write([]byte("bad data"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 }
 
 func TestWriteReadEmptyFileTimestamp(t *testing.T) {

--- a/plugins/cri/runtime/load_test.go
+++ b/plugins/cri/runtime/load_test.go
@@ -39,7 +39,7 @@ func TestLoadBaseOCISpec(t *testing.T) {
 	})
 
 	err = json.NewEncoder(file).Encode(&spec)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	config := criconfig.Config{}
 	config.Runtimes = map[string]criconfig.Runtime{
@@ -47,7 +47,7 @@ func TestLoadBaseOCISpec(t *testing.T) {
 	}
 
 	specs, err := loadBaseOCISpecs(&config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, specs, 1)
 


### PR DESCRIPTION
#### Description

Enable and fixes several rules from [testifylint](https://golangci-lint.run/usage/linters/#testifylint) linter: