### PR TITLE
ci: enable gofumpt and local-prefix from goimports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,6 +101,7 @@ issues:
 formatters:
   enable:
     - gofmt
+    - gofumpt
     - goimports
   exclusions:
     generated: strict
@@ -111,3 +112,9 @@ formatters:
       - docs/man
       - releases
       - test
+  settings:
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/containerd/containerd/v2

--- a/client/client.go
+++ b/client/client.go
@@ -27,8 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc/resolver"
-
 	containersapi "github.com/containerd/containerd/api/services/containers/v1"
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
@@ -40,6 +38,19 @@ import (
 	transferapi "github.com/containerd/containerd/api/services/transfer/v1"
 	versionservice "github.com/containerd/containerd/api/services/version/v1"
 	apitypes "github.com/containerd/containerd/api/types"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	"github.com/containerd/typeurl/v2"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go/features"
+	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/resolver"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/content"
 	contentproxy "github.com/containerd/containerd/v2/core/content/proxy"
@@ -64,17 +75,6 @@ import (
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
 	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
-	"github.com/containerd/typeurl/v2"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/opencontainers/runtime-spec/specs-go/features"
-	"golang.org/x/sync/semaphore"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func init() {

--- a/client/client_opts.go
+++ b/client/client_opts.go
@@ -19,14 +19,14 @@ package client
 import (
 	"time"
 
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/remotes"
-	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/semaphore"
-
 	"google.golang.org/grpc"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/snapshots"
 )
 
 type clientOpts struct {

--- a/client/container_checkpoint_opts.go
+++ b/client/container_checkpoint_opts.go
@@ -25,15 +25,16 @@ import (
 
 	tasks "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types/runc/options"
+	"github.com/containerd/platforms"
+	"github.com/containerd/typeurl/v2"
+	"github.com/opencontainers/go-digest"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/containerd/containerd/v2/pkg/rootfs"
-	"github.com/containerd/platforms"
-	"github.com/containerd/typeurl/v2"
-	"github.com/opencontainers/go-digest"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ErrMediaTypeNotFound returns an error when a media type in the manifest is unknown
@@ -128,7 +129,6 @@ func WithCheckpointRW(ctx context.Context, client *Client, c *containers.Contain
 	)
 	if err != nil {
 		return err
-
 	}
 	rw.Platform = &imagespec.Platform{
 		OS:           runtime.GOOS,

--- a/client/container_opts.go
+++ b/client/container_opts.go
@@ -22,16 +22,17 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/typeurl/v2"
+	"github.com/opencontainers/image-spec/identity"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/typeurl/v2"
-	"github.com/opencontainers/image-spec/identity"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // DeleteOpts allows the caller to set options for the deletion of a container

--- a/client/container_opts_unix.go
+++ b/client/container_opts_unix.go
@@ -25,13 +25,13 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/containerd/containerd/v2/core/containers"
-	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/internal/userns"
-
 	"github.com/containerd/errdefs"
 	"github.com/opencontainers/image-spec/identity"
 	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/internal/userns"
 )
 
 // WithRemappedSnapshot creates a new snapshot and remaps the uid/gid for the

--- a/client/container_restore_opts.go
+++ b/client/container_restore_opts.go
@@ -21,13 +21,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/opencontainers/image-spec/identity"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/opencontainers/image-spec/identity"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (

--- a/client/containerstore.go
+++ b/client/containerstore.go
@@ -118,7 +118,6 @@ func (r *remoteContainers) Create(ctx context.Context, container containers.Cont
 	}
 
 	return containerFromProto(created.Container), nil
-
 }
 
 func (r *remoteContainers) Update(ctx context.Context, container containers.Container, fieldpaths ...string) (containers.Container, error) {
@@ -138,7 +137,6 @@ func (r *remoteContainers) Update(ctx context.Context, container containers.Cont
 	}
 
 	return containerFromProto(updated.Container), nil
-
 }
 
 func (r *remoteContainers) Delete(ctx context.Context, id string) error {
@@ -147,7 +145,6 @@ func (r *remoteContainers) Delete(ctx context.Context, id string) error {
 	})
 
 	return errgrpc.ToNative(err)
-
 }
 
 func containerToProto(container *containers.Container) *containersapi.Container {

--- a/client/diff.go
+++ b/client/diff.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
+
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/diff/proxy"
 )

--- a/client/grpc.go
+++ b/client/grpc.go
@@ -19,8 +19,9 @@ package client
 import (
 	"context"
 
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"google.golang.org/grpc"
+
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 
 type namespaceInterceptor struct {

--- a/client/image.go
+++ b/client/image.go
@@ -23,6 +23,12 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/images"
@@ -31,11 +37,6 @@ import (
 	"github.com/containerd/containerd/v2/internal/kmutex"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/rootfs"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
-	"github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/identity"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Image describes an image used by containers

--- a/client/import.go
+++ b/client/import.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"io"
 
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/images/archive"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/images/archive"
 )
 
 type importOpts struct {
@@ -171,7 +172,7 @@ func (c *Client) Import(ctx context.Context, reader io.Reader, opts ...ImportOpt
 			Target: index,
 		})
 	}
-	var platformMatcher = c.platform
+	platformMatcher := c.platform
 	if iopts.allPlatforms {
 		platformMatcher = platforms.All
 	} else if iopts.platformMatcher != nil {

--- a/client/pull.go
+++ b/client/pull.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/semaphore"
 
@@ -30,8 +32,6 @@ import (
 	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/core/unpack"
 	"github.com/containerd/containerd/v2/pkg/tracing"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
 )
 
 const (

--- a/client/services.go
+++ b/client/services.go
@@ -24,6 +24,8 @@ import (
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
 	namespacesapi "github.com/containerd/containerd/api/services/namespaces/v1"
 	"github.com/containerd/containerd/api/services/tasks/v1"
+	"github.com/containerd/plugin"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
@@ -35,7 +37,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/plugins"
 	srv "github.com/containerd/containerd/v2/plugins/services"
-	"github.com/containerd/plugin"
 )
 
 type services struct {

--- a/client/signals.go
+++ b/client/signals.go
@@ -22,10 +22,11 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
 	"github.com/moby/sys/signal"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
 )
 
 // StopSignalLabel is a well-known containerd label for storing the stop

--- a/client/snapshotter_opts_unix.go
+++ b/client/snapshotter_opts_unix.go
@@ -24,10 +24,11 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/internal/userns"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/internal/userns"
 )
 
 const (

--- a/client/task.go
+++ b/client/task.go
@@ -722,7 +722,7 @@ func (t *task) checkpointTask(ctx context.Context, index *v1.Index, request *tas
 	return nil
 }
 
-func (t *task) checkpointRWSnapshot(ctx context.Context, index *v1.Index, snapshotterName string, id string) error {
+func (t *task) checkpointRWSnapshot(ctx context.Context, index *v1.Index, snapshotterName, id string) error {
 	opts := []diff.Opt{
 		diff.WithReference(fmt.Sprintf("checkpoint-rw-%s", id)),
 	}

--- a/client/task_opts.go
+++ b/client/task_opts.go
@@ -24,10 +24,11 @@ import (
 
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/api/types/runc/options"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/errdefs"
 	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 // NewTaskOpts allows the caller to set options on a new task

--- a/client/transfer.go
+++ b/client/transfer.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containerd/containerd/v2/core/transfer/proxy"
 )
 
-func (c *Client) Transfer(ctx context.Context, src interface{}, dest interface{}, opts ...transfer.Opt) error {
+func (c *Client) Transfer(ctx context.Context, src, dest interface{}, opts ...transfer.Opt) error {
 	ctx, done, err := c.WithLease(ctx)
 	if err != nil {
 		return err

--- a/cmd/containerd-shim-runc-v2/manager/manager_linux.go
+++ b/cmd/containerd-shim-runc-v2/manager/manager_linux.go
@@ -36,6 +36,13 @@ import (
 	cgroupsv2 "github.com/containerd/cgroups/v3/cgroup2"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/api/types/runc/options"
+	"github.com/containerd/errdefs"
+	runcC "github.com/containerd/go-runc"
+	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+	"github.com/opencontainers/runtime-spec/specs-go/features"
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/process"
 	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/runc"
 	"github.com/containerd/containerd/v2/core/mount"
@@ -43,12 +50,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/schedcore"
 	"github.com/containerd/containerd/v2/pkg/shim"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/errdefs"
-	runcC "github.com/containerd/go-runc"
-	"github.com/containerd/log"
-	"github.com/containerd/typeurl/v2"
-	"github.com/opencontainers/runtime-spec/specs-go/features"
-	"golang.org/x/sys/unix"
 )
 
 // NewShimManager returns an implementation of the shim manager

--- a/cmd/containerd-shim-runc-v2/process/deleted_state.go
+++ b/cmd/containerd-shim-runc-v2/process/deleted_state.go
@@ -24,12 +24,12 @@ import (
 	"fmt"
 
 	"github.com/containerd/console"
-	google_protobuf "github.com/containerd/containerd/v2/pkg/protobuf/types"
 	"github.com/containerd/errdefs"
+
+	google_protobuf "github.com/containerd/containerd/v2/pkg/protobuf/types"
 )
 
-type deletedState struct {
-}
+type deletedState struct{}
 
 func (s *deletedState) Pause(ctx context.Context) error {
 	return errors.New("cannot pause a deleted process")

--- a/cmd/containerd-shim-runc-v2/process/exec.go
+++ b/cmd/containerd-shim-runc-v2/process/exec.go
@@ -28,14 +28,14 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/v2/pkg/stdio"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/pkg/stdio"
 )
 
 type execProcess struct {

--- a/cmd/containerd-shim-runc-v2/process/init.go
+++ b/cmd/containerd-shim-runc-v2/process/init.go
@@ -31,14 +31,15 @@ import (
 	"time"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/v2/core/mount"
-	google_protobuf "github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/containerd/v2/pkg/stdio"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
 	"github.com/containerd/log"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	google_protobuf "github.com/containerd/containerd/v2/pkg/protobuf/types"
+	"github.com/containerd/containerd/v2/pkg/stdio"
 )
 
 // Init represents an initial process for a container

--- a/cmd/containerd-shim-runc-v2/process/init_state.go
+++ b/cmd/containerd-shim-runc-v2/process/init_state.go
@@ -23,9 +23,10 @@ import (
 	"errors"
 	"fmt"
 
-	google_protobuf "github.com/containerd/containerd/v2/pkg/protobuf/types"
 	runc "github.com/containerd/go-runc"
 	"github.com/containerd/log"
+
+	google_protobuf "github.com/containerd/containerd/v2/pkg/protobuf/types"
 )
 
 type initState interface {

--- a/cmd/containerd-shim-runc-v2/process/io.go
+++ b/cmd/containerd-shim-runc-v2/process/io.go
@@ -32,11 +32,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/containerd/containerd/v2/pkg/stdio"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
 	"github.com/containerd/log"
+
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/stdio"
 )
 
 const binaryIOProcTermTimeout = 12 * time.Second // Give logger process solid 10 seconds for cleanup
@@ -109,11 +110,11 @@ func createIO(ctx context.Context, id string, ioUID, ioGID int, stdio stdio.Stdi
 		pio.io, err = NewBinaryIO(ctx, id, u)
 	case "file":
 		filePath := u.Path
-		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
 			return nil, err
 		}
 		var f *os.File
-		f, err = os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		f, err = os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/containerd-shim-runc-v2/process/process.go
+++ b/cmd/containerd-shim-runc-v2/process/process.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/containerd/console"
+
 	"github.com/containerd/containerd/v2/pkg/stdio"
 )
 

--- a/cmd/containerd-shim-runc-v2/process/utils.go
+++ b/cmd/containerd-shim-runc-v2/process/utils.go
@@ -59,7 +59,7 @@ func getLastRuntimeError(r *runc.Runc) (string, error) {
 		return "", nil
 	}
 
-	f, err := os.OpenFile(r.Log, os.O_RDONLY, 0400)
+	f, err := os.OpenFile(r.Log, os.O_RDONLY, 0o400)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/containerd-shim-runc-v2/runc/container.go
+++ b/cmd/containerd-shim-runc-v2/runc/container.go
@@ -74,7 +74,7 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 	rootfs := ""
 	if len(pmounts) > 0 {
 		rootfs = filepath.Join(r.Bundle, "rootfs")
-		if err := os.Mkdir(rootfs, 0711); err != nil && !os.IsExist(err) {
+		if err := os.Mkdir(rootfs, 0o711); err != nil && !os.IsExist(err) {
 			return nil, err
 		}
 	}
@@ -183,7 +183,7 @@ func WriteOptions(path string, opts *options.Options) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(path, optionsFilename), data, 0600)
+	return os.WriteFile(filepath.Join(path, optionsFilename), data, 0o600)
 }
 
 // ReadRuntime reads the runtime information from the path
@@ -197,11 +197,12 @@ func ReadRuntime(path string) (string, error) {
 
 // WriteRuntime writes the runtime information into the path
 func WriteRuntime(path, runtime string) error {
-	return os.WriteFile(filepath.Join(path, "runtime"), []byte(runtime), 0600)
+	return os.WriteFile(filepath.Join(path, "runtime"), []byte(runtime), 0o600)
 }
 
 func newInit(ctx context.Context, path, workDir, namespace string, platform stdio.Platform,
-	r *process.CreateConfig, options *options.Options, rootfs string) (*process.Init, error) {
+	r *process.CreateConfig, options *options.Options, rootfs string,
+) (*process.Init, error) {
 	runtime := process.NewRunc(options.Root, path, namespace, options.BinaryName, options.SystemdCgroup)
 	p := process.New(r.ID, runtime, stdio.Stdio{
 		Stdin:    r.Stdin,

--- a/cmd/containerd-shim-runc-v2/runc/platform.go
+++ b/cmd/containerd-shim-runc-v2/runc/platform.go
@@ -29,10 +29,11 @@ import (
 	"syscall"
 
 	"github.com/containerd/console"
+	"github.com/containerd/fifo"
+
 	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/process"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/stdio"
-	"github.com/containerd/fifo"
 )
 
 var bufPool = sync.Pool{

--- a/cmd/containerd-shim-runc-v2/task/plugin/plugin_linux.go
+++ b/cmd/containerd-shim-runc-v2/task/plugin/plugin_linux.go
@@ -17,12 +17,13 @@
 package plugin
 
 import (
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
 	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/task"
 	"github.com/containerd/containerd/v2/pkg/shim"
 	"github.com/containerd/containerd/v2/pkg/shutdown"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 func init() {
@@ -45,5 +46,4 @@ func init() {
 			return task.NewTaskService(ic.Context, pp.(shim.Publisher), ss.(shutdown.Service))
 		},
 	})
-
 }

--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -24,8 +24,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/moby/sys/userns"
-
 	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/cgroups/v3/cgroup1"
 	cgroupsv2 "github.com/containerd/cgroups/v3/cgroup2"
@@ -39,6 +37,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl/v2"
+	"github.com/moby/sys/userns"
 
 	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/process"
 	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/runc"

--- a/cmd/containerd-stress/cri_worker.go
+++ b/cmd/containerd-stress/cri_worker.go
@@ -23,10 +23,11 @@ import (
 	"sync"
 	"time"
 
-	internalapi "github.com/containerd/containerd/v2/integration/cri-api/pkg/apis"
-	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	internalapi "github.com/containerd/containerd/v2/integration/cri-api/pkg/apis"
+	"github.com/containerd/containerd/v2/internal/cri/util"
 )
 
 type criWorker struct {
@@ -91,7 +92,6 @@ func (w *criWorker) run(ctx, tctx context.Context) {
 }
 
 func (w *criWorker) runSandbox(tctx, ctx context.Context, id string) (err error) {
-
 	sbConfig := &runtime.PodSandboxConfig{
 		Metadata: &runtime.PodSandboxMetadata{
 			Name: id,

--- a/cmd/containerd-stress/density.go
+++ b/cmd/containerd-stress/density.go
@@ -29,12 +29,13 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containerd/log"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/log"
-	"github.com/urfave/cli/v2"
 )
 
 var densityCommand = &cli.Command{

--- a/cmd/containerd-stress/exec_worker.go
+++ b/cmd/containerd-stress/exec_worker.go
@@ -23,11 +23,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/log"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/log"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 type execWorker struct {

--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -28,14 +28,15 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/log"
+	metrics "github.com/docker/go-metrics"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/integration/remote"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/log"
-	metrics "github.com/docker/go-metrics"
-	"github.com/urfave/cli/v2"
 )
 
 var (

--- a/cmd/containerd-stress/worker.go
+++ b/cmd/containerd-stress/worker.go
@@ -23,10 +23,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/log"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/log"
 )
 
 type ctrWorker struct {

--- a/cmd/containerd/builtins/builtins_freebsd.go
+++ b/cmd/containerd/builtins/builtins_freebsd.go
@@ -17,6 +17,7 @@
 package builtins
 
 import (
-	_ "github.com/containerd/containerd/v2/plugins/diff/walking/plugin"
 	_ "github.com/containerd/zfs/v2/plugin"
+
+	_ "github.com/containerd/containerd/v2/plugins/diff/walking/plugin"
 )

--- a/cmd/containerd/builtins/builtins_linux.go
+++ b/cmd/containerd/builtins/builtins_linux.go
@@ -18,6 +18,7 @@ package builtins
 
 import (
 	_ "github.com/containerd/containerd/api/types/runc/options"
+
 	_ "github.com/containerd/containerd/v2/core/metrics/cgroups"
 	_ "github.com/containerd/containerd/v2/core/metrics/cgroups/v2"
 	_ "github.com/containerd/containerd/v2/plugins/diff/erofs/plugin"

--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -21,16 +21,17 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containerd/plugin/registry"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pelletier/go-toml/v2"
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/cmd/containerd/server"
 	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/plugin/registry"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pelletier/go-toml/v2"
-	"github.com/urfave/cli/v2"
 )
 
 func outputConfig(ctx context.Context, config *srvconfig.Config) error {

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -27,6 +27,11 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/urfave/cli/v2"
+	"google.golang.org/grpc/grpclog"
+
 	"github.com/containerd/containerd/v2/cmd/containerd/server"
 	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	_ "github.com/containerd/containerd/v2/core/metrics" // import containerd build info
@@ -34,10 +39,6 @@ import (
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/urfave/cli/v2"
-	"google.golang.org/grpc/grpclog"
 )
 
 const usage = `

--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -23,9 +23,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/containerd/v2/cmd/containerd/server"
 	"github.com/containerd/log"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/cmd/containerd/server"
 )
 
 var handledSignals = []os.Signal{

--- a/cmd/containerd/command/main_windows.go
+++ b/cmd/containerd/command/main_windows.go
@@ -26,18 +26,17 @@ import (
 	"github.com/Microsoft/go-winio/pkg/etw"
 	"github.com/Microsoft/go-winio/pkg/etwlogrus"
 	"github.com/Microsoft/go-winio/pkg/guid"
-	"github.com/containerd/containerd/v2/cmd/containerd/server"
 	"github.com/containerd/log"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
+
+	"github.com/containerd/containerd/v2/cmd/containerd/server"
 )
 
-var (
-	handledSignals = []os.Signal{
-		windows.SIGTERM,
-		windows.SIGINT,
-	}
-)
+var handledSignals = []os.Signal{
+	windows.SIGTERM,
+	windows.SIGINT,
+}
 
 func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *server.Server, cancel func()) chan struct{} {
 	done := make(chan struct{})
@@ -96,7 +95,7 @@ func setupDumpStacks() {
 	}()
 }
 
-func etwCallback(sourceID guid.GUID, state etw.ProviderState, level etw.Level, matchAnyKeyword uint64, matchAllKeyword uint64, filterData uintptr) {
+func etwCallback(sourceID guid.GUID, state etw.ProviderState, level etw.Level, matchAnyKeyword, matchAllKeyword uint64, filterData uintptr) {
 	if state == etw.ProviderStateCaptureState {
 		dumpStacks(false)
 	}

--- a/cmd/containerd/command/notify_systemd.go
+++ b/cmd/containerd/command/notify_systemd.go
@@ -21,9 +21,8 @@ package command
 import (
 	"context"
 
-	sd "github.com/coreos/go-systemd/v22/daemon"
-
 	"github.com/containerd/log"
+	sd "github.com/coreos/go-systemd/v22/daemon"
 )
 
 // notifyReady notifies systemd that the daemon is ready to serve requests

--- a/cmd/containerd/command/oci-hook.go
+++ b/cmd/containerd/command/oci-hook.go
@@ -25,9 +25,10 @@ import (
 	"syscall"
 	"text/template"
 
-	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
 var ociHook = &cli.Command{

--- a/cmd/containerd/command/service_unsupported.go
+++ b/cmd/containerd/command/service_unsupported.go
@@ -19,8 +19,9 @@
 package command
 
 import (
-	"github.com/containerd/containerd/v2/cmd/containerd/server"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/containerd/server"
 )
 
 // serviceFlags returns an array of flags for configuring containerd to run

--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/containerd/containerd/v2/cmd/containerd/server"
 	"github.com/containerd/errdefs"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -32,6 +31,8 @@ import (
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/mgr"
+
+	"github.com/containerd/containerd/v2/cmd/containerd/server"
 )
 
 var (
@@ -242,7 +243,7 @@ func registerUnregisterService(root string) (bool, error) {
 		// to the panic.log file as the underlying handle itself has been redirected.
 		var f *os.File
 		if logFileFlag != "" {
-			f, err = os.OpenFile(logFileFlag, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			f, err = os.OpenFile(logFileFlag, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 			if err != nil {
 				return true, fmt.Errorf("open log file %q: %w", logFileFlag, err)
 			}
@@ -330,7 +331,7 @@ Loop:
 
 func initPanicFile(path string) error {
 	var err error
-	panicFile, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	panicFile, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return err
 	}

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -20,9 +20,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/containerd/containerd/v2/cmd/containerd/command"
-
 	_ "github.com/containerd/containerd/v2/cmd/containerd/builtins"
+	"github.com/containerd/containerd/v2/cmd/containerd/command"
 )
 
 func main() {

--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -34,12 +34,12 @@ import (
 	"strings"
 
 	"dario.cat/mergo"
-	"github.com/pelletier/go-toml/v2"
-
-	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
+	"github.com/pelletier/go-toml/v2"
+
+	"github.com/containerd/containerd/v2/version"
 )
 
 // migrations hold the migration functions for every prior containerd config version

--- a/cmd/containerd/server/namespace.go
+++ b/cmd/containerd/server/namespace.go
@@ -19,8 +19,9 @@ package server
 import (
 	"context"
 
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"google.golang.org/grpc"
+
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 
 func unaryNamespaceInterceptor(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {

--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -34,7 +34,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	diffapi "github.com/containerd/containerd/api/services/diff/v1"
+	sbapi "github.com/containerd/containerd/api/services/sandbox/v1"
+	ssapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
 	"github.com/containerd/ttrpc"
 	"github.com/docker/go-metrics"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
@@ -45,13 +51,6 @@ import (
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-
-	diffapi "github.com/containerd/containerd/api/services/diff/v1"
-	sbapi "github.com/containerd/containerd/api/services/sandbox/v1"
-	ssapi "github.com/containerd/containerd/api/services/snapshots/v1"
-	"github.com/containerd/platforms"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 
 	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	csproxy "github.com/containerd/containerd/v2/core/content/proxy"

--- a/cmd/containerd/server/server_linux.go
+++ b/cmd/containerd/server/server_linux.go
@@ -23,12 +23,13 @@ import (
 	"github.com/containerd/cgroups/v3"
 	cgroup1 "github.com/containerd/cgroups/v3/cgroup1"
 	cgroupsv2 "github.com/containerd/cgroups/v3/cgroup2"
-	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
-	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/log"
 	"github.com/containerd/otelttrpc"
 	"github.com/containerd/ttrpc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
+	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
+	"github.com/containerd/containerd/v2/pkg/sys"
 )
 
 // apply sets config settings on the server process

--- a/cmd/containerd/server/server_unsupported.go
+++ b/cmd/containerd/server/server_unsupported.go
@@ -21,8 +21,9 @@ package server
 import (
 	"context"
 
-	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/ttrpc"
+
+	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 )
 
 func apply(_ context.Context, _ *srvconfig.Config) error {

--- a/cmd/containerd/server/server_windows.go
+++ b/cmd/containerd/server/server_windows.go
@@ -19,9 +19,10 @@ package server
 import (
 	"context"
 
-	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/otelttrpc"
 	"github.com/containerd/ttrpc"
+
+	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 )
 
 func apply(_ context.Context, _ *srvconfig.Config) error {

--- a/cmd/ctr/commands/client.go
+++ b/cmd/ctr/commands/client.go
@@ -22,11 +22,12 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/containerd/log"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/epoch"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/containerd/log"
-	"github.com/urfave/cli/v2"
 )
 
 // AppContext returns the context for a command. Should only be called once per

--- a/cmd/ctr/commands/cni.go
+++ b/cmd/ctr/commands/cni.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/typeurl/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/containerd/typeurl/v2"
 )
 
 func init() {

--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -23,10 +23,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/atomicfile"
-
-	"github.com/urfave/cli/v2"
 )
 
 var (

--- a/cmd/ctr/commands/containers/checkpoint.go
+++ b/cmd/ctr/commands/containers/checkpoint.go
@@ -20,10 +20,11 @@ import (
 	"errors"
 	"fmt"
 
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/errdefs"
 	"github.com/urfave/cli/v2"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 )
 
 var checkpointCommand = &cli.Command{

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -23,15 +23,16 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands/run"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/cio"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/containerd/typeurl/v2"
-	"github.com/urfave/cli/v2"
 )
 
 // Command is the cli command for managing containers
@@ -203,7 +204,6 @@ func deleteContainer(ctx context.Context, client *containerd.Client, id string, 
 		return container.Delete(ctx, opts...)
 	}
 	return fmt.Errorf("cannot delete a non stopped container: %v", status)
-
 }
 
 var setLabelsCommand = &cli.Command{

--- a/cmd/ctr/commands/containers/restore.go
+++ b/cmd/ctr/commands/containers/restore.go
@@ -20,13 +20,14 @@ import (
 	"errors"
 
 	"github.com/containerd/console"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands/tasks"
 	"github.com/containerd/containerd/v2/pkg/cio"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/urfave/cli/v2"
 )
 
 var restoreCommand = &cli.Command{

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -27,15 +27,16 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	units "github.com/docker/go-units"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/remotes"
 )
 
 var (
@@ -413,9 +414,7 @@ var (
 		Description: `Fetch objects by identifier from a remote.`,
 		Flags:       commands.RegistryFlags,
 		Action: func(cliContext *cli.Context) error {
-			var (
-				ref = cliContext.Args().First()
-			)
+			ref := cliContext.Args().First()
 			ctx, cancel := commands.AppContext(cliContext)
 			defer cancel()
 
@@ -611,7 +610,7 @@ func edit(cliContext *cli.Context, rd io.Reader) (_ io.ReadCloser, retErr error)
 		return nil, err
 	}
 	// The editor might recreate new file and override the original one. We should reopen the file
-	edited, err := os.OpenFile(tmp.Name(), os.O_RDONLY, 0600)
+	edited, err := os.OpenFile(tmp.Name(), os.O_RDONLY, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -25,6 +25,13 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/core/content"
@@ -32,12 +39,6 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/pkg/httpdbg"
 	"github.com/containerd/containerd/v2/pkg/progress"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/containerd/platforms"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli/v2"
 )
 
 var fetchCommand = &cli.Command{
@@ -82,9 +83,7 @@ Most of this is experimental and there are few leaps to make this work.`,
 		},
 	),
 	Action: func(cliContext *cli.Context) error {
-		var (
-			ref = cliContext.Args().First()
-		)
+		ref := cliContext.Args().First()
 		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err

--- a/cmd/ctr/commands/content/prune.go
+++ b/cmd/ctr/commands/content/prune.go
@@ -21,11 +21,12 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/containerd/log"
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/leases"
-	"github.com/containerd/log"
-	"github.com/urfave/cli/v2"
 )
 
 const (

--- a/cmd/ctr/commands/deprecations/deprecations.go
+++ b/cmd/ctr/commands/deprecations/deprecations.go
@@ -22,9 +22,9 @@ import (
 	"text/tabwriter"
 	"time"
 
+	api "github.com/containerd/containerd/api/services/introspection/v1"
 	"github.com/urfave/cli/v2"
 
-	api "github.com/containerd/containerd/api/services/introspection/v1"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 )
@@ -36,6 +36,7 @@ var Command = &cli.Command{
 		listCommand,
 	},
 }
+
 var listCommand = &cli.Command{
 	Name:  "list",
 	Usage: "Print warnings for deprecations",
@@ -79,7 +80,6 @@ var listCommand = &cli.Command{
 				}
 				return w.Flush()
 			}
-
 		}
 		return nil
 	},
@@ -102,6 +102,7 @@ func warnings(in *api.ServerResponse) []deprecationWarning {
 	}
 	return warnings
 }
+
 func deprecationWarningFromPB(in *api.DeprecationWarning) *deprecationWarning {
 	if in == nil {
 		return nil

--- a/cmd/ctr/commands/events/events.go
+++ b/cmd/ctr/commands/events/events.go
@@ -20,14 +20,14 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
-	"github.com/containerd/containerd/v2/core/events"
+	// Register grpc event types
+	_ "github.com/containerd/containerd/api/events"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	"github.com/urfave/cli/v2"
 
-	// Register grpc event types
-	_ "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
+	"github.com/containerd/containerd/v2/core/events"
 )
 
 // Command is the cli command for displaying containerd events

--- a/cmd/ctr/commands/images/convert.go
+++ b/cmd/ctr/commands/images/convert.go
@@ -20,11 +20,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containerd/platforms"
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/core/images/converter"
 	"github.com/containerd/containerd/v2/core/images/converter/uncompress"
-	"github.com/containerd/platforms"
-	"github.com/urfave/cli/v2"
 )
 
 var convertCommand = &cli.Command{

--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/containerd/platforms"
 	"github.com/urfave/cli/v2"
 
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
@@ -29,7 +30,6 @@ import (
 	"github.com/containerd/containerd/v2/core/transfer"
 	tarchive "github.com/containerd/containerd/v2/core/transfer/archive"
 	"github.com/containerd/containerd/v2/core/transfer/image"
-	"github.com/containerd/platforms"
 )
 
 var exportCommand = &cli.Command{

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/pkg/progress"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/progress"
 )
 
 // Command is the cli command for managing images
@@ -225,7 +226,7 @@ var checkCommand = &cli.Command{
 		}
 		defer cancel()
 
-		var contentStore = client.ContentStore()
+		contentStore := client.ContentStore()
 
 		args := cliContext.Args().Slice()
 		imageList, err := client.ListImages(ctx, args...)
@@ -237,7 +238,7 @@ var checkCommand = &cli.Command{
 			return exitErr
 		}
 
-		var tw = tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
+		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
 		if !quiet {
 			fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSTATUS\tSIZE\tUNPACKED\t")
 		}

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
 	"github.com/urfave/cli/v2"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -32,8 +34,6 @@ import (
 	"github.com/containerd/containerd/v2/core/transfer"
 	tarchive "github.com/containerd/containerd/v2/core/transfer/archive"
 	"github.com/containerd/containerd/v2/core/transfer/image"
-	"github.com/containerd/log"
-	"github.com/containerd/platforms"
 )
 
 var importCommand = &cli.Command{

--- a/cmd/ctr/commands/images/inspect.go
+++ b/cmd/ctr/commands/images/inspect.go
@@ -19,9 +19,10 @@ package images
 import (
 	"os"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/pkg/display"
-	"github.com/urfave/cli/v2"
 )
 
 var inspectCommand = &cli.Command{

--- a/cmd/ctr/commands/images/mount.go
+++ b/cmd/ctr/commands/images/mount.go
@@ -21,16 +21,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/image-spec/identity"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
-	"github.com/opencontainers/image-spec/identity"
-	"github.com/urfave/cli/v2"
 )
 
 var mountCommand = &cli.Command{

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -25,6 +25,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands/content"
@@ -34,11 +40,6 @@ import (
 	"github.com/containerd/containerd/v2/core/transfer/image"
 	"github.com/containerd/containerd/v2/core/transfer/registry"
 	"github.com/containerd/containerd/v2/pkg/progress"
-	"github.com/containerd/log"
-	"github.com/containerd/platforms"
-	"github.com/opencontainers/image-spec/identity"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli/v2"
 )
 
 var pullCommand = &cli.Command{
@@ -91,9 +92,7 @@ command. As part of this process, we do the following:
 		},
 	),
 	Action: func(cliContext *cli.Context) error {
-		var (
-			ref = cliContext.Args().First()
-		)
+		ref := cliContext.Args().First()
 		if ref == "" {
 			return errors.New("please provide an image reference to pull")
 		}
@@ -105,7 +104,8 @@ command. As part of this process, we do the following:
 		defer cancel()
 
 		if !cliContext.Bool("local") {
-			unsupportedFlags := []string{"max-concurrent-downloads", "print-chainid",
+			unsupportedFlags := []string{
+				"max-concurrent-downloads", "print-chainid",
 				"skip-verify", "tlscacert", "tlscert", "tlskey", // RegistryFlags
 			}
 			for _, s := range unsupportedFlags {
@@ -324,7 +324,6 @@ func ProgressHandler(ctx context.Context, out io.Writer) (transfer.ProgressFunc,
 								parents = append(parents, parent)
 								var found bool
 								for _, child := range pStatus.children {
-
 									if child.Progress.Name == p.Name {
 										found = true
 										break
@@ -332,7 +331,6 @@ func ProgressHandler(ctx context.Context, out io.Writer) (transfer.ProgressFunc,
 								}
 								if !found {
 									pStatus.children = append(pStatus.children, node)
-
 								}
 								if node.root {
 									removeRoot = true
@@ -441,7 +439,7 @@ func displayNode(w io.Writer, prefix string, nodes []*progressNode) int64 {
 	return total
 }
 
-func prefixes(index, length int) (prefix string, childPrefix string) {
+func prefixes(index, length int) (prefix, childPrefix string) {
 	if index+1 == length {
 		prefix = "└──"
 		childPrefix = "   "

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -25,6 +25,13 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/sync/errgroup"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands/content"
@@ -36,12 +43,6 @@ import (
 	"github.com/containerd/containerd/v2/core/transfer/registry"
 	"github.com/containerd/containerd/v2/pkg/httpdbg"
 	"github.com/containerd/containerd/v2/pkg/progress"
-	"github.com/containerd/log"
-	"github.com/containerd/platforms"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli/v2"
-	"golang.org/x/sync/errgroup"
 )
 
 var pushCommand = &cli.Command{

--- a/cmd/ctr/commands/images/tag.go
+++ b/cmd/ctr/commands/images/tag.go
@@ -20,12 +20,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containerd/errdefs"
+	"github.com/distribution/reference"
 	"github.com/urfave/cli/v2"
 
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/core/transfer/image"
-	"github.com/containerd/errdefs"
-	"github.com/distribution/reference"
 )
 
 var tagCommand = &cli.Command{
@@ -48,9 +48,7 @@ var tagCommand = &cli.Command{
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
-		var (
-			ref = cliContext.Args().First()
-		)
+		ref := cliContext.Args().First()
 		if ref == "" {
 			return errors.New("please provide an image reference to tag from")
 		}

--- a/cmd/ctr/commands/images/unmount.go
+++ b/cmd/ctr/commands/images/unmount.go
@@ -20,11 +20,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containerd/errdefs"
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/errdefs"
-	"github.com/urfave/cli/v2"
 )
 
 var unmountCommand = &cli.Command{
@@ -39,9 +40,7 @@ var unmountCommand = &cli.Command{
 		},
 	),
 	Action: func(cliContext *cli.Context) error {
-		var (
-			target = cliContext.Args().First()
-		)
+		target := cliContext.Args().First()
 		if target == "" {
 			return errors.New("please provide a target path to unmount from")
 		}

--- a/cmd/ctr/commands/images/usage.go
+++ b/cmd/ctr/commands/images/usage.go
@@ -22,13 +22,13 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/opencontainers/image-spec/identity"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/progress"
-
-	"github.com/opencontainers/image-spec/identity"
-	"github.com/urfave/cli/v2"
 )
 
 var usageCommand = &cli.Command{
@@ -37,7 +37,7 @@ var usageCommand = &cli.Command{
 	ArgsUsage: "[flags] <ref>",
 	Flags:     commands.SnapshotterFlags,
 	Action: func(cliContext *cli.Context) error {
-		var ref = cliContext.Args().First()
+		ref := cliContext.Args().First()
 		if ref == "" {
 			return errors.New("please provide an image reference to mount")
 		}

--- a/cmd/ctr/commands/info/info.go
+++ b/cmd/ctr/commands/info/info.go
@@ -18,8 +18,9 @@ package info
 
 import (
 	api "github.com/containerd/containerd/api/services/introspection/v1"
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 )
 
 type Info struct {

--- a/cmd/ctr/commands/install/install.go
+++ b/cmd/ctr/commands/install/install.go
@@ -17,9 +17,10 @@
 package install
 
 import (
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
-	"github.com/urfave/cli/v2"
 )
 
 // Command to install binary packages

--- a/cmd/ctr/commands/leases/leases.go
+++ b/cmd/ctr/commands/leases/leases.go
@@ -24,9 +24,10 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/core/leases"
-	"github.com/urfave/cli/v2"
 )
 
 // Command is the cli command for managing content
@@ -41,7 +42,6 @@ var Command = &cli.Command{
 }
 
 var listCommand = &cli.Command{
-
 	Name:        "list",
 	Aliases:     []string{"ls"},
 	Usage:       "List all active leases",
@@ -118,7 +118,7 @@ var createCommand = &cli.Command{
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
-		var labelstr = cliContext.Args().Slice()
+		labelstr := cliContext.Args().Slice()
 		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
@@ -167,7 +167,7 @@ var deleteCommand = &cli.Command{
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
-		var lids = cliContext.Args().Slice()
+		lids := cliContext.Args().Slice()
 		if len(lids) == 0 {
 			return cli.ShowSubcommandHelp(cliContext)
 		}

--- a/cmd/ctr/commands/namespaces/namespaces.go
+++ b/cmd/ctr/commands/namespaces/namespaces.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 )
 
 // Command is the cli command for managing namespaces
@@ -174,7 +175,6 @@ var removeCommand = &cli.Command{
 					log.G(ctx).WithError(err).Errorf("unable to delete %v", target)
 					continue
 				}
-
 			}
 
 			fmt.Println(target)

--- a/cmd/ctr/commands/namespaces/namespaces_linux.go
+++ b/cmd/ctr/commands/namespaces/namespaces_linux.go
@@ -17,9 +17,10 @@
 package namespaces
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/core/runtime/opts"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/urfave/cli/v2"
 )
 
 func deleteOpts(cliContext *cli.Context) []namespaces.DeleteOpts {

--- a/cmd/ctr/commands/namespaces/namespaces_other.go
+++ b/cmd/ctr/commands/namespaces/namespaces_other.go
@@ -19,8 +19,9 @@
 package namespaces
 
 import (
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 
 func deleteOpts(cliContext *cli.Context) []namespaces.DeleteOpts {

--- a/cmd/ctr/commands/oci/oci.go
+++ b/cmd/ctr/commands/oci/oci.go
@@ -19,12 +19,12 @@ package oci
 import (
 	"fmt"
 
+	"github.com/containerd/platforms"
 	"github.com/urfave/cli/v2"
 
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/platforms"
 )
 
 // Command is the parent for all OCI related tools under 'oci'

--- a/cmd/ctr/commands/plugins/plugins.go
+++ b/cmd/ctr/commands/plugins/plugins.go
@@ -25,12 +25,13 @@ import (
 	"text/tabwriter"
 
 	"github.com/containerd/containerd/api/types"
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/platforms"
 	pluginutils "github.com/containerd/plugin"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli/v2"
 	"google.golang.org/grpc/codes"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 )
 
 // Command is a cli command that outputs plugin information
@@ -133,7 +134,7 @@ var listCommand = &cli.Command{
 				}
 			}
 
-			var platformColumn = "-"
+			platformColumn := "-"
 			if len(plugin.Platforms) > 0 {
 				platformColumn = prettyPlatforms(plugin.Platforms)
 			}

--- a/cmd/ctr/commands/pprof/pprof.go
+++ b/cmd/ctr/commands/pprof/pprof.go
@@ -23,8 +23,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/containerd/containerd/v2/defaults"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/defaults"
 )
 
 type pprofDialer struct {

--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -28,12 +28,13 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/remotes/docker/config"
 	"github.com/containerd/containerd/v2/core/transfer/registry"
 	"github.com/containerd/containerd/v2/pkg/httpdbg"
-	"github.com/urfave/cli/v2"
 )
 
 // PushTracker returns a new InMemoryTracker which tracks the ref status

--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -24,7 +24,9 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
+	"github.com/containerd/errdefs"
 	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/log"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli/v2"
 
@@ -35,8 +37,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cio"
 	clabels "github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
 )
 
 func withMounts(cliContext *cli.Context) oci.SpecOpts {

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -29,6 +29,11 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
+	"github.com/intel/goresctrl/pkg/blockio"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/urfave/cli/v2"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
+	"tags.cncf.io/container-device-interface/pkg/parser"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
@@ -40,12 +45,6 @@ import (
 	"github.com/containerd/containerd/v2/core/snapshots"
 	cdispec "github.com/containerd/containerd/v2/pkg/cdi"
 	"github.com/containerd/containerd/v2/pkg/oci"
-
-	"github.com/intel/goresctrl/pkg/blockio"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/urfave/cli/v2"
-	"tags.cncf.io/container-device-interface/pkg/cdi"
-	"tags.cncf.io/container-device-interface/pkg/parser"
 )
 
 var platformRunFlags = []cli.Flag{

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -23,15 +23,16 @@ import (
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/containerd/console"
+	"github.com/containerd/log"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/netns"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/log"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/urfave/cli/v2"
 )
 
 var platformRunFlags = []cli.Flag{

--- a/cmd/ctr/commands/sandboxes/sandboxes.go
+++ b/cmd/ctr/commands/sandboxes/sandboxes.go
@@ -22,13 +22,14 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/urfave/cli/v2"
 )
 
 // Command is a set of subcommands to manage runtimes with sandbox support

--- a/cmd/ctr/commands/shim/io_unix.go
+++ b/cmd/ctr/commands/shim/io_unix.go
@@ -39,7 +39,7 @@ func prepareStdio(stdin, stdout, stderr string, console bool) (wg *sync.WaitGrou
 	wg = &sync.WaitGroup{}
 	ctx := context.Background()
 
-	f, err := fifo.OpenFifo(ctx, stdin, unix.O_WRONLY|unix.O_CREAT|unix.O_NONBLOCK, 0700)
+	f, err := fifo.OpenFifo(ctx, stdin, unix.O_WRONLY|unix.O_CREAT|unix.O_NONBLOCK, 0o700)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func prepareStdio(stdin, stdout, stderr string, console bool) (wg *sync.WaitGrou
 		w.Close()
 	}(f)
 
-	f, err = fifo.OpenFifo(ctx, stdout, unix.O_RDONLY|unix.O_CREAT|unix.O_NONBLOCK, 0700)
+	f, err = fifo.OpenFifo(ctx, stdout, unix.O_RDONLY|unix.O_CREAT|unix.O_NONBLOCK, 0o700)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func prepareStdio(stdin, stdout, stderr string, console bool) (wg *sync.WaitGrou
 		wg.Done()
 	}(f)
 
-	f, err = fifo.OpenFifo(ctx, stderr, unix.O_RDONLY|unix.O_CREAT|unix.O_NONBLOCK, 0700)
+	f, err = fifo.OpenFifo(ctx, stderr, unix.O_RDONLY|unix.O_CREAT|unix.O_NONBLOCK, 0o700)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ctr/commands/shim/pprof.go
+++ b/cmd/ctr/commands/shim/pprof.go
@@ -26,10 +26,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/cmd/ctr/commands/pprof"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/shim"
-	"github.com/urfave/cli/v2"
 )
 
 var pprofCommand = &cli.Command{

--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -284,6 +284,7 @@ func getTaskService(cliContext *cli.Context) (task.TTRPCTaskService, error) {
 	}
 	return task.NewTTRPCTaskClient(client), nil
 }
+
 func getTaskServiceV2(cliContext *cli.Context) (taskv2.TaskService, error) {
 	client, err := getTTRPCClient(cliContext)
 	if err != nil {

--- a/cmd/ctr/commands/signals.go
+++ b/cmd/ctr/commands/signals.go
@@ -22,9 +22,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
+	containerd "github.com/containerd/containerd/v2/client"
 )
 
 type killer interface {

--- a/cmd/ctr/commands/tasks/attach.go
+++ b/cmd/ctr/commands/tasks/attach.go
@@ -18,10 +18,11 @@ package tasks
 
 import (
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
-	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/log"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
+	"github.com/containerd/containerd/v2/pkg/cio"
 )
 
 var attachCommand = &cli.Command{

--- a/cmd/ctr/commands/tasks/checkpoint.go
+++ b/cmd/ctr/commands/tasks/checkpoint.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd/api/types/runc/options"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
-	"github.com/urfave/cli/v2"
 )
 
 var checkpointCommand = &cli.Command{

--- a/cmd/ctr/commands/tasks/delete.go
+++ b/cmd/ctr/commands/tasks/delete.go
@@ -19,11 +19,12 @@ package tasks
 import (
 	"context"
 
+	"github.com/containerd/log"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/pkg/cio"
-	"github.com/containerd/log"
-	"github.com/urfave/cli/v2"
 )
 
 var deleteCommand = &cli.Command{

--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -23,12 +23,13 @@ import (
 	"os"
 
 	"github.com/containerd/console"
+	"github.com/containerd/log"
+	"github.com/urfave/cli/v2"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/log"
-	"github.com/urfave/cli/v2"
 )
 
 var execCommand = &cli.Command{

--- a/cmd/ctr/commands/tasks/kill.go
+++ b/cmd/ctr/commands/tasks/kill.go
@@ -21,13 +21,14 @@ import (
 	"errors"
 	"fmt"
 
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	"github.com/moby/sys/signal"
 	"github.com/urfave/cli/v2"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 )
 
 const defaultSignal = "SIGTERM"

--- a/cmd/ctr/commands/tasks/list.go
+++ b/cmd/ctr/commands/tasks/list.go
@@ -22,8 +22,9 @@ import (
 	"text/tabwriter"
 
 	tasks "github.com/containerd/containerd/api/services/tasks/v1"
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 )
 
 var listCommand = &cli.Command{

--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -26,9 +26,10 @@ import (
 	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/typeurl/v2"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 )
 
 const (

--- a/cmd/ctr/commands/tasks/pause.go
+++ b/cmd/ctr/commands/tasks/pause.go
@@ -17,8 +17,9 @@
 package tasks
 
 import (
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 )
 
 var pauseCommand = &cli.Command{

--- a/cmd/ctr/commands/tasks/ps.go
+++ b/cmd/ctr/commands/tasks/ps.go
@@ -22,9 +22,10 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/typeurl/v2"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 )
 
 var psCommand = &cli.Command{

--- a/cmd/ctr/commands/tasks/resume.go
+++ b/cmd/ctr/commands/tasks/resume.go
@@ -17,8 +17,9 @@
 package tasks
 
 import (
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 )
 
 var resumeCommand = &cli.Command{

--- a/cmd/ctr/commands/tasks/start.go
+++ b/cmd/ctr/commands/tasks/start.go
@@ -20,12 +20,13 @@ import (
 	"errors"
 
 	"github.com/containerd/console"
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/cmd/ctr/commands"
-	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/urfave/cli/v2"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
+	"github.com/containerd/containerd/v2/pkg/cio"
 )
 
 var startCommand = &cli.Command{

--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -26,11 +26,12 @@ import (
 	"os/signal"
 
 	"github.com/containerd/console"
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/log"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/cio"
 )
 
 var platformStartFlags = []cli.Flag{

--- a/cmd/ctr/commands/tasks/tasks_windows.go
+++ b/cmd/ctr/commands/tasks/tasks_windows.go
@@ -23,10 +23,11 @@ import (
 	"time"
 
 	"github.com/containerd/console"
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/log"
 	"github.com/urfave/cli/v2"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/cio"
 )
 
 var platformStartFlags = []cli.Flag{}

--- a/cmd/ctr/commands/version/version.go
+++ b/cmd/ctr/commands/version/version.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/urfave/cli/v2"
 )
 
 // Command is a cli command to output the client and containerd server version

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/containerd/containerd/v2/cmd/ctr/app"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/app"
 )
 
 var pluginCmds = []*cli.Command{}

--- a/cmd/gen-manpages/main.go
+++ b/cmd/gen-manpages/main.go
@@ -23,9 +23,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/containerd/containerd/v2/cmd/containerd/command"
 	"github.com/containerd/containerd/v2/cmd/ctr/app"
-	"github.com/urfave/cli/v2"
 )
 
 func main() {
@@ -60,7 +61,7 @@ func run() error {
 		return err
 	}
 	_ = os.MkdirAll(dir, os.ModePerm)
-	if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("%s.%s", name, section)), []byte(data), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("%s.%s", name, section)), []byte(data), 0o644); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/protoc-gen-go-fieldpath/generator.go
+++ b/cmd/protoc-gen-go-fieldpath/generator.go
@@ -50,7 +50,6 @@ func (gen *generator) genFieldMethod(m *protogen.Message) {
 		} else {
 			unhandled = append(unhandled, f)
 		}
-
 	}
 
 	if len(fields) > 0 {

--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -24,9 +24,10 @@ import (
 	"fmt"
 	"os"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // WithProfile sets the provided apparmor profile to the spec

--- a/contrib/apparmor/apparmor_unsupported.go
+++ b/contrib/apparmor/apparmor_unsupported.go
@@ -22,9 +22,10 @@ import (
 	"context"
 	"errors"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // WithProfile sets the provided apparmor profile to the spec

--- a/contrib/diffservice/service.go
+++ b/contrib/diffservice/service.go
@@ -42,6 +42,7 @@ func FromApplierAndComparer(a diff.Applier, c diff.Comparer) diffapi.DiffServer 
 		comparer: c,
 	}
 }
+
 func (s *service) Apply(ctx context.Context, er *diffapi.ApplyRequest) (*diffapi.ApplyResponse, error) {
 	if s.applier == nil {
 		return nil, errgrpc.ToGRPC(errdefs.ErrNotImplemented)

--- a/contrib/fuzz/builtins_linux.go
+++ b/contrib/fuzz/builtins_linux.go
@@ -19,6 +19,7 @@ package fuzz
 import (
 	// Linux specific imports
 	_ "github.com/containerd/containerd/api/types/runc/options"
+
 	_ "github.com/containerd/containerd/v2/core/metrics/cgroups"
 	_ "github.com/containerd/containerd/v2/core/metrics/cgroups/v2"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/blockfile/plugin"

--- a/contrib/fuzz/daemon.go
+++ b/contrib/fuzz/daemon.go
@@ -21,12 +21,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/log"
+
 	"github.com/containerd/containerd/v2/cmd/containerd/server"
 	"github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/log"
 )
 
 const (
@@ -35,9 +36,7 @@ const (
 	defaultAddress = "/tmp/containerd/containerd.sock"
 )
 
-var (
-	initDaemon sync.Once
-)
+var initDaemon sync.Once
 
 func startDaemon() {
 	ctx := context.Background()

--- a/contrib/nvidia/nvidia.go
+++ b/contrib/nvidia/nvidia.go
@@ -24,9 +24,10 @@ import (
 	"strconv"
 	"strings"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // NvidiaCLI is the path to the Nvidia helper binary

--- a/contrib/seccomp/seccomp.go
+++ b/contrib/seccomp/seccomp.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // WithProfile receives the name of a file stored on disk comprising a json

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -21,10 +21,10 @@ package seccomp
 import (
 	"runtime"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/containerd/v2/pkg/kernelversion"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func arches() []specs.Arch {

--- a/contrib/snapshotservice/service.go
+++ b/contrib/snapshotservice/service.go
@@ -151,7 +151,6 @@ func (s service) List(sr *snapshotsapi.ListSnapshotsRequest, ss snapshotsapi.Sna
 	}
 
 	return nil
-
 }
 
 func (s service) Usage(ctx context.Context, ur *snapshotsapi.UsageRequest) (*snapshotsapi.UsageResponse, error) {

--- a/core/content/helpers.go
+++ b/core/content/helpers.go
@@ -25,11 +25,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd/v2/internal/randutil"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/internal/randutil"
 )
 
 var ErrReset = errors.New("writer has been reset")

--- a/core/diff/apply/apply.go
+++ b/core/diff/apply/apply.go
@@ -22,12 +22,13 @@ import (
 	"io"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/diff"
-	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/diff"
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 // NewFileSystemApplier returns an applier which simply mounts

--- a/core/diff/apply/apply_linux.go
+++ b/core/diff/apply/apply_linux.go
@@ -23,12 +23,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/containerd/errdefs"
 	"github.com/moby/sys/userns"
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/archive"
-	"github.com/containerd/errdefs"
 )
 
 func apply(ctx context.Context, mounts []mount.Mount, r io.Reader, sync bool) (retErr error) {

--- a/core/diff/diff.go
+++ b/core/diff/diff.go
@@ -21,9 +21,10 @@ import (
 	"io"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/typeurl/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 // Config is used to hold parameters needed for a diff operation

--- a/core/diff/stream.go
+++ b/core/diff/stream.go
@@ -22,10 +22,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/containerd/typeurl/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/archive/compression"
 )
 
 var (

--- a/core/diff/stream_unix.go
+++ b/core/diff/stream_unix.go
@@ -28,8 +28,9 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/containerd/typeurl/v2"
+
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 )
 
 // NewBinaryProcessor returns a binary processor for use with processing content streams

--- a/core/diff/stream_windows.go
+++ b/core/diff/stream_windows.go
@@ -28,10 +28,10 @@ import (
 	"sync"
 
 	"github.com/Microsoft/go-winio"
-
-	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
+
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 )
 
 const processorPipe = "STREAM_PROCESSOR_PIPE"

--- a/core/events/exchange/exchange.go
+++ b/core/events/exchange/exchange.go
@@ -22,14 +22,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/events"
-	"github.com/containerd/containerd/v2/pkg/filters"
-	"github.com/containerd/containerd/v2/pkg/identifiers"
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	goevents "github.com/docker/go-events"
+
+	"github.com/containerd/containerd/v2/core/events"
+	"github.com/containerd/containerd/v2/pkg/filters"
+	"github.com/containerd/containerd/v2/pkg/identifiers"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 
 // Exchange broadcasts events
@@ -44,9 +45,11 @@ func NewExchange() *Exchange {
 	}
 }
 
-var _ events.Publisher = &Exchange{}
-var _ events.Forwarder = &Exchange{}
-var _ events.Subscriber = &Exchange{}
+var (
+	_ events.Publisher  = &Exchange{}
+	_ events.Forwarder  = &Exchange{}
+	_ events.Subscriber = &Exchange{}
+)
 
 // Forward accepts an envelope to be directly distributed on the exchange.
 //

--- a/core/images/archive/exporter.go
+++ b/core/images/archive/exporter.go
@@ -26,15 +26,16 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/labels"
 )
 
 type exportOptions struct {
@@ -320,7 +321,6 @@ func Export(ctx context.Context, store content.InfoReaderProvider, writer io.Wri
 					mt := dManifests[d]
 					mt.names = append(mt.names, name)
 				}
-
 			}
 		} else {
 			return fmt.Errorf("only manifests may be exported: %w", errdefs.ErrInvalidArgument)
@@ -339,9 +339,9 @@ func Export(ctx context.Context, store content.InfoReaderProvider, writer io.Wri
 	}
 
 	if len(algorithms) > 0 {
-		records = append(records, directoryRecord("blobs/", 0755))
+		records = append(records, directoryRecord("blobs/", 0o755))
 		for alg := range algorithms {
-			records = append(records, directoryRecord("blobs/"+alg+"/", 0755))
+			records = append(records, directoryRecord("blobs/"+alg+"/", 0o755))
 		}
 	}
 
@@ -397,7 +397,7 @@ func blobRecord(cs content.Provider, desc ocispec.Descriptor, opts *blobRecordOp
 	return tarRecord{
 		Header: &tar.Header{
 			Name:     path.Join(ocispec.ImageBlobsDir, desc.Digest.Algorithm().String(), desc.Digest.Encoded()),
-			Mode:     0444,
+			Mode:     0o444,
 			Size:     desc.Size,
 			Typeflag: tar.TypeReg,
 		},
@@ -449,7 +449,7 @@ func ociLayoutFile(version string) tarRecord {
 	return tarRecord{
 		Header: &tar.Header{
 			Name:     ocispec.ImageLayoutFile,
-			Mode:     0444,
+			Mode:     0o444,
 			Size:     int64(len(b)),
 			Typeflag: tar.TypeReg,
 		},
@@ -458,7 +458,6 @@ func ociLayoutFile(version string) tarRecord {
 			return int64(n), err
 		},
 	}
-
 }
 
 func ociIndexRecord(manifests []ocispec.Descriptor) tarRecord {
@@ -478,7 +477,7 @@ func ociIndexRecord(manifests []ocispec.Descriptor) tarRecord {
 	return tarRecord{
 		Header: &tar.Header{
 			Name:     ocispec.ImageIndexFile,
-			Mode:     0644,
+			Mode:     0o644,
 			Size:     int64(len(b)),
 			Typeflag: tar.TypeReg,
 		},
@@ -542,7 +541,7 @@ func manifestsRecord(ctx context.Context, store content.Provider, manifests map[
 	return tarRecord{
 		Header: &tar.Header{
 			Name:     "manifest.json",
-			Mode:     0644,
+			Mode:     0o644,
 			Size:     int64(len(b)),
 			Typeflag: tar.TypeReg,
 		},

--- a/core/images/archive/importer.go
+++ b/core/images/archive/importer.go
@@ -27,16 +27,17 @@ import (
 	"io"
 	"path"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/pkg/archive/compression"
-	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/archive/compression"
+	"github.com/containerd/containerd/v2/pkg/labels"
 )
 
 type importOpts struct {

--- a/core/images/archive/reference.go
+++ b/core/images/archive/reference.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/containerd/containerd/v2/pkg/reference"
 	distref "github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
+
+	"github.com/containerd/containerd/v2/pkg/reference"
 )
 
 // FilterRefPrefix restricts references to having the given image

--- a/core/images/converter/converter.go
+++ b/core/images/converter/converter.go
@@ -20,10 +20,11 @@ package converter
 import (
 	"context"
 
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/leases"
-	"github.com/containerd/platforms"
 )
 
 type convertOpts struct {

--- a/core/images/converter/default.go
+++ b/core/images/converter/default.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
 )
 
 // ConvertFunc returns a converted content descriptor.

--- a/core/images/converter/uncompress/uncompress.go
+++ b/core/images/converter/uncompress/uncompress.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/containerd/errdefs"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/converter"
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/containerd/containerd/v2/pkg/labels"
-	"github.com/containerd/errdefs"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var _ converter.ConvertFunc = LayerConvertFunc

--- a/core/images/diffid.go
+++ b/core/images/diffid.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"io"
 
+	"github.com/containerd/log"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/containerd/containerd/v2/pkg/labels"
-	"github.com/containerd/log"
 )
 
 // GetDiffID gets the diff ID of the layer blob descriptor.

--- a/core/images/handlers.go
+++ b/core/images/handlers.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
+
+	"github.com/containerd/containerd/v2/core/content"
 )
 
 var (

--- a/core/images/image.go
+++ b/core/images/image.go
@@ -23,12 +23,13 @@ import (
 	"sort"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
 )
 
 // Image provides the model for how containerd views container images.

--- a/core/images/importexport.go
+++ b/core/images/importexport.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/containerd/containerd/v2/core/content"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
 )
 
 // Importer is the interface for image importer.

--- a/core/images/usage/calculator.go
+++ b/core/images/usage/calculator.go
@@ -21,14 +21,14 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-
 	"golang.org/x/sync/semaphore"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/snapshots"
 )
 
 type usageOptions struct {

--- a/core/introspection/proxy/remote.go
+++ b/core/introspection/proxy/remote.go
@@ -60,7 +60,6 @@ func (i *introspectionRemote) Plugins(ctx context.Context, filters ...string) (*
 	resp, err := i.client.Plugins(ctx, &api.PluginsRequest{
 		Filters: filters,
 	})
-
 	if err != nil {
 		return nil, errgrpc.ToNative(err)
 	}
@@ -70,7 +69,6 @@ func (i *introspectionRemote) Plugins(ctx context.Context, filters ...string) (*
 
 func (i *introspectionRemote) Server(ctx context.Context) (*api.ServerResponse, error) {
 	resp, err := i.client.Server(ctx, &emptypb.Empty{})
-
 	if err != nil {
 		return nil, errgrpc.ToNative(err)
 	}
@@ -102,9 +100,11 @@ type convertIntrospection struct {
 func (c convertIntrospection) Plugins(ctx context.Context, req *api.PluginsRequest) (*api.PluginsResponse, error) {
 	return c.client.Plugins(ctx, req)
 }
+
 func (c convertIntrospection) Server(ctx context.Context, in *emptypb.Empty) (*api.ServerResponse, error) {
 	return c.client.Server(ctx, in)
 }
+
 func (c convertIntrospection) PluginInfo(ctx context.Context, req *api.PluginInfoRequest) (*api.PluginInfoResponse, error) {
 	return c.client.PluginInfo(ctx, req)
 }

--- a/core/metadata/adaptors.go
+++ b/core/metadata/adaptors.go
@@ -60,6 +60,7 @@ func adaptImage(o interface{}) filters.Adaptor {
 		return "", false
 	})
 }
+
 func adaptContainer(o interface{}) filters.Adaptor {
 	obj := o.(containers.Container)
 	return filters.AdapterFunc(func(fieldpath []string) (string, bool) {

--- a/core/metadata/boltutil/helpers.go
+++ b/core/metadata/boltutil/helpers.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
-	"github.com/containerd/containerd/v2/pkg/protobuf/types"
 	"github.com/containerd/typeurl/v2"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
+	"github.com/containerd/containerd/v2/pkg/protobuf/types"
 )
 
 var (

--- a/core/metadata/containers.go
+++ b/core/metadata/containers.go
@@ -22,6 +22,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/typeurl/v2"
+	bolt "go.etcd.io/bbolt"
+	errbolt "go.etcd.io/bbolt/errors"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/metadata/boltutil"
 	"github.com/containerd/containerd/v2/pkg/filters"
@@ -31,10 +36,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/containerd/containerd/v2/pkg/protobuf/types"
 	"github.com/containerd/containerd/v2/pkg/tracing"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/typeurl/v2"
-	bolt "go.etcd.io/bbolt"
-	errbolt "go.etcd.io/bbolt/errors"
 )
 
 const (

--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -288,7 +288,6 @@ func (cs *contentStore) ListStatuses(ctx context.Context, fs ...string) ([]conte
 	}
 
 	return statuses, nil
-
 }
 
 func getRef(tx *bolt.Tx, ns, ref string) string {
@@ -367,7 +366,6 @@ func (cs *contentStore) Abort(ctx context.Context, ref string) error {
 
 		return nil
 	})
-
 }
 
 func (cs *contentStore) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {

--- a/core/metadata/db.go
+++ b/core/metadata/db.go
@@ -144,7 +144,7 @@ func (m *DB) Init(ctx context.Context) error {
 	// errSkip is used when no migration or version needs to be written
 	// to the database and the transaction can be immediately rolled
 	// back rather than performing a much slower and unnecessary commit.
-	var errSkip = errors.New("skip update")
+	errSkip := errors.New("skip update")
 
 	err := m.db.Update(func(tx *bolt.Tx) error {
 		var (

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -25,9 +25,10 @@ import (
 	"time"
 
 	eventstypes "github.com/containerd/containerd/api/events"
-	"github.com/containerd/containerd/v2/pkg/gc"
 	"github.com/containerd/log"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/containerd/containerd/v2/pkg/gc"
 )
 
 const (

--- a/core/metadata/images.go
+++ b/core/metadata/images.go
@@ -25,17 +25,18 @@ import (
 	"time"
 
 	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/errdefs"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	bolt "go.etcd.io/bbolt"
+	errbolt "go.etcd.io/bbolt/errors"
+
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/metadata/boltutil"
 	"github.com/containerd/containerd/v2/pkg/epoch"
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/containerd/errdefs"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	bolt "go.etcd.io/bbolt"
-	errbolt "go.etcd.io/bbolt/errors"
 )
 
 type imageStore struct {
@@ -276,7 +277,6 @@ func (s *imageStore) Update(ctx context.Context, image images.Image, fieldpaths 
 	}
 
 	return updated, nil
-
 }
 
 func (s *imageStore) Delete(ctx context.Context, name string, opts ...images.DeleteOpt) error {

--- a/core/metadata/leases.go
+++ b/core/metadata/leases.go
@@ -23,14 +23,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/leases"
-	"github.com/containerd/containerd/v2/core/metadata/boltutil"
-	"github.com/containerd/containerd/v2/pkg/filters"
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
 	digest "github.com/opencontainers/go-digest"
 	bolt "go.etcd.io/bbolt"
 	errbolt "go.etcd.io/bbolt/errors"
+
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/core/metadata/boltutil"
+	"github.com/containerd/containerd/v2/pkg/filters"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 
 // leaseManager manages the create/delete lifecycle of leases
@@ -259,7 +260,6 @@ func (lm *leaseManager) ListResources(ctx context.Context, lease leases.Lease) (
 	var rs []leases.Resource
 
 	if err := view(ctx, lm.db, func(tx *bolt.Tx) error {
-
 		topbkt := getBucket(tx, bucketKeyVersion, []byte(namespace), bucketKeyObjectLeases, []byte(lease.ID))
 		if topbkt == nil {
 			return fmt.Errorf("lease %q: %w", lease.ID, errdefs.ErrNotFound)

--- a/core/metadata/namespaces.go
+++ b/core/metadata/namespaces.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/containerd/containerd/v2/pkg/identifiers"
-	l "github.com/containerd/containerd/v2/pkg/labels"
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
 	bolt "go.etcd.io/bbolt"
 	errbolt "go.etcd.io/bbolt/errors"
+
+	"github.com/containerd/containerd/v2/pkg/identifiers"
+	l "github.com/containerd/containerd/v2/pkg/labels"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 
 type namespaceStore struct {
@@ -108,7 +109,6 @@ func (s *namespaceStore) SetLabel(ctx context.Context, namespace, key, value str
 
 		return bkt.Put([]byte(key), []byte(value))
 	})
-
 }
 
 func (s *namespaceStore) List(ctx context.Context) ([]string, error) {

--- a/core/metadata/sandbox.go
+++ b/core/metadata/sandbox.go
@@ -23,16 +23,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/typeurl/v2"
+	"go.etcd.io/bbolt"
+	errbolt "go.etcd.io/bbolt/errors"
+
 	"github.com/containerd/containerd/v2/core/metadata/boltutil"
 	api "github.com/containerd/containerd/v2/core/sandbox"
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/tracing"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/typeurl/v2"
-	"go.etcd.io/bbolt"
-	errbolt "go.etcd.io/bbolt/errors"
 )
 
 const (
@@ -214,9 +215,7 @@ func (s *sandboxStore) List(ctx context.Context, fields ...string) ([]api.Sandbo
 		return nil, fmt.Errorf("%s: %w", err.Error(), errdefs.ErrInvalidArgument)
 	}
 
-	var (
-		list []api.Sandbox
-	)
+	var list []api.Sandbox
 
 	if err := view(ctx, s.db, func(tx *bbolt.Tx) error {
 		bucket := getSandboxBucket(tx, ns)

--- a/core/metadata/snapshot.go
+++ b/core/metadata/snapshot.go
@@ -24,16 +24,17 @@ import (
 	"time"
 
 	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	bolt "go.etcd.io/bbolt"
+	errbolt "go.etcd.io/bbolt/errors"
+
 	"github.com/containerd/containerd/v2/core/metadata/boltutil"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	bolt "go.etcd.io/bbolt"
-	errbolt "go.etcd.io/bbolt/errors"
 )
 
 const (
@@ -403,7 +404,6 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 					tinfo = &i
 				}
 				return nil
-
 			}, filter); err != nil {
 				return nil, fmt.Errorf("failed walking backend snapshots: %w", err)
 			}
@@ -645,7 +645,6 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 	}); err != nil {
 		if bname != "" {
 			log.G(ctx).WithField("snapshotter", s.name).WithField("key", key).WithField("bname", bname).WithError(err).Error("uncommittable snapshot: transaction failed after commit, snapshot should be removed")
-
 		}
 		return err
 	}
@@ -663,7 +662,6 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 	}
 
 	return rerr
-
 }
 
 func (s *snapshotter) Remove(ctx context.Context, key string) error {

--- a/core/metrics/cgroups/cgroups.go
+++ b/core/metrics/cgroups/cgroups.go
@@ -22,16 +22,17 @@ import (
 	"context"
 
 	"github.com/containerd/cgroups/v3"
+	"github.com/containerd/platforms"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	metrics "github.com/docker/go-metrics"
+
 	"github.com/containerd/containerd/v2/core/events"
 	v1 "github.com/containerd/containerd/v2/core/metrics/cgroups/v1"
 	v2 "github.com/containerd/containerd/v2/core/metrics/cgroups/v2"
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/platforms"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
-	metrics "github.com/docker/go-metrics"
 )
 
 // Config for the cgroups monitor

--- a/core/metrics/cgroups/v1/blkio.go
+++ b/core/metrics/cgroups/v1/blkio.go
@@ -21,9 +21,10 @@ package v1
 import (
 	"strconv"
 
-	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 )
 
 var blkioMetrics = []*metric{

--- a/core/metrics/cgroups/v1/cgroups.go
+++ b/core/metrics/cgroups/v1/cgroups.go
@@ -23,12 +23,13 @@ import (
 
 	cgroups "github.com/containerd/cgroups/v3/cgroup1"
 	eventstypes "github.com/containerd/containerd/api/events"
-	"github.com/containerd/containerd/v2/core/events"
-	"github.com/containerd/containerd/v2/core/runtime"
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/go-metrics"
+
+	"github.com/containerd/containerd/v2/core/events"
+	"github.com/containerd/containerd/v2/core/runtime"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 
 // NewTaskMonitor returns a new cgroups monitor

--- a/core/metrics/cgroups/v1/cpu.go
+++ b/core/metrics/cgroups/v1/cpu.go
@@ -21,9 +21,10 @@ package v1
 import (
 	"strconv"
 
-	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 )
 
 var cpuMetrics = []*metric{

--- a/core/metrics/cgroups/v1/hugetlb.go
+++ b/core/metrics/cgroups/v1/hugetlb.go
@@ -19,9 +19,10 @@
 package v1
 
 import (
-	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 )
 
 var hugetlbMetrics = []*metric{

--- a/core/metrics/cgroups/v1/memory.go
+++ b/core/metrics/cgroups/v1/memory.go
@@ -19,9 +19,10 @@
 package v1
 
 import (
-	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 )
 
 var memoryMetrics = []*metric{

--- a/core/metrics/cgroups/v1/metric.go
+++ b/core/metrics/cgroups/v1/metric.go
@@ -19,9 +19,10 @@
 package v1
 
 import (
-	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 )
 
 // IDName is the name that is used to identify the id being collected in the metric

--- a/core/metrics/cgroups/v1/metrics.go
+++ b/core/metrics/cgroups/v1/metrics.go
@@ -24,15 +24,16 @@ import (
 	"sync"
 
 	cgroups "github.com/containerd/cgroups/v3/cgroup1"
+	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+	"github.com/docker/go-metrics"
+	"github.com/prometheus/client_golang/prometheus"
+
 	cmetrics "github.com/containerd/containerd/v2/core/metrics"
 	"github.com/containerd/containerd/v2/core/metrics/cgroups/common"
 	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/timeout"
-	"github.com/containerd/log"
-	"github.com/containerd/typeurl/v2"
-	"github.com/docker/go-metrics"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Trigger will be called when an event happens and provides the cgroup

--- a/core/metrics/cgroups/v1/oom.go
+++ b/core/metrics/cgroups/v1/oom.go
@@ -22,13 +22,13 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"golang.org/x/sys/unix"
-
 	cgroups "github.com/containerd/cgroups/v3/cgroup1"
-	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/log"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/pkg/sys"
 )
 
 func newOOMCollector(ns *metrics.Namespace) (*oomCollector, error) {

--- a/core/metrics/cgroups/v1/pids.go
+++ b/core/metrics/cgroups/v1/pids.go
@@ -19,9 +19,10 @@
 package v1
 
 import (
-	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/v2/core/metrics/types/v1"
 )
 
 var pidMetrics = []*metric{

--- a/core/metrics/cgroups/v2/cgroups.go
+++ b/core/metrics/cgroups/v2/cgroups.go
@@ -21,9 +21,10 @@ package v2
 import (
 	"context"
 
+	"github.com/docker/go-metrics"
+
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/core/runtime"
-	"github.com/docker/go-metrics"
 )
 
 // NewTaskMonitor returns a new cgroups monitor

--- a/core/metrics/cgroups/v2/cpu.go
+++ b/core/metrics/cgroups/v2/cpu.go
@@ -19,9 +19,10 @@
 package v2
 
 import (
-	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 )
 
 var cpuMetrics = []*metric{

--- a/core/metrics/cgroups/v2/io.go
+++ b/core/metrics/cgroups/v2/io.go
@@ -21,9 +21,10 @@ package v2
 import (
 	"strconv"
 
-	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 )
 
 var ioMetrics = []*metric{

--- a/core/metrics/cgroups/v2/memory.go
+++ b/core/metrics/cgroups/v2/memory.go
@@ -19,9 +19,10 @@
 package v2
 
 import (
-	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 )
 
 var memoryMetrics = []*metric{

--- a/core/metrics/cgroups/v2/metric.go
+++ b/core/metrics/cgroups/v2/metric.go
@@ -19,9 +19,10 @@
 package v2
 
 import (
-	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 )
 
 // IDName is the name that is used to identify the id being collected in the metric

--- a/core/metrics/cgroups/v2/metrics.go
+++ b/core/metrics/cgroups/v2/metrics.go
@@ -23,15 +23,16 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+	"github.com/docker/go-metrics"
+	"github.com/prometheus/client_golang/prometheus"
+
 	cmetrics "github.com/containerd/containerd/v2/core/metrics"
 	"github.com/containerd/containerd/v2/core/metrics/cgroups/common"
 	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/timeout"
-	"github.com/containerd/log"
-	"github.com/containerd/typeurl/v2"
-	"github.com/docker/go-metrics"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // NewCollector registers the collector with the provided namespace and returns it so

--- a/core/metrics/cgroups/v2/pids.go
+++ b/core/metrics/cgroups/v2/pids.go
@@ -19,9 +19,10 @@
 package v2
 
 import (
-	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v2 "github.com/containerd/containerd/v2/core/metrics/types/v2"
 )
 
 var pidMetrics = []*metric{

--- a/core/metrics/metrics.go
+++ b/core/metrics/metrics.go
@@ -19,9 +19,10 @@ package metrics
 import (
 	"time"
 
+	goMetrics "github.com/docker/go-metrics"
+
 	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/containerd/v2/version"
-	goMetrics "github.com/docker/go-metrics"
 )
 
 const (

--- a/core/mount/losetup_linux.go
+++ b/core/mount/losetup_linux.go
@@ -23,9 +23,10 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/containerd/v2/internal/randutil"
 	kernel "github.com/containerd/containerd/v2/pkg/kernelversion"
-	"golang.org/x/sys/unix"
 )
 
 const (

--- a/core/mount/mount_idmapped_linux.go
+++ b/core/mount/mount_idmapped_linux.go
@@ -83,10 +83,8 @@ func IDMapMount(source, target string, usernsFd int) (err error) {
 }
 
 // IDMapMountWithAttrs clones the mount at source to target with the provided mount options and idmapping of the user namespace.
-func IDMapMountWithAttrs(source, target string, usernsFd int, attrSet uint64, attrClr uint64) (err error) {
-	var (
-		attr unix.MountAttr
-	)
+func IDMapMountWithAttrs(source, target string, usernsFd int, attrSet, attrClr uint64) (err error) {
+	var attr unix.MountAttr
 
 	attr.Attr_set = unix.MOUNT_ATTR_IDMAP | attrSet
 	attr.Attr_clr = attrClr

--- a/core/mount/mount_idmapped_utils_linux.go
+++ b/core/mount/mount_idmapped_utils_linux.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/containerd/containerd/v2/pkg/sys"
-
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/pkg/sys"
 )
 
 // getUsernsFD returns pinnable user namespace's file descriptor.

--- a/core/mount/mount_linux.go
+++ b/core/mount/mount_linux.go
@@ -110,9 +110,7 @@ func (m *Mount) mount(target string) (err error) {
 
 		// overlay expects lowerdir's to be remapped instead
 		if m.Type == "overlay" {
-			var (
-				userNsCleanUp func()
-			)
+			var userNsCleanUp func()
 			options, userNsCleanUp, err = prepareIDMappedOverlay(int(usernsFd.Fd()), options)
 			defer userNsCleanUp()
 
@@ -480,7 +478,7 @@ func optionsSize(opts []string) int {
 	return size
 }
 
-func mountAt(chdir string, source, target, fstype string, flags uintptr, data string) error {
+func mountAt(chdir, source, target, fstype string, flags uintptr, data string) error {
 	if chdir == "" {
 		err := unix.Mount(source, target, fstype, flags, data)
 		if err != nil {

--- a/core/mount/mount_windows.go
+++ b/core/mount/mount_windows.go
@@ -46,7 +46,7 @@ func (m *Mount) mount(target string) (retErr error) {
 		return err
 	}
 
-	var di = hcsshim.DriverInfo{
+	di := hcsshim.DriverInfo{
 		HomeDir: home,
 	}
 
@@ -100,7 +100,7 @@ func (m *Mount) mount(target string) (retErr error) {
 	// Add an Alternate Data Stream to record the layer source.
 	// See https://docs.microsoft.com/en-au/archive/blogs/askcore/alternate-data-streams-in-ntfs
 	// for details on Alternate Data Streams.
-	if err := os.WriteFile(filepath.Clean(target)+":"+sourceStreamName, []byte(m.Source), 0666); err != nil {
+	if err := os.WriteFile(filepath.Clean(target)+":"+sourceStreamName, []byte(m.Source), 0o666); err != nil {
 		return fmt.Errorf("failed to record source for layer %s: %w", m.Source, err)
 	}
 
@@ -251,7 +251,6 @@ func GetCimPath(m *Mount) (string, error) {
 		return "", fmt.Errorf("cim path not found")
 	}
 	return cimPath, nil
-
 }
 
 // GetEnableLayerIntegrity checks if the enableLayerIntegrity flag is present in mount options

--- a/core/mount/temp_unix.go
+++ b/core/mount/temp_unix.go
@@ -27,7 +27,7 @@ import (
 
 // SetTempMountLocation sets the temporary mount location
 func SetTempMountLocation(root string) error {
-	err := os.MkdirAll(root, 0700)
+	err := os.MkdirAll(root, 0o700)
 	if err != nil {
 		return err
 	}

--- a/core/remotes/docker/auth/fetch.go
+++ b/core/remotes/docker/auth/fetch.go
@@ -26,17 +26,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/log"
+
 	remoteserrors "github.com/containerd/containerd/v2/core/remotes/errors"
 	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/log"
 )
 
-var (
-	// ErrNoToken is returned if a request is successful but the body does not
-	// contain an authorization token.
-	ErrNoToken = errors.New("authorization server did not include a token in the response")
-)
+// ErrNoToken is returned if a request is successful but the body does not
+// contain an authorization token.
+var ErrNoToken = errors.New("authorization server did not include a token in the response")
 
 // GenerateTokenOptions generates options for fetching a token based on a challenge
 func GenerateTokenOptions(ctx context.Context, host, username, secret string, c Challenge) (TokenOptions, error) {

--- a/core/remotes/docker/auth/parse.go
+++ b/core/remotes/docker/auth/parse.go
@@ -164,7 +164,7 @@ func expectToken(s string) (token, rest string) {
 	return s[:i], s[i:]
 }
 
-func expectTokenOrQuoted(s string) (value string, rest string) {
+func expectTokenOrQuoted(s string) (value, rest string) {
 	if !strings.HasPrefix(s, "\"") {
 		return expectToken(s)
 	}

--- a/core/remotes/docker/authorizer.go
+++ b/core/remotes/docker/authorizer.go
@@ -26,10 +26,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/remotes/docker/auth"
-	remoteerrors "github.com/containerd/containerd/v2/core/remotes/errors"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker/auth"
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/errors"
 )
 
 type dockerAuthorizer struct {

--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -116,7 +116,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 					// When port is 80, protocol is not ambiguous
 					if port != "80" {
 						// Skipping TLS verification for localhost
-						var skipVerify = true
+						skipVerify := true
 						hosts[len(hosts)-1].skipVerify = &skipVerify
 					}
 				} else {
@@ -235,7 +235,6 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 
 		return rhosts, nil
 	}
-
 }
 
 func updateTLSConfigFromHost(tlsConfig *tls.Config, host *hostConfig) error {
@@ -391,9 +390,7 @@ func parseHostsFile(baseDir string, b []byte) ([]hostConfig, error) {
 		HostConfigs map[string]hostFileConfig `toml:"host"`
 	}{}
 
-	var (
-		hosts []hostConfig
-	)
+	var hosts []hostConfig
 
 	if err := toml.Unmarshal(b, &c); err != nil {
 		return nil, err
@@ -420,7 +417,7 @@ func parseHostsFile(baseDir string, b []byte) ([]hostConfig, error) {
 	return hosts, nil
 }
 
-func parseHostConfig(server string, baseDir string, config hostFileConfig) (hostConfig, error) {
+func parseHostConfig(server, baseDir string, config hostFileConfig) (hostConfig, error) {
 	var (
 		result = hostConfig{}
 		err    error
@@ -600,7 +597,7 @@ func makeStringSlice(slice []interface{}, cb func(string) string) ([]string, err
 	return out, nil
 }
 
-func makeAbsPath(p string, base string) string {
+func makeAbsPath(p, base string) string {
 	if filepath.IsAbs(p) {
 		return p
 	}

--- a/core/remotes/docker/converter.go
+++ b/core/remotes/docker/converter.go
@@ -22,12 +22,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
 )
 
 // LegacyConfigMediaType should be replaced by OCI image spec.

--- a/core/remotes/docker/errdesc.go
+++ b/core/remotes/docker/errdesc.go
@@ -91,8 +91,10 @@ var (
 	})
 )
 
-var nextCode = 1000
-var registerLock sync.Mutex
+var (
+	nextCode     = 1000
+	registerLock sync.Mutex
+)
 
 // Register will make the passed-in error known to the environment and
 // return a new ErrorCode

--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -324,7 +324,6 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 		}
 
 		return nil, firstErr
-
 	})
 }
 

--- a/core/remotes/docker/handler.go
+++ b/core/remotes/docker/handler.go
@@ -22,12 +22,13 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/reference"
-	"github.com/containerd/log"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // AppendDistributionSourceLabel updates the label of blob with distribution source.

--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -318,7 +318,6 @@ func getManifestPath(object string, dgst digest.Digest) []string {
 			// strip @<digest> for registry path to make tag
 			object = object[:i]
 		}
-
 	}
 
 	if object == "" {
@@ -471,7 +470,6 @@ func (pw *pushWriter) Status() (content.Status, error) {
 		return content.Status{}, err
 	}
 	return status.Status, nil
-
 }
 
 func (pw *pushWriter) Digest() digest.Digest {

--- a/core/remotes/docker/status.go
+++ b/core/remotes/docker/status.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/errdefs"
 	"github.com/moby/locker"
+
+	"github.com/containerd/containerd/v2/core/content"
 )
 
 // Status of a content operation

--- a/core/remotes/handlers.go
+++ b/core/remotes/handlers.go
@@ -25,14 +25,15 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/semaphore"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/labels"
 )
 
 type refKeyPrefix struct{}
@@ -208,7 +209,6 @@ func push(ctx context.Context, provider content.Provider, pusher Pusher, desc oc
 // content.Manager) then this will also annotate the distribution sources using
 // labels prefixed with "containerd.io/distribution.source".
 func PushContent(ctx context.Context, pusher Pusher, desc ocispec.Descriptor, store content.Provider, limiter *semaphore.Weighted, platform platforms.MatchComparer, wrapper func(h images.Handler) images.Handler) error {
-
 	var m sync.Mutex
 	manifests := []ocispec.Descriptor{}
 	indexStack := []ocispec.Descriptor{}

--- a/core/remotes/resolver.go
+++ b/core/remotes/resolver.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"io"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/transfer"
 )
 
 // Resolver provides remotes based on a locator.
@@ -102,7 +103,7 @@ func (fn PusherFunc) Push(ctx context.Context, desc ocispec.Descriptor) (content
 
 // FetchByDigestConfig provides configuration for fetching content by digest
 type FetchByDigestConfig struct {
-	//Mediatype specifies mediatype header to append for fetch request
+	// Mediatype specifies mediatype header to append for fetch request
 	Mediatype string
 }
 

--- a/core/runtime/monitor.go
+++ b/core/runtime/monitor.go
@@ -37,8 +37,7 @@ func NewNoopMonitor() TaskMonitor {
 	return &noopTaskMonitor{}
 }
 
-type noopTaskMonitor struct {
-}
+type noopTaskMonitor struct{}
 
 func (mm *noopTaskMonitor) Monitor(c Task, labels map[string]string) error {
 	return nil

--- a/core/runtime/nsmap.go
+++ b/core/runtime/nsmap.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
+
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 
 type object interface {

--- a/core/runtime/opts/opts_linux.go
+++ b/core/runtime/opts/opts_linux.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containerd/cgroups/v3"
 	cgroup1 "github.com/containerd/cgroups/v3/cgroup1"
 	cgroup2 "github.com/containerd/cgroups/v3/cgroup2"
+
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 

--- a/core/runtime/restart/restart.go
+++ b/core/runtime/restart/restart.go
@@ -36,9 +36,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containerd/log"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
-	"github.com/containerd/log"
 )
 
 const (

--- a/core/runtime/runtime.go
+++ b/core/runtime/runtime.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/typeurl/v2"
+
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 // IO holds process IO information

--- a/core/runtime/v2/binary.go
+++ b/core/runtime/v2/binary.go
@@ -26,13 +26,14 @@ import (
 	gruntime "runtime"
 
 	"github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/log"
+
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/containerd/containerd/v2/pkg/protobuf/types"
 	client "github.com/containerd/containerd/v2/pkg/shim"
-	"github.com/containerd/log"
 )
 
 type shimBinaryConfig struct {
@@ -125,7 +126,7 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 		f.Close()
 	}
 	// Save runtime binary path for restore.
-	if err := os.WriteFile(filepath.Join(b.bundle.Path, "shim-binary-path"), []byte(b.runtime), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(b.bundle.Path, "shim-binary-path"), []byte(b.runtime), 0o600); err != nil {
 		return nil, err
 	}
 
@@ -184,7 +185,6 @@ func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 			Opts:         nil,
 			Args:         args,
 		})
-
 	if err != nil {
 		return nil, err
 	}

--- a/core/runtime/v2/bridge.go
+++ b/core/runtime/v2/bridge.go
@@ -20,13 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	v2 "github.com/containerd/containerd/api/runtime/task/v2"
+	api "github.com/containerd/containerd/api/runtime/task/v3" // Current version used by TaskServiceClient
 	"github.com/containerd/ttrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
-
-	v2 "github.com/containerd/containerd/api/runtime/task/v2"
-
-	api "github.com/containerd/containerd/api/runtime/task/v3" // Current version used by TaskServiceClient
 )
 
 // TaskServiceClient exposes a client interface to shims, which aims to hide

--- a/core/runtime/v2/bundle.go
+++ b/core/runtime/v2/bundle.go
@@ -22,12 +22,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containerd/typeurl/v2"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/typeurl/v2"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // LoadBundle loads an existing bundle from disk
@@ -68,10 +69,10 @@ func NewBundle(ctx context.Context, root, state, id string, spec typeurl.Any) (b
 		}
 	}()
 	// create state directory for the bundle
-	if err := os.MkdirAll(filepath.Dir(b.Path), 0711); err != nil {
+	if err := os.MkdirAll(filepath.Dir(b.Path), 0o711); err != nil {
 		return nil, err
 	}
-	if err := os.Mkdir(b.Path, 0700); err != nil {
+	if err := os.Mkdir(b.Path, 0o700); err != nil {
 		return nil, err
 	}
 	if typeurl.Is(spec, &specs.Spec{}) {
@@ -81,20 +82,20 @@ func NewBundle(ctx context.Context, root, state, id string, spec typeurl.Any) (b
 	}
 	paths = append(paths, b.Path)
 	// create working directory for the bundle
-	if err := os.MkdirAll(filepath.Dir(work), 0711); err != nil {
+	if err := os.MkdirAll(filepath.Dir(work), 0o711); err != nil {
 		return nil, err
 	}
 	rootfs := filepath.Join(b.Path, "rootfs")
-	if err := os.MkdirAll(rootfs, 0711); err != nil {
+	if err := os.MkdirAll(rootfs, 0o711); err != nil {
 		return nil, err
 	}
 	paths = append(paths, rootfs)
-	if err := os.Mkdir(work, 0711); err != nil {
+	if err := os.Mkdir(work, 0o711); err != nil {
 		if !os.IsExist(err) {
 			return nil, err
 		}
 		os.RemoveAll(work)
-		if err := os.Mkdir(work, 0711); err != nil {
+		if err := os.Mkdir(work, 0o711); err != nil {
 			return nil, err
 		}
 	}
@@ -106,7 +107,7 @@ func NewBundle(ctx context.Context, root, state, id string, spec typeurl.Any) (b
 	if spec := spec.GetValue(); spec != nil {
 		// write the spec to the bundle
 		specPath := filepath.Join(b.Path, oci.ConfigFilename)
-		err = os.WriteFile(specPath, spec, 0666)
+		err = os.WriteFile(specPath, spec, 0o666)
 		if err != nil {
 			return nil, fmt.Errorf("failed to write bundle spec: %w", err)
 		}

--- a/core/runtime/v2/bundle_linux.go
+++ b/core/runtime/v2/bundle_linux.go
@@ -38,7 +38,7 @@ func prepareBundleDirectoryPermissions(path string, spec []byte) error {
 	if err := os.Chown(path, -1, int(gid)); err != nil {
 		return err
 	}
-	return os.Chmod(path, 0710)
+	return os.Chmod(path, 0o710)
 }
 
 // ociSpecUserNS is a subset of specs.Spec used to reduce garbage during

--- a/core/runtime/v2/example/example.go
+++ b/core/runtime/v2/example/example.go
@@ -23,14 +23,15 @@ import (
 
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
 	apitypes "github.com/containerd/containerd/api/types"
-	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/containerd/v2/pkg/shim"
-	"github.com/containerd/containerd/v2/pkg/shutdown"
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"github.com/containerd/ttrpc"
+
+	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
+	"github.com/containerd/containerd/v2/pkg/shim"
+	"github.com/containerd/containerd/v2/pkg/shutdown"
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 func init() {
@@ -91,12 +92,9 @@ func newTaskService(ctx context.Context, publisher shim.Publisher, sd shutdown.S
 	return &exampleTaskService{}, nil
 }
 
-var (
-	_ = shim.TTRPCService(&exampleTaskService{})
-)
+var _ = shim.TTRPCService(&exampleTaskService{})
 
-type exampleTaskService struct {
-}
+type exampleTaskService struct{}
 
 // RegisterTTRPC allows TTRPC services to be registered with the underlying server
 func (s *exampleTaskService) RegisterTTRPC(server *ttrpc.Server) error {

--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -28,11 +28,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials/insecure"
-
 	crmetadata "github.com/checkpoint-restore/checkpointctl/lib"
 	eventstypes "github.com/containerd/containerd/api/events"
 	task "github.com/containerd/containerd/api/runtime/task/v3"
@@ -43,6 +38,10 @@ import (
 	"github.com/containerd/otelttrpc"
 	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl/v2"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/containerd/containerd/v2/core/events/exchange"
 	"github.com/containerd/containerd/v2/core/runtime"
@@ -396,8 +395,10 @@ type shim struct {
 	version int
 }
 
-var _ ShimInstance = (*shim)(nil)
-var _ clientVersionDowngrader = (*shim)(nil)
+var (
+	_ ShimInstance            = (*shim)(nil)
+	_ clientVersionDowngrader = (*shim)(nil)
+)
 
 // ID of the shim/task
 func (s *shim) ID() string {
@@ -649,7 +650,6 @@ func (s *shimTask) Create(ctx context.Context, opts runtime.CreateOpts) (runtime
 				rootfs,
 				decompressed,
 			)
-
 			if err != nil {
 				return nil, fmt.Errorf("unpacking of rootfs-diff archive %s into %s failed: %w", rootfsDiffTar.Name(), rootfs, err)
 			}

--- a/core/runtime/v2/shim_load.go
+++ b/core/runtime/v2/shim_load.go
@@ -33,7 +33,7 @@ import (
 
 // LoadExistingShims loads existing shims from the path specified by stateDir
 // rootDir is for cleaning up the unused paths of removed shims.
-func (m *ShimManager) LoadExistingShims(ctx context.Context, stateDir string, rootDir string) error {
+func (m *ShimManager) LoadExistingShims(ctx context.Context, stateDir, rootDir string) error {
 	nsDirs, err := os.ReadDir(stateDir)
 	if err != nil {
 		return err

--- a/core/runtime/v2/shim_manager.go
+++ b/core/runtime/v2/shim_manager.go
@@ -26,6 +26,12 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	"github.com/containerd/typeurl/v2"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/events/exchange"
 	"github.com/containerd/containerd/v2/core/metadata"
@@ -36,11 +42,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
-	"github.com/containerd/typeurl/v2"
 )
 
 // ShimConfig for the shim
@@ -226,7 +227,7 @@ func (m *ShimManager) Start(ctx context.Context, id string, bundle *Bundle, opts
 
 	if !shouldInvokeShimBinary {
 		// Write sandbox ID this task belongs to.
-		if err := os.WriteFile(filepath.Join(bundle.Path, "sandbox"), []byte(opts.SandboxID), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(bundle.Path, "sandbox"), []byte(opts.SandboxID), 0o600); err != nil {
 			return nil, err
 		}
 

--- a/core/runtime/v2/shim_unix.go
+++ b/core/runtime/v2/shim_unix.go
@@ -32,7 +32,7 @@ import (
 )
 
 func openShimLog(ctx context.Context, bundle *Bundle, _ func(string, time.Duration) (net.Conn, error)) (io.ReadCloser, error) {
-	return fifo.OpenFifo(ctx, filepath.Join(bundle.Path, "log"), unix.O_RDWR|unix.O_CREAT|unix.O_NONBLOCK, 0700)
+	return fifo.OpenFifo(ctx, filepath.Join(bundle.Path, "log"), unix.O_RDWR|unix.O_CREAT|unix.O_NONBLOCK, 0o700)
 }
 
 func checkCopyShimLogError(ctx context.Context, err error) error {

--- a/core/runtime/v2/shim_windows.go
+++ b/core/runtime/v2/shim_windows.go
@@ -48,6 +48,7 @@ func (dpc *deferredPipeConnection) Read(p []byte) (n int, err error) {
 	}
 	return dpc.c.Read(p)
 }
+
 func (dpc *deferredPipeConnection) Close() error {
 	var err error
 	dpc.once.Do(func() {

--- a/core/runtime/v2/task_manager.go
+++ b/core/runtime/v2/task_manager.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"slices"
 
+	apitypes "github.com/containerd/containerd/api/types"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -33,8 +34,6 @@ import (
 	"github.com/containerd/typeurl/v2"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-spec/specs-go/features"
-
-	apitypes "github.com/containerd/containerd/api/types"
 
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
@@ -74,7 +73,7 @@ func init() {
 			shimManager := shimManagerI.(*ShimManager)
 			root, state := ic.Properties[plugins.PropertyRootDir], ic.Properties[plugins.PropertyStateDir]
 			for _, d := range []string{root, state} {
-				if err := os.MkdirAll(d, 0711); err != nil {
+				if err := os.MkdirAll(d, 0o711); err != nil {
 					return nil, err
 				}
 			}
@@ -235,7 +234,6 @@ func (m *TaskManager) Delete(ctx context.Context, taskID string) (*runtime.Exit,
 	exit, err := shimTask.delete(ctx, sandboxed, func(ctx context.Context, id string) {
 		m.manager.shims.Delete(ctx, id)
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete task: %w", err)
 	}

--- a/core/sandbox/bridge.go
+++ b/core/sandbox/bridge.go
@@ -20,10 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	api "github.com/containerd/containerd/api/runtime/sandbox/v1"
 	"github.com/containerd/ttrpc"
 	"google.golang.org/grpc"
-
-	api "github.com/containerd/containerd/api/runtime/sandbox/v1"
 )
 
 // NewClient returns a new sandbox client that handles both GRPC and TTRPC clients.

--- a/core/sandbox/controller.go
+++ b/core/sandbox/controller.go
@@ -22,9 +22,10 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/api/types"
-	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/typeurl/v2"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 type CreateOptions struct {

--- a/core/sandbox/helpers.go
+++ b/core/sandbox/helpers.go
@@ -18,9 +18,10 @@ package sandbox
 
 import (
 	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/typeurl/v2"
+
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	gogo_types "github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/typeurl/v2"
 )
 
 // ToProto will map Sandbox struct to it's protobuf definition

--- a/core/sandbox/proxy/controller.go
+++ b/core/sandbox/proxy/controller.go
@@ -208,7 +208,8 @@ func (s *remoteSandboxController) Update(
 	ctx context.Context,
 	sandboxID string,
 	sb sandbox.Sandbox,
-	fields ...string) error {
+	fields ...string,
+) error {
 	apiSandbox := sandbox.ToProto(&sb)
 	_, err := s.client.Update(ctx, &api.ControllerUpdateRequest{
 		SandboxID: sandboxID,

--- a/core/sandbox/store.go
+++ b/core/sandbox/store.go
@@ -85,7 +85,7 @@ func (s *Sandbox) AddExtension(name string, obj interface{}) error {
 }
 
 // AddLabel adds a label to sandbox's labels.
-func (s *Sandbox) AddLabel(name string, value string) {
+func (s *Sandbox) AddLabel(name, value string) {
 	if s.Labels == nil {
 		s.Labels = map[string]string{}
 	}

--- a/core/snapshots/proxy/convert.go
+++ b/core/snapshots/proxy/convert.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
+
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 )

--- a/core/snapshots/storage/bolt.go
+++ b/core/snapshots/storage/bolt.go
@@ -25,12 +25,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/metadata/boltutil"
-	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/errdefs"
 	bolt "go.etcd.io/bbolt"
 	errbolt "go.etcd.io/bbolt/errors"
+
+	"github.com/containerd/containerd/v2/core/metadata/boltutil"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/pkg/filters"
 )
 
 var (
@@ -228,9 +229,7 @@ func CreateSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string
 	}
 
 	err = createBucketIfNotExists(ctx, func(ctx context.Context, bkt, pbkt *bolt.Bucket) error {
-		var (
-			spbkt *bolt.Bucket
-		)
+		var spbkt *bolt.Bucket
 		if parent != "" {
 			spbkt = bkt.Bucket([]byte(parent))
 			if spbkt == nil {

--- a/core/snapshots/storage/metastore.go
+++ b/core/snapshots/storage/metastore.go
@@ -27,9 +27,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/log"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
 )
 
 // Transactor is used to finalize an active transaction.
@@ -100,7 +101,7 @@ type transactionKey struct{}
 func (ms *MetaStore) TransactionContext(ctx context.Context, writable bool) (context.Context, Transactor, error) {
 	ms.dbL.Lock()
 	if ms.db == nil {
-		db, err := bolt.Open(ms.dbfile, 0600, &ms.opts)
+		db, err := bolt.Open(ms.dbfile, 0o600, &ms.opts)
 		if err != nil {
 			ms.dbL.Unlock()
 			return ctx, nil, fmt.Errorf("failed to open database file: %w", err)

--- a/core/transfer/archive/exporter.go
+++ b/core/transfer/archive/exporter.go
@@ -20,19 +20,19 @@ import (
 	"context"
 	"io"
 
+	"github.com/containerd/containerd/api/types"
+	transfertypes "github.com/containerd/containerd/api/types/transfer"
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
 	"github.com/containerd/typeurl/v2"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/containerd/containerd/api/types"
-	transfertypes "github.com/containerd/containerd/api/types/transfer"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/archive"
 	"github.com/containerd/containerd/v2/core/streaming"
 	"github.com/containerd/containerd/v2/core/transfer/plugins"
 	tstreaming "github.com/containerd/containerd/v2/core/transfer/streaming"
-	"github.com/containerd/log"
-	"github.com/containerd/platforms"
 )
 
 func init() {

--- a/core/transfer/archive/importer.go
+++ b/core/transfer/archive/importer.go
@@ -20,16 +20,16 @@ import (
 	"context"
 	"io"
 
+	transferapi "github.com/containerd/containerd/api/types/transfer"
+	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	transferapi "github.com/containerd/containerd/api/types/transfer"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images/archive"
 	"github.com/containerd/containerd/v2/core/streaming"
 	tstreaming "github.com/containerd/containerd/v2/core/transfer/streaming"
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
-	"github.com/containerd/log"
 )
 
 type ImportOpt func(*ImageImportStream)

--- a/core/transfer/image/imagestore.go
+++ b/core/transfer/image/imagestore.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/containerd/api/types"
+	transfertypes "github.com/containerd/containerd/api/types/transfer"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
 	"github.com/containerd/typeurl/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/containerd/containerd/api/types"
-	transfertypes "github.com/containerd/containerd/api/types/transfer"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/archive"
@@ -32,8 +34,6 @@ import (
 	"github.com/containerd/containerd/v2/core/streaming"
 	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/core/transfer/plugins"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
 )
 
 func init() {
@@ -139,7 +139,7 @@ func WithNamedPrefix(name string, allowOverwrite bool) StoreOpt {
 // the image which does not have name as the prefix
 // - skipNamed: is set if no digest reference should be created if a named reference
 // is successfully resolved from the annotations.
-func WithDigestRef(name string, allowOverwrite bool, skipNamed bool) StoreOpt {
+func WithDigestRef(name string, allowOverwrite, skipNamed bool) StoreOpt {
 	ref := Reference{
 		Name:            name,
 		IsPrefix:        true,
@@ -418,6 +418,7 @@ func referencesFromProto(references []*transfertypes.ImageReference) []Reference
 	}
 	return or
 }
+
 func unpackToProto(uc []transfer.UnpackConfiguration) []*transfertypes.UnpackConfiguration {
 	auc := make([]*transfertypes.UnpackConfiguration, len(uc))
 	for i := range uc {

--- a/core/transfer/local/import.go
+++ b/core/transfer/local/import.go
@@ -21,10 +21,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"

--- a/core/transfer/local/progress.go
+++ b/core/transfer/local/progress.go
@@ -22,13 +22,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/remotes"
-	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/transfer"
 )
 
 type ProgressTracker struct {
@@ -60,7 +61,7 @@ type jobStatus struct {
 type jobUpdate struct {
 	desc   ocispec.Descriptor
 	exists bool
-	//children []ocispec.Descriptor
+	// children []ocispec.Descriptor
 }
 
 type ActiveJobs interface {
@@ -164,7 +165,7 @@ func (j *ProgressTracker) HandleProgress(ctx context.Context, pf transfer.Progre
 					Event:   "waiting",
 					Name:    name,
 					Parents: parents,
-					//Digest:   desc.Digest.String(),
+					// Digest:   desc.Digest.String(),
 					Progress: 0,
 					Total:    update.desc.Size,
 					Desc:     &job.desc,
@@ -210,7 +211,6 @@ func (j *ProgressTracker) MarkExists(desc ocispec.Descriptor) {
 		desc:   desc,
 		exists: true,
 	}
-
 }
 
 // AddChildren adds hierarchy information
@@ -223,7 +223,6 @@ func (j *ProgressTracker) AddChildren(desc ocispec.Descriptor, children []ocispe
 	for _, child := range children {
 		j.parents[child.Digest] = append(j.parents[child.Digest], desc)
 	}
-
 }
 
 func (j *ProgressTracker) Wait() {

--- a/core/transfer/local/push.go
+++ b/core/transfer/local/push.go
@@ -22,14 +22,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/remotes"
-	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/transfer"
 )
 
 func (ts *localTransferService) push(ctx context.Context, ig transfer.ImageGetter, p transfer.ImagePusher, tops *transfer.Config) error {
@@ -52,7 +53,7 @@ func (ts *localTransferService) push(ctx context.Context, ig transfer.ImageGette
 		tops.Progress(transfer.Progress{
 			Event: "pushing content",
 			Name:  img.Name,
-			//Digest: img.Target.Digest.String(),
+			// Digest: img.Target.Digest.String(),
 			Desc: &img.Target,
 		})
 	}
@@ -67,7 +68,7 @@ func (ts *localTransferService) push(ctx context.Context, ig transfer.ImageGette
 
 	ctx, cancel := context.WithCancel(ctx)
 	if tops.Progress != nil {
-		progressTracker := NewProgressTracker(img.Name, "uploading") //Pass in first name as root
+		progressTracker := NewProgressTracker(img.Name, "uploading") // Pass in first name as root
 
 		p := newProgressPusher(pusher, progressTracker)
 		go progressTracker.HandleProgress(ctx, tops.Progress, p)
@@ -99,7 +100,7 @@ func (ts *localTransferService) push(ctx context.Context, ig transfer.ImageGette
 		tops.Progress(transfer.Progress{
 			Event: "pushed content",
 			Name:  img.Name,
-			//Digest: img.Target.Digest.String(),
+			// Digest: img.Target.Digest.String(),
 			Desc: &img.Target,
 		})
 		tops.Progress(transfer.Progress{
@@ -133,7 +134,6 @@ func newProgressPusher(pusher remotes.Pusher, progress *ProgressTracker) *progre
 			complete: map[digest.Digest]struct{}{},
 		},
 	}
-
 }
 
 func (p *progressPusher) WrapHandler(h images.Handler) images.Handler {
@@ -201,6 +201,7 @@ func (ps *pushStatus) add(ref string, d ocispec.Descriptor) {
 	}
 	ps.l.Unlock()
 }
+
 func (ps *pushStatus) markComplete(ref string, d ocispec.Descriptor) {
 	ps.l.Lock()
 	_, ok := ps.statuses[ref]
@@ -209,7 +210,6 @@ func (ps *pushStatus) markComplete(ref string, d ocispec.Descriptor) {
 	}
 	ps.complete[d.Digest] = struct{}{}
 	ps.l.Unlock()
-
 }
 
 func (ps *pushStatus) Status(name string) (content.Status, bool) {
@@ -251,6 +251,7 @@ func (pw *progressWriter) Write(p []byte) (n int, err error) {
 	pw.status.update(pw.ref, n)
 	return
 }
+
 func (pw *progressWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
 	err := pw.Writer.Commit(ctx, size, expected, opts...)
 	if err != nil {

--- a/core/transfer/local/transfer.go
+++ b/core/transfer/local/transfer.go
@@ -22,10 +22,9 @@ import (
 	"io"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
 	"golang.org/x/sync/semaphore"
-
-	"github.com/containerd/errdefs"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
@@ -60,7 +59,7 @@ func NewTransferService(cs content.Store, is images.Store, tc TransferConfig) tr
 	return ts
 }
 
-func (ts *localTransferService) Transfer(ctx context.Context, src interface{}, dest interface{}, opts ...transfer.Opt) error {
+func (ts *localTransferService) Transfer(ctx context.Context, src, dest interface{}, opts ...transfer.Opt) error {
 	topts := &transfer.Config{}
 	for _, opt := range opts {
 		opt(topts)

--- a/core/transfer/proxy/transfer.go
+++ b/core/transfer/proxy/transfer.go
@@ -22,10 +22,6 @@ import (
 	"fmt"
 	"io"
 
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/emptypb"
-
 	transferapi "github.com/containerd/containerd/api/services/transfer/v1"
 	transfertypes "github.com/containerd/containerd/api/types/transfer"
 	"github.com/containerd/errdefs"
@@ -34,6 +30,9 @@ import (
 	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/containerd/containerd/v2/core/streaming"
 	"github.com/containerd/containerd/v2/core/transfer"
@@ -85,7 +84,7 @@ func (c convertClient) Transfer(ctx context.Context, r *transferapi.TransferRequ
 	return c.TransferClient.Transfer(ctx, r)
 }
 
-func (p *proxyTransferrer) Transfer(ctx context.Context, src interface{}, dst interface{}, opts ...transfer.Opt) error {
+func (p *proxyTransferrer) Transfer(ctx context.Context, src, dst interface{}, opts ...transfer.Opt) error {
 	o := &transfer.Config{}
 	for _, opt := range opts {
 		opt(o)
@@ -154,6 +153,7 @@ func (p *proxyTransferrer) Transfer(ctx context.Context, src interface{}, dst in
 	_, err = p.client.Transfer(ctx, req)
 	return errgrpc.ToNative(err)
 }
+
 func (p *proxyTransferrer) marshalAny(ctx context.Context, i interface{}) (typeurl.Any, error) {
 	switch m := i.(type) {
 	case streamMarshaler:

--- a/core/transfer/registry/registry.go
+++ b/core/transfer/registry/registry.go
@@ -26,6 +26,10 @@ import (
 	"sync"
 
 	transfertypes "github.com/containerd/containerd/api/types/transfer"
+	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/remotes/docker/config"
@@ -34,9 +38,6 @@ import (
 	"github.com/containerd/containerd/v2/core/transfer/plugins"
 	tstreaming "github.com/containerd/containerd/v2/core/transfer/streaming"
 	"github.com/containerd/containerd/v2/pkg/httpdbg"
-	"github.com/containerd/log"
-	"github.com/containerd/typeurl/v2"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func init() {
@@ -226,7 +227,7 @@ func (r *OCIRegistry) Fetcher(ctx context.Context, ref string) (transfer.Fetcher
 }
 
 func (r *OCIRegistry) Pusher(ctx context.Context, desc ocispec.Descriptor) (transfer.Pusher, error) {
-	var ref = r.reference
+	ref := r.reference
 	// Annotate ref with digest to push only push tag for single digest
 	if !strings.Contains(ref, "@") {
 		ref = ref + "@" + desc.Digest.String()
@@ -299,7 +300,6 @@ func (r *OCIRegistry) MarshalAny(ctx context.Context, sm streaming.StreamCreator
 					return
 				}
 			}
-
 		}()
 		res.AuthStream = sid
 	}

--- a/core/transfer/streaming/reader.go
+++ b/core/transfer/streaming/reader.go
@@ -23,8 +23,9 @@ import (
 	"io"
 
 	transferapi "github.com/containerd/containerd/api/types/transfer"
-	"github.com/containerd/containerd/v2/core/streaming"
 	"github.com/containerd/typeurl/v2"
+
+	"github.com/containerd/containerd/v2/core/streaming"
 )
 
 type readByteStream struct {
@@ -68,7 +69,6 @@ func ReadByteStream(ctx context.Context, stream streaming.Stream) io.ReadCloser 
 				rbs.errCh <- err
 			}
 		}
-
 	}()
 	return rbs
 }
@@ -113,7 +113,6 @@ func (r *readByteStream) Read(p []byte) (n int, err error) {
 	default:
 		return 0, fmt.Errorf("stream received error type %v", v)
 	}
-
 }
 
 func (r *readByteStream) Close() error {

--- a/core/transfer/streaming/stream.go
+++ b/core/transfer/streaming/stream.go
@@ -27,13 +27,16 @@ import (
 	"time"
 
 	transferapi "github.com/containerd/containerd/api/types/transfer"
-	"github.com/containerd/containerd/v2/core/streaming"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
+
+	"github.com/containerd/containerd/v2/core/streaming"
 )
 
-const maxRead = 32 * 1024
-const windowSize = 2 * maxRead
+const (
+	maxRead    = 32 * 1024
+	windowSize = 2 * maxRead
+)
 
 var bufPool = &sync.Pool{
 	New: func() interface{} {
@@ -196,7 +199,6 @@ func ReceiveStream(ctx context.Context, stream streaming.Stream) io.Reader {
 				continue
 			}
 		}
-
 	}()
 
 	return r

--- a/core/transfer/streaming/writer.go
+++ b/core/transfer/streaming/writer.go
@@ -23,9 +23,10 @@ import (
 	"sync/atomic"
 
 	transferapi "github.com/containerd/containerd/api/types/transfer"
-	"github.com/containerd/containerd/v2/core/streaming"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
+
+	"github.com/containerd/containerd/v2/core/streaming"
 )
 
 func WriteByteStream(ctx context.Context, stream streaming.Stream) io.WriteCloser {

--- a/core/transfer/transfer.go
+++ b/core/transfer/transfer.go
@@ -20,16 +20,15 @@ import (
 	"context"
 	"io"
 
-	"golang.org/x/sync/semaphore"
-
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 )
 
 type Transferrer interface {
-	Transfer(ctx context.Context, source interface{}, destination interface{}, opts ...Opt) error
+	Transfer(ctx context.Context, source, destination interface{}, opts ...Opt) error
 }
 
 type ImageResolver interface {

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -23,9 +23,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/containerd/log/logtest"
+
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/containerd/log/logtest"
 )
 
 const (

--- a/integration/client/daemon.go
+++ b/integration/client/daemon.go
@@ -28,8 +28,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd/v2/client"
 	"github.com/containerd/plugin"
+
+	"github.com/containerd/containerd/v2/client"
 )
 
 type daemon struct {

--- a/integration/client/tracing.go
+++ b/integration/client/tracing.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-//This file defines funcs to adding integration test around opentelemetry tracing by
+// This file defines funcs to adding integration test around opentelemetry tracing by
 // First, create tracer provider and in memory exporter to store generated spans from code.
 // Then run the instrumented code where we expect spans.
 // Then we check if the spans in exporter match expectation, like span name, status code and etc.
@@ -33,10 +33,10 @@ import (
 // newInMemoryExporterTracer creates in memory exporter and tracer provider to be
 // used as tracing test
 func newInMemoryExporterTracer() (*tracetest.InMemoryExporter, *sdktrace.TracerProvider) {
-	//create in memory exporter
+	// create in memory exporter
 	exp := tracetest.NewInMemoryExporter()
 
-	//create tracer provider
+	// create tracer provider
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exp),
 	)
@@ -48,8 +48,8 @@ func newInMemoryExporterTracer() (*tracetest.InMemoryExporter, *sdktrace.TracerP
 // name and the status code is not error
 func validateRootSpan(t *testing.T, spanNameExpected string, spans []tracetest.SpanStub) {
 	for _, span := range spans {
-		//We only look for root span
-		//A span is root span if its parent SpanContext is invalid
+		// We only look for root span
+		// A span is root span if its parent SpanContext is invalid
 		if !span.Parent.IsValid() {
 			if span.Name == spanNameExpected {
 				assert.NotEqual(t, span.Status.Code, codes.Error)

--- a/integration/failpoint/cmd/cni-bridge-fp/main_linux.go
+++ b/integration/failpoint/cmd/cni-bridge-fp/main_linux.go
@@ -25,11 +25,12 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/containerd/containerd/v2/internal/failpoint"
 	"github.com/containerd/continuity"
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/version"
+
+	"github.com/containerd/containerd/v2/internal/failpoint"
 )
 
 const delegatedPlugin = "bridge"
@@ -154,7 +155,6 @@ func (c *failpointControl) delegatedEvalFn(cmdKind string) (failpoint.EvalFn, er
 
 		*fpStr = fp.Marshal()
 		return nil
-
 	}); err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (c *failpointControl) delegatedEvalFn(cmdKind string) (failpoint.EvalFn, er
 }
 
 func (c *failpointControl) updateTx(updateFn func(conf *failpointConf) error) error {
-	f, err := os.OpenFile(c.confPath, os.O_RDWR, 0666)
+	f, err := os.OpenFile(c.confPath, os.O_RDWR, 0o666)
 	if err != nil {
 		return fmt.Errorf("failed to open confPath %s: %w", c.confPath, err)
 	}
@@ -191,7 +191,7 @@ func (c *failpointControl) updateTx(updateFn func(conf *failpointConf) error) er
 	if err != nil {
 		return fmt.Errorf("failed to marshal failpoint conf: %w", err)
 	}
-	return continuity.AtomicWriteFile(c.confPath, data, 0666)
+	return continuity.AtomicWriteFile(c.confPath, data, 0o666)
 }
 
 func nopEvalFn() error {

--- a/integration/failpoint/cmd/containerd-shim-runc-fp-v1/plugin_linux.go
+++ b/integration/failpoint/cmd/containerd-shim-runc-fp-v1/plugin_linux.go
@@ -24,15 +24,16 @@ import (
 	"strings"
 
 	taskapi "github.com/containerd/containerd/api/runtime/task/v3"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	"github.com/containerd/ttrpc"
+
 	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/task"
 	"github.com/containerd/containerd/v2/internal/failpoint"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/pkg/shim"
 	"github.com/containerd/containerd/v2/pkg/shutdown"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
-	"github.com/containerd/ttrpc"
 )
 
 const (
@@ -73,9 +74,7 @@ func init() {
 	})
 }
 
-var (
-	_ = shim.TTRPCServerUnaryOptioner(&taskServiceWithFp{})
-)
+var _ = shim.TTRPCServerUnaryOptioner(&taskServiceWithFp{})
 
 type taskServiceWithFp struct {
 	fps   map[string]*failpoint.Failpoint

--- a/integration/failpoint/cmd/runc-fp/delayexec.go
+++ b/integration/failpoint/cmd/runc-fp/delayexec.go
@@ -82,11 +82,11 @@ func fifoFromProcessEnv() (fifosync.Trigger, fifosync.Waiter, error) {
 		return nil, nil, fmt.Errorf("fifo: failed to find %q env var in %v", failpoint.DelayExecDelayEnv, env)
 	}
 	logrus.WithField("ready", readyName).WithField("delay", delayName).Debug("Found FIFOs!")
-	readyFIFO, err := fifosync.NewTrigger(readyName, 0600)
+	readyFIFO, err := fifosync.NewTrigger(readyName, 0o600)
 	if err != nil {
 		return nil, nil, err
 	}
-	delayFIFO, err := fifosync.NewWaiter(delayName, 0600)
+	delayFIFO, err := fifosync.NewWaiter(delayName, 0o600)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/integration/failpoint/cmd/runc-fp/main.go
+++ b/integration/failpoint/cmd/runc-fp/main.go
@@ -38,12 +38,10 @@ type invoker func(context.Context) error
 
 type invokerInterceptor func(context.Context, invoker) error
 
-var (
-	failpointProfiles = map[string]invokerInterceptor{
-		"issue9103": issue9103KillInitAfterCreate,
-		"delayExec": delayExec,
-	}
-)
+var failpointProfiles = map[string]invokerInterceptor{
+	"issue9103": issue9103KillInitAfterCreate,
+	"delayExec": delayExec,
+}
 
 // setupLog setups messages into log file.
 func setupLog() {

--- a/integration/images/volume-ownership/tools/get_owner_windows.go
+++ b/integration/images/volume-ownership/tools/get_owner_windows.go
@@ -37,7 +37,6 @@ func main() {
 	secInfo, err := windows.GetNamedSecurityInfo(
 		os.Args[1], windows.SE_FILE_OBJECT,
 		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
-
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/integration/remote/logreduction/logreduction.go
+++ b/integration/remote/logreduction/logreduction.go
@@ -70,7 +70,7 @@ func (l *LogReduction) cleanupErrorTimeouts() {
 
 // ShouldMessageBePrinted determines whether a message should be printed based
 // on how long ago this particular message was last printed
-func (l *LogReduction) ShouldMessageBePrinted(message string, parentID string) bool {
+func (l *LogReduction) ShouldMessageBePrinted(message, parentID string) bool {
 	l.errorMapLock.Lock()
 	defer l.errorMapLock.Unlock()
 	l.cleanupErrorTimeouts()

--- a/integration/remote/remote_image.go
+++ b/integration/remote/remote_image.go
@@ -37,13 +37,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-
-	internalapi "github.com/containerd/containerd/v2/integration/cri-api/pkg/apis"
-	"github.com/containerd/log"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	internalapi "github.com/containerd/containerd/v2/integration/cri-api/pkg/apis"
 	"github.com/containerd/containerd/v2/integration/remote/util"
 )
 

--- a/integration/remote/remote_runtime.go
+++ b/integration/remote/remote_runtime.go
@@ -39,6 +39,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -47,7 +48,6 @@ import (
 	"github.com/containerd/containerd/v2/integration/remote/logreduction"
 	"github.com/containerd/containerd/v2/integration/remote/util"
 	executil "github.com/containerd/containerd/v2/internal/cri/executil"
-	"github.com/containerd/log"
 )
 
 // RuntimeService is a gRPC implementation of internalapi.RuntimeService.
@@ -384,7 +384,7 @@ func (r *RuntimeService) UpdateContainerResources(containerID string, resources 
 
 // ExecSync executes a command in the container, and returns the stdout output.
 // If command exits with a non-zero exit code, an error is returned.
-func (r *RuntimeService) ExecSync(containerID string, cmd []string, timeout time.Duration, opts ...grpc.CallOption) (stdout []byte, stderr []byte, err error) {
+func (r *RuntimeService) ExecSync(containerID string, cmd []string, timeout time.Duration, opts ...grpc.CallOption) (stdout, stderr []byte, err error) {
 	log.L.Infof("[RuntimeService] ExecSync (containerID=%v, timeout=%v)", containerID, timeout)
 	// Do not set timeout when timeout is 0.
 	var ctx context.Context
@@ -501,7 +501,6 @@ func (r *RuntimeService) UpdateRuntimeConfig(runtimeConfig *runtimeapi.RuntimeCo
 	_, err := r.runtimeClient.UpdateRuntimeConfig(ctx, &runtimeapi.UpdateRuntimeConfigRequest{
 		RuntimeConfig: runtimeConfig,
 	}, opts...)
-
 	if err != nil {
 		return err
 	}

--- a/integration/remote/util/util_unix.go
+++ b/integration/remote/util/util_unix.go
@@ -67,7 +67,7 @@ func CreateListener(endpoint string) (net.Listener, error) {
 		return nil, fmt.Errorf("failed to unlink socket file %q: %v", addr, err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(addr), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(addr), 0o750); err != nil {
 		return nil, fmt.Errorf("error creating socket directory %q: %v", filepath.Dir(addr), err)
 	}
 
@@ -116,7 +116,7 @@ func dial(ctx context.Context, addr string) (net.Conn, error) {
 	return (&net.Dialer{}).DialContext(ctx, unixProtocol, addr)
 }
 
-func parseEndpointWithFallbackProtocol(endpoint string, fallbackProtocol string) (protocol string, addr string, err error) {
+func parseEndpointWithFallbackProtocol(endpoint, fallbackProtocol string) (protocol, addr string, err error) {
 	if protocol, addr, err = parseEndpoint(endpoint); err != nil && protocol == "" {
 		fallbackEndpoint := fallbackProtocol + "://" + endpoint
 		protocol, addr, err = parseEndpoint(fallbackEndpoint)

--- a/internal/cri/annotations/annotations.go
+++ b/internal/cri/annotations/annotations.go
@@ -17,9 +17,10 @@
 package annotations
 
 import (
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // ContainerType values

--- a/internal/cri/bandwidth/fake_shaper.go
+++ b/internal/cri/bandwidth/fake_shaper.go
@@ -33,8 +33,9 @@ limitations under the License.
 package bandwidth
 
 import (
-	resource "github.com/containerd/containerd/v2/internal/cri/resourcequantity"
 	"github.com/containerd/errdefs"
+
+	resource "github.com/containerd/containerd/v2/internal/cri/resourcequantity"
 )
 
 // FakeShaper provides an implementation of the bandwidth.Shaper.

--- a/internal/cri/bandwidth/linux.go
+++ b/internal/cri/bandwidth/linux.go
@@ -42,11 +42,12 @@ import (
 	"net"
 	"strings"
 
+	"github.com/containerd/log"
+
 	executil "github.com/containerd/containerd/v2/internal/cri/executil"
 	resource "github.com/containerd/containerd/v2/internal/cri/resourcequantity"
 	"github.com/containerd/containerd/v2/internal/cri/setutils"
 	"github.com/containerd/containerd/v2/internal/lazyregexp"
-	"github.com/containerd/log"
 )
 
 var (

--- a/internal/cri/bandwidth/unsupported.go
+++ b/internal/cri/bandwidth/unsupported.go
@@ -35,12 +35,12 @@ limitations under the License.
 package bandwidth
 
 import (
-	resource "github.com/containerd/containerd/v2/internal/cri/resourcequantity"
 	"github.com/containerd/errdefs"
+
+	resource "github.com/containerd/containerd/v2/internal/cri/resourcequantity"
 )
 
-type unsupportedShaper struct {
-}
+type unsupportedShaper struct{}
 
 // NewTCShaper makes a new unsupportedShapper for the given interface
 func NewTCShaper(iface string) Shaper {

--- a/internal/cri/bandwidth/utils.go
+++ b/internal/cri/bandwidth/utils.go
@@ -38,8 +38,10 @@ import (
 	resource "github.com/containerd/containerd/v2/internal/cri/resourcequantity"
 )
 
-var minRsrc = resource.MustParse("1k")
-var maxRsrc = resource.MustParse("1P")
+var (
+	minRsrc = resource.MustParse("1k")
+	maxRsrc = resource.MustParse("1P")
+)
 
 func validateBandwidthIsReasonable(rsrc *resource.Quantity) error {
 	if rsrc.Value() < minRsrc.Value() {

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -25,13 +25,13 @@ import (
 	"slices"
 	"time"
 
+	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
+	runcoptions "github.com/containerd/containerd/api/types/runc/options"
+	runtimeoptions "github.com/containerd/containerd/api/types/runtimeoptions/v1"
 	"github.com/containerd/log"
 	"github.com/pelletier/go-toml/v2"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
-	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
-	runcoptions "github.com/containerd/containerd/api/types/runc/options"
-	runtimeoptions "github.com/containerd/containerd/api/types/runtimeoptions/v1"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	"github.com/containerd/containerd/v2/internal/cri/opts"
 	streaming "github.com/containerd/containerd/v2/internal/cri/streamingserver"
@@ -714,7 +714,6 @@ func (config *Config) GetSandboxRuntime(podSandboxConfig *runtime.PodSandboxConf
 		return Runtime{}, fmt.Errorf("no runtime for %q is configured", runtimeHandler)
 	}
 	return r, nil
-
 }
 
 // untrustedWorkload returns true if the sandbox contains untrusted workload.

--- a/internal/cri/config/config_unix.go
+++ b/internal/cri/config/config_unix.go
@@ -19,8 +19,9 @@
 package config
 
 import (
-	"github.com/containerd/containerd/v2/defaults"
 	"github.com/pelletier/go-toml/v2"
+
+	"github.com/containerd/containerd/v2/defaults"
 )
 
 func defaultNetworkPluginBinDirs() []string {

--- a/internal/cri/instrument/instrumented_service.go
+++ b/internal/cri/instrument/instrumented_service.go
@@ -25,9 +25,8 @@ import (
 	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
-	"github.com/containerd/containerd/v2/pkg/tracing"
-
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
+	"github.com/containerd/containerd/v2/pkg/tracing"
 )
 
 // criService is an CRI server dependency to be wrapped with instrumentation.

--- a/internal/cri/io/helpers.go
+++ b/internal/cri/io/helpers.go
@@ -87,7 +87,7 @@ func (g *wgCloser) Cancel() {
 // newFifos creates fifos directory for a container.
 func newFifos(root, id string, tty, stdin bool) (*cio.FIFOSet, error) {
 	root = filepath.Join(root, "io")
-	if err := os.MkdirAll(root, 0700); err != nil {
+	if err := os.MkdirAll(root, 0o700); err != nil {
 		return nil, err
 	}
 	fifos, err := cio.NewFIFOSetInDir(root, id, tty)
@@ -177,7 +177,7 @@ func newStdioStream(fifos *cio.FIFOSet) (_ *stdioStream, _ *wgCloser, err error)
 func openStdin(ctx context.Context, url string) (io.WriteCloser, error) {
 	ok := strings.Contains(url, "://")
 	if !ok {
-		return openPipe(ctx, url, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+		return openPipe(ctx, url, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0o700)
 	}
 
 	return openStdinStream(ctx, url)
@@ -194,7 +194,7 @@ func openStdinStream(ctx context.Context, url string) (io.WriteCloser, error) {
 func openOutput(ctx context.Context, url string) (io.ReadCloser, error) {
 	ok := strings.Contains(url, "://")
 	if !ok {
-		return openPipe(ctx, url, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+		return openPipe(ctx, url, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0o700)
 	}
 
 	return openOutputStream(ctx, url)

--- a/internal/cri/io/logger.go
+++ b/internal/cri/io/logger.go
@@ -23,10 +23,10 @@ import (
 	"io"
 	"time"
 
+	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	cioutil "github.com/containerd/containerd/v2/pkg/ioutil"
-	"github.com/containerd/log"
 )
 
 const (

--- a/internal/cri/opts/container.go
+++ b/internal/cri/opts/container.go
@@ -24,14 +24,14 @@ import (
 	"strings"
 
 	"github.com/containerd/continuity/fs"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
 )
 
 // WithNewSnapshot wraps `containerd.WithNewSnapshot` so that if creating the

--- a/internal/cri/opts/spec_darwin_opts.go
+++ b/internal/cri/opts/spec_darwin_opts.go
@@ -90,7 +90,7 @@ func WithDarwinMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra
 				if !os.IsNotExist(err) {
 					return fmt.Errorf("failed to stat %q: %w", src, err)
 				}
-				if err := osi.MkdirAll(src, 0755); err != nil {
+				if err := osi.MkdirAll(src, 0o755); err != nil {
 					return fmt.Errorf("failed to mkdir %q: %w", src, err)
 				}
 			}

--- a/internal/cri/opts/spec_linux.go
+++ b/internal/cri/opts/spec_linux.go
@@ -27,11 +27,10 @@ import (
 	"syscall"
 
 	"github.com/containerd/cgroups/v3"
+	"github.com/containerd/log"
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"tags.cncf.io/container-device-interface/pkg/cdi"
-
-	"github.com/containerd/log"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	cdispec "github.com/containerd/containerd/v2/pkg/cdi"

--- a/internal/cri/opts/spec_linux_opts.go
+++ b/internal/cri/opts/spec_linux_opts.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containerd/log"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -36,7 +37,6 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	osinterface "github.com/containerd/containerd/v2/pkg/os"
-	"github.com/containerd/log"
 )
 
 func withMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*runtime.Mount, mountLabel string, handler *runtime.RuntimeHandler, cgroupWritable bool) oci.SpecOpts {
@@ -112,7 +112,7 @@ func withMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*ru
 				if !os.IsNotExist(err) {
 					return fmt.Errorf("failed to stat %q: %w", src, err)
 				}
-				if err := osi.MkdirAll(src, 0755); err != nil {
+				if err := osi.MkdirAll(src, 0o755); err != nil {
 					return fmt.Errorf("failed to mkdir %q: %w", src, err)
 				}
 			}
@@ -219,7 +219,6 @@ func withMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*ru
 // WithMounts sorts and adds runtime and CRI mounts to the spec
 func WithMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*runtime.Mount, mountLabel string, handler *runtime.RuntimeHandler) oci.SpecOpts {
 	return withMounts(osi, config, extra, mountLabel, handler, false)
-
 }
 
 // WithMountsCgroupWritable sorts and adds runtime and CRI mounts to the spec if cgroup_writable is enabled.

--- a/internal/cri/opts/spec_nonlinux.go
+++ b/internal/cri/opts/spec_nonlinux.go
@@ -21,9 +21,10 @@ package opts
 import (
 	"context"
 
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func isHugetlbControllerPresent() bool {

--- a/internal/cri/opts/spec_nonwindows.go
+++ b/internal/cri/opts/spec_nonwindows.go
@@ -21,12 +21,13 @@ package opts
 import (
 	"context"
 
-	"github.com/containerd/containerd/v2/core/containers"
-	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
 func WithProcessCommandLineOrArgsForWindows(config *runtime.ContainerConfig, image *imagespec.ImageConfig) oci.SpecOpts {

--- a/internal/cri/opts/spec_opts.go
+++ b/internal/cri/opts/spec_opts.go
@@ -346,7 +346,7 @@ func WithNamespacePath(t runtimespec.LinuxNamespaceType, nsPath string) oci.Spec
 }
 
 // WithPodNamespaces sets the pod namespaces for the container
-func WithPodNamespaces(config *runtime.LinuxContainerSecurityContext, sandboxPid uint32, targetPid uint32, uids, gids []runtimespec.LinuxIDMapping) oci.SpecOpts {
+func WithPodNamespaces(config *runtime.LinuxContainerSecurityContext, sandboxPid, targetPid uint32, uids, gids []runtimespec.LinuxIDMapping) oci.SpecOpts {
 	namespaces := config.GetNamespaceOptions()
 
 	opts := []oci.SpecOpts{

--- a/internal/cri/opts/spec_windows.go
+++ b/internal/cri/opts/spec_windows.go
@@ -23,12 +23,13 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/containerd/containerd/v2/core/containers"
-	"github.com/containerd/containerd/v2/pkg/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/windows"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
 func escapeAndCombineArgsWindows(args []string) string {
@@ -81,7 +82,7 @@ func WithProcessCommandLineOrArgsForWindows(config *runtime.ContainerConfig, ima
 
 // getArgs is used to evaluate the overall args for the container by taking into account the image command and entrypoints
 // along with the container command and entrypoints specified through the podspec if any
-func getArgs(imgEntrypoint []string, imgCmd []string, ctrEntrypoint []string, ctrCmd []string) ([]string, bool, error) {
+func getArgs(imgEntrypoint, imgCmd, ctrEntrypoint, ctrCmd []string) ([]string, bool, error) {
 	//nolint:dupword
 	// firstArgFromImg is a flag that is returned to indicate that the first arg in the slice comes from either the image
 	// Entrypoint or Cmd. If the first arg instead comes from the container config (e.g. overriding the image values),

--- a/internal/cri/opts/spec_windows_opts.go
+++ b/internal/cri/opts/spec_windows_opts.go
@@ -24,11 +24,12 @@ import (
 	"sort"
 	"strings"
 
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	osinterface "github.com/containerd/containerd/v2/pkg/os"
-	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // namedPipePath returns true if the given path is to a named pipe.
@@ -62,7 +63,7 @@ func parseMount(osi osinterface.OS, mount *runtime.Mount) (*runtimespec.Mount, e
 			if !os.IsNotExist(err) {
 				return nil, fmt.Errorf("failed to stat %q: %w", src, err)
 			}
-			if err := osi.MkdirAll(src, 0755); err != nil {
+			if err := osi.MkdirAll(src, 0o755); err != nil {
 				return nil, fmt.Errorf("failed to mkdir %q: %w", src, err)
 			}
 		}

--- a/internal/cri/resourcequantity/math.go
+++ b/internal/cri/resourcequantity/math.go
@@ -65,8 +65,10 @@ var (
 	MaxMilliValue = int64(((1 << 63) - 1) / 1000)
 )
 
-const mostNegative = -(mostPositive + 1)
-const mostPositive = 1<<63 - 1
+const (
+	mostNegative = -(mostPositive + 1)
+	mostPositive = 1<<63 - 1
+)
 
 // int64Add returns a+b, or false if that would overflow int64.
 func int64Add(a, b int64) (int64, bool) {
@@ -101,7 +103,7 @@ func int64Multiply(a, b int64) (int64, bool) {
 
 // int64MultiplyScale returns a*b, assuming b is greater than one, or false if that would overflow or underflow int64.
 // Use when b is known to be greater than one.
-func int64MultiplyScale(a int64, b int64) (int64, bool) {
+func int64MultiplyScale(a, b int64) (int64, bool) {
 	if a == 0 || a == 1 {
 		return a * b, true
 	}
@@ -275,7 +277,7 @@ func divideByScaleInt64(base int64, scale Scale) (result, remainder int64, exact
 
 // removeInt64Factors divides in a loop; the return values have the property that
 // value == result * base ^ scale
-func removeInt64Factors(value int64, base int64) (result int64, times int32) {
+func removeInt64Factors(value, base int64) (result int64, times int32) {
 	times = 0
 	result = value
 	negative := result < 0

--- a/internal/cri/server/blockio_linux.go
+++ b/internal/cri/server/blockio_linux.go
@@ -21,8 +21,9 @@ package server
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/v2/pkg/blockio"
 	"github.com/containerd/log"
+
+	"github.com/containerd/containerd/v2/pkg/blockio"
 )
 
 // blockIOClassFromAnnotations examines container and pod annotations of a

--- a/internal/cri/server/cni_conf_syncer.go
+++ b/internal/cri/server/cni_conf_syncer.go
@@ -50,11 +50,11 @@ func newCNINetConfSyncer(confDir string, netPlugin cni.CNI, loadOpts []cni.Opt) 
 	// /etc/cni has to be readable for non-root users (0755), because /etc/cni/tuning/allowlist.conf is used for rootless mode too.
 	// This file was introduced in CNI plugins 1.2.0 (https://github.com/containernetworking/plugins/pull/693), and its path is hard-coded.
 	confDirParent := filepath.Dir(confDir)
-	if err := os.MkdirAll(confDirParent, 0755); err != nil {
+	if err := os.MkdirAll(confDirParent, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create the parent of the cni conf dir=%s: %w", confDirParent, err)
 	}
 
-	if err := os.MkdirAll(confDir, 0700); err != nil {
+	if err := os.MkdirAll(confDir, 0o700); err != nil {
 		return nil, fmt.Errorf("failed to create cni conf dir=%s for watch: %w", confDir, err)
 	}
 

--- a/internal/cri/server/container_attach.go
+++ b/internal/cri/server/container_attach.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"io"
 
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/log"
 	"k8s.io/client-go/tools/remotecommand"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	containerd "github.com/containerd/containerd/v2/client"
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
+	"github.com/containerd/containerd/v2/pkg/tracing"
 )
 
 // Attach prepares a streaming endpoint to attach to a running container, and returns the address.
@@ -46,7 +46,8 @@ func (c *criService) Attach(ctx context.Context, r *runtime.AttachRequest) (*run
 }
 
 func (c *criService) attachContainer(ctx context.Context, id string, stdin io.Reader, stdout, stderr io.WriteCloser,
-	tty bool, resize <-chan remotecommand.TerminalSize) error {
+	tty bool, resize <-chan remotecommand.TerminalSize,
+) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// Get container from our container store.

--- a/internal/cri/server/container_checkpoint.go
+++ b/internal/cri/server/container_checkpoint.go
@@ -22,12 +22,13 @@ import (
 	"context"
 	"time"
 
-	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
-	"github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/errdefs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
+	"github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 )
 
 func (c *criService) checkIfCheckpointOCIImage(ctx context.Context, input string) (string, error) {

--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -34,6 +34,16 @@ import (
 	"github.com/checkpoint-restore/go-criu/v7/stats"
 	"github.com/checkpoint-restore/go-criu/v7/utils"
 	"github.com/containerd/containerd/api/types/runc/options"
+	"github.com/containerd/continuity/fs"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+	"github.com/distribution/reference"
+	"github.com/opencontainers/image-spec/identity"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
@@ -47,16 +57,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/continuity/fs"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/containerd/platforms"
-
-	"github.com/distribution/reference"
-	"github.com/opencontainers/image-spec/identity"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	spec "github.com/opencontainers/runtime-spec/specs-go"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // checkIfCheckpointOCIImage returns checks if the input refers to a checkpoint image.
@@ -214,7 +214,6 @@ func (c *criService) CRImportCheckpoint(
 			archiveFile,
 			[]archive.ApplyOpt{filter}...,
 		)
-
 		if err != nil {
 			return "", fmt.Errorf("unpacking of checkpoint archive %s failed: %w", mountPoint, err)
 		}
@@ -438,7 +437,6 @@ func (c *criService) CRImportCheckpoint(
 		// Start from the beginning of the checkpoint archive
 		archiveFile.Seek(0, 0)
 		_, err = archive.Apply(ctx, containerRootDir, archiveFile, []archive.ApplyOpt{filter}...)
-
 		if err != nil {
 			return "", fmt.Errorf("unpacking of checkpoint archive %s failed: %w", containerRootDir, err)
 		}
@@ -449,7 +447,7 @@ func (c *criService) CRImportCheckpoint(
 	containerLog := filepath.Join(containerRootDir, "container.log")
 	_, err = c.os.Stat(containerLog)
 	if err == nil {
-		if err := c.os.CopyFile(containerLog, meta.LogPath, 0600); err != nil {
+		if err := c.os.CopyFile(containerLog, meta.LogPath, 0o600); err != nil {
 			return "", fmt.Errorf("restoring container log file %s failed: %w", containerLog, err)
 		}
 	}

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -25,6 +25,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+	"github.com/containerd/typeurl/v2"
+	"github.com/davecgh/go-spew/spew"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/selinux/go-selinux"
+	"github.com/opencontainers/selinux/go-selinux/label"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
@@ -38,15 +48,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/blockio"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/pkg/tracing"
-	"github.com/containerd/log"
-	"github.com/containerd/platforms"
-	"github.com/containerd/typeurl/v2"
-	"github.com/davecgh/go-spew/spew"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/opencontainers/selinux/go-selinux"
-	"github.com/opencontainers/selinux/go-selinux/label"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func init() {
@@ -225,7 +226,7 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 	span := tracing.SpanFromContext(r.ctx)
 	// Create container root directory.
 	containerRootDir := c.getContainerRootDir(r.containerID)
-	if err := c.os.MkdirAll(containerRootDir, 0755); err != nil {
+	if err := c.os.MkdirAll(containerRootDir, 0o755); err != nil {
 		return "", fmt.Errorf(
 			"failed to create container root directory %q: %w",
 			containerRootDir,
@@ -244,7 +245,7 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 		}
 	}()
 	volatileContainerRootDir := c.getVolatileContainerRootDir(r.containerID)
-	if err := c.os.MkdirAll(volatileContainerRootDir, 0755); err != nil {
+	if err := c.os.MkdirAll(volatileContainerRootDir, 0o755); err != nil {
 		return "", fmt.Errorf(
 			"failed to create volatile container root directory %q: %w",
 			volatileContainerRootDir,

--- a/internal/cri/server/container_create_linux.go
+++ b/internal/cri/server/container_create_linux.go
@@ -25,10 +25,9 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/pkg/oci"
-
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
 	"github.com/containerd/containerd/v2/internal/cri/sputil"
+	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
 func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {

--- a/internal/cri/server/container_exec.go
+++ b/internal/cri/server/container_exec.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/containerd/containerd/v2/pkg/tracing"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/pkg/tracing"
 )
 
 // Exec prepares a streaming endpoint to execute a command in the container, and returns the address.

--- a/internal/cri/server/container_execsync.go
+++ b/internal/cri/server/container_execsync.go
@@ -24,8 +24,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"k8s.io/client-go/tools/remotecommand"
@@ -37,6 +35,8 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/util"
 	containerdio "github.com/containerd/containerd/v2/pkg/cio"
 	cioutil "github.com/containerd/containerd/v2/pkg/ioutil"
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/containerd/v2/pkg/tracing"
 )
 
 type cappedWriter struct {
@@ -272,7 +272,6 @@ func (c *criService) execInContainer(ctx context.Context, id string, opts execOp
 	span := tracing.SpanFromContext(ctx)
 	// Get container from our container store.
 	cntr, err := c.containerStore.Get(id)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to find container %q in store: %w", id, err)
 	}

--- a/internal/cri/server/container_image_mount.go
+++ b/internal/cri/server/container_image_mount.go
@@ -22,9 +22,6 @@ import (
 	"os"
 	"path/filepath"
 
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/core/leases"
-	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -32,6 +29,10 @@ import (
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	crierrors "k8s.io/cri-api/pkg/errors"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 func (c *criService) mutateMounts(
@@ -140,7 +141,7 @@ func (c *criService) mutateImageMount(
 			}
 		}()
 
-		err = os.MkdirAll(target, 0755)
+		err = os.MkdirAll(target, 0o755)
 		if err != nil {
 			return fmt.Errorf("failed to create directory to image volume target path %q: %w", target, err)
 		}

--- a/internal/cri/server/container_remove.go
+++ b/internal/cri/server/container_remove.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"time"
 
-	containerd "github.com/containerd/containerd/v2/client"
-	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
-	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
+	"github.com/containerd/containerd/v2/pkg/tracing"
 )
 
 // RemoveContainer removes the container.

--- a/internal/cri/server/container_start.go
+++ b/internal/cri/server/container_start.go
@@ -25,13 +25,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/containerd/containerd/v2/pkg/tracing"
+	crmetadata "github.com/checkpoint-restore/checkpointctl/lib"
+	"github.com/checkpoint-restore/go-criu/v7/stats"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
-	crmetadata "github.com/checkpoint-restore/checkpointctl/lib"
-	"github.com/checkpoint-restore/go-criu/v7/stats"
 	containerd "github.com/containerd/containerd/v2/client"
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
@@ -39,6 +38,7 @@ import (
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
 	containerdio "github.com/containerd/containerd/v2/pkg/cio"
 	cioutil "github.com/containerd/containerd/v2/pkg/ioutil"
+	"github.com/containerd/containerd/v2/pkg/tracing"
 )
 
 // StartContainer starts the container.
@@ -114,7 +114,6 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 			ioCreation,
 			filepath.Join(c.getContainerRootDir(r.GetContainerId()), crmetadata.CheckpointDirectory),
 		)
-
 		if err != nil {
 			return nil, fmt.Errorf("failed to restore containerd task: %w", err)
 		}
@@ -317,7 +316,7 @@ func resetContainerStarting(container containerstore.Container) error {
 }
 
 // createContainerLoggers creates container loggers and return write closer for stdout and stderr.
-func (c *criService) createContainerLoggers(logPath string, tty bool) (stdout io.WriteCloser, stderr io.WriteCloser, err error) {
+func (c *criService) createContainerLoggers(logPath string, tty bool) (stdout, stderr io.WriteCloser, err error) {
 	if logPath != "" {
 		// Only generate container log when log path is specified.
 		f, err := openLogFile(logPath)

--- a/internal/cri/server/container_start_linux.go
+++ b/internal/cri/server/container_start_linux.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/internal/userns"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // updateContainerIOOwner updates I/O files' owner to align with initial processe's UID/GID.

--- a/internal/cri/server/container_start_other.go
+++ b/internal/cri/server/container_start_other.go
@@ -21,8 +21,9 @@ package server
 import (
 	"context"
 
-	containerd "github.com/containerd/containerd/v2/client"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerd "github.com/containerd/containerd/v2/client"
 )
 
 // updateContainerIOOwner updates I/O files' owner to align with initial processe's UID/GID.

--- a/internal/cri/server/container_stats_list.go
+++ b/internal/cri/server/container_stats_list.go
@@ -26,16 +26,16 @@ import (
 	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
 	cg1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	cg2 "github.com/containerd/cgroups/v3/cgroup2/stats"
+	"github.com/containerd/containerd/api/services/tasks/v1"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
-	"github.com/containerd/containerd/api/services/tasks/v1"
-	"github.com/containerd/containerd/api/types"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	"github.com/containerd/containerd/v2/internal/cri/store/stats"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
-	"github.com/containerd/errdefs"
 )
 
 // ListContainerStats returns stats of all running containers.

--- a/internal/cri/server/container_status.go
+++ b/internal/cri/server/container_status.go
@@ -21,13 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
-	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
-
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
+	"github.com/containerd/containerd/v2/internal/cri/util"
 )
 
 // ContainerStatus inspects the container and returns the status.

--- a/internal/cri/server/container_status_linux.go
+++ b/internal/cri/server/container_status_linux.go
@@ -21,8 +21,9 @@ import (
 	"errors"
 	"fmt"
 
-	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 )
 
 func toCRIContainerUser(ctx context.Context, container containerstore.Container) (*runtime.ContainerUser, error) {

--- a/internal/cri/server/container_status_other.go
+++ b/internal/cri/server/container_status_other.go
@@ -21,8 +21,9 @@ package server
 import (
 	"context"
 
-	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 )
 
 func toCRIContainerUser(ctx context.Context, container containerstore.Container) (*runtime.ContainerUser, error) {

--- a/internal/cri/server/container_status_windows.go
+++ b/internal/cri/server/container_status_windows.go
@@ -19,8 +19,9 @@ package server
 import (
 	"context"
 
-	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 )
 
 func toCRIContainerUser(ctx context.Context, container containerstore.Container) (*runtime.ContainerUser, error) {

--- a/internal/cri/server/container_stop.go
+++ b/internal/cri/server/container_stop.go
@@ -24,15 +24,15 @@ import (
 	"time"
 
 	eventtypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/moby/sys/signal"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	"github.com/containerd/containerd/v2/pkg/tracing"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-
-	"github.com/moby/sys/signal"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // StopContainer stops a running container with a grace period (i.e., timeout).

--- a/internal/cri/server/container_update_resources.go
+++ b/internal/cri/server/container_update_resources.go
@@ -22,15 +22,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
 )
@@ -78,8 +77,8 @@ func (c *criService) UpdateContainerResources(ctx context.Context, r *runtime.Up
 func (c *criService) updateContainerResources(ctx context.Context,
 	cntr containerstore.Container,
 	r *runtime.UpdateContainerResourcesRequest,
-	status containerstore.Status) (newStatus containerstore.Status, retErr error) {
-
+	status containerstore.Status,
+) (newStatus containerstore.Status, retErr error) {
 	newStatus = status
 	id := cntr.ID
 	// Do not update the container when there is a removal in progress.

--- a/internal/cri/server/container_update_resources_linux.go
+++ b/internal/cri/server/container_update_resources_linux.go
@@ -30,8 +30,8 @@ import (
 
 // updateOCIResource updates container resource limit.
 func updateOCIResource(ctx context.Context, spec *runtimespec.Spec, r *runtime.UpdateContainerResourcesRequest,
-	config criconfig.Config) (*runtimespec.Spec, error) {
-
+	config criconfig.Config,
+) (*runtimespec.Spec, error) {
 	// Copy to make sure old spec is not changed.
 	var cloned runtimespec.Spec
 	if err := util.DeepCopy(&cloned, spec); err != nil {

--- a/internal/cri/server/container_update_resources_windows.go
+++ b/internal/cri/server/container_update_resources_windows.go
@@ -30,8 +30,8 @@ import (
 
 // updateOCIResource updates container resource limit.
 func updateOCIResource(ctx context.Context, spec *runtimespec.Spec, r *runtime.UpdateContainerResourcesRequest,
-	config criconfig.Config) (*runtimespec.Spec, error) {
-
+	config criconfig.Config,
+) (*runtimespec.Spec, error) {
 	// Copy to make sure old spec is not changed.
 	var cloned runtimespec.Spec
 	if err := util.DeepCopy(&cloned, spec); err != nil {

--- a/internal/cri/server/events.go
+++ b/internal/cri/server/events.go
@@ -21,13 +21,12 @@ import (
 	"fmt"
 	"time"
 
+	eventtypes "github.com/containerd/containerd/api/events"
+	apitasks "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	eventtypes "github.com/containerd/containerd/api/events"
-	apitasks "github.com/containerd/containerd/api/services/tasks/v1"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"

--- a/internal/cri/server/events/events.go
+++ b/internal/cri/server/events/events.go
@@ -23,10 +23,10 @@ import (
 	"sync"
 	"time"
 
+	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 
-	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/internal/cri/clock"
 	"github.com/containerd/containerd/v2/internal/cri/constants"

--- a/internal/cri/server/helpers.go
+++ b/internal/cri/server/helpers.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -36,8 +38,6 @@ import (
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
 )
 
 // TODO: Move common helpers for sbserver and podsandbox to a dedicated package once basic services are functinal.
@@ -347,7 +347,7 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 	return status
 }
 
-func (c *criService) generateAndSendContainerEvent(ctx context.Context, containerID string, sandboxID string, eventType runtime.ContainerEventType) {
+func (c *criService) generateAndSendContainerEvent(ctx context.Context, containerID, sandboxID string, eventType runtime.ContainerEventType) {
 	podSandboxStatus, err := c.getPodSandboxStatus(ctx, sandboxID)
 	if err != nil {
 		log.G(ctx).Warnf("Failed to get podSandbox status for container event for sandboxID %q: %v. Sending the event with nil podSandboxStatus.", sandboxID, err)

--- a/internal/cri/server/helpers_linux.go
+++ b/internal/cri/server/helpers_linux.go
@@ -56,10 +56,10 @@ func (c *criService) seccompEnabled() bool {
 
 // openLogFile opens/creates a container log file.
 func openLogFile(path string) (*os.File, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, err
 	}
-	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
+	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640)
 }
 
 // unmountRecursive unmounts the target and all mounts underneath, starting with

--- a/internal/cri/server/helpers_other.go
+++ b/internal/cri/server/helpers_other.go
@@ -27,7 +27,7 @@ import (
 
 // openLogFile opens/creates a container log file.
 func openLogFile(path string) (*os.File, error) {
-	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
+	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640)
 }
 
 // ensureRemoveAll wraps `os.RemoveAll` to check for specific errors that can

--- a/internal/cri/server/images/check.go
+++ b/internal/cri/server/images/check.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
+
+	"github.com/containerd/containerd/v2/core/images"
 )
 
 // LoadImages checks all existing images to ensure they are ready to

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -99,7 +99,6 @@ import (
 
 // PullImage pulls an image with authentication config.
 func (c *GRPCCRIImageService) PullImage(ctx context.Context, r *runtime.PullImageRequest) (_ *runtime.PullImageResponse, err error) {
-
 	imageRef := r.GetImage().GetImage()
 
 	credentials := func(host string) (string, string, error) {
@@ -143,7 +142,6 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 			config := c.config.Registry.Configs[host]
 			if config.Auth != nil {
 				hostauth = toRuntimeAuthConfig(*config.Auth)
-
 			}
 
 			return ParseAuth(hostauth, host)
@@ -264,7 +262,7 @@ func (c *CRIImageService) pullImageWithLocalPull(
 	}
 
 	// Temporarily removed for v2 upgrade
-	//pullOpts = append(pullOpts, c.encryptedImagesPullOpts()...)
+	// pullOpts = append(pullOpts, c.encryptedImagesPullOpts()...)
 	if !c.config.DisableSnapshotAnnotations {
 		pullOpts = append(pullOpts,
 			containerd.WithImageHandlerWrapper(snpkg.AppendInfoHandlerWrapper(ref)))
@@ -697,7 +695,7 @@ func (reporter *pullProgressReporter) start(ctx context.Context) {
 			reportInterval = reporter.timeout / 2
 		}
 
-		var ticker = time.NewTicker(reportInterval)
+		ticker := time.NewTicker(reportInterval)
 		defer ticker.Stop()
 
 		for {
@@ -828,7 +826,8 @@ func (rt *pullRequestReporterRoundTripper) RoundTrip(req *http.Request) (*http.R
 // Once we know the runtime, try to override default snapshotter if it is set for this runtime.
 // See https://github.com/containerd/containerd/issues/6657
 func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, imageRef string,
-	s *runtime.PodSandboxConfig) (string, error) {
+	s *runtime.PodSandboxConfig,
+) (string, error) {
 	snapshotter := c.config.Snapshotter
 	if s == nil || s.Annotations == nil {
 		return snapshotter, nil
@@ -865,7 +864,7 @@ func newCRICredentials(ref string, credentials func(string) (string, string, err
 }
 
 // GetCredentials gets credential from criCredentials makes criCredentials a registry.CredentialHelper
-func (cc *criCredentials) GetCredentials(ctx context.Context, ref string, host string) (registry.Credentials, error) {
+func (cc *criCredentials) GetCredentials(ctx context.Context, ref, host string) (registry.Credentials, error) {
 	if cc.credentials == nil {
 		return registry.Credentials{}, fmt.Errorf("credential handler not initialized for ref %q", ref)
 	}
@@ -968,9 +967,7 @@ func (reporter *transferProgressReporter) start(ctx context.Context) {
 	}
 
 	go func() {
-		var (
-			reportInterval = defaultPullProgressReportInterval
-		)
+		reportInterval := defaultPullProgressReportInterval
 
 		reporter.lastSeenBytesRead = uint64(0)
 		reporter.lastSeenTimestamp = time.Now()
@@ -980,7 +977,7 @@ func (reporter *transferProgressReporter) start(ctx context.Context) {
 			reportInterval = reporter.timeout / 2
 		}
 
-		var ticker = time.NewTicker(reportInterval)
+		ticker := time.NewTicker(reportInterval)
 		defer ticker.Stop()
 
 		for {

--- a/internal/cri/server/images/image_remove.go
+++ b/internal/cri/server/images/image_remove.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/errdefs"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/tracing"
-	"github.com/containerd/errdefs"
-
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // RemoveImage removes the image.

--- a/internal/cri/server/images/image_status.go
+++ b/internal/cri/server/images/image_status.go
@@ -23,13 +23,13 @@ import (
 	"strconv"
 	"strings"
 
-	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
-	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
-
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
+	"github.com/containerd/containerd/v2/internal/cri/util"
 )
 
 // ImageStatus returns the status of the image, returns nil if the image isn't present.

--- a/internal/cri/server/images/imagefs_info.go
+++ b/internal/cri/server/images/imagefs_info.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/containerd/containerd/v2/internal/cri/store/snapshot"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/internal/cri/store/snapshot"
 )
 
 // ImageFsInfo returns information of the filesystem that is used to store images.

--- a/internal/cri/server/images/service.go
+++ b/internal/cri/server/images/service.go
@@ -20,6 +20,14 @@ import (
 	"context"
 	"time"
 
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+	docker "github.com/distribution/reference"
+	imagedigest "github.com/opencontainers/go-digest"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/semaphore"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
@@ -29,14 +37,6 @@ import (
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
 	snapshotstore "github.com/containerd/containerd/v2/internal/cri/store/snapshot"
 	"github.com/containerd/containerd/v2/internal/kmutex"
-	"github.com/containerd/log"
-	"github.com/containerd/platforms"
-	"golang.org/x/sync/semaphore"
-
-	docker "github.com/distribution/reference"
-	imagedigest "github.com/opencontainers/go-digest"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 type imageClient interface {

--- a/internal/cri/server/images/snapshots.go
+++ b/internal/cri/server/images/snapshots.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+
 	snapshot "github.com/containerd/containerd/v2/core/snapshots"
 	snapshotstore "github.com/containerd/containerd/v2/internal/cri/store/snapshot"
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
 )
 
 // snapshotsSyncer syncs snapshot stats periodically. imagefs info and container stats
@@ -40,7 +41,8 @@ type snapshotsSyncer struct {
 
 // newSnapshotsSyncer creates a snapshot syncer.
 func newSnapshotsSyncer(store *snapshotstore.Store, snapshotters map[string]snapshot.Snapshotter,
-	period time.Duration) *snapshotsSyncer {
+	period time.Duration,
+) *snapshotsSyncer {
 	return &snapshotsSyncer{
 		store:        store,
 		snapshotters: snapshotters,

--- a/internal/cri/server/nri_linux.go
+++ b/internal/cri/server/nri_linux.go
@@ -22,8 +22,9 @@ import (
 	"context"
 	"time"
 
-	cstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	cstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 )
 
 func (i *criImplementation) UpdateContainerResources(ctx context.Context, ctr cstore.Container, req *cri.UpdateContainerResourcesRequest, status cstore.Status) (cstore.Status, error) {

--- a/internal/cri/server/nri_other.go
+++ b/internal/cri/server/nri_other.go
@@ -22,8 +22,9 @@ import (
 	"context"
 	"time"
 
-	cstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	cstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 )
 
 func (i *criImplementation) UpdateContainerResources(ctx context.Context, ctr cstore.Container, req *cri.UpdateContainerResourcesRequest, status cstore.Status) (cstore.Status, error) {

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -21,13 +21,15 @@ import (
 	"fmt"
 	"time"
 
+	eventtypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
-	eventtypes "github.com/containerd/containerd/api/events"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/sandbox"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
@@ -40,8 +42,6 @@ import (
 	osinterface "github.com/containerd/containerd/v2/pkg/os"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
 )
 
 func init() {
@@ -143,7 +143,6 @@ func (c *Controller) Wait(ctx context.Context, sandboxID string) (sandbox.ExitSt
 	podSandbox := c.store.Get(sandboxID)
 	if podSandbox == nil {
 		return sandbox.ExitStatus{}, fmt.Errorf("failed to get exit channel. %q", sandboxID)
-
 	}
 	exit, err := podSandbox.Wait(ctx)
 	if err != nil {
@@ -153,14 +152,14 @@ func (c *Controller) Wait(ctx context.Context, sandboxID string) (sandbox.ExitSt
 		ExitStatus: exit.ExitCode(),
 		ExitedAt:   exit.ExitTime(),
 	}, err
-
 }
 
 func (c *Controller) Update(
 	ctx context.Context,
 	sandboxID string,
 	sandbox sandbox.Sandbox,
-	fields ...string) error {
+	fields ...string,
+) error {
 	return nil
 }
 

--- a/internal/cri/server/podsandbox/events.go
+++ b/internal/cri/server/podsandbox/events.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"time"
 
+	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/log"
 
-	eventtypes "github.com/containerd/containerd/api/events"
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
 )
 

--- a/internal/cri/server/podsandbox/helpers.go
+++ b/internal/cri/server/podsandbox/helpers.go
@@ -70,7 +70,7 @@ func (c *Controller) toContainerdImage(ctx context.Context, image imagestore.Ima
 }
 
 // runtimeSpec returns a default runtime spec used in cri-containerd.
-func (c *Controller) runtimeSpec(id string, baseSpecFile string, opts ...oci.SpecOpts) (*runtimespec.Spec, error) {
+func (c *Controller) runtimeSpec(id, baseSpecFile string, opts ...oci.SpecOpts) (*runtimespec.Spec, error) {
 	// GenerateSpec needs namespace.
 	ctx := ctrdutil.NamespacedContext()
 	container := &containers.Container{ID: id}

--- a/internal/cri/server/podsandbox/helpers_linux.go
+++ b/internal/cri/server/podsandbox/helpers_linux.go
@@ -101,15 +101,15 @@ func (c *Controller) getSandboxPinnedUserNamespace(id string) string {
 }
 
 // pinUserNamespace persists user namespace in namespace filesystem.
-func (c *Controller) pinUserNamespace(sandboxID string, netnsPath string) error {
+func (c *Controller) pinUserNamespace(sandboxID, netnsPath string) error {
 	nsPath := c.getSandboxPinnedUserNamespace(sandboxID)
 
 	baseDir := filepath.Dir(nsPath)
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
 		return fmt.Errorf("failed to init pinned-namespaces directory %s: %w", baseDir, err)
 	}
 
-	emptyFd, err := os.OpenFile(nsPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+	emptyFd, err := os.OpenFile(nsPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
 	if err != nil {
 		return fmt.Errorf("failed to create empty file %s: %w", nsPath, err)
 	}

--- a/internal/cri/server/podsandbox/opts.go
+++ b/internal/cri/server/podsandbox/opts.go
@@ -19,10 +19,11 @@ package podsandbox
 import (
 	"context"
 
-	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
 	"github.com/containerd/nri"
 	v1 "github.com/containerd/nri/types/v1"
+
+	containerd "github.com/containerd/containerd/v2/client"
 )
 
 // WithNRISandboxDelete calls delete for a sandbox'd task

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/nri"
 	v1 "github.com/containerd/nri/types/v1"
@@ -41,7 +42,6 @@ import (
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
 	containerdio "github.com/containerd/containerd/v2/pkg/cio"
-	"github.com/containerd/errdefs"
 )
 
 func init() {
@@ -98,7 +98,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 
 	// Create sandbox container root directories.
 	sandboxRootDir := c.getSandboxRootDir(id)
-	if err := c.os.MkdirAll(sandboxRootDir, 0755); err != nil {
+	if err := c.os.MkdirAll(sandboxRootDir, 0o755); err != nil {
 		return cin, fmt.Errorf("failed to create sandbox root directory %q: %w",
 			sandboxRootDir, err)
 	}
@@ -113,7 +113,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 	}()
 
 	volatileSandboxRootDir := c.getVolatileSandboxRootDir(id)
-	if err := c.os.MkdirAll(volatileSandboxRootDir, 0755); err != nil {
+	if err := c.os.MkdirAll(volatileSandboxRootDir, 0o755); err != nil {
 		return cin, fmt.Errorf("failed to create volatile sandbox root directory %q: %w",
 			volatileSandboxRootDir, err)
 	}

--- a/internal/cri/server/podsandbox/sandbox_run_other.go
+++ b/internal/cri/server/podsandbox/sandbox_run_other.go
@@ -19,16 +19,18 @@
 package podsandbox
 
 import (
-	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/internal/cri/annotations"
-	"github.com/containerd/containerd/v2/pkg/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/internal/cri/annotations"
+	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
 func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
+	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string,
+) (_ *runtimespec.Spec, retErr error) {
 	return c.runtimeSpec(id, "", annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...)
 }
 

--- a/internal/cri/server/podsandbox/sandbox_run_windows.go
+++ b/internal/cri/server/podsandbox/sandbox_run_windows.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/containerd/containerd/v2/pkg/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -29,10 +28,12 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
 	"github.com/containerd/containerd/v2/internal/cri/util"
+	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
 func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (*runtimespec.Spec, error) {
+	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string,
+) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
 	specOpts := []oci.SpecOpts{
 		oci.WithEnv(imageConfig.Env),

--- a/internal/cri/server/podsandbox/sandbox_status.go
+++ b/internal/cri/server/podsandbox/sandbox_status.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -28,7 +29,6 @@ import (
 	"github.com/containerd/containerd/v2/core/sandbox"
 	"github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
 	critypes "github.com/containerd/containerd/v2/internal/cri/types"
-	"github.com/containerd/errdefs"
 )
 
 func (c *Controller) Status(ctx context.Context, sandboxID string, verbose bool) (sandbox.ControllerStatus, error) {

--- a/internal/cri/server/podsandbox/sandbox_stop.go
+++ b/internal/cri/server/podsandbox/sandbox_stop.go
@@ -22,10 +22,10 @@ import (
 	"syscall"
 	"time"
 
+	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 
-	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/v2/core/sandbox"
 	"github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"

--- a/internal/cri/server/rdt.go
+++ b/internal/cri/server/rdt.go
@@ -21,8 +21,9 @@ package server
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/v2/pkg/rdt"
 	"github.com/containerd/log"
+
+	"github.com/containerd/containerd/v2/pkg/rdt"
 )
 
 // rdtClassFromAnnotations examines container and pod annotations of a

--- a/internal/cri/server/restart.go
+++ b/internal/cri/server/restart.go
@@ -24,22 +24,22 @@ import (
 	"path/filepath"
 	"time"
 
-	containerd "github.com/containerd/containerd/v2/client"
-	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
-	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
-	"github.com/containerd/containerd/v2/internal/cri/server/podsandbox"
-	containerdio "github.com/containerd/containerd/v2/pkg/cio"
-	"github.com/containerd/containerd/v2/pkg/netns"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	"golang.org/x/sync/errgroup"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	containerd "github.com/containerd/containerd/v2/client"
+	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
+	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
+	"github.com/containerd/containerd/v2/internal/cri/server/podsandbox"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
+	containerdio "github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/netns"
 )
 
 // NOTE: The recovery logic has following assumption: when the cri plugin is down:

--- a/internal/cri/server/runtime_config_linux.go
+++ b/internal/cri/server/runtime_config_linux.go
@@ -21,10 +21,11 @@ import (
 	"sort"
 
 	runcoptions "github.com/containerd/containerd/api/types/runc/options"
-	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
-	"github.com/containerd/containerd/v2/internal/cri/systemd"
 	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
+	"github.com/containerd/containerd/v2/internal/cri/systemd"
 )
 
 func (c *criService) getLinuxRuntimeConfig(ctx context.Context) *runtime.LinuxRuntimeConfiguration {

--- a/internal/cri/server/sandbox_portforward_linux.go
+++ b/internal/cri/server/sandbox_portforward_linux.go
@@ -125,7 +125,6 @@ func (c *criService) portForward(ctx context.Context, id string, port int32, str
 
 		return errFwd
 	})
-
 	if err != nil {
 		return fmt.Errorf("failed to execute portforward in network namespace %q: %w", netNSPath, err)
 	}

--- a/internal/cri/server/sandbox_portforward_windows.go
+++ b/internal/cri/server/sandbox_portforward_windows.go
@@ -100,7 +100,6 @@ func (c *criService) portForward(ctx context.Context, id string, port int32, str
 
 		return errFwd
 	}()
-
 	if err != nil {
 		return fmt.Errorf("failed to execute portforward for podId %v, podIp %v, err: %w", id, podIP, err)
 	}

--- a/internal/cri/server/sandbox_remove.go
+++ b/internal/cri/server/sandbox_remove.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/leases"
-	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
-
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/pkg/tracing"
 )
 
 // RemovePodSandbox removes the sandbox. If there are running containers in the

--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -195,7 +195,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		// handle. NetNSPath in sandbox metadata and NetNS is non empty only for non host network
 		// namespaces. If the pod is in host network namespace then both are empty and should not
 		// be used.
-		var netnsMountDir = "/var/run/netns"
+		netnsMountDir := "/var/run/netns"
 		if c.config.NetNSMountsUnderStateDir {
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}

--- a/internal/cri/server/sandbox_run_linux.go
+++ b/internal/cri/server/sandbox_run_linux.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/containerd/containerd/v2/pkg/netns"
-	"github.com/containerd/containerd/v2/pkg/sys"
-
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/pkg/netns"
+	"github.com/containerd/containerd/v2/pkg/sys"
 )
 
 func (c *criService) bringUpLoopback(netns string) error {

--- a/internal/cri/server/sandbox_run_other.go
+++ b/internal/cri/server/sandbox_run_other.go
@@ -21,8 +21,9 @@ package server
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/v2/pkg/netns"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/pkg/netns"
 )
 
 func (c *criService) bringUpLoopback(string) error {

--- a/internal/cri/server/sandbox_run_windows.go
+++ b/internal/cri/server/sandbox_run_windows.go
@@ -19,8 +19,9 @@ package server
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/v2/pkg/netns"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/pkg/netns"
 )
 
 func (c *criService) bringUpLoopback(string) error {

--- a/internal/cri/server/sandbox_service.go
+++ b/internal/cri/server/sandbox_service.go
@@ -56,7 +56,7 @@ func (c *criSandboxService) CreateSandbox(ctx context.Context, info sandbox.Sand
 	return ctrl.Create(ctx, info, opts...)
 }
 
-func (c *criSandboxService) StartSandbox(ctx context.Context, sandboxer string, sandboxID string) (sandbox.ControllerInstance, error) {
+func (c *criSandboxService) StartSandbox(ctx context.Context, sandboxer, sandboxID string) (sandbox.ControllerInstance, error) {
 	ctrl, err := c.SandboxController(sandboxer)
 	if err != nil {
 		return sandbox.ControllerInstance{}, err
@@ -64,7 +64,7 @@ func (c *criSandboxService) StartSandbox(ctx context.Context, sandboxer string, 
 	return ctrl.Start(ctx, sandboxID)
 }
 
-func (c *criSandboxService) WaitSandbox(ctx context.Context, sandboxer string, sandboxID string) (<-chan client.ExitStatus, error) {
+func (c *criSandboxService) WaitSandbox(ctx context.Context, sandboxer, sandboxID string) (<-chan client.ExitStatus, error) {
 	ctrl, err := c.SandboxController(sandboxer)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (c *criSandboxService) WaitSandbox(ctx context.Context, sandboxer string, s
 	return ch, nil
 }
 
-func (c *criSandboxService) SandboxStatus(ctx context.Context, sandboxer string, sandboxID string, verbose bool) (sandbox.ControllerStatus, error) {
+func (c *criSandboxService) SandboxStatus(ctx context.Context, sandboxer, sandboxID string, verbose bool) (sandbox.ControllerStatus, error) {
 	ctrl, err := c.SandboxController(sandboxer)
 	if err != nil {
 		return sandbox.ControllerStatus{}, err
@@ -94,7 +94,7 @@ func (c *criSandboxService) SandboxStatus(ctx context.Context, sandboxer string,
 	return ctrl.Status(ctx, sandboxID, verbose)
 }
 
-func (c *criSandboxService) SandboxPlatform(ctx context.Context, sandboxer string, sandboxID string) (imagespec.Platform, error) {
+func (c *criSandboxService) SandboxPlatform(ctx context.Context, sandboxer, sandboxID string) (imagespec.Platform, error) {
 	ctrl, err := c.SandboxController(sandboxer)
 	if err != nil {
 		return imagespec.Platform{}, err
@@ -102,7 +102,7 @@ func (c *criSandboxService) SandboxPlatform(ctx context.Context, sandboxer strin
 	return ctrl.Platform(ctx, sandboxID)
 }
 
-func (c *criSandboxService) ShutdownSandbox(ctx context.Context, sandboxer string, sandboxID string) error {
+func (c *criSandboxService) ShutdownSandbox(ctx context.Context, sandboxer, sandboxID string) error {
 	ctrl, err := c.SandboxController(sandboxer)
 	if err != nil {
 		return err

--- a/internal/cri/server/sandbox_stats.go
+++ b/internal/cri/server/sandbox_stats.go
@@ -27,7 +27,6 @@ func (c *criService) PodSandboxStats(
 	ctx context.Context,
 	r *runtime.PodSandboxStatsRequest,
 ) (*runtime.PodSandboxStatsResponse, error) {
-
 	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when trying to find sandbox %s: %w", r.GetPodSandboxId(), err)

--- a/internal/cri/server/sandbox_stats_linux.go
+++ b/internal/cri/server/sandbox_stats_linux.go
@@ -24,17 +24,19 @@ import (
 	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/cgroups/v3/cgroup1"
 	cgroupsv2 "github.com/containerd/cgroups/v3/cgroup2"
-	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 )
 
 func (c *criService) podSandboxStats(
 	ctx context.Context,
-	sandbox sandboxstore.Sandbox) (*runtime.PodSandboxStats, error) {
+	sandbox sandboxstore.Sandbox,
+) (*runtime.PodSandboxStats, error) {
 	meta := sandbox.Metadata
 
 	if sandbox.Status.Get().State != sandboxstore.StateReady {

--- a/internal/cri/server/sandbox_stats_list.go
+++ b/internal/cri/server/sandbox_stats_list.go
@@ -22,11 +22,12 @@ import (
 	"fmt"
 	"sync"
 
-	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 )
 
 // ListPodSandboxStats returns stats of all ready sandboxes.

--- a/internal/cri/server/sandbox_stats_other.go
+++ b/internal/cri/server/sandbox_stats_other.go
@@ -22,13 +22,15 @@ import (
 	"context"
 	"fmt"
 
-	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/errdefs"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 )
 
 func (c *criService) podSandboxStats(
 	ctx context.Context,
-	sandbox sandboxstore.Sandbox) (*runtime.PodSandboxStats, error) {
+	sandbox sandboxstore.Sandbox,
+) (*runtime.PodSandboxStats, error) {
 	return nil, fmt.Errorf("pod sandbox stats not implemented: %w", errdefs.ErrNotImplemented)
 }

--- a/internal/cri/server/sandbox_status.go
+++ b/internal/cri/server/sandbox_status.go
@@ -22,11 +22,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/errdefs"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/containerd/v2/internal/cri/types"
-	"github.com/containerd/errdefs"
 )
 
 // PodSandboxStatus returns the status of the PodSandbox.

--- a/internal/cri/server/sandbox_stop.go
+++ b/internal/cri/server/sandbox_stop.go
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containerd/containerd/v2/pkg/tracing"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
-	"github.com/containerd/errdefs"
+	"github.com/containerd/containerd/v2/pkg/tracing"
 )
 
 // StopPodSandbox stops the sandbox. If there are any running containers in the

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -26,14 +26,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	apitypes "github.com/containerd/containerd/api/types"
 	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go/features"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	apitypes "github.com/containerd/containerd/api/types"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/introspection"
@@ -74,12 +73,12 @@ type CRIService interface {
 
 type sandboxService interface {
 	CreateSandbox(ctx context.Context, info sandbox.Sandbox, opts ...sandbox.CreateOpt) error
-	StartSandbox(ctx context.Context, sandboxer string, sandboxID string) (sandbox.ControllerInstance, error)
-	WaitSandbox(ctx context.Context, sandboxer string, sandboxID string) (<-chan containerd.ExitStatus, error)
+	StartSandbox(ctx context.Context, sandboxer, sandboxID string) (sandbox.ControllerInstance, error)
+	WaitSandbox(ctx context.Context, sandboxer, sandboxID string) (<-chan containerd.ExitStatus, error)
 	StopSandbox(ctx context.Context, sandboxer, sandboxID string, opts ...sandbox.StopOpt) error
-	ShutdownSandbox(ctx context.Context, sandboxer string, sandboxID string) error
-	SandboxStatus(ctx context.Context, sandboxer string, sandboxID string, verbose bool) (sandbox.ControllerStatus, error)
-	SandboxPlatform(ctx context.Context, sandboxer string, sandboxID string) (imagespec.Platform, error)
+	ShutdownSandbox(ctx context.Context, sandboxer, sandboxID string) error
+	SandboxStatus(ctx context.Context, sandboxer, sandboxID string, verbose bool) (sandbox.ControllerStatus, error)
+	SandboxPlatform(ctx context.Context, sandboxer, sandboxID string) (imagespec.Platform, error)
 	SandboxController(sandboxer string) (sandbox.Controller, error)
 }
 

--- a/internal/cri/server/service_linux.go
+++ b/internal/cri/server/service_linux.go
@@ -19,14 +19,14 @@ package server
 import (
 	"fmt"
 
+	"github.com/containerd/go-cni"
+	"github.com/containerd/log"
 	"github.com/moby/sys/userns"
 	"github.com/opencontainers/selinux/go-selinux"
 	"tags.cncf.io/container-device-interface/pkg/cdi"
 
 	"github.com/containerd/containerd/v2/pkg/cap"
 	"github.com/containerd/containerd/v2/pkg/kernelversion"
-	"github.com/containerd/go-cni"
-	"github.com/containerd/log"
 )
 
 func init() {

--- a/internal/cri/server/streaming.go
+++ b/internal/cri/server/streaming.go
@@ -41,7 +41,8 @@ func newStreamRuntime(c *criService) streaming.Runtime {
 // Exec executes a command inside the container. executil.ExitError is returned if the command
 // returns non-zero exit code.
 func (s *streamRuntime) Exec(ctx context.Context, containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser,
-	tty bool, resize <-chan remotecommand.TerminalSize) error {
+	tty bool, resize <-chan remotecommand.TerminalSize,
+) error {
 	exitCode, err := s.c.execInContainer(ctrdutil.WithNamespace(ctx), containerID, execOptions{
 		cmd:    cmd,
 		stdin:  stdin,
@@ -63,7 +64,8 @@ func (s *streamRuntime) Exec(ctx context.Context, containerID string, cmd []stri
 }
 
 func (s *streamRuntime) Attach(ctx context.Context, containerID string, in io.Reader, out, err io.WriteCloser, tty bool,
-	resize <-chan remotecommand.TerminalSize) error {
+	resize <-chan remotecommand.TerminalSize,
+) error {
 	return s.c.attachContainer(ctrdutil.WithNamespace(ctx), containerID, in, out, err, tty, resize)
 }
 

--- a/internal/cri/server/update_runtime_config.go
+++ b/internal/cri/server/update_runtime_config.go
@@ -26,10 +26,10 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/pkg/atomicfile"
-	"github.com/containerd/log"
 )
 
 // cniConfigTemplate contains the values containerd will overwrite
@@ -122,14 +122,14 @@ func getRoutes(cidrs []string) ([]string, error) {
 	return routes, nil
 }
 
-func writeCNIConfigFile(ctx context.Context, confDir string, confTemplate string, podCIDR string, podCIDRRanges []string, routes []string) error {
+func writeCNIConfigFile(ctx context.Context, confDir, confTemplate, podCIDR string, podCIDRRanges, routes []string) error {
 	log.G(ctx).Infof("Generating cni config from template %q", confTemplate)
 	// generate cni config file from the template with updated pod cidr.
 	t, err := template.ParseFiles(confTemplate)
 	if err != nil {
 		return fmt.Errorf("failed to parse cni config template %q: %w", confTemplate, err)
 	}
-	if err := os.MkdirAll(confDir, 0755); err != nil {
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create cni config directory: %q: %w", confDir, err)
 	}
 	confFile := filepath.Join(confDir, cniConfigFileName)

--- a/internal/cri/server/version.go
+++ b/internal/cri/server/version.go
@@ -19,10 +19,10 @@ package server
 import (
 	"context"
 
-	"github.com/containerd/containerd/v2/version"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/internal/cri/constants"
+	"github.com/containerd/containerd/v2/version"
 )
 
 const (

--- a/internal/cri/sputil/seccomp_linux.go
+++ b/internal/cri/sputil/seccomp_linux.go
@@ -26,7 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
-func GenerateSeccompSecurityProfile(profilePath string, unsetProfilePath string) (*runtime.SecurityProfile, error) {
+func GenerateSeccompSecurityProfile(profilePath, unsetProfilePath string) (*runtime.SecurityProfile, error) {
 	if profilePath != "" {
 		return generateSecurityProfile(profilePath)
 	}

--- a/internal/cri/store/container/container.go
+++ b/internal/cri/store/container/container.go
@@ -19,15 +19,15 @@ package container
 import (
 	"sync"
 
+	"github.com/containerd/errdefs"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
 	"github.com/containerd/containerd/v2/internal/cri/store"
 	"github.com/containerd/containerd/v2/internal/cri/store/label"
 	"github.com/containerd/containerd/v2/internal/cri/store/stats"
 	"github.com/containerd/containerd/v2/internal/truncindex"
-	"github.com/containerd/errdefs"
-
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // Container contains all resources associated with the container. All methods to

--- a/internal/cri/store/container/status.go
+++ b/internal/cri/store/container/status.go
@@ -173,7 +173,7 @@ func StoreStatus(root, id string, status Status) (StatusStorage, error) {
 		return nil, fmt.Errorf("failed to encode status: %w", err)
 	}
 	path := filepath.Join(root, "status")
-	if err := continuity.AtomicWriteFile(path, data, 0600); err != nil {
+	if err := continuity.AtomicWriteFile(path, data, 0o600); err != nil {
 		return nil, fmt.Errorf("failed to checkpoint status to %q: %w", path, err)
 	}
 	return &statusStorage{
@@ -273,7 +273,7 @@ func (s *statusStorage) UpdateSync(u UpdateFunc) error {
 	if err != nil {
 		return fmt.Errorf("failed to encode status: %w", err)
 	}
-	if err := continuity.AtomicWriteFile(s.path, data, 0600); err != nil {
+	if err := continuity.AtomicWriteFile(s.path, data, 0o600); err != nil {
 		return fmt.Errorf("failed to checkpoint status to %q: %w", s.path, err)
 	}
 	s.status = newStatus

--- a/internal/cri/store/image/image.go
+++ b/internal/cri/store/image/image.go
@@ -22,20 +22,20 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	docker "github.com/distribution/reference"
+	imagedigest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest/digestset"
+	imageidentity "github.com/opencontainers/image-spec/identity"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/usage"
 	"github.com/containerd/containerd/v2/internal/cri/labels"
 	"github.com/containerd/containerd/v2/internal/cri/setutils"
 	"github.com/containerd/containerd/v2/internal/cri/util"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
-	docker "github.com/distribution/reference"
-
-	imagedigest "github.com/opencontainers/go-digest"
-	"github.com/opencontainers/go-digest/digestset"
-	imageidentity "github.com/opencontainers/image-spec/identity"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Image contains all resources associated with the image. All fields
@@ -185,7 +185,6 @@ func (s *Store) getImage(ctx context.Context, i images.Image) (*Image, error) {
 		ImageSpec:  spec,
 		Pinned:     pinned,
 	}, nil
-
 }
 
 // Resolve resolves a image reference to image id.

--- a/internal/cri/store/sandbox/sandbox.go
+++ b/internal/cri/store/sandbox/sandbox.go
@@ -19,13 +19,14 @@ package sandbox
 import (
 	"sync"
 
+	"github.com/containerd/errdefs"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/internal/cri/store"
 	"github.com/containerd/containerd/v2/internal/cri/store/label"
 	"github.com/containerd/containerd/v2/internal/cri/store/stats"
 	"github.com/containerd/containerd/v2/internal/truncindex"
 	"github.com/containerd/containerd/v2/pkg/netns"
-	"github.com/containerd/errdefs"
 )
 
 // Sandbox contains all resources associated with the sandbox. All methods to

--- a/internal/cri/store/snapshot/snapshot.go
+++ b/internal/cri/store/snapshot/snapshot.go
@@ -19,8 +19,9 @@ package snapshot
 import (
 	"sync"
 
-	snapshot "github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/errdefs"
+
+	snapshot "github.com/containerd/containerd/v2/core/snapshots"
 )
 
 type Key struct {

--- a/internal/cri/streamingserver/portforward/httpstream.go
+++ b/internal/cri/streamingserver/portforward/httpstream.go
@@ -41,12 +41,13 @@ import (
 	"sync"
 	"time"
 
-	api "github.com/containerd/containerd/v2/internal/cri/streamingserver/v1"
 	"github.com/containerd/log"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	api "github.com/containerd/containerd/v2/internal/cri/streamingserver/v1"
 )
 
 func handleHTTPStreams(req *http.Request, w http.ResponseWriter, portForwarder PortForwarder, podName string, uid types.UID, supportedPortForwardProtocols []string, idleTimeout, streamCreationTimeout time.Duration) error {

--- a/internal/cri/streamingserver/portforward/portforward.go
+++ b/internal/cri/streamingserver/portforward/portforward.go
@@ -55,7 +55,7 @@ type PortForwarder interface {
 // been timed out due to idleness. This function handles multiple forwarded
 // connections; i.e., multiple `curl http://localhost:8888/` requests will be
 // handled by a single invocation of ServePortForward.
-func ServePortForward(w http.ResponseWriter, req *http.Request, portForwarder PortForwarder, podName string, uid types.UID, portForwardOptions *V4Options, idleTimeout time.Duration, streamCreationTimeout time.Duration, supportedProtocols []string) {
+func ServePortForward(w http.ResponseWriter, req *http.Request, portForwarder PortForwarder, podName string, uid types.UID, portForwardOptions *V4Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
 	var err error
 	if wsstream.IsWebSocketRequest(req) {
 		err = handleWebSocketStreams(req, w, portForwarder, podName, uid, portForwardOptions, supportedProtocols, idleTimeout, streamCreationTimeout)

--- a/internal/cri/streamingserver/portforward/websocket.go
+++ b/internal/cri/streamingserver/portforward/websocket.go
@@ -43,12 +43,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd/v2/internal/cri/streamingserver/responsewriter"
-	api "github.com/containerd/containerd/v2/internal/cri/streamingserver/v1"
 	"github.com/containerd/log"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
 	"k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/containerd/containerd/v2/internal/cri/streamingserver/responsewriter"
+	api "github.com/containerd/containerd/v2/internal/cri/streamingserver/v1"
 )
 
 const (

--- a/internal/cri/streamingserver/remotecommand/exec.go
+++ b/internal/cri/streamingserver/remotecommand/exec.go
@@ -39,13 +39,14 @@ import (
 	"net/http"
 	"time"
 
-	utilexec "github.com/containerd/containerd/v2/internal/cri/executil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/remotecommand"
+
+	utilexec "github.com/containerd/containerd/v2/internal/cri/executil"
 )
 
 // Executor knows how to execute a command in a container in a pod.

--- a/internal/cri/streamingserver/remotecommand/httpstream.go
+++ b/internal/cri/streamingserver/remotecommand/httpstream.go
@@ -41,7 +41,6 @@ import (
 	"net/http"
 	"time"
 
-	api "github.com/containerd/containerd/v2/internal/cri/streamingserver/v1"
 	"github.com/containerd/log"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,6 +50,8 @@ import (
 	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/remotecommand"
+
+	api "github.com/containerd/containerd/v2/internal/cri/streamingserver/v1"
 )
 
 // Options contains details about which streams are required for

--- a/internal/cri/streamingserver/remotecommand/websocket.go
+++ b/internal/cri/streamingserver/remotecommand/websocket.go
@@ -37,9 +37,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/containerd/containerd/v2/internal/cri/streamingserver/responsewriter"
 	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
 	"k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/containerd/containerd/v2/internal/cri/streamingserver/responsewriter"
 )
 
 const (

--- a/internal/cri/streamingserver/server.go
+++ b/internal/cri/streamingserver/server.go
@@ -43,17 +43,16 @@ import (
 	"path"
 	"time"
 
+	restful "github.com/emicklei/go-restful/v3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	restful "github.com/emicklei/go-restful/v3"
-
-	"github.com/containerd/containerd/v2/internal/cri/streamingserver/portforward"
-	remotecommandserver "github.com/containerd/containerd/v2/internal/cri/streamingserver/remotecommand"
 	"k8s.io/apimachinery/pkg/types"
 	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
 	"k8s.io/client-go/tools/remotecommand"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/internal/cri/streamingserver/portforward"
+	remotecommandserver "github.com/containerd/containerd/v2/internal/cri/streamingserver/remotecommand"
 )
 
 // Server is the library interface to serve the stream requests.
@@ -383,9 +382,11 @@ type criAdapter struct {
 	Runtime
 }
 
-var _ remotecommandserver.Executor = &criAdapter{}
-var _ remotecommandserver.Attacher = &criAdapter{}
-var _ portforward.PortForwarder = &criAdapter{}
+var (
+	_ remotecommandserver.Executor = &criAdapter{}
+	_ remotecommandserver.Attacher = &criAdapter{}
+	_ portforward.PortForwarder    = &criAdapter{}
+)
 
 func (a *criAdapter) ExecInContainer(ctx context.Context, podName string, podUID types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize, timeout time.Duration) error {
 	return a.Runtime.Exec(ctx, container, cmd, in, out, err, tty, resize)

--- a/internal/cri/util/deep_copy.go
+++ b/internal/cri/util/deep_copy.go
@@ -23,7 +23,7 @@ import (
 )
 
 // DeepCopy makes a deep copy from src into dst.
-func DeepCopy(dst interface{}, src interface{}) error {
+func DeepCopy(dst, src interface{}) error {
 	if dst == nil {
 		return errors.New("dst cannot be nil")
 	}

--- a/internal/cri/util/strings.go
+++ b/internal/cri/util/strings.go
@@ -47,7 +47,7 @@ func SubtractStringSlice(ss []string, str string) []string {
 }
 
 // MergeStringSlices merges 2 string slices into one and remove duplicated elements.
-func MergeStringSlices(a []string, b []string) []string {
+func MergeStringSlices(a, b []string) []string {
 	set := setutils.NewString(a...)
 	set.Insert(b...)
 	return set.UnsortedList()

--- a/internal/cri/util/util.go
+++ b/internal/cri/util/util.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/internal/cri/constants"
@@ -30,7 +31,6 @@ import (
 	clabels "github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/timeout"
-	"github.com/containerd/log"
 )
 
 // deferCleanupTimeoutKey is used to retrieve the configurable timeout for containerd cleanup operations in defer.
@@ -62,7 +62,8 @@ func WithNamespace(ctx context.Context) context.Context {
 // GetPassthroughAnnotations filters requested pod annotations by comparing
 // against permitted annotations for the given runtime.
 func GetPassthroughAnnotations(podAnnotations map[string]string,
-	runtimePodAnnotations []string) (passthroughAnnotations map[string]string) {
+	runtimePodAnnotations []string,
+) (passthroughAnnotations map[string]string) {
 	passthroughAnnotations = make(map[string]string)
 
 	for podAnnotationKey, podAnnotationValue := range podAnnotations {

--- a/internal/erofsutils/mount_linux.go
+++ b/internal/erofsutils/mount_linux.go
@@ -26,9 +26,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 func ConvertTarErofs(ctx context.Context, r io.Reader, layerPath, uuid string, mkfsExtraOpts []string) error {
@@ -81,7 +82,7 @@ func GenerateTarIndexAndAppendTar(ctx context.Context, r io.Reader, layerPath st
 		cmd.Path, strings.Join(cmd.Args, " "), string(out))
 
 	// Open layerPath for appending
-	f, err := os.OpenFile(layerPath, os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(layerPath, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to open layer file for appending: %w", err)
 	}
@@ -102,7 +103,7 @@ func GenerateTarIndexAndAppendTar(ctx context.Context, r io.Reader, layerPath st
 	return nil
 }
 
-func ConvertErofs(ctx context.Context, layerPath string, srcDir string, mkfsExtraOpts []string) error {
+func ConvertErofs(ctx context.Context, layerPath, srcDir string, mkfsExtraOpts []string) error {
 	args := append([]string{"--quiet", "-Enoinline_data"}, mkfsExtraOpts...)
 	args = append(args, layerPath, srcDir)
 	cmd := exec.CommandContext(ctx, "mkfs.erofs", args...)

--- a/internal/eventq/eventq.go
+++ b/internal/eventq/eventq.go
@@ -128,7 +128,6 @@ func New[T any](discardAfter time.Duration, discardFn func(T)) EventQueue[T] {
 					discardTime = time.After(time.Until(discardQueue[0].discardAt).Abs() + 10*time.Millisecond)
 				}
 			}
-
 		}
 	}()
 

--- a/internal/failpoint/fail.go
+++ b/internal/failpoint/fail.go
@@ -93,7 +93,7 @@ type Failpoint struct {
 }
 
 // NewFailpoint returns failpoint control.
-func NewFailpoint(fnName string, terms string) (*Failpoint, error) {
+func NewFailpoint(fnName, terms string) (*Failpoint, error) {
 	entries, err := parseTerms([]byte(terms))
 	if err != nil {
 		return nil, err
@@ -222,7 +222,7 @@ func parseTerms(term []byte) ([]*failpointEntry, error) {
 
 func parseTerm(term []byte) ([]byte, *failpointEntry, error) {
 	var err error
-	var entry = newFailpointEntry()
+	entry := newFailpointEntry()
 
 	// count*
 	term, err = parseInt64(term, '*', &entry.count)
@@ -236,7 +236,7 @@ func parseTerm(term []byte) ([]byte, *failpointEntry, error) {
 }
 
 func parseType(term []byte, entry *failpointEntry) ([]byte, error) {
-	var nameToTyp = map[string]Type{
+	nameToTyp := map[string]Type{
 		"off":    TypeOff,
 		"error(": TypeError,
 		"panic(": TypePanic,

--- a/internal/fsverity/fsverity_linux.go
+++ b/internal/fsverity/fsverity_linux.go
@@ -23,8 +23,9 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/containerd/containerd/v2/pkg/kernelversion"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/pkg/kernelversion"
 )
 
 type fsverityEnableArg struct {
@@ -100,7 +101,7 @@ func Enable(path string) error {
 		return err
 	}
 
-	var args = &fsverityEnableArg{}
+	args := &fsverityEnableArg{}
 	args.version = 1
 	args.hashAlgorithm = 1
 

--- a/internal/kmutex/noop.go
+++ b/internal/kmutex/noop.go
@@ -22,8 +22,7 @@ func NewNoop() KeyedLocker {
 	return &noopMutex{}
 }
 
-type noopMutex struct {
-}
+type noopMutex struct{}
 
 func (*noopMutex) Lock(_ context.Context, _ string) error {
 	return nil

--- a/internal/nri/config.go
+++ b/internal/nri/config.go
@@ -17,10 +17,11 @@
 package nri
 
 import (
-	"github.com/containerd/containerd/v2/internal/tomlext"
 	nri "github.com/containerd/nri/pkg/adaptation"
 	"github.com/containerd/otelttrpc"
 	"github.com/containerd/ttrpc"
+
+	"github.com/containerd/containerd/v2/internal/tomlext"
 )
 
 // Config data for NRI.

--- a/internal/nri/domain.go
+++ b/internal/nri/domain.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	nri "github.com/containerd/nri/pkg/adaptation"
+
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 
 // Domain implements the functions the generic NRI interface needs to

--- a/internal/nri/nri.go
+++ b/internal/nri/nri.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 
 	"github.com/containerd/log"
+	nri "github.com/containerd/nri/pkg/adaptation"
 
 	"github.com/containerd/containerd/v2/version"
-	nri "github.com/containerd/nri/pkg/adaptation"
 )
 
 // API implements a common API for interfacing NRI from containerd. It is

--- a/internal/pprof/plugin.go
+++ b/internal/pprof/plugin.go
@@ -22,9 +22,10 @@ import (
 	"net/http/pprof"
 	"time"
 
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 const pluginName = "pprof"

--- a/internal/truncindex/truncindex.go
+++ b/internal/truncindex/truncindex.go
@@ -119,9 +119,7 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 	if s == "" {
 		return "", ErrEmptyPrefix
 	}
-	var (
-		id string
-	)
+	var id string
 	subTreeVisitFunc := func(prefix patricia.Prefix, item patricia.Item) error {
 		if id != "" {
 			// we haven't found the ID if there are two or more IDs

--- a/internal/userns/idmap.go
+++ b/internal/userns/idmap.go
@@ -157,9 +157,7 @@ func serializeLinuxIDMapping(m specs.LinuxIDMapping) string {
 
 // deserializeLinuxIDMapping unmarshals a string to a LinuxIDMapping object
 func deserializeLinuxIDMapping(str string) (specs.LinuxIDMapping, error) {
-	var (
-		hostID, ctrID, length int64
-	)
+	var hostID, ctrID, length int64
 	_, err := fmt.Sscanf(str, "%d:%d:%d", &ctrID, &hostID, &length)
 	if err != nil {
 		return specs.LinuxIDMapping{}, fmt.Errorf("input value %s unparsable: %w", str, err)

--- a/pkg/archive/compression/compression.go
+++ b/pkg/archive/compression/compression.go
@@ -59,11 +59,9 @@ var (
 	gzipPath string
 )
 
-var (
-	bufioReader32KPool = &sync.Pool{
-		New: func() interface{} { return bufio.NewReaderSize(nil, 32*1024) },
-	}
-)
+var bufioReader32KPool = &sync.Pool{
+	New: func() interface{} { return bufio.NewReaderSize(nil, 32*1024) },
+}
 
 // DecompressReadCloser include the stream after decompress and the compress method detected.
 type DecompressReadCloser interface {

--- a/pkg/archive/link_freebsd.go
+++ b/pkg/archive/link_freebsd.go
@@ -19,8 +19,9 @@ package archive
 import (
 	"os"
 
-	"github.com/containerd/containerd/v2/pkg/sys"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/pkg/sys"
 )
 
 func link(oldname, newname string) error {

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -29,12 +29,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/continuity/fs"
+	"github.com/containerd/log"
 	"github.com/moby/sys/userns"
 
 	"github.com/containerd/containerd/v2/pkg/archive/tarheader"
 	"github.com/containerd/containerd/v2/pkg/epoch"
-	"github.com/containerd/continuity/fs"
-	"github.com/containerd/log"
 )
 
 var bufPool = &sync.Pool{
@@ -457,7 +457,7 @@ func mkparent(ctx context.Context, path, root string, parents []string) error {
 		}
 	}
 
-	if err := mkdir(path, 0755); err != nil {
+	if err := mkdir(path, 0o755); err != nil {
 		// Check that still doesn't exist
 		dir, err1 := os.Lstat(path)
 		if err1 == nil && dir.IsDir() {
@@ -766,7 +766,6 @@ func copyBuffered(ctx context.Context, dst io.Writer, src io.Reader) (written in
 		}
 	}
 	return written, err
-
 }
 
 // hardlinkRootPath returns target linkname, evaluating and bounding any

--- a/pkg/archive/tar_freebsd.go
+++ b/pkg/archive/tar_freebsd.go
@@ -29,7 +29,7 @@ func mknod(path string, mode uint32, dev uint64) error {
 }
 
 // lsetxattrCreate wraps unix.Lsetxattr with FreeBSD-specific flags and errors
-func lsetxattrCreate(link string, attr string, data []byte) error {
+func lsetxattrCreate(link, attr string, data []byte) error {
 	err := unix.Lsetxattr(link, attr, data, 0)
 	if err == unix.ENOTSUP || err == unix.EEXIST {
 		return nil

--- a/pkg/archive/tar_mostunix.go
+++ b/pkg/archive/tar_mostunix.go
@@ -31,7 +31,7 @@ func mknod(path string, mode uint32, dev uint64) error {
 
 // lsetxattrCreate wraps unix.Lsetxattr, passes the unix.XATTR_CREATE flag on
 // supported operating systems,and ignores appropriate errors
-func lsetxattrCreate(link string, attr string, data []byte) error {
+func lsetxattrCreate(link, attr string, data []byte) error {
 	err := unix.Lsetxattr(link, attr, data, unix.XATTR_CREATE)
 	if err == unix.ENOTSUP || err == unix.ENODATA || err == unix.EEXIST {
 		return nil

--- a/pkg/archive/tar_unix.go
+++ b/pkg/archive/tar_unix.go
@@ -27,11 +27,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/moby/sys/userns"
-	"golang.org/x/sys/unix"
-
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/continuity/sysx"
+	"github.com/moby/sys/userns"
+	"golang.org/x/sys/unix"
 )
 
 func chmodTarEntry(perm os.FileMode) os.FileMode {
@@ -111,7 +110,7 @@ func skipFile(hdr *tar.Header) bool {
 // This function must not be called for Block and Char when running in userns.
 // (skipFile() should return true for them.)
 func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
-	mode := uint32(hdr.Mode & 07777)
+	mode := uint32(hdr.Mode & 0o7777)
 	switch hdr.Typeflag {
 	case tar.TypeBlock:
 		mode |= unix.S_IFBLK

--- a/pkg/archive/tar_windows.go
+++ b/pkg/archive/tar_windows.go
@@ -29,9 +29,9 @@ import (
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
 func chmodTarEntry(perm os.FileMode) os.FileMode {
-	perm &= 0755
+	perm &= 0o755
 	// Add the x bit: make everything +x from windows
-	perm |= 0111
+	perm |= 0o111
 
 	return perm
 }

--- a/pkg/blockio/blockio_linux.go
+++ b/pkg/blockio/blockio_linux.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/containerd/log"
 	"github.com/intel/goresctrl/pkg/blockio"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-
-	"github.com/containerd/log"
 )
 
 var (

--- a/pkg/cio/io.go
+++ b/pkg/cio/io.go
@@ -290,7 +290,7 @@ func LogFile(path string) Creator {
 }
 
 // LogURIGenerator is the helper to generate log uri with specific scheme.
-func LogURIGenerator(scheme string, path string, args map[string]string) (*url.URL, error) {
+func LogURIGenerator(scheme, path string, args map[string]string) (*url.URL, error) {
 	path = filepath.Clean(path)
 	if !filepath.IsAbs(path) {
 		return nil, fmt.Errorf("%q must be absolute", path)
@@ -329,11 +329,9 @@ func (l *logURI) Config() Config {
 }
 
 func (l *logURI) Cancel() {
-
 }
 
 func (l *logURI) Wait() {
-
 }
 
 func (l *logURI) Close() error {

--- a/pkg/cio/io_unix.go
+++ b/pkg/cio/io_unix.go
@@ -34,7 +34,7 @@ import (
 // NewFIFOSetInDir returns a new FIFOSet with paths in a temporary directory under root
 func NewFIFOSetInDir(root, id string, terminal bool) (*FIFOSet, error) {
 	if root != "" {
-		if err := os.MkdirAll(root, 0700); err != nil {
+		if err := os.MkdirAll(root, 0o700); err != nil {
 			return nil, err
 		}
 	}
@@ -54,7 +54,7 @@ func NewFIFOSetInDir(root, id string, terminal bool) (*FIFOSet, error) {
 }
 
 func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
-	var ctx, cancel = context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	pipes, err := openFifos(ctx, fifos)
 	if err != nil {
 		cancel()
@@ -71,7 +71,7 @@ func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
 		}()
 	}
 
-	var wg = &sync.WaitGroup{}
+	wg := &sync.WaitGroup{}
 	if fifos.Stdout != "" {
 		wg.Add(1)
 		go func() {
@@ -118,7 +118,7 @@ func openFifos(ctx context.Context, fifos *FIFOSet) (f pipes, retErr error) {
 	}()
 
 	if fifos.Stdin != "" {
-		if f.Stdin, retErr = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); retErr != nil {
+		if f.Stdin, retErr = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0o700); retErr != nil {
 			return f, fmt.Errorf("failed to open stdin fifo: %w", retErr)
 		}
 		defer func() {
@@ -128,7 +128,7 @@ func openFifos(ctx context.Context, fifos *FIFOSet) (f pipes, retErr error) {
 		}()
 	}
 	if fifos.Stdout != "" {
-		if f.Stdout, retErr = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); retErr != nil {
+		if f.Stdout, retErr = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0o700); retErr != nil {
 			return f, fmt.Errorf("failed to open stdout fifo: %w", retErr)
 		}
 		defer func() {
@@ -138,7 +138,7 @@ func openFifos(ctx context.Context, fifos *FIFOSet) (f pipes, retErr error) {
 		}()
 	}
 	if !fifos.Terminal && fifos.Stderr != "" {
-		if f.Stderr, retErr = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); retErr != nil {
+		if f.Stderr, retErr = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0o700); retErr != nil {
 			return f, fmt.Errorf("failed to open stderr fifo: %w", retErr)
 		}
 	}

--- a/pkg/gc/gc.go
+++ b/pkg/gc/gc.go
@@ -147,7 +147,6 @@ func ConcurrentMark(ctx context.Context, root <-chan Node, refs func(context.Con
 						cancel()
 					})
 				}
-
 			}(gray)
 		}
 	}()

--- a/pkg/identifiers/validate.go
+++ b/pkg/identifiers/validate.go
@@ -27,8 +27,9 @@ package identifiers
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/v2/internal/lazyregexp"
 	"github.com/containerd/errdefs"
+
+	"github.com/containerd/containerd/v2/internal/lazyregexp"
 )
 
 const (
@@ -37,10 +38,8 @@ const (
 	separators = `[._-]`
 )
 
-var (
-	// identifierRe defines the pattern for valid identifiers.
-	identifierRe = lazyregexp.New(reAnchor(alphanum + reGroup(separators+reGroup(alphanum)) + "*"))
-)
+// identifierRe defines the pattern for valid identifiers.
+var identifierRe = lazyregexp.New(reAnchor(alphanum + reGroup(separators+reGroup(alphanum)) + "*"))
 
 // Validate returns nil if the string s is a valid identifier.
 //

--- a/pkg/imageverifier/bindir/bindir.go
+++ b/pkg/imageverifier/bindir/bindir.go
@@ -29,10 +29,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/containerd/v2/internal/tomlext"
-	"github.com/containerd/containerd/v2/pkg/imageverifier"
 	"github.com/containerd/log"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/internal/tomlext"
+	"github.com/containerd/containerd/v2/pkg/imageverifier"
 )
 
 const outputLimitBytes = 1 << 15 // 32 KiB
@@ -110,7 +111,7 @@ func (v *ImageVerifier) VerifyImage(ctx context.Context, name string, desc ocisp
 	}, nil
 }
 
-func (v *ImageVerifier) runVerifier(ctx context.Context, bin string, imageName string, desc ocispec.Descriptor) (exitCode int, reason string, err error) {
+func (v *ImageVerifier) runVerifier(ctx context.Context, bin, imageName string, desc ocispec.Descriptor) (exitCode int, reason string, err error) {
 	ctx, cancel := context.WithTimeout(ctx, tomlext.ToStdTime(v.config.PerVerifierTimeout))
 	defer cancel()
 

--- a/pkg/kernelversion/kernel_linux.go
+++ b/pkg/kernelversion/kernel_linux.go
@@ -64,7 +64,7 @@ func getKernelVersion() (*KernelVersion, error) {
 
 // parseRelease parses a string and creates a KernelVersion based on it.
 func parseRelease(release string) (*KernelVersion, error) {
-	var version = KernelVersion{}
+	version := KernelVersion{}
 
 	// We're only make sure we get the "kernel" and "major revision". Sometimes we have
 	// 3.12.25-gentoo, but sometimes we just have 3.12-1-amd64.

--- a/pkg/namespaces/context.go
+++ b/pkg/namespaces/context.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/errdefs"
+
+	"github.com/containerd/containerd/v2/pkg/identifiers"
 )
 
 const (

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -39,10 +39,11 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/containerd/containerd/v2/core/mount"
 	cnins "github.com/containernetworking/plugins/pkg/ns"
 	"github.com/moby/sys/symlink"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 // Some of the following functions are migrated from
@@ -63,14 +64,14 @@ func newNS(baseDir string, pid uint32) (nsPath string, err error) {
 	// Create the directory for mounting network namespaces
 	// This needs to be a shared mountpoint in case it is mounted in to
 	// other namespaces (containers)
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
 		return "", err
 	}
 
 	// create an empty file at the mount point and fail if it already exists
 	nsName := fmt.Sprintf("cni-%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 	nsPath = path.Join(baseDir, nsName)
-	mountPointFd, err := os.OpenFile(nsPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+	mountPointFd, err := os.OpenFile(nsPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -19,9 +19,10 @@ package oci
 import (
 	"context"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/snapshots"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Client interface used by SpecOpt

--- a/pkg/oci/mounts_freebsd.go
+++ b/pkg/oci/mounts_freebsd.go
@@ -46,7 +46,7 @@ func appendOSMounts(s *Spec, os string) {
 	/* The nosuid noexec options are for consistency with Linux mounts: on FreeBSD it is
 	   by default impossible to execute anything from these filesystems.
 	*/
-	var mounts = []specs.Mount{
+	mounts := []specs.Mount{
 		{
 			Destination: "/proc",
 			Type:        "linprocfs",

--- a/pkg/oci/spec.go
+++ b/pkg/oci/spec.go
@@ -23,14 +23,14 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/platforms"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/containerd/platforms"
 )
 
 const (
@@ -38,11 +38,9 @@ const (
 	defaultRootfsPath = "rootfs"
 )
 
-var (
-	defaultUnixEnv = []string{
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-	}
-)
+var defaultUnixEnv = []string{
+	"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+}
 
 // Spec is a type alias to the OCI runtime spec to allow third part SpecOpts
 // to be created without the "issues" with go vendoring and package imports

--- a/pkg/oci/spec_opts_linux.go
+++ b/pkg/oci/spec_opts_linux.go
@@ -19,9 +19,10 @@ package oci
 import (
 	"context"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/cap"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // WithHostDevices adds all the hosts device nodes to the container's spec

--- a/pkg/oom/v1/v1.go
+++ b/pkg/oom/v1/v1.go
@@ -25,12 +25,13 @@ import (
 
 	"github.com/containerd/cgroups/v3/cgroup1"
 	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/log"
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/containerd/v2/pkg/oom"
 	"github.com/containerd/containerd/v2/pkg/sys"
-	"github.com/containerd/log"
-	"golang.org/x/sys/unix"
 )
 
 // New returns an epoll implementation that listens to OOM events

--- a/pkg/oom/v2/v2.go
+++ b/pkg/oom/v2/v2.go
@@ -24,10 +24,11 @@ import (
 
 	cgroupsv2 "github.com/containerd/cgroups/v3/cgroup2"
 	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/log"
+
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/containerd/v2/pkg/oom"
-	"github.com/containerd/log"
 )
 
 // New returns an implementation that listens to OOM events

--- a/pkg/os/mount_linux.go
+++ b/pkg/os/mount_linux.go
@@ -17,12 +17,13 @@
 package os
 
 import (
-	"github.com/containerd/containerd/v2/core/mount"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 // Mount will call unix.Mount to mount the file.
-func (RealOS) Mount(source string, target string, fstype string, flags uintptr, data string) error {
+func (RealOS) Mount(source, target, fstype string, flags uintptr, data string) error {
 	return unix.Mount(source, target, fstype, flags, data)
 }
 

--- a/pkg/os/mount_unix.go
+++ b/pkg/os/mount_unix.go
@@ -19,12 +19,13 @@
 package os
 
 import (
-	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/errdefs"
+
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 // Mount will call unix.Mount to mount the file.
-func (RealOS) Mount(source string, target string, fstype string, flags uintptr, data string) error {
+func (RealOS) Mount(source, target, fstype string, flags uintptr, data string) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/pkg/os/mount_windows.go
+++ b/pkg/os/mount_windows.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Mount is an empty stub on Windows.
-func (RealOS) Mount(source string, target string, fstype string, flags uintptr, data string) error {
+func (RealOS) Mount(source, target, fstype string, flags uintptr, data string) error {
 	return errors.New("mount is not supported on Windows")
 }
 

--- a/pkg/os/os.go
+++ b/pkg/os/os.go
@@ -36,7 +36,7 @@ type OS interface {
 	CopyFile(src, dest string, perm os.FileMode) error
 	WriteFile(filename string, data []byte, perm os.FileMode) error
 	Hostname() (string, error)
-	Mount(source string, target string, fstype string, flags uintptr, data string) error
+	Mount(source, target, fstype string, flags uintptr, data string) error
 	Unmount(target string) error
 	LookupMount(path string) (mount.Info, error)
 }

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -24,12 +24,11 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
+
 	"github.com/containerd/containerd/v2/internal/lazyregexp"
 )
 
-var (
-	regexCleanLine = lazyregexp.New("\x1b\\[[0-9]+m[\x1b]?")
-)
+var regexCleanLine = lazyregexp.New("\x1b\\[[0-9]+m[\x1b]?")
 
 // Writer buffers writes until flush, at which time the last screen is cleared
 // and the current buffer contents are written. This is useful for

--- a/pkg/protobuf/types/types.go
+++ b/pkg/protobuf/types/types.go
@@ -23,6 +23,8 @@ import (
 	field_mask "google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
-type Empty = emptypb.Empty
-type Any = anypb.Any
-type FieldMask = field_mask.FieldMask
+type (
+	Empty     = emptypb.Empty
+	Any       = anypb.Any
+	FieldMask = field_mask.FieldMask
+)

--- a/pkg/rdt/rdt_linux.go
+++ b/pkg/rdt/rdt_linux.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"github.com/containerd/log"
-
 	"github.com/intel/goresctrl/pkg/rdt"
 )
 

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -22,8 +22,9 @@ import (
 	"path"
 	"strings"
 
-	"github.com/containerd/containerd/v2/internal/lazyregexp"
 	digest "github.com/opencontainers/go-digest"
+
+	"github.com/containerd/containerd/v2/internal/lazyregexp"
 )
 
 var (

--- a/pkg/rootfs/apply.go
+++ b/pkg/rootfs/apply.go
@@ -23,14 +23,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/diff"
-	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/diff"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
 )
 
 // Layer represents the descriptors for a layer diff. These descriptions
@@ -107,7 +108,6 @@ func ApplyLayerWithOpts(ctx context.Context, layer Layer, chain []digest.Digest,
 		}
 	}
 	return applied, nil
-
 }
 
 func applyLayers(ctx context.Context, layers []Layer, chain []digest.Digest, sn snapshots.Snapshotter, a diff.Applier, opts []snapshots.Opt, applyOpts []diff.ApplyOpt) error {

--- a/pkg/rootfs/diff.go
+++ b/pkg/rootfs/diff.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/internal/cleanup"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // CreateDiff creates a layer diff for the given snapshot identifier from the

--- a/pkg/rootfs/init.go
+++ b/pkg/rootfs/init.go
@@ -22,15 +22,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
 )
 
-var (
-	initializers = map[string]initializerFunc{}
-)
+var initializers = map[string]initializerFunc{}
 
 type initializerFunc func(string) error
 

--- a/pkg/rootfs/init_linux.go
+++ b/pkg/rootfs/init_linux.go
@@ -46,12 +46,12 @@ func createDirectory(name string, uid, gid int) initializerFunc {
 				if err := os.Remove(dname); err != nil {
 					return err
 				}
-				if err := os.Mkdir(dname, 0755); err != nil {
+				if err := os.Mkdir(dname, 0o755); err != nil {
 					return err
 				}
 			}
 		} else {
-			if err := os.Mkdir(dname, 0755); err != nil {
+			if err := os.Mkdir(dname, 0o755); err != nil {
 				return err
 			}
 		}
@@ -75,7 +75,7 @@ func touchFile(name string, uid, gid int) initializerFunc {
 			return os.Chown(fname, uid, gid)
 		}
 
-		f, err := os.OpenFile(fname, os.O_CREATE, 0644)
+		f, err := os.OpenFile(fname, os.O_CREATE, 0o644)
 		if err != nil {
 			return err
 		}

--- a/pkg/shim/publisher.go
+++ b/pkg/shim/publisher.go
@@ -23,13 +23,14 @@ import (
 
 	v1 "github.com/containerd/containerd/api/services/ttrpc/events/v1"
 	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/log"
+	"github.com/containerd/ttrpc"
+	"github.com/containerd/typeurl/v2"
+
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	"github.com/containerd/containerd/v2/pkg/ttrpcutil"
-	"github.com/containerd/log"
-	"github.com/containerd/ttrpc"
-	"github.com/containerd/typeurl/v2"
 )
 
 const (

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -32,6 +32,11 @@ import (
 
 	shimapi "github.com/containerd/containerd/api/runtime/task/v3"
 	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	"github.com/containerd/ttrpc"
+
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
@@ -39,10 +44,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/shutdown"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/log"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
-	"github.com/containerd/ttrpc"
 )
 
 // Publisher for events

--- a/pkg/shim/shim_linux.go
+++ b/pkg/shim/shim_linux.go
@@ -17,8 +17,9 @@
 package shim
 
 import (
-	"github.com/containerd/containerd/v2/pkg/sys/reaper"
 	"github.com/containerd/ttrpc"
+
+	"github.com/containerd/containerd/v2/pkg/sys/reaper"
 )
 
 func newServer(opts ...ttrpc.ServerOpt) (*ttrpc.Server, error) {

--- a/pkg/shim/shim_unix.go
+++ b/pkg/shim/shim_unix.go
@@ -27,10 +27,11 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/containerd/containerd/v2/pkg/sys/reaper"
 	"github.com/containerd/fifo"
 	"github.com/containerd/log"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/pkg/sys/reaper"
 )
 
 // setupSignals creates a new signal handler for all signals and sets the shim as a
@@ -108,5 +109,5 @@ func handleExitSignals(ctx context.Context, logger *log.Entry, cancel context.Ca
 }
 
 func openLog(ctx context.Context, _ string) (io.Writer, error) {
-	return fifo.OpenFifoDup2(ctx, "log", unix.O_WRONLY, 0700, int(os.Stderr.Fd()))
+	return fifo.OpenFifoDup2(ctx, "log", unix.O_WRONLY, 0o700, int(os.Stderr.Fd()))
 }

--- a/pkg/shim/util.go
+++ b/pkg/shim/util.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl/v2"
 
@@ -36,7 +37,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/errdefs"
 )
 
 type CommandConfig struct {

--- a/pkg/shim/util_unix.go
+++ b/pkg/shim/util_unix.go
@@ -119,12 +119,12 @@ func NewSocket(address string) (*net.UnixListener, error) {
 		sock       = socket(address)
 		path       = sock.path()
 		isAbstract = sock.isAbstract()
-		perm       = os.FileMode(0600)
+		perm       = os.FileMode(0o600)
 	)
 
 	// Darwin needs +x to access socket, otherwise it'll fail with "bind: permission denied" when running as non-root.
 	if runtime.GOOS == "darwin" {
-		perm = 0700
+		perm = 0o700
 	}
 
 	if !isAbstract {
@@ -244,7 +244,6 @@ func hybridVsockDialer(addr string, port uint64, timeout time.Duration) (net.Con
 			return nil, fmt.Errorf("timeout waiting for hybrid vsocket handshake of %s:%d", addr, port)
 		}
 	}
-
 }
 
 func dialVsock(address string) (net.Conn, error) {

--- a/pkg/snapshotters/annotations.go
+++ b/pkg/snapshotters/annotations.go
@@ -19,10 +19,11 @@ package snapshotters
 import (
 	"context"
 
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/log"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/labels"
 )
 
 // NOTE: The following labels contain "cri" prefix but they are not specific to CRI and

--- a/pkg/sys/socket_unix.go
+++ b/pkg/sys/socket_unix.go
@@ -33,7 +33,7 @@ func CreateUnixSocket(path string) (net.Listener, error) {
 	if len(path) > 104 {
 		return nil, fmt.Errorf("%q: unix socket path too long (> 104)", path)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0660); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o660); err != nil {
 		return nil, err
 	}
 	if err := unix.Unlink(path); err != nil && !os.IsNotExist(err) {
@@ -54,7 +54,7 @@ func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
 		return l, fmt.Errorf("failed to create unix socket on %s: %w", path, err)
 	}
 
-	if err := os.Chmod(path, 0660); err != nil {
+	if err := os.Chmod(path, 0o660); err != nil {
 		l.Close()
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func mkdirAs(path string, uid, gid int) error {
 		return err
 	}
 
-	if err := os.MkdirAll(path, 0770); err != nil {
+	if err := os.MkdirAll(path, 0o770); err != nil {
 		return err
 	}
 

--- a/pkg/tracing/plugin/otlp.go
+++ b/pkg/tracing/plugin/otlp.go
@@ -24,10 +24,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/containerd/containerd/v2/pkg/deprecation"
-	"github.com/containerd/containerd/v2/pkg/tracing"
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/services/warning"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
@@ -38,6 +34,11 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/containerd/containerd/v2/pkg/deprecation"
+	"github.com/containerd/containerd/v2/pkg/tracing"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/services/warning"
 )
 
 const exporterPlugin = "otlp"
@@ -199,7 +200,6 @@ func newTracer(ctx context.Context, procs []trace.SpanProcessor) (io.Closer, err
 	return closerFunc(func() error {
 		return provider.Shutdown(ctx)
 	}), nil
-
 }
 
 func warnTraceConfig(ic *plugin.InitContext) error {

--- a/pkg/tracing/plugin/ttrpc.go
+++ b/pkg/tracing/plugin/ttrpc.go
@@ -17,11 +17,12 @@
 package plugin
 
 import (
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/otelttrpc"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"github.com/containerd/ttrpc"
+
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 func init() {

--- a/pkg/ttrpcutil/client.go
+++ b/pkg/ttrpcutil/client.go
@@ -24,8 +24,9 @@ import (
 	"time"
 
 	v1 "github.com/containerd/containerd/api/services/ttrpc/events/v1"
-	"github.com/containerd/containerd/v2/pkg/dialer"
 	"github.com/containerd/ttrpc"
+
+	"github.com/containerd/containerd/v2/pkg/dialer"
 )
 
 const ttrpcDialTimeout = 5 * time.Second

--- a/plugins/content/local/readerat.go
+++ b/plugins/content/local/readerat.go
@@ -21,8 +21,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/errdefs"
+
+	"github.com/containerd/containerd/v2/core/content"
 )
 
 // readerat implements io.ReaderAt in a completely stateless manner by opening

--- a/plugins/content/local/store.go
+++ b/plugins/content/local/store.go
@@ -29,13 +29,12 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/internal/fsverity"
 	"github.com/containerd/containerd/v2/pkg/filters"
-
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var bufPool = sync.Pool{
@@ -547,7 +546,7 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 	}
 
 	// ensure that the ingest path has been created.
-	if err := os.Mkdir(path, 0755); err != nil {
+	if err := os.Mkdir(path, 0o755); err != nil {
 		if !os.IsExist(err) {
 			return nil, err
 		}
@@ -569,7 +568,7 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 
 		// the ingest is new, we need to setup the target location.
 		// write the ref to a file for later use
-		if err := os.WriteFile(refp, []byte(ref), 0666); err != nil {
+		if err := os.WriteFile(refp, []byte(ref), 0o666); err != nil {
 			return nil, err
 		}
 
@@ -582,13 +581,13 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 		}
 
 		if total > 0 {
-			if err := os.WriteFile(filepath.Join(path, "total"), []byte(fmt.Sprint(total)), 0666); err != nil {
+			if err := os.WriteFile(filepath.Join(path, "total"), []byte(fmt.Sprint(total)), 0o666); err != nil {
 				return nil, err
 			}
 		}
 	}
 
-	fp, err := os.OpenFile(data, os.O_WRONLY|os.O_CREATE, 0666)
+	fp, err := os.OpenFile(data, os.O_WRONLY|os.O_CREATE, 0o666)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open data file: %w", err)
 	}
@@ -657,7 +656,7 @@ func (s *store) ingestPaths(ref string) (string, string, string) {
 }
 
 func (s *store) ensureIngestRoot() error {
-	return os.MkdirAll(filepath.Join(s.root, "ingest"), 0777)
+	return os.MkdirAll(filepath.Join(s.root, "ingest"), 0o777)
 }
 
 func readFileString(path string) (string, error) {
@@ -688,7 +687,7 @@ func writeTimestampFile(p string, t time.Time) error {
 	if err != nil {
 		return err
 	}
-	return writeToCompletion(p, b, 0666)
+	return writeToCompletion(p, b, 0o666)
 }
 
 func writeToCompletion(path string, data []byte, mode os.FileMode) error {

--- a/plugins/content/local/writer.go
+++ b/plugins/content/local/writer.go
@@ -123,7 +123,7 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	)
 
 	// make sure parent directories of blob exist
-	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return err
 	}
 
@@ -175,7 +175,7 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	//
 	// NOTE: Windows does not support this operation
 	if runtime.GOOS != "windows" {
-		if err := os.Chmod(target, (fi.Mode()&os.ModePerm)&^0333); err != nil {
+		if err := os.Chmod(target, (fi.Mode()&os.ModePerm)&^0o333); err != nil {
 			log.G(ctx).WithField("ref", w.ref).Error("failed to make readonly")
 		}
 	}

--- a/plugins/cri/cri.go
+++ b/plugins/cri/cri.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"google.golang.org/grpc"
@@ -37,7 +38,6 @@ import (
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services/warning"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/platforms"
 )
 
 // Register CRI service plugin

--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -21,6 +21,11 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -31,10 +36,6 @@ import (
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services/warning"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/log"
-	"github.com/containerd/platforms"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 func init() {
@@ -182,6 +183,7 @@ func configMigration(ctx context.Context, configVersion int, pluginConfigs map[s
 	pluginConfigs[string(plugins.CRIServicePlugin)+".images"] = dst
 	return nil
 }
+
 func migrateConfig(dst, src map[string]interface{}) {
 	var pinnedImages map[string]interface{}
 	if v, ok := dst["pinned_images"]; ok {

--- a/plugins/cri/runtime/plugin.go
+++ b/plugins/cri/runtime/plugin.go
@@ -24,7 +24,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -36,8 +38,6 @@ import (
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services/warning"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
 )
 
 func init() {

--- a/plugins/diff/erofs/differ_linux.go
+++ b/plugins/diff/erofs/differ_linux.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/google/uuid"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -43,8 +44,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/containerd/containerd/v2/pkg/epoch"
 	"github.com/containerd/containerd/v2/pkg/labels"
-
-	"github.com/google/uuid"
 )
 
 var emptyDesc = ocispec.Descriptor{}

--- a/plugins/diff/erofs/plugin/plugin_linux.go
+++ b/plugins/diff/erofs/plugin/plugin_linux.go
@@ -19,13 +19,14 @@ package plugin
 import (
 	"fmt"
 
+	"github.com/containerd/platforms"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/internal/erofsutils"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/diff/erofs"
-	"github.com/containerd/platforms"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 // Config represents configuration for the erofs plugin.

--- a/plugins/diff/lcow/lcow.go
+++ b/plugins/diff/lcow/lcow.go
@@ -30,17 +30,18 @@ import (
 
 	"github.com/Microsoft/go-winio/pkg/security"
 	"github.com/Microsoft/hcsshim/ext4/tar2ext4"
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/diff"
-	"github.com/containerd/containerd/v2/core/metadata"
-	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/diff"
+	"github.com/containerd/containerd/v2/core/metadata"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 const (

--- a/plugins/diff/walking/plugin/plugin.go
+++ b/plugins/diff/walking/plugin/plugin.go
@@ -17,14 +17,15 @@
 package plugin
 
 import (
+	"github.com/containerd/platforms"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/diff/apply"
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/diff/walking"
-	"github.com/containerd/platforms"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 func init() {

--- a/plugins/diff/windows/cimfs.go
+++ b/plugins/diff/windows/cimfs.go
@@ -30,11 +30,6 @@ import (
 
 	"github.com/Microsoft/hcsshim/pkg/cimfs"
 	ocicimlayer "github.com/Microsoft/hcsshim/pkg/ociwclayer/cim"
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/diff"
-	"github.com/containerd/containerd/v2/core/metadata"
-	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -43,6 +38,12 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/diff"
+	"github.com/containerd/containerd/v2/core/metadata"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 func init() {
@@ -162,9 +163,7 @@ func NewBlockCimDiff(store content.Store) (CompareApplier, error) {
 
 // parseBlockCIMMount parses the mount returned by the BlockCIM snapshotter and returns
 func parseBlockCIMMount(m *mount.Mount) (*cimfs.BlockCIM, []*cimfs.BlockCIM, error) {
-	var (
-		parentPaths []string
-	)
+	var parentPaths []string
 
 	for _, option := range m.Options {
 		if val, ok := strings.CutPrefix(option, mount.ParentLayerCimPathsFlag); ok {
@@ -241,7 +240,6 @@ func (c blockCIMDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts
 	}
 
 	return applyCIMLayerCommon(ctx, desc, c.store, applyFunc, opts...)
-
 }
 
 // Compare creates a diff between the given mounts and uploads the result
@@ -308,5 +306,4 @@ func applyCIMLayerCommon(ctx context.Context, desc ocispec.Descriptor, store con
 		Size:      rc.c,
 		Digest:    digester.Digest(),
 	}, nil
-
 }

--- a/plugins/diff/windows/windows.go
+++ b/plugins/diff/windows/windows.go
@@ -167,7 +167,6 @@ func (s windowsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts 
 		Size:      rc.c,
 		Digest:    digester.Digest(),
 	}, nil
-
 }
 
 // Compare creates a diff between the given mounts and uploads the result
@@ -214,7 +213,6 @@ func (s windowsDiff) Compare(ctx context.Context, lower, upper []mount.Mount, op
 	cw, err := s.store.Writer(ctx, content.WithRef(config.Reference), content.WithDescriptor(ocispec.Descriptor{
 		MediaType: config.MediaType,
 	}))
-
 	if err != nil {
 		return emptyDesc, fmt.Errorf("failed to open writer: %w", err)
 	}
@@ -357,7 +355,6 @@ func mountsToLayerAndParents(mounts []mount.Mount) (string, []string, error) {
 // parent-and-child, or orphan-and-empty-list, and return the full list of layers, starting
 // with the upper-most (most childish?)
 func mountPairToLayerStack(lower, upper []mount.Mount) ([]string, error) {
-
 	// May return an ErrNotImplemented, which will fall back to LCOW
 	upperLayer, upperParentLayerPaths, err := mountsToLayerAndParents(upper)
 	if err != nil {

--- a/plugins/events/plugin.go
+++ b/plugins/events/plugin.go
@@ -17,10 +17,11 @@
 package events
 
 import (
-	"github.com/containerd/containerd/v2/core/events/exchange"
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/core/events/exchange"
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 func init() {

--- a/plugins/gc/scheduler.go
+++ b/plugins/gc/scheduler.go
@@ -23,12 +23,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd/v2/internal/tomlext"
-	"github.com/containerd/containerd/v2/pkg/gc"
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/internal/tomlext"
+	"github.com/containerd/containerd/v2/pkg/gc"
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 // config configures the garbage collection policies.

--- a/plugins/imageverifier/plugin.go
+++ b/plugins/imageverifier/plugin.go
@@ -19,11 +19,12 @@ package imageverifier
 import (
 	"time"
 
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
 	"github.com/containerd/containerd/v2/internal/tomlext"
 	"github.com/containerd/containerd/v2/pkg/imageverifier/bindir"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 // Register default image verifier service plugin

--- a/plugins/leases/local.go
+++ b/plugins/leases/local.go
@@ -19,12 +19,13 @@ package plugin
 import (
 	"context"
 
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/pkg/gc"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 func init() {
@@ -80,5 +81,4 @@ func (l *local) Delete(ctx context.Context, lease leases.Lease, opts ...leases.D
 	}
 
 	return nil
-
 }

--- a/plugins/metadata/plugin.go
+++ b/plugins/metadata/plugin.go
@@ -22,18 +22,18 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
-
-	bolt "go.etcd.io/bbolt"
 )
 
 const (
@@ -106,7 +106,7 @@ func init() {
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			root := ic.Properties[plugins.PropertyRootDir]
-			if err := os.MkdirAll(root, 0711); err != nil {
+			if err := os.MkdirAll(root, 0o711); err != nil {
 				return nil, err
 			}
 			cs, err := ic.GetSingle(plugins.ContentPlugin)
@@ -176,7 +176,7 @@ func init() {
 				}
 			}()
 
-			db, err := bolt.Open(path, 0644, &options)
+			db, err := bolt.Open(path, 0o644, &options)
 			close(doneCh)
 			if err != nil {
 				return nil, err

--- a/plugins/nri/plugin.go
+++ b/plugins/nri/plugin.go
@@ -17,10 +17,11 @@
 package nri
 
 import (
-	"github.com/containerd/containerd/v2/internal/nri"
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/internal/nri"
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 func init() {

--- a/plugins/restart/monitor.go
+++ b/plugins/restart/monitor.go
@@ -23,15 +23,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/runtime/restart"
 	"github.com/containerd/containerd/v2/internal/tomlext"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/log"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 // Config for the restart monitor

--- a/plugins/sandbox/controller.go
+++ b/plugins/sandbox/controller.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"time"
 
+	runtimeAPI "github.com/containerd/containerd/api/runtime/sandbox/v1"
+	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/log"
@@ -29,9 +31,6 @@ import (
 	"github.com/containerd/plugin/registry"
 	"github.com/containerd/typeurl/v2"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-
-	runtimeAPI "github.com/containerd/containerd/api/runtime/sandbox/v1"
-	"github.com/containerd/containerd/api/types"
 
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/core/events/exchange"
@@ -68,7 +67,7 @@ func init() {
 			state := ic.Properties[plugins.PropertyStateDir]
 			root := ic.Properties[plugins.PropertyRootDir]
 			for _, d := range []string{root, state} {
-				if err := os.MkdirAll(d, 0711); err != nil {
+				if err := os.MkdirAll(d, 0o711); err != nil {
 					return nil, err
 				}
 			}
@@ -267,7 +266,6 @@ func (c *controllerLocal) Wait(ctx context.Context, sandboxID string) (sandbox.E
 	resp, err := svc.WaitSandbox(ctx, &runtimeAPI.WaitSandboxRequest{
 		SandboxID: sandboxID,
 	})
-
 	if err != nil {
 		return sandbox.ExitStatus{}, fmt.Errorf("failed to wait sandbox %s: %w", sandboxID, errgrpc.ToNative(err))
 	}
@@ -334,7 +332,8 @@ func (c *controllerLocal) Update(
 	ctx context.Context,
 	sandboxID string,
 	sandbox sandbox.Sandbox,
-	fields ...string) error {
+	fields ...string,
+) error {
 	return nil
 }
 

--- a/plugins/services/containers/helpers.go
+++ b/plugins/services/containers/helpers.go
@@ -18,10 +18,11 @@ package containers
 
 import (
 	api "github.com/containerd/containerd/api/services/containers/v1"
+	"github.com/containerd/typeurl/v2"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	"github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/typeurl/v2"
 )
 
 func containersToProto(containers []containers.Container) []*api.Container {

--- a/plugins/services/containers/service.go
+++ b/plugins/services/containers/service.go
@@ -21,12 +21,13 @@ import (
 	"io"
 
 	api "github.com/containerd/containerd/api/services/containers/v1"
-	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/services"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"google.golang.org/grpc"
+
+	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/services"
 )
 
 func init() {

--- a/plugins/services/content/service.go
+++ b/plugins/services/content/service.go
@@ -17,12 +17,13 @@
 package content
 
 import (
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services"
 	"github.com/containerd/containerd/v2/plugins/services/content/contentserver"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 func init() {

--- a/plugins/services/diff/local.go
+++ b/plugins/services/diff/local.go
@@ -133,7 +133,6 @@ func (l *local) Apply(ctx context.Context, er *diffapi.ApplyRequest, _ ...grpc.C
 	return &diffapi.ApplyResponse{
 		Applied: oci.DescriptorToProto(ocidesc),
 	}, nil
-
 }
 
 func (l *local) Diff(ctx context.Context, dr *diffapi.DiffRequest, _ ...grpc.CallOption) (*diffapi.DiffResponse, error) {

--- a/plugins/services/diff/service.go
+++ b/plugins/services/diff/service.go
@@ -20,11 +20,12 @@ import (
 	"context"
 
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/services"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"google.golang.org/grpc"
+
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/services"
 )
 
 func init() {

--- a/plugins/services/healthcheck/service.go
+++ b/plugins/services/healthcheck/service.go
@@ -17,13 +17,13 @@
 package healthcheck
 
 import (
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 type service struct {

--- a/plugins/services/images/helpers.go
+++ b/plugins/services/images/helpers.go
@@ -18,6 +18,7 @@ package images
 
 import (
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
+
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/pkg/protobuf"

--- a/plugins/services/images/local.go
+++ b/plugins/services/images/local.go
@@ -19,15 +19,14 @@ package images
 import (
 	"context"
 
+	imagesapi "github.com/containerd/containerd/api/services/images/v1"
 	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	imagesapi "github.com/containerd/containerd/api/services/images/v1"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/metadata"

--- a/plugins/services/images/service.go
+++ b/plugins/services/images/service.go
@@ -20,12 +20,13 @@ import (
 	"context"
 
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
-	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/services"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"google.golang.org/grpc"
+
+	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/services"
 )
 
 func init() {

--- a/plugins/services/introspection/local.go
+++ b/plugins/services/introspection/local.go
@@ -25,11 +25,6 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/google/uuid"
-	"google.golang.org/genproto/googleapis/rpc/code"
-	rpc "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc/status"
-
 	api "github.com/containerd/containerd/api/services/introspection/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/errdefs"
@@ -37,6 +32,10 @@ import (
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"github.com/containerd/typeurl/v2"
+	"github.com/google/uuid"
+	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/status"
 
 	"github.com/containerd/containerd/v2/core/introspection"
 	"github.com/containerd/containerd/v2/pkg/filters"
@@ -170,11 +169,11 @@ func (l *Local) generateUUID() (string, error) {
 		return "", err
 	}
 	path := l.uuidPath()
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", err
 	}
 	uu := u.String()
-	if err := os.WriteFile(path, []byte(uu), 0666); err != nil {
+	if err := os.WriteFile(path, []byte(uu), 0o666); err != nil {
 		return "", err
 	}
 	return uu, nil

--- a/plugins/services/namespaces/local.go
+++ b/plugins/services/namespaces/local.go
@@ -149,7 +149,6 @@ func (l *local) Create(ctx context.Context, req *api.CreateNamespaceRequest, _ .
 	}
 
 	return &resp, nil
-
 }
 
 func (l *local) Update(ctx context.Context, req *api.UpdateNamespaceRequest, _ ...grpc.CallOption) (*api.UpdateNamespaceResponse, error) {
@@ -185,7 +184,6 @@ func (l *local) Update(ctx context.Context, req *api.UpdateNamespaceRequest, _ .
 				if err := store.SetLabel(ctx, req.Namespace.Name, k, v); err != nil {
 					return err
 				}
-
 			}
 		}
 

--- a/plugins/services/namespaces/service.go
+++ b/plugins/services/namespaces/service.go
@@ -20,12 +20,13 @@ import (
 	"context"
 
 	api "github.com/containerd/containerd/api/services/namespaces/v1"
-	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/services"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"google.golang.org/grpc"
+
+	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/services"
 )
 
 func init() {

--- a/plugins/services/opt/service.go
+++ b/plugins/services/opt/service.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 // Config for the opt manager
@@ -43,7 +44,7 @@ func init() {
 			path := ic.Config.(*Config).Path
 			ic.Meta.Exports["path"] = path
 			bin := filepath.Join(path, "bin")
-			if err := os.MkdirAll(bin, 0711); err != nil {
+			if err := os.MkdirAll(bin, 0o711); err != nil {
 				return nil, err
 			}
 			if err := os.Setenv("PATH", fmt.Sprintf("%s%c%s", bin, os.PathListSeparator, os.Getenv("PATH"))); err != nil {
@@ -51,7 +52,7 @@ func init() {
 			}
 
 			lib := filepath.Join(path, "lib")
-			if err := os.MkdirAll(lib, 0711); err != nil {
+			if err := os.MkdirAll(lib, 0o711); err != nil {
 				return nil, err
 			}
 			if err := os.Setenv("LD_LIBRARY_PATH", fmt.Sprintf("%s%c%s", lib, os.PathListSeparator, os.Getenv("LD_LIBRARY_PATH"))); err != nil {
@@ -62,5 +63,4 @@ func init() {
 	})
 }
 
-type manager struct {
-}
+type manager struct{}

--- a/plugins/services/sandbox/controller_service.go
+++ b/plugins/services/sandbox/controller_service.go
@@ -21,9 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/anypb"
-
 	eventtypes "github.com/containerd/containerd/api/events"
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/errdefs"
@@ -31,6 +28,8 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/core/sandbox"
@@ -244,7 +243,8 @@ func (s *controllerService) Metrics(ctx context.Context, req *api.ControllerMetr
 
 func (s *controllerService) Update(
 	ctx context.Context,
-	req *api.ControllerUpdateRequest) (*api.ControllerUpdateResponse, error) {
+	req *api.ControllerUpdateRequest,
+) (*api.ControllerUpdateResponse, error) {
 	log.G(ctx).WithField("req", req).Debug("sandbox update resource")
 	ctrl, err := s.getController(req.Sandboxer)
 	if err != nil {

--- a/plugins/services/sandbox/store_local.go
+++ b/plugins/services/sandbox/store_local.go
@@ -17,10 +17,11 @@
 package sandbox
 
 import (
-	"github.com/containerd/containerd/v2/core/metadata"
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/core/metadata"
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 func init() {

--- a/plugins/services/sandbox/store_service.go
+++ b/plugins/services/sandbox/store_service.go
@@ -19,14 +19,13 @@ package sandbox
 import (
 	"context"
 
-	"google.golang.org/grpc"
-
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+	"google.golang.org/grpc"
 
 	"github.com/containerd/containerd/v2/core/sandbox"
 	"github.com/containerd/containerd/v2/plugins"

--- a/plugins/services/snapshots/snapshotters.go
+++ b/plugins/services/snapshots/snapshotters.go
@@ -17,11 +17,12 @@
 package snapshots
 
 import (
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 func init() {

--- a/plugins/services/tasks/service.go
+++ b/plugins/services/tasks/service.go
@@ -20,17 +20,16 @@ import (
 	"context"
 
 	api "github.com/containerd/containerd/api/services/tasks/v1"
-	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/services"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"google.golang.org/grpc"
+
+	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/services"
 )
 
-var (
-	_ = (api.TasksServer)(&service{})
-)
+var _ = (api.TasksServer)(&service{})
 
 func init() {
 	registry.Register(&plugin.Registration{

--- a/plugins/services/version/service.go
+++ b/plugins/services/version/service.go
@@ -20,12 +20,13 @@ import (
 	"context"
 
 	api "github.com/containerd/containerd/api/services/version/v1"
-	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/containerd/v2/plugins"
-	ctrdversion "github.com/containerd/containerd/v2/version"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"google.golang.org/grpc"
+
+	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
+	"github.com/containerd/containerd/v2/plugins"
+	ctrdversion "github.com/containerd/containerd/v2/version"
 )
 
 var _ api.VersionServer = &service{}

--- a/plugins/services/warning/service.go
+++ b/plugins/services/warning/service.go
@@ -22,11 +22,11 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
 
 	deprecation "github.com/containerd/containerd/v2/pkg/deprecation"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 type Service interface {
@@ -66,6 +66,7 @@ func (s *service) Emit(ctx context.Context, warning deprecation.Warning) {
 	defer s.m.Unlock()
 	s.warnings[warning] = time.Now()
 }
+
 func (s *service) Warnings() []Warning {
 	s.m.RLock()
 	defer s.m.RUnlock()

--- a/plugins/snapshots/blockfile/blockfile.go
+++ b/plugins/snapshots/blockfile/blockfile.go
@@ -25,16 +25,17 @@ import (
 	"runtime"
 	"slices"
 
-	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/core/snapshots/storage"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/storage"
 )
 
 // viewHookHelper is only used in test for recover the filesystem.
-type viewHookHelper func(backingFile string, fsType string, defaultOpts []string) error
+type viewHookHelper func(backingFile, fsType string, defaultOpts []string) error
 
 // SnapshotterConfig holds the configurable properties for the blockfile snapshotter
 type SnapshotterConfig struct {
@@ -91,7 +92,6 @@ func WithMountOptions(options []string) Opt {
 	return func(root string, config *SnapshotterConfig) {
 		config.mountOptions = options
 	}
-
 }
 
 // WithRecreateScratch is used to determine that scratch should be recreated
@@ -126,7 +126,7 @@ type snapshotter struct {
 // file system. A metadata file is stored under the root.
 func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 	var config SnapshotterConfig
-	if err := os.MkdirAll(root, 0700); err != nil {
+	if err := os.MkdirAll(root, 0o700); err != nil {
 		return nil, err
 	}
 
@@ -170,7 +170,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		return nil, err
 	}
 
-	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0o700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 
@@ -349,7 +349,6 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		restore = true
 		return nil
 	})
-
 	if err != nil {
 		if renamed != "" && restore {
 			if err1 := os.Rename(renamed, path); err1 != nil {

--- a/plugins/snapshots/blockfile/plugin/plugin.go
+++ b/plugins/snapshots/blockfile/plugin/plugin.go
@@ -19,11 +19,12 @@ package plugin
 import (
 	"errors"
 
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/snapshots/blockfile"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/snapshots/blockfile"
 )
 
 // Config represents configuration for the native plugin.

--- a/plugins/snapshots/btrfs/plugin/plugin.go
+++ b/plugins/snapshots/btrfs/plugin/plugin.go
@@ -21,13 +21,13 @@ package plugin
 import (
 	"errors"
 
+	"github.com/containerd/platforms"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/snapshots/btrfs"
-	"github.com/containerd/platforms"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 // Config represents configuration for the btrfs plugin.

--- a/plugins/snapshots/devmapper/dmsetup/dmsetup.go
+++ b/plugins/snapshots/devmapper/dmsetup/dmsetup.go
@@ -29,8 +29,9 @@ import (
 	"strconv"
 	"strings"
 
-	blkdiscard "github.com/containerd/containerd/v2/plugins/snapshots/devmapper/blkdiscard"
 	"golang.org/x/sys/unix"
+
+	blkdiscard "github.com/containerd/containerd/v2/plugins/snapshots/devmapper/blkdiscard"
 )
 
 const (
@@ -131,7 +132,7 @@ func CreateDevice(poolName string, deviceID uint32) error {
 }
 
 // ActivateDevice activates the given thin-device using the 'thin' target
-func ActivateDevice(poolName string, deviceName string, deviceID uint32, size uint64, external string) error {
+func ActivateDevice(poolName, deviceName string, deviceID uint32, size uint64, external string) error {
 	mapping := makeThinMapping(poolName, deviceID, size, external)
 	_, err := dmsetup("create", deviceName, "--table", mapping)
 	return err
@@ -170,7 +171,7 @@ func Table(deviceName string) (string, error) {
 
 // CreateSnapshot sends "create_snap" message to the given thin-pool.
 // Caller needs to suspend and resume device if it is active.
-func CreateSnapshot(poolName string, deviceID uint32, baseDeviceID uint32) error {
+func CreateSnapshot(poolName string, deviceID, baseDeviceID uint32) error {
 	_, err := dmsetup("message", poolName, "0", fmt.Sprintf("create_snap %d %d", deviceID, baseDeviceID))
 	return err
 }
@@ -231,7 +232,6 @@ func Info(deviceName string) ([]*DeviceInfo, error) {
 		"--separator",
 		" ",
 		deviceName)
-
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +256,6 @@ func Info(deviceName string) ([]*DeviceInfo, error) {
 			&info.OpenCount,
 			&info.TargetCount,
 			&info.EventNumber)
-
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse line %q: %w", line, err)
 		}

--- a/plugins/snapshots/devmapper/metadata.go
+++ b/plugins/snapshots/devmapper/metadata.go
@@ -64,7 +64,7 @@ type PoolMetadata struct {
 
 // NewPoolMetadata creates new or opens existing pool metadata database
 func NewPoolMetadata(dbfile string) (*PoolMetadata, error) {
-	db, err := bolt.Open(dbfile, 0600, nil)
+	db, err := bolt.Open(dbfile, 0o600, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,6 @@ func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo) error {
 
 		return putObject(devicesBucket, info.Name, info, true)
 	})
-
 	if err != nil {
 		return fmt.Errorf("failed to save metadata for device %q (parent: %q): %w", info.Name, info.ParentName, err)
 	}
@@ -320,7 +319,6 @@ func (m *PoolMetadata) GetDeviceNames(ctx context.Context) ([]string, error) {
 			return nil
 		})
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/snapshots/devmapper/plugin/plugin.go
+++ b/plugins/snapshots/devmapper/plugin/plugin.go
@@ -22,11 +22,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/snapshots/devmapper"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/snapshots/devmapper"
 )
 
 func init() {

--- a/plugins/snapshots/devmapper/snapshotter.go
+++ b/plugins/snapshots/devmapper/snapshotter.go
@@ -28,12 +28,13 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
 	"github.com/containerd/containerd/v2/plugins/snapshots/devmapper/dmsetup"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
 )
 
 type fsType string
@@ -76,7 +77,7 @@ func NewSnapshotter(ctx context.Context, config *Config) (*Snapshotter, error) {
 
 	var cleanupFn []closeFunc
 
-	if err := os.MkdirAll(config.RootPath, 0750); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(config.RootPath, 0o750); err != nil && !os.IsExist(err) {
 		return nil, fmt.Errorf("failed to create root directory: %s: %w", config.RootPath, err)
 	}
 
@@ -457,7 +458,7 @@ func (s *Snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 
 // mkfs creates filesystem on the given devmapper device based on type
 // specified in config.
-func mkfs(ctx context.Context, fs fsType, fsOptions string, path string) error {
+func mkfs(ctx context.Context, fs fsType, fsOptions, path string) error {
 	mkfsCommand := ""
 	var args []string
 

--- a/plugins/snapshots/erofs/erofs_linux.go
+++ b/plugins/snapshots/erofs/erofs_linux.go
@@ -116,7 +116,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		opt(&config)
 	}
 
-	if err := os.MkdirAll(root, 0700); err != nil {
+	if err := os.MkdirAll(root, 0o700); err != nil {
 		return nil, err
 	}
 	supportsDType, err := fs.SupportsDType(root)
@@ -147,7 +147,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		return nil, err
 	}
 
-	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0o700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 
@@ -197,18 +197,18 @@ func (s *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
-	if err := os.Mkdir(filepath.Join(td, "fs"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(td, "fs"), 0o755); err != nil {
 		return td, err
 	}
 
 	if kind == snapshots.KindActive {
-		if err := os.Mkdir(filepath.Join(td, "work"), 0711); err != nil {
+		if err := os.Mkdir(filepath.Join(td, "work"), 0o711); err != nil {
 			return td, err
 		}
 	}
 	// Create a special file for the EROFS differ to indicate it will be
 	// prepared as an EROFS layer by the EROFS snapshotter.
-	if err := os.WriteFile(filepath.Join(td, ".erofslayer"), []byte{}, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(td, ".erofslayer"), []byte{}, 0o644); err != nil {
 		return td, err
 	}
 	return td, nil
@@ -452,7 +452,6 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 		}
 		return nil
 	})
-
 	if err != nil {
 		return err
 	}

--- a/plugins/snapshots/erofs/plugin/plugin_linux.go
+++ b/plugins/snapshots/erofs/plugin/plugin_linux.go
@@ -19,11 +19,12 @@ package plugin
 import (
 	"errors"
 
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/snapshots/erofs"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/snapshots/erofs"
 )
 
 // Config represents configuration for the native plugin.

--- a/plugins/snapshots/lcow/lcow.go
+++ b/plugins/snapshots/lcow/lcow.go
@@ -34,16 +34,17 @@ import (
 
 	winfs "github.com/Microsoft/go-winio/pkg/fs"
 	"github.com/Microsoft/hcsshim/pkg/go-runhcs"
-	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/core/snapshots/storage"
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/storage"
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 func init() {
@@ -84,7 +85,7 @@ func NewSnapshotter(root string) (snapshots.Snapshotter, error) {
 		return nil, fmt.Errorf("%s is not on an NTFS volume - only NTFS volumes are supported: %w", root, errdefs.ErrInvalidArgument)
 	}
 
-	if err := os.MkdirAll(root, 0700); err != nil {
+	if err := os.MkdirAll(root, 0o700); err != nil {
 		return nil, err
 	}
 	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"))
@@ -92,7 +93,7 @@ func NewSnapshotter(root string) (snapshots.Snapshotter, error) {
 		return nil, err
 	}
 
-	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0o700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 
@@ -315,7 +316,7 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		log.G(ctx).Debug("createSnapshot active")
 		// Create the new snapshot dir
 		snDir := s.getSnapshotDir(newSnapshot.ID)
-		if err = os.MkdirAll(snDir, 0700); err != nil {
+		if err = os.MkdirAll(snDir, 0o700); err != nil {
 			return err
 		}
 
@@ -372,7 +373,7 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 
 				// Create the sandbox.vhdx for this snapshot from the cache
 				destPath := filepath.Join(snDir, "sandbox.vhdx")
-				dest, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE, 0700)
+				dest, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE, 0o700)
 				if err != nil {
 					return fmt.Errorf("failed to create sandbox.vhdx in snapshot: %w", err)
 				}
@@ -439,7 +440,7 @@ func (s *snapshotter) openOrCreateScratch(ctx context.Context, sizeGB int, scrat
 		scratchFinalPath = filepath.Join(scratchLoc, vhdFileName)
 	}
 
-	scratchSource, err := os.OpenFile(scratchFinalPath, os.O_RDONLY, 0700)
+	scratchSource, err := os.OpenFile(scratchFinalPath, os.O_RDONLY, 0o700)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("failed to open vhd %s for read: %w", vhdFileName, err)
@@ -474,7 +475,7 @@ func (s *snapshotter) openOrCreateScratch(ctx context.Context, sizeGB int, scrat
 			os.Remove(scratchTempPath)
 			return nil, fmt.Errorf("failed to rename '%s' temp file to 'scratch.vhdx': %w", scratchTempName, err)
 		}
-		scratchSource, err = os.OpenFile(scratchFinalPath, os.O_RDONLY, 0700)
+		scratchSource, err = os.OpenFile(scratchFinalPath, os.O_RDONLY, 0o700)
 		if err != nil {
 			os.Remove(scratchFinalPath)
 			return nil, fmt.Errorf("failed to open scratch.vhdx for read after creation: %w", err)

--- a/plugins/snapshots/native/native.go
+++ b/plugins/snapshots/native/native.go
@@ -22,12 +22,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containerd/continuity/fs"
+	"github.com/containerd/log"
+
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
-	"github.com/containerd/log"
-
-	"github.com/containerd/continuity/fs"
 )
 
 type snapshotter struct {
@@ -38,7 +38,7 @@ type snapshotter struct {
 // NewSnapshotter returns a Snapshotter which copies layers on the underlying
 // file system. A metadata file is stored under the root.
 func NewSnapshotter(root string) (snapshots.Snapshotter, error) {
-	if err := os.MkdirAll(root, 0700); err != nil {
+	if err := os.MkdirAll(root, 0o700); err != nil {
 		return nil, err
 	}
 	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"))
@@ -46,7 +46,7 @@ func NewSnapshotter(root string) (snapshots.Snapshotter, error) {
 		return nil, err
 	}
 
-	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0o700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 
@@ -184,7 +184,6 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		restore = true
 		return nil
 	})
-
 	if err != nil {
 		if renamed != "" && restore {
 			if err1 := os.Rename(renamed, path); err1 != nil {
@@ -222,7 +221,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temp dir: %w", err)
 		}
-		if err := os.Chmod(td, 0755); err != nil {
+		if err := os.Chmod(td, 0o755); err != nil {
 			return nil, fmt.Errorf("failed to chmod %s to 0755: %w", td, err)
 		}
 		defer func() {

--- a/plugins/snapshots/native/plugin/plugin.go
+++ b/plugins/snapshots/native/plugin/plugin.go
@@ -19,11 +19,12 @@ package plugin
 import (
 	"errors"
 
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/snapshots/native"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/snapshots/native"
 )
 
 // Config represents configuration for the native plugin.

--- a/plugins/snapshots/overlay/overlay.go
+++ b/plugins/snapshots/overlay/overlay.go
@@ -26,13 +26,14 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containerd/continuity/fs"
+	"github.com/containerd/log"
+
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
 	"github.com/containerd/containerd/v2/internal/userns"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
-	"github.com/containerd/continuity/fs"
-	"github.com/containerd/log"
 )
 
 // upperdirKey is a key of an optional label to each snapshot.
@@ -126,7 +127,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		}
 	}
 
-	if err := os.MkdirAll(root, 0700); err != nil {
+	if err := os.MkdirAll(root, 0o700); err != nil {
 		return nil, err
 	}
 	supportsDType, err := fs.SupportsDType(root)
@@ -143,7 +144,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		}
 	}
 
-	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0o700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 
@@ -536,12 +537,12 @@ func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
-	if err := os.Mkdir(filepath.Join(td, "fs"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(td, "fs"), 0o755); err != nil {
 		return td, err
 	}
 
 	if kind == snapshots.KindActive {
-		if err := os.Mkdir(filepath.Join(td, "work"), 0711); err != nil {
+		if err := os.Mkdir(filepath.Join(td, "work"), 0o711); err != nil {
 			return td, err
 		}
 	}

--- a/plugins/snapshots/overlay/overlayutils/check.go
+++ b/plugins/snapshots/overlay/overlayutils/check.go
@@ -24,13 +24,13 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/containerd/continuity/fs"
+	"github.com/containerd/log"
 	"github.com/moby/sys/userns"
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	kernel "github.com/containerd/containerd/v2/pkg/kernelversion"
-	"github.com/containerd/continuity/fs"
-	"github.com/containerd/log"
 )
 
 const (
@@ -57,7 +57,7 @@ func SupportsMultipleLowerDir(d string) error {
 	}()
 
 	for _, dir := range []string{"lower1", "lower2", "upper", "work", "merged"} {
-		if err := os.Mkdir(filepath.Join(td, dir), 0755); err != nil {
+		if err := os.Mkdir(filepath.Join(td, dir), 0o755); err != nil {
 			return err
 		}
 	}
@@ -82,7 +82,7 @@ func SupportsMultipleLowerDir(d string) error {
 // Supported is not called during plugin initialization, but exposed for downstream projects which uses
 // this snapshotter as a library.
 func Supported(root string) error {
-	if err := os.MkdirAll(root, 0700); err != nil {
+	if err := os.MkdirAll(root, 0o700); err != nil {
 		return err
 	}
 	supportsDType, err := fs.SupportsDType(root)
@@ -155,7 +155,7 @@ func NeedsUserXAttr(d string) (bool, error) {
 		log.L.WithError(err).Warnf("Failed to remove check directory %v", tdRoot)
 	}
 
-	if err := os.MkdirAll(tdRoot, 0700); err != nil {
+	if err := os.MkdirAll(tdRoot, 0o700); err != nil {
 		return false, err
 	}
 
@@ -171,7 +171,7 @@ func NeedsUserXAttr(d string) (bool, error) {
 	}
 
 	for _, dir := range []string{"lower1", "lower2", "upper", "work", "merged"} {
-		if err := os.Mkdir(filepath.Join(td, dir), 0755); err != nil {
+		if err := os.Mkdir(filepath.Join(td, dir), 0o755); err != nil {
 			return false, err
 		}
 	}
@@ -237,7 +237,7 @@ func SupportsIDMappedMounts() (bool, error) {
 	}()
 
 	for _, dir := range []string{"lower", "upper", "work", "merged"} {
-		if err = os.Mkdir(filepath.Join(td, dir), 0755); err != nil {
+		if err = os.Mkdir(filepath.Join(td, dir), 0o755); err != nil {
 			return false, fmt.Errorf("failed to create %s directory: %w", dir, err)
 		}
 	}

--- a/plugins/snapshots/overlay/plugin/plugin.go
+++ b/plugins/snapshots/overlay/plugin/plugin.go
@@ -21,12 +21,13 @@ package overlay
 import (
 	"errors"
 
-	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/snapshots/overlay"
-	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/snapshots/overlay"
+	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
 )
 
 const (

--- a/plugins/snapshots/windows/block_cimfs.go
+++ b/plugins/snapshots/windows/block_cimfs.go
@@ -30,11 +30,6 @@ import (
 	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/hcsshim/pkg/cimfs"
 	cimlayer "github.com/Microsoft/hcsshim/pkg/ociwclayer/cim"
-	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/core/snapshots/storage"
-	"github.com/containerd/containerd/v2/internal/kmutex"
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
@@ -43,6 +38,12 @@ import (
 	"github.com/containerd/plugin/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/storage"
+	"github.com/containerd/containerd/v2/internal/kmutex"
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 const (
@@ -120,7 +121,6 @@ func NewBlockCIMSnapshotter(root string, config *BlockCIMSnapshotterConfig) (sna
 		// copy the differing VHD for every new scratch snapshot. If a different size is
 		// specified, we use ExpandVHD to change the size.
 		err = createDifferencingScratchVHDs(context.Background(), root)
-
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare scratch VHDs: %w", err)
@@ -173,7 +173,6 @@ func (s *blockCIMSnapshotter) getSnapshotBlockCIM(ctx context.Context, snID stri
 		Type:      cimfs.BlockCIMTypeSingleFile,
 		BlockPath: s.getSingleFileCIMBlockPath(snID),
 	}, nil
-
 }
 
 func (s *blockCIMSnapshotter) Usage(ctx context.Context, key string) (usage snapshots.Usage, err error) {
@@ -279,7 +278,7 @@ func (s *blockCIMSnapshotter) createSnapshot(ctx context.Context, kind snapshots
 
 		// Create the new snapshot dir
 		snDir := s.getSnapshotDir(newSnapshot.ID)
-		if err = os.MkdirAll(snDir, 0700); err != nil {
+		if err = os.MkdirAll(snDir, 0o700); err != nil {
 			return fmt.Errorf("failed to create snapshot dir %s: %w", snDir, err)
 		}
 		defer func() {

--- a/plugins/snapshots/windows/cimfs.go
+++ b/plugins/snapshots/windows/cimfs.go
@@ -33,10 +33,6 @@ import (
 	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/hcsshim/computestorage"
 	"github.com/Microsoft/hcsshim/pkg/cimfs"
-	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/core/snapshots/storage"
-	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -44,6 +40,11 @@ import (
 	"github.com/containerd/plugin/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sys/windows"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/storage"
+	"github.com/containerd/containerd/v2/plugins"
 )
 
 const (
@@ -130,7 +131,7 @@ func NewCimFSSnapshotter(root string) (snapshots.Snapshotter, error) {
 		return nil, fmt.Errorf("failed to init base scratch VHD: %w", err)
 	}
 
-	if err = os.MkdirAll(filepath.Join(baseSn.info.HomeDir, "cim-layers"), 0755); err != nil {
+	if err = os.MkdirAll(filepath.Join(baseSn.info.HomeDir, "cim-layers"), 0o755); err != nil {
 		return nil, err
 	}
 
@@ -270,7 +271,7 @@ func (s *cimFSSnapshotter) createSnapshot(ctx context.Context, kind snapshots.Ki
 		log.G(ctx).Debug("createSnapshot")
 		// Create the new snapshot dir
 		snDir := s.getSnapshotDir(newSnapshot.ID)
-		if err = os.MkdirAll(snDir, 0700); err != nil {
+		if err = os.MkdirAll(snDir, 0o700); err != nil {
 			return fmt.Errorf("failed to create snapshot dir %s: %w", snDir, err)
 		}
 		defer func() {
@@ -343,9 +344,7 @@ func (s *cimFSSnapshotter) createScratchLayer(ctx context.Context, snDir string,
 }
 
 func (s *cimFSSnapshotter) mounts(sn storage.Snapshot, key string) []mount.Mount {
-	var (
-		roFlag string
-	)
+	var roFlag string
 
 	if sn.Kind == snapshots.KindView {
 		roFlag = "ro"

--- a/plugins/snapshots/windows/common.go
+++ b/plugins/snapshots/windows/common.go
@@ -29,10 +29,11 @@ import (
 	"strconv"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/core/snapshots/storage"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/log"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/storage"
 )
 
 // windowsBaseSnapshotter is a type that implements common functionality required by both windows & cimfs
@@ -48,7 +49,7 @@ type windowsBaseSnapshotter struct {
 }
 
 func newBaseSnapshotter(root string) (*windowsBaseSnapshotter, error) {
-	if err := os.MkdirAll(root, 0700); err != nil {
+	if err := os.MkdirAll(root, 0o700); err != nil {
 		return nil, err
 	}
 
@@ -57,7 +58,7 @@ func newBaseSnapshotter(root string) (*windowsBaseSnapshotter, error) {
 		return nil, err
 	}
 
-	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0o700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 
@@ -223,7 +224,7 @@ func (w *windowsBaseSnapshotter) createUVMScratchLayer(ctx context.Context, snDi
 
 	// Move the sandbox.vhdx into a nested vm folder to avoid clashing with a containers sandbox.vhdx.
 	vmScratchDir := filepath.Join(snDir, "vm")
-	if err := os.MkdirAll(vmScratchDir, 0777); err != nil {
+	if err := os.MkdirAll(vmScratchDir, 0o777); err != nil {
 		return fmt.Errorf("failed to make `vm` directory for vm's scratch space: %w", err)
 	}
 
@@ -231,13 +232,13 @@ func (w *windowsBaseSnapshotter) createUVMScratchLayer(ctx context.Context, snDi
 }
 
 func copyScratchDisk(source, dest string) error {
-	scratchSource, err := os.OpenFile(source, os.O_RDWR, 0700)
+	scratchSource, err := os.OpenFile(source, os.O_RDWR, 0o700)
 	if err != nil {
 		return fmt.Errorf("failed to open %s: %w", source, err)
 	}
 	defer scratchSource.Close()
 
-	f, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE, 0700)
+	f, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE, 0o700)
 	if err != nil {
 		return fmt.Errorf("failed to create sandbox.vhdx in snapshot: %w", err)
 	}

--- a/plugins/streaming/manager.go
+++ b/plugins/streaming/manager.go
@@ -21,15 +21,16 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/core/streaming"
 	"github.com/containerd/containerd/v2/pkg/gc"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/registry"
 )
 
 func init() {
@@ -184,7 +185,6 @@ func (cc *collectionContext) All(fn func(gc.Node)) {
 			})
 		}
 	}
-
 }
 
 func (cc *collectionContext) Active(ns string, fn func(gc.Node)) {

--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -28,17 +28,17 @@ import (
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/metadata"
+
+	// Load packages with type registrations
+	_ "github.com/containerd/containerd/v2/core/transfer/archive"
+	_ "github.com/containerd/containerd/v2/core/transfer/image"
 	"github.com/containerd/containerd/v2/core/transfer/local"
+	_ "github.com/containerd/containerd/v2/core/transfer/registry"
 	"github.com/containerd/containerd/v2/core/unpack"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/internal/kmutex"
 	"github.com/containerd/containerd/v2/pkg/imageverifier"
 	"github.com/containerd/containerd/v2/plugins"
-
-	// Load packages with type registrations
-	_ "github.com/containerd/containerd/v2/core/transfer/archive"
-	_ "github.com/containerd/containerd/v2/core/transfer/image"
-	_ "github.com/containerd/containerd/v2/core/transfer/registry"
 )
 
 // Register local transfer service plugin

--- a/plugins/transfer/plugin_defaults_other.go
+++ b/plugins/transfer/plugin_defaults_other.go
@@ -19,8 +19,9 @@
 package transfer
 
 import (
-	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/platforms"
+
+	"github.com/containerd/containerd/v2/defaults"
 )
 
 func defaultUnpackConfig() []unpackConfiguration {

--- a/plugins/transfer/plugin_defaults_windows.go
+++ b/plugins/transfer/plugin_defaults_windows.go
@@ -17,8 +17,9 @@
 package transfer
 
 import (
-	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/platforms"
+
+	"github.com/containerd/containerd/v2/defaults"
 )
 
 func defaultUnpackConfig() []unpackConfiguration {


### PR DESCRIPTION
#### Description


Enable and fixes gofumpt with extra-rules (also fixes https://go-critic.com/overview.html#paramtypecombine and https://go-critic.com/overview.html#octalliteral from go-critic) and define `github.com/containerd/containerd/v2` as local-prefix from goimports