### PR TITLE
ci: add Go 1.25.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022]
-        go-version: ["1.24.6"]
+        go-version: ["1.24.6", "1.25.0"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/install-go


### PR DESCRIPTION
Initial release of Go 1.25 has arrived.

> The latest Go release, version 1.25, arrives in [August 2025](https://go.dev/doc/devel/release#go1.25.0), six months after [Go 1.24](https://go.dev/doc/go1.24). Most of its changes are in the implementation of the toolchain, runtime, and libraries. As always, the release maintains the Go 1 promise of compatibility. We expect almost all Go programs to continue to compile and run as before.

Ref: https://go.dev/doc/go1.25