### PR TITLE
feature:add custom containerd.sock symlink path

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -132,6 +132,7 @@ func platformAgnosticDefaultConfig() *srvconfig.Config {
 		State:   defaults.DefaultStateDir,
 		GRPC: srvconfig.GRPCConfig{
 			Address:        defaults.DefaultAddress,
+			AddressSymlink: "",
 			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
 			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
 		},

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -281,6 +281,18 @@ can be used and modified as necessary as a custom configuration.`
 		if err != nil {
 			return fmt.Errorf("failed to get listener for main endpoint: %w", err)
 		}
+		if config.GRPC.AddressSymlink != "" {
+			if _, err := os.Stat(config.GRPC.AddressSymlink); err == nil {
+				os.Remove(config.GRPC.AddressSymlink)
+			}
+			// Ensure parent directory is created
+			if err = os.MkdirAll(filepath.Dir(config.GRPC.AddressSymlink), 0770); err != nil {
+				return err
+			}
+			if err = os.Symlink(config.GRPC.Address, config.GRPC.AddressSymlink); err != nil {
+				return err
+			}
+		}
 		serve(ctx, l, server.ServeGRPC)
 
 		readyC := make(chan struct{})

--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -205,6 +205,7 @@ func v1Migrate(ctx context.Context, c *Config) error {
 // GRPCConfig provides GRPC configuration for the socket
 type GRPCConfig struct {
 	Address        string `toml:"address"`
+	AddressSymlink string `toml:"address_symlink"`
 	TCPAddress     string `toml:"tcp_address"`
 	TCPTLSCA       string `toml:"tcp_tls_ca"`
 	TCPTLSCert     string `toml:"tcp_tls_cert"`


### PR DESCRIPTION
containerd default address /run/containerd/containerd.sock
```
[grpc]
  address = '/run/containerd/containerd.sock'
```
some user want to use it in container, have to bind  /run/containerd/ into container because ontainerd.sock will be recreated.
but /run/containerd/ have many other important data, it is not safety.
so I think we can create a symlink of  /run/containerd/containerd.sock for user to use to make it more safety.

```
  address = '/run/containerd/containerd.sock'
  address_symlink = '/somepath/containerd.sock'
```
user just need bind /somepath/ into container.