### PR TITLE
[release/2.0] Backport various overlayfs related user namespace fixes and improvements

### DIFF
--- a/core/mount/mount_linux.go
+++ b/core/mount/mount_linux.go
@@ -266,8 +266,12 @@ func doPrepareIDMappedOverlay(tmpDir string, lowerDirs []string, usernsFd int) (
 		return nil, nil, err
 	}
 	cleanMount := func() {
-		if err := unix.Unmount(tempRemountsLocation, 0); err != nil {
-			log.L.WithError(err).Warnf("failed to unmount idmapped directory %s", tempRemountsLocation)
+		// Use the Unmount helper that does retries because there can be easily an open fd
+		// to the idmapped directory and when containerd forks to create a userns fd (maybe
+		// for another container), it will make the mount busy for a few ms.
+		err := Unmount(tempRemountsLocation, 0)
+		if err != nil {
+			log.L.WithError(err).Warnf("failed to unmount idmapped directory %s: %v", tempRemountsLocation, err)
 		}
 	}
 	defer func() {

--- a/core/mount/mount_linux_test.go
+++ b/core/mount/mount_linux_test.go
@@ -204,6 +204,105 @@ func TestUnmountRecursive(t *testing.T) {
 	}
 }
 
+func TestDoPrepareIDMappedOverlayCleanups(t *testing.T) {
+	testutil.RequiresRoot(t)
+	if !supportsIDMap(t.TempDir()) {
+		t.Skip("IDmapped mounts not supported on filesystem selected by t.TempDir()")
+	}
+
+	testCases := []struct {
+		name            string
+		lowerDirs       []string
+		tmpDir          string
+		callbackFailure bool
+		success         bool
+	}{
+		{
+			name:      "mount failure",
+			lowerDirs: []string{"/non/existent/path"},
+		},
+		{
+			name:      "tmpdir creation failure",
+			lowerDirs: []string{"/non/existent/path"},
+			tmpDir:    "/non/existent/",
+		},
+		{
+			name:            "cleanup callback failure",
+			callbackFailure: true,
+			success:         true,
+		},
+		{
+			name:    "all fine",
+			success: true,
+		},
+	}
+
+	usernsFD, err := getUsernsFD(testUIDMaps, testGIDMaps)
+	require.NoError(t, err)
+	defer usernsFD.Close()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := tc.tmpDir
+			if tmpDir == "" {
+				tmpDir = t.TempDir()
+			}
+			lowerDirs := tc.lowerDirs
+			if len(lowerDirs) == 0 {
+				// Create a temporary directory with a file to simulate lowerDirs
+				dir := t.TempDir()
+				require.NoError(t, os.Mkdir(dir+"/l", 0755))
+				require.NoError(t, os.WriteFile(dir+"/l/bar", []byte("foo"), 0644))
+				lowerDirs = []string{dir + "/l"}
+			}
+
+			retLowerDirs, cleanup, err := doPrepareIDMappedOverlay(tmpDir, lowerDirs, int(usernsFD.Fd()))
+			if tc.success && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !tc.success && err == nil {
+				t.Fatal("expected error but got none")
+			}
+			if err != nil {
+				return
+			}
+
+			if !tc.callbackFailure {
+				cleanup()
+				// Verify that tmpDir is empty
+				assert.NoError(t, os.Remove(tmpDir), "expected temporary directory %s to be removed, but got error", tmpDir)
+			}
+
+			// Let's make the cleanup callback fail and make sure nothing is deleted.
+			if tc.callbackFailure {
+				// We won't be able to umount if there is an open fd to it.
+				busyDh, err := os.Open(retLowerDirs[0])
+				assert.NoError(t, err)
+				cleanup()
+				defer busyDh.Close() // close even if asserts fails before we close manually below.
+
+				// Verify that tmpDir is NOT empty (cleanup failed and child dirs
+				// were not removed).
+				assert.Error(t, os.Remove(tmpDir), "expected remove directory %v to fail, but worked fine", tmpDir)
+
+				// Let's not leak mounts, let's close the handle and do the unmount.
+				// If this fails, golang will mark the test as failed, as it can't
+				// clean up the tmp directories.
+				assert.NoError(t, busyDh.Close())
+				cleanup()
+			}
+
+			// Verify that the lowerDirs were not modified.
+			// So we don't regress on issue #10704.
+			for _, dir := range lowerDirs {
+				_, err := os.Stat(dir)
+				assert.NoError(t, err, "expected lower directory %s to exist, but it does not", dir)
+				assert.Error(t, os.Remove(dir), "expected remove directory %s to fail, but worked fine", dir)
+			}
+		})
+	}
+}
+
 func TestDoPrepareIDMappedOverlay(t *testing.T) {
 	testutil.RequiresRoot(t)
 

--- a/plugins/snapshots/overlay/overlayutils/check.go
+++ b/plugins/snapshots/overlay/overlayutils/check.go
@@ -261,7 +261,8 @@ func SupportsIDMappedMounts() (bool, error) {
 	}
 	defer usernsFd.Close()
 
-	if err = mount.IDMapMount(lowerDir, lowerDir, int(usernsFd.Fd())); err != nil {
+	// MOUNT_ATTR_RDONLY to replicate our actual construction of overlayfs
+	if err = mount.IDMapMountWithAttrs(lowerDir, lowerDir, int(usernsFd.Fd()), unix.MOUNT_ATTR_RDONLY, 0); err != nil {
 		return false, fmt.Errorf("failed to remap lowerdir %s: %w", lowerDir, err)
 	}
 	defer func() {


### PR DESCRIPTION
Backport various overlayfs related user namespace fixes and improvements

This backports various fixes related to the following issues:

    Issue #12048
    Issue #12139

And pulls in 1e3d10dc2 ("Make ovl idmap mounts read-only") as
a dependency.

These patches make:

    1. The temporary idmap'ed bind mounts r/o and not MNT_DETACHED,
       which prevents accidental modification and makes unmount semantics
       more clear
    2. Makes far less bind mounts happen per overlayfs, greatly improving
       performance which was shown to be devastating enough to kill the node
    3. Retries on umount errors (a common containerd pattern) for the temporary
       bind mounts to prevent leaking mounts on long running containerd daemons

These are great improvements to the stability of containerd when using
user namespaces + overlayfs.
