### PR TITLE
cri: Fix userns with container image VOLUME mounts that need copy

### DIFF
--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containerd/log"
 )
@@ -101,6 +102,25 @@ func RemoveVolatileOption(mounts []Mount) []Mount {
 		return out
 	}
 
+	return mounts
+}
+
+// RemoveIDMapOption copies and removes the uidmap/gidmap options on any of the mounts using it.
+func RemoveIDMapOption(mounts []Mount) []Mount {
+	var out []Mount
+	for i, m := range mounts {
+		for j, opt := range m.Options {
+			if strings.HasPrefix(opt, "uidmap") || strings.HasPrefix(opt, "gidmap") {
+				if out == nil {
+					out = copyMounts(mounts)
+				}
+				out[i].Options = append(out[i].Options[:j], out[i].Options[j+1:]...)
+			}
+		}
+	}
+	if out != nil {
+		return out
+	}
 	return mounts
 }
 

--- a/internal/cri/opts/container.go
+++ b/internal/cri/opts/container.go
@@ -76,6 +76,11 @@ func WithVolumes(volumeMounts map[string]string, platform imagespec.Platform) co
 		}
 		mounts = mount.RemoveVolatileOption(mounts)
 
+		// Always copy files without UID/GID transformations.
+		// The ID transformations are only needed when running inside a userns, that is not
+		// the case here.
+		mounts = mount.RemoveIDMapOption(mounts)
+
 		root, err := os.MkdirTemp("", "ctd-volume")
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR fixes the "copy-up" used in `VOLUME` directives if the path in the rootfs has some contents AND the pod is using user-namespaces (it was working fine if the rootfs didn't have content for the volume path).

The issue is that when doing the copy-up, we screw up the permissions in the userns case. This is explained in more detail in the commit msg (c&p below). Also, I've added an integration test that test the copy-up with userns. It's based in the existing copy-up test case, that is testing already a lot of things.

The copy-up integration test adapted for userns fails without this PR (and works with this, of course :)). I've also added to the test to check the file permissions, for completeness, although it wasn't needed to detect this bug.

Below the commit msg with the long explanation.

---

If a Dockerfile is using a `VOLUME` directive and the directory exists
in the rootfs, like in this example:
   
            FROM docker.io/library/alpine:latest
            VOLUME [ "/run" ]
    
The alpine container image already contains a "/run" directory. This
will force the code in WithVolumes() to copy its  content to the new
volume created for the VOLUME directive. This copies the content as well
as the ownership.
    
However, as we perform the mounts from the host POV without being inside
a userns, the idmap option will just shift the IDs in ways that will
screw up the ownerships when copied. We should only use the idmap option
when running the container inside a userns, so the ownerships are fine
(the userns will do a shift and the idmap another, to make it all seem
as if there was no UID/GID shift in the first place).
    
This PR does just that, remove the idmap option from mounts so we copy
the files without any ID transformations. It's simpler and easier to
reason about if we just don't mount with the idmap option here: all
files are copied just fine without ID transformations and ID
transformation is applied via the idmap option at mount time when
running the pod.
    
Also, note that `VOLUME` directives that refer to directories that don't
exist on the rootfs work fine (`VOLUME [ "/rata" ]` for example), as
there is no copy done in that case so the permissions weren't changed.

---

In case you are curious, if you run the repro on a k8s pod and also add `automountServiceAccountToken: false`, the pod will start and you will see the wrong permissions.

Before the PR:

```bash
/ # ls -ldn /run
drwxr-xr-x    3 65534    65534         4096 Aug 22 12:46 /run
/ # ls -ln /run
total 4
drwxr-xr-x    2 65534    65534         4096 Jul 15 10:42 lock
```
Basically the UID/GIDs this is using are not mapped in the userns after all the ids transformations. That is why we can't create a directory there.

If the container userns is using the host UID 100000 mapped to 0 inside the container, then /run will be changed to be owned by that. But then that ID is not mapped inside the userns and it shows like this, mapped to the overflow uid.

After this PR, the permissions look as expected:
```bash

/ # ls -ld /run
drwxr-xr-x    3 root     root          4096 Aug 22 12:46 /run
/ # ls -ldn /run
drwxr-xr-x    3 0        0             4096 Aug 22 12:46 /run
/ # ls -ldn /run
drwxr-xr-x    3 0        0             4096 Aug 22 12:46 /run
/ # ls -ln /run
total 4
drwxr-xr-x    2 0        0             4096 Jul 15 10:42 lock
```
And we can create the mountpoint for the k8s service account token too.

The files copied and the permission for the /run directory itself is as UID 0 (as we don't use an idmap at all for the copy now), and then we use the idmap when accessing the volumes and all works as expected.

Fixes: #11852 