### PR TITLE
fix: hide `go-cmp` library from the non-test code path

### DIFF
--- a/core/events/exchange/exchange_test.go
+++ b/core/events/exchange/exchange_test.go
@@ -25,7 +25,7 @@ import (
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/containerd/containerd/v2/pkg/protobuf"
+	"github.com/containerd/containerd/v2/pkg/protobuf/prototestutil"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
 	"github.com/google/go-cmp/cmp"
@@ -103,7 +103,7 @@ func TestExchangeBasic(t *testing.T) {
 				break subscribercheck
 			}
 
-			if cmp.Equal(received, testevents, protobuf.Compare) {
+			if cmp.Equal(received, testevents, prototestutil.Compare) {
 				// when we do this, we expect the errs channel to be closed and
 				// this will return.
 				subscriber.cancel()
@@ -261,7 +261,7 @@ func TestExchangeFilters(t *testing.T) {
 				break subscribercheck
 			}
 
-			if cmp.Equal(received, subscriber.expectEvents, protobuf.Compare) {
+			if cmp.Equal(received, subscriber.expectEvents, prototestutil.Compare) {
 				// when we do this, we expect the errs channel to be closed and
 				// this will return.
 				subscriber.cancel()

--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/integration/images"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/containerd/v2/pkg/protobuf"
+	"github.com/containerd/containerd/v2/pkg/protobuf/prototestutil"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/errdefs/pkg/errgrpc"
@@ -143,7 +143,7 @@ func TestNewTaskWithRuntimeOption(t *testing.T) {
 
 			gotOptions := &options.Options{}
 			require.NoError(t, typeurl.UnmarshalTo(req.Options, gotOptions))
-			require.True(t, cmp.Equal(tc.expectedOptions, gotOptions, protobuf.Compare))
+			require.True(t, cmp.Equal(tc.expectedOptions, gotOptions, prototestutil.Compare))
 		})
 	}
 }

--- a/internal/cri/server/events/events_test.go
+++ b/internal/cri/server/events/events_test.go
@@ -22,7 +22,7 @@ import (
 
 	eventtypes "github.com/containerd/containerd/api/events"
 	testingclock "github.com/containerd/containerd/v2/internal/cri/clock/testing"
-	"github.com/containerd/containerd/v2/pkg/protobuf"
+	"github.com/containerd/containerd/v2/pkg/protobuf/prototestutil"
 	"github.com/containerd/typeurl/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -144,7 +144,7 @@ func TestBackOff(t *testing.T) {
 	for k := range inputQueues {
 		actQueue := actual.deBackOff(k)
 		doneQueues[k] = actQueue
-		assert.True(t, cmp.Equal(actQueue.events, expectedQueues[k].events, protobuf.Compare))
+		assert.True(t, cmp.Equal(actQueue.events, expectedQueues[k].events, prototestutil.Compare))
 	}
 
 	t.Logf("Should not get out the event again after having got out the backOff event")

--- a/pkg/protobuf/prototestutil/compare.go
+++ b/pkg/protobuf/prototestutil/compare.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package protobuf
+package prototestutil
 
 import (
 	"github.com/google/go-cmp/cmp"


### PR DESCRIPTION
The `go-cmp` library has issues with Go deadcode elimination:

```
github.com/google/go-cmp/cmp/internal/value.appendTypeName reachable from:
         github.com/google/go-cmp/cmp.pathStep.String
         type:github.com/google/go-cmp/cmp.pathStep
         type:github.com/google/go-cmp/cmp.structField
         type:*github.com/google/go-cmp/cmp.structField
         type:github.com/google/go-cmp/cmp.StructField
         go:itab.github.com/google/go-cmp/cmp.StructField,github.com/google/go-cmp/cmp.PathStep
         github.com/google/go-cmp/cmp.Path.String
         type:github.com/google/go-cmp/cmp.Path
         type:github.com/google/go-cmp/cmp.state
         type:*github.com/google/go-cmp/cmp.state
         type:func(*github.com/google/go-cmp/cmp.state, reflect.Type, reflect.Value, reflect.Value) github.com/google/go-cmp/cmp.applicableOption
         type:github.com/google/go-cmp/cmp.Option
         github.com/google/go-cmp/cmp.flattenOptions
         github.com/google/go-cmp/cmp.normalizeOption
         github.com/google/go-cmp/cmp.FilterValues
         github.com/containerd/containerd/v2/pkg/protobuf.init
         github.com/containerd/containerd/v2/pkg/protobuf..inittask
         go:main.inittasks
```

The `pkg/protobuf` is imported unconditionally is
`github.com/containerd/containerd` Go module is imported via init tasks, so there is no way e.g. to use containerd client without triggering this import.

It seems that within containerd itself this function is only used from tests, so hiding it this way allows to import `containerd/client` while keeping deadcode elimination.