### PR TITLE
fix: create bootstrap.json with 0644 permission

### DIFF
--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -248,7 +248,7 @@ func writeBootstrapParams(path string, params client.BootstrapParams) error {
 		return err
 	}
 
-	f, err := atomicfile.New(path, 0o666)
+	f, err := atomicfile.New(path, 0o644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes: #12176

Also needs to be backported to release/2.0 and release/2.1