### PR TITLE
Fix ctr snapshot mount produce invalid mount command for empty option

### DIFF
--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -651,6 +651,10 @@ func printNode(name string, tree *snapshotTree, level int) {
 func printMounts(target string, mounts []mount.Mount) {
 	// FIXME: This is specific to Unix
 	for _, m := range mounts {
-		fmt.Printf("mount -t %s %s %s -o %s\n", m.Type, m.Source, filepath.Join(target, m.Target), strings.Join(m.Options, ","))
+		var opt string
+		if len(m.Options) > 0 {
+			opt = fmt.Sprintf(" -o %s", strings.Join(m.Options, ","))
+		}
+		fmt.Printf("mount -t %s %s %s%s\n", m.Type, m.Source, filepath.Join(target, m.Target), opt)
 	}
 }


### PR DESCRIPTION
snapshotter.Mounts() maybe get empty Options for different snapshot service.

Empty Options will produce invalid mount command from printMounts:
```
$ ctr -n flintlock snapshot --snapshotter devmapper mount /mnt flintlock/flintlock/demo-2/01K24ZRN9EFAVQVNGXQS26BYVG/root
mount -t ext4 /dev/mapper/fc-dev-thinpool-snap-19 /mnt -o
$ cmd=$(ctr -n flintlock snapshot --snapshotter devmapper mount /mnt flintlock/flintlock/demo-2/01K24ZRN9EFAVQVNGXQS26BYVG/root)
$ $cmd
mount: option requires an argument -- 'o'
Try 'mount --help' for more information.
```