### PR TITLE
Add registry host namespace query parameter to mirror push requests

### DIFF
--- a/core/remotes/docker/pusher_test.go
+++ b/core/remotes/docker/pusher_test.go
@@ -93,6 +93,23 @@ func TestPusherErrClosedRetry(t *testing.T) {
 		t.Errorf("upload should succeed but got %v", err)
 	}
 }
+func TestPusherCustomNamespace(t *testing.T) {
+	ctx := context.Background()
+	p, reg, _, done := samplePusher(t)
+	defer done()
+
+	reg.uploadable = true
+	reg.putHandlerFunc = func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path == "/upload" {
+			reg.lastPutQueryParams = r.URL.Query()
+		}
+		return false
+	}
+
+	assert.Nil(t, tryUpload(ctx, t, p, []byte("test")))
+	assert.Equal(t, samplePusherHostname, reg.lastPutQueryParams.Get("ns"))
+	assert.NotEmpty(t, reg.lastPutQueryParams.Get("digest"))
+}
 
 func TestPusherHTTPFallback(t *testing.T) {
 	ctx := logtest.WithT(context.Background(), t)
@@ -417,6 +434,7 @@ type uploadableMockRegistry struct {
 	locationPrefix     string
 	username           string
 	secret             string
+	lastPutQueryParams url.Values // Track query params from last PUT request
 }
 
 func (u *uploadableMockRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -558,11 +558,11 @@ func (r *request) addNamespace(ns string) (err error) {
 	var q url.Values
 	// Parse query
 	if i := strings.IndexByte(r.path, '?'); i > 0 {
-		r.path = r.path[:i+1]
 		q, err = url.ParseQuery(r.path[i+1:])
 		if err != nil {
 			return
 		}
+		r.path = r.path[:i+1]
 	} else {
 		r.path = r.path + "?"
 		q = url.Values{}


### PR DESCRIPTION
If a registry host has a different name from its namespace (ie, it's a mirror / proxy, `RegistryHost.isProxy` is true), then containerd appends the namespace to requests as a query parameter called `ns` (`request.addNamespace`), as outlined in the [Registry Host Namespace](https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-host-namespace) documentation.

This query parameter is currently only added for 'pull' and 'resolve' actions, but not 'push' actions. This matches the [documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md#capabilities-field)'s recommendation that "pushing is a capability which should only be performed on an upstream source, not a mirror." Despite this, I have a use-case for pushing to a proxy mirror (as a performance optimization), and expect the query parameter to be appended properly.

This PR updates the `dockerPusher` implementation to set the `ns` query parameter on mirror push requests to support pushing to a proxy mirror.