### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/internal/cri/server/container_execsync.go
+++ b/internal/cri/server/container_execsync.go
@@ -49,10 +49,7 @@ func (cw *cappedWriter) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 
-	end := cw.remain
-	if end > len(p) {
-		end = len(p)
-	}
+	end := min(cw.remain, len(p))
 	written, err := cw.w.Write(p[0:end])
 	cw.remain -= written
 

--- a/internal/cri/server/events/events.go
+++ b/internal/cri/server/events/events.go
@@ -252,10 +252,7 @@ func (b *backOff) reBackOff(key string, events []interface{}, oldDuration time.D
 	b.queuePoolMu.Lock()
 	defer b.queuePoolMu.Unlock()
 
-	duration := 2 * oldDuration
-	if duration > b.maxDuration {
-		duration = b.maxDuration
-	}
+	duration := min(2*oldDuration, b.maxDuration)
 	b.queuePool[key] = newBackOffQueue(events, duration, b.clock)
 }
 


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.