### PR TITLE
[release/2.0] ci: bump Go 1.23.12, 1.24.6

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.23.11"
+			"version": "1.23.12"
 		}
 	},
 

--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.23.11"
+    default: "1.23.12"
     description: "Go version to install"
 
 runs:

--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -6,7 +6,7 @@ on:
 name: API Release
 
 env:
-  GO_VERSION: "1.23.11"
+  GO_VERSION: "1.23.12"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022]
-        go-version: ["1.23.11", "1.24.5"]
+        go-version: ["1.23.12", "1.24.6"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Release
 
 env:
-  GO_VERSION: "1.23.11"
+  GO_VERSION: "1.23.12"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -107,7 +107,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.23.11",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.23.12",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -34,7 +34,7 @@
 #   docker run --privileged --group-add keep-groups -v ./critest_exit_code.txt:/tmp/critest_exit_code.txt containerd-test
 # ------------------------------------------------------------------------------
 
-ARG GOLANG_VERSION=1.23.11
+ARG GOLANG_VERSION=1.23.12
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -43,11 +43,11 @@ go run main.go --target_dir $SRC/containerd/images
 
 apt-get update && apt-get install -y wget
 cd $SRC
-wget --quiet https://go.dev/dl/go1.23.11.linux-amd64.tar.gz
+wget --quiet https://go.dev/dl/go1.23.12.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
-tar -C temp-go/ -xzf go1.23.11.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.23.12.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
 cd $SRC/containerd
 

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.11"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.12"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
This change backports https://github.com/containerd/containerd/pull/12180 to release/2.0 branch to bump the golang version used in CI to Go 1.23.12, 1.24.6.

> go1.23.12 (released 2025-08-06) includes security fixes to the database/sql and os/exec packages, as well as bug fixes to the runtime. See the [Go 1.23.12 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.12+label%3ACherryPickApproved) on our issue tracker for details.

full diff: https://github.com/golang/go/compare/go1.23.11...go1.23.12

> go1.24.6 (released 2025-08-06) includes security fixes to the database/sql and os/exec packages, as well as bug fixes to the runtime. See the [Go 1.24.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.6+label%3ACherryPickApproved) on our issue tracker for details.

full diff: https://github.com/golang/go/compare/go1.24.5...go1.24.6

(cherry picked from commit db31fbc5a17180cb2d9ac073d026ec2a4d39fa2a)