### PR TITLE
sys: fix pidfd leak in UnshareAfterEnterUserns

### DIFF
--- a/pkg/sys/unshare_linux.go
+++ b/pkg/sys/unshare_linux.go
@@ -64,6 +64,12 @@ func UnshareAfterEnterUserns(uidMap, gidMap string, unshareFlags uintptr, f func
 		return fmt.Errorf("failed to start noop process for unshare: %w", err)
 	}
 
+	defer func() {
+		if pidfd != -1 {
+			unix.Close(pidfd)
+		}
+	}()
+
 	if pidfd == -1 || !SupportsPidFD() {
 		proc.Kill()
 		proc.Wait()


### PR DESCRIPTION
UnshareAfterEnterUserns() creates a pidfd via os.StartProcess() with CLONE_PIDFD but fails to close the file descriptor in any code path, resulting in a file descriptor leak for every container that uses user namespace isolation.

The leak occurs because:
- The pidfd is created when PidFD field is set in SysProcAttr
- The defer block only calls PidfdSendSignal() and pidfdWaitid()
- No code path calls unix.Close(pidfd) to release the file descriptor

This causes one pidfd leak per container launch when user namespace isolation is enabled (e.g., Kubernetes pods with hostUsers: false). In production environments with high container churn, this can exhaust the system's file descriptor limit.

Fix the leak by adding a defer statement immediately after process creation that ensures unix.Close(pidfd) is always called, regardless of which code path is taken. This guarantees cleanup even if the function returns early due to errors or lack of pidfd support.

This follows the same cleanup pattern already established in core/mount/mount_idmapped_utils_linux.go:getUsernsFD(), which properly closes its pidfd.

Closes: #12166
Fixes: #10607