### PR TITLE
cri/tracing: introduce Phase 1 lifecycle tracing MVP

### DIFF
--- a/client/pull.go
+++ b/client/pull.go
@@ -167,6 +167,9 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 			unpackSpan.End()
 			return nil, err
 		}
+		unpackSpan.SetAttributes(
+			tracing.Attribute("unpack.count", ur.Unpacks),
+		)
 		unpackSpan.End()
 	}
 
@@ -197,6 +200,12 @@ func (c *Client) fetch(ctx context.Context, rCtx *RemoteContext, ref string, lim
 	if err != nil {
 		return images.Image{}, fmt.Errorf("failed to resolve reference %q: %w", ref, err)
 	}
+	span.SetAttributes(
+		tracing.Attribute("container.image.ref", ref),
+		tracing.Attribute("image.name", name),
+		tracing.Attribute("target.mediaType", desc.MediaType),
+		tracing.Attribute("image.digest", desc.Digest.String()),
+	)
 
 	fetcher, err := rCtx.Resolver.Fetcher(ctx, name)
 	if err != nil {
@@ -268,14 +277,20 @@ func (c *Client) fetch(ctx context.Context, rCtx *RemoteContext, ref string, lim
 		handler = rCtx.HandlerWrapper(handler)
 	}
 
+	_, dspan := tracing.StartSpan(ctx, tracing.Name(pullSpanPrefix, "dispatch"))
 	if err := images.Dispatch(ctx, handler, limiter, desc); err != nil {
+		dspan.End()
 		return images.Image{}, err
 	}
+	dspan.End()
 
 	if isConvertible {
+		_, cspan := tracing.StartSpan(ctx, tracing.Name(pullSpanPrefix, "convert_manifest"))
+		defer cspan.End()
 		if desc, err = converterFunc(ctx, desc); err != nil {
 			return images.Image{}, err
 		}
+
 	}
 
 	return images.Image{

--- a/client/task.go
+++ b/client/task.go
@@ -42,6 +42,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	google_protobuf "github.com/containerd/containerd/v2/pkg/protobuf/types"
@@ -241,10 +242,11 @@ func (t *task) Pid() uint32 {
 }
 
 func (t *task) Start(ctx context.Context) error {
-	ctx, span := tracing.StartSpan(ctx, "task.Start",
-		tracing.WithAttribute("task.id", t.ID()),
-	)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name("client.task", "Start"),
+		tracing.WithAttribute("task.id", t.ID()))
 	defer span.End()
+	span.SetAttributes(tracing.Attribute("containerd.namespace", "k8s.io"))
+
 	r, err := t.client.TaskService().Start(ctx, &tasks.StartRequest{
 		ContainerID: t.id,
 	})
@@ -261,11 +263,15 @@ func (t *task) Start(ctx context.Context) error {
 }
 
 func (t *task) Kill(ctx context.Context, s syscall.Signal, opts ...KillOpts) error {
-	ctx, span := tracing.StartSpan(ctx, "task.Kill",
+	_, span := tracing.StartSpan(ctx, tracing.Name("client.task", "Kill"),
 		tracing.WithAttribute("task.id", t.ID()),
 		tracing.WithAttribute("task.pid", int(t.Pid())),
 	)
 	defer span.End()
+	if ns, err := namespaces.NamespaceRequired(ctx); err == nil {
+		span.SetAttributes(tracing.Attribute("containerd.namespace", ns))
+	}
+
 	var i KillInfo
 	for _, o := range opts {
 		if err := o(ctx, &i); err != nil {
@@ -347,6 +353,7 @@ func (t *task) Wait(ctx context.Context) (<-chan ExitStatus, error) {
 			}
 			return
 		}
+
 		c <- ExitStatus{
 			code:     r.ExitStatus,
 			exitedAt: protobuf.FromTimestamp(r.ExitedAt),
@@ -359,10 +366,13 @@ func (t *task) Wait(ctx context.Context) (<-chan ExitStatus, error) {
 // it returns the exit status of the task and any errors that were encountered
 // during cleanup
 func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStatus, error) {
-	ctx, span := tracing.StartSpan(ctx, "task.Delete",
+	ctx, span := tracing.StartSpan(ctx, tracing.Name("client.task", "Delete"),
 		tracing.WithAttribute("task.id", t.ID()),
 	)
 	defer span.End()
+	if ns, err := namespaces.NamespaceRequired(ctx); err == nil {
+		span.SetAttributes(tracing.Attribute("containerd.namespace", ns))
+	}
 	for _, o := range opts {
 		if err := o(ctx, t); err != nil {
 			return nil, err
@@ -414,18 +424,29 @@ func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStat
 	if err != nil {
 		return nil, errgrpc.ToNative(err)
 	}
+
+	es := &ExitStatus{code: r.ExitStatus, exitedAt: protobuf.FromTimestamp(r.ExitedAt)}
+	span.SetAttributes(
+		tracing.Attribute("task.exit_status", int64(es.code)),
+		tracing.Attribute("task.exited_at", es.exitedAt.Format(time.RFC3339)),
+	)
+
 	// Only cleanup the IO after a successful Delete
 	if t.io != nil {
 		t.io.Close()
 	}
-	return &ExitStatus{code: r.ExitStatus, exitedAt: protobuf.FromTimestamp(r.ExitedAt)}, nil
+	return es, nil
 }
 
 func (t *task) Exec(ctx context.Context, id string, spec *specs.Process, ioCreate cio.Creator) (_ Process, retErr error) {
-	ctx, span := tracing.StartSpan(ctx, "task.Exec",
+	ctx, span := tracing.StartSpan(ctx, tracing.Name("client.task", "Exec"),
 		tracing.WithAttribute("task.id", t.ID()),
 	)
 	defer span.End()
+	if ns, err := namespaces.NamespaceRequired(ctx); err == nil {
+		span.SetAttributes(tracing.Attribute("containerd.namespace", ns))
+	}
+
 	if id == "" {
 		return nil, fmt.Errorf("exec id must not be empty: %w", errdefs.ErrInvalidArgument)
 	}
@@ -507,10 +528,15 @@ func (t *task) IO() cio.IO {
 }
 
 func (t *task) Resize(ctx context.Context, w, h uint32) error {
-	ctx, span := tracing.StartSpan(ctx, "task.Resize",
+	ctx, span := tracing.StartSpan(ctx, tracing.Name("client.task", "Resize"),
 		tracing.WithAttribute("task.id", t.ID()),
 	)
 	defer span.End()
+	span.SetAttributes(
+		tracing.Attribute("task.pty.width", int64(w)),
+		tracing.Attribute("task.pty.height", int64(h)),
+	)
+
 	_, err := t.client.TaskService().ResizePty(ctx, &tasks.ResizePtyRequest{
 		ContainerID: t.id,
 		Width:       w,

--- a/core/metadata/containers.go
+++ b/core/metadata/containers.go
@@ -35,6 +35,7 @@ import (
 	"github.com/containerd/typeurl/v2"
 	bolt "go.etcd.io/bbolt"
 	errbolt "go.etcd.io/bbolt/errors"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
@@ -126,10 +127,16 @@ func (s *containerStore) Create(ctx context.Context, container containers.Contai
 		tracing.WithAttribute("container.id", container.ID),
 	)
 	defer span.End()
+	if container.SandboxID != "" {
+		ctx = tracing.ContextWithSandboxID(ctx, container.SandboxID)
+	}
 	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return containers.Container{}, err
 	}
+
+	AddStandardAttributes(span, container.SandboxID, container.ID, "", "")
+	span.SetAttributes(tracing.Attribute("containerd.namespace", namespace))
 
 	if err := validateContainer(&container); err != nil {
 		return containers.Container{}, fmt.Errorf("create container failed validation: %w", err)
@@ -157,6 +164,7 @@ func (s *containerStore) Create(ctx context.Context, container containers.Contai
 
 		span.SetAttributes(
 			tracing.Attribute("container.createdAt", container.CreatedAt.Format(time.RFC3339)),
+			tracing.Attribute("container.updatedAt", container.UpdatedAt.Format(time.RFC3339)),
 		)
 		return nil
 	}); err != nil {
@@ -172,6 +180,9 @@ func (s *containerStore) Update(ctx context.Context, container containers.Contai
 		tracing.WithAttribute("container.id", container.ID),
 	)
 	defer span.End()
+	if container.SandboxID != "" {
+		ctx = tracing.ContextWithSandboxID(ctx, container.SandboxID)
+	}
 	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return containers.Container{}, err
@@ -180,6 +191,9 @@ func (s *containerStore) Update(ctx context.Context, container containers.Contai
 	if container.ID == "" {
 		return containers.Container{}, fmt.Errorf("must specify a container id: %w", errdefs.ErrInvalidArgument)
 	}
+
+	AddStandardAttributes(span, container.SandboxID, container.ID, "", "")
+	span.SetAttributes(tracing.Attribute("containerd.namespace", namespace))
 
 	var updated containers.Container
 	if err := update(ctx, s.db, func(tx *bolt.Tx) error {
@@ -282,10 +296,18 @@ func (s *containerStore) Delete(ctx context.Context, id string) error {
 	)
 	defer span.End()
 
+	if meta, err := s.Get(ctx, id); err == nil && meta.SandboxID != "" {
+		ctx = tracing.ContextWithSandboxID(ctx, meta.SandboxID)
+		AddStandardAttributes(span, meta.SandboxID, id, "", "")
+	}
+
 	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return err
 	}
+
+	AddStandardAttributes(span, "", id, "", "")
+	span.SetAttributes(tracing.Attribute("containerd.namespace", namespace))
 
 	return update(ctx, s.db, func(tx *bolt.Tx) error {
 		bkt := getContainersBucket(tx, namespace)
@@ -442,4 +464,26 @@ func writeContainer(bkt *bolt.Bucket, container *containers.Container) error {
 	}
 
 	return boltutil.WriteLabels(bkt, container.Labels)
+}
+
+func AddStandardAttributes(span *tracing.Span, sandboxID, containerID, podName, podNS string) {
+	if span == nil {
+		return
+	}
+	kv := make([]attribute.KeyValue, 0, 4)
+	if sandboxID != "" {
+		kv = append(kv, attribute.String("sandbox.id", sandboxID))
+	}
+	if containerID != "" {
+		kv = append(kv, attribute.String("container.id", containerID))
+	}
+	if podName != "" {
+		kv = append(kv, attribute.String("pod.name", podName))
+	}
+	if podNS != "" {
+		kv = append(kv, attribute.String("pod.namespace", podNS))
+	}
+	if len(kv) > 0 {
+		span.SetAttributes(kv...)
+	}
 }

--- a/core/metadata/sandbox.go
+++ b/core/metadata/sandbox.go
@@ -57,10 +57,16 @@ func (s *sandboxStore) Create(ctx context.Context, sandbox api.Sandbox) (api.San
 		tracing.WithAttribute("sandbox.id", sandbox.ID),
 	)
 	defer span.End()
+
+	ctx = tracing.ContextWithSandboxID(ctx, sandbox.ID)
+
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return api.Sandbox{}, err
 	}
+
+	AddStandardAttributes(span, sandbox.ID, "", "", "")
+	span.SetAttributes(tracing.Attribute("containerd.namespace", ns))
 
 	sandbox.CreatedAt = time.Now().UTC()
 	sandbox.UpdatedAt = sandbox.CreatedAt
@@ -97,10 +103,16 @@ func (s *sandboxStore) Update(ctx context.Context, sandbox api.Sandbox, fieldpat
 		tracing.WithAttribute("sandbox.id", sandbox.ID),
 	)
 	defer span.End()
+
+	ctx = tracing.ContextWithSandboxID(ctx, sandbox.ID)
+
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return api.Sandbox{}, err
 	}
+
+	AddStandardAttributes(span, sandbox.ID, "", "", "")
+	span.SetAttributes(tracing.Attribute("containerd.namespace", ns))
 
 	ret := api.Sandbox{}
 	if err := update(ctx, s.db, func(tx *bbolt.Tx) error {
@@ -255,10 +267,16 @@ func (s *sandboxStore) Delete(ctx context.Context, id string) error {
 		tracing.WithAttribute("sandbox.id", id),
 	)
 	defer span.End()
+
+	ctx = tracing.ContextWithSandboxID(ctx, id)
+
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return err
 	}
+
+	AddStandardAttributes(span, id, "", "", "")
+	span.SetAttributes(tracing.Attribute("containerd.namespace", ns))
 
 	if err := update(ctx, s.db, func(tx *bbolt.Tx) error {
 		buckets := getSandboxBucket(tx, ns)

--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -65,8 +65,7 @@ type unpackerConfig struct {
 
 	limiter               Limiter
 	duplicationSuppressor KeyedLocker
-
-	unpackLimiter Limiter
+	unpackLimiter         Limiter
 }
 
 // Platform represents a platform-specific unpack configuration which includes

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -427,6 +427,9 @@ type RuntimeConfig struct {
 	// IgnoreDeprecationWarnings is the list of the deprecation IDs (such as "io.containerd.deprecation/pull-schema-1-image")
 	// that should be ignored for checking "ContainerdHasNoDeprecationWarnings" condition.
 	IgnoreDeprecationWarnings []string `toml:"ignore_deprecation_warnings" json:"ignoreDeprecationWarnings"`
+
+	// Tracing is used to turn on/off enhanced tracing
+	Tracing *TracingConfig `toml:"tracing,omitempty"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/internal/cri/config/tracing.go
+++ b/internal/cri/config/tracing.go
@@ -1,0 +1,33 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+// TracingConfig holds tracing settings used by CRI to initialize TraceManager.
+type TracingConfig struct {
+	Enabled          bool             `toml:"enabled"`
+	SamplingRate     float64          `toml:"sampling_rate"`
+	UseSandboxID     bool             `toml:"use_sandbox_id"`
+	MaxSpansPerTrace int              `toml:"max_spans_per_trace"`
+	Exporters        []ExporterConfig `toml:"exporters"`
+}
+
+// ExporterConfig describes one tracing exporter endpoint and options.
+type ExporterConfig struct {
+	Type     string                 `toml:"type" json:"type"`
+	Endpoint string                 `toml:"endpoint" json:"endpoint"`
+	Options  map[string]interface{} `toml:"options" json:"options"`
+}

--- a/pkg/tracing/common/kvutils.go
+++ b/pkg/tracing/common/kvutils.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package tracing
+package common
 
 import (
 	"encoding/json"
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func keyValue(k string, v any) attribute.KeyValue {
+func KeyValue(k string, v any) attribute.KeyValue {
 	if v == nil {
 		return attribute.String(k, "<nil>")
 	}

--- a/pkg/tracing/enhanced/otel_bridge.go
+++ b/pkg/tracing/enhanced/otel_bridge.go
@@ -1,0 +1,51 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package enhanced
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// StartSpanFromOTEL creates an enhanced span from an existing OTEL span context
+func StartSpanFromOTEL(ctx context.Context, tracer Tracer, opName string, otelSpan trace.Span) (Span, context.Context) {
+	if tracer == nil || !tracer.IsEnabled() {
+		return nil, ctx
+	}
+	var traceID string
+	if otelSpan != nil && otelSpan.SpanContext().IsValid() {
+		traceID = otelSpan.SpanContext().TraceID().String()
+	}
+	span, newCtx := tracer.StartSpan(ctx, opName, traceID)
+	return span, newCtx
+}
+
+// SpanFromContext retrieves enhanced span from context
+func SpanFromContext(ctx context.Context) Span {
+	if span, ok := ctx.Value(enhancedSpanKey{}).(Span); ok {
+		return span
+	}
+	return nil
+}
+
+// ContextWithSpan stores enhanced span in context
+func ContextWithSpan(ctx context.Context, span Span) context.Context {
+	return context.WithValue(ctx, enhancedSpanKey{}, span)
+}
+
+type enhancedSpanKey struct{}

--- a/pkg/tracing/enhanced/span.go
+++ b/pkg/tracing/enhanced/span.go
@@ -1,0 +1,137 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package enhanced
+
+import (
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/v2/pkg/tracing/exporters"
+)
+
+// Span interface for enhanced tracing spans
+type Span interface {
+	SetAttribute(key string, value interface{})
+	SetAttributes(attrs ...Attribute)
+	SetStatus(code StatusCode, message string)
+	RecordError(err error)
+	AddEvent(name string, attrs ...Attribute)
+	End()
+	IsRecording() bool
+}
+
+// EnhancedSpan implements the enhanced span functionality
+type EnhancedSpan struct {
+	tracer     *EnhancedTracer
+	startTime  time.Time
+	endTime    time.Time
+	attributes map[string]interface{}
+	name       string
+	traceID    string
+	spanID     string
+	status     StatusCode
+	statusMsg  string
+	mu         sync.RWMutex
+}
+
+// Attribute represents a key-value pair for span attributes
+type Attribute struct {
+	Key   string
+	Value interface{}
+}
+
+// StatusCode represents span status codes
+type StatusCode int
+
+const (
+	StatusCodeUnset StatusCode = 0
+	StatusCodeOk    StatusCode = 1
+	StatusCodeError StatusCode = 2
+)
+
+func (s *EnhancedSpan) SetAttribute(key string, value interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.attributes == nil {
+		s.attributes = make(map[string]interface{})
+	}
+	s.attributes[key] = value
+}
+
+func (s *EnhancedSpan) SetAttributes(attrs ...Attribute) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.attributes == nil {
+		s.attributes = make(map[string]interface{})
+	}
+	for _, attr := range attrs {
+		s.attributes[attr.Key] = attr.Value
+	}
+}
+
+func (s *EnhancedSpan) SetStatus(code StatusCode, message string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = code
+	s.statusMsg = message
+}
+
+func (s *EnhancedSpan) RecordError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = StatusCodeError
+	if err != nil {
+		s.statusMsg = err.Error()
+		s.attributes["error"] = err.Error()
+	}
+}
+
+func (s *EnhancedSpan) AddEvent(name string, attrs ...Attribute) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.attributes == nil {
+		s.attributes = make(map[string]interface{})
+	}
+	for _, attr := range attrs {
+		s.attributes["event."+name+"."+attr.Key] = attr.Value
+	}
+}
+
+func (s *EnhancedSpan) End() {
+	s.mu.Lock()
+	s.endTime = time.Now()
+	spanData := exporters.SpanData{
+		TraceID:    s.traceID,
+		SpanID:     s.spanID,
+		Name:       s.name,
+		StartTime:  s.startTime,
+		EndTime:    s.endTime,
+		Duration:   s.endTime.Sub(s.startTime),
+		Attributes: s.attributes,
+		Status:     s.statusMsg,
+	}
+	s.mu.Unlock()
+
+	s.tracer.ExportSpan(spanData)
+}
+
+func (s *EnhancedSpan) IsRecording() bool {
+	// A span is recording until it is ended.
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.endTime.IsZero()
+}

--- a/pkg/tracing/enhanced/tracer.go
+++ b/pkg/tracing/enhanced/tracer.go
@@ -1,0 +1,152 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package enhanced
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/containerd/containerd/v2/pkg/tracing/exporters"
+)
+
+// Tracer interface for enhanced tracing
+type Tracer interface {
+	StartSpan(ctx context.Context, operationName string, traceID string, attrs ...Attribute) (Span, context.Context)
+	IsEnabled() bool
+	Shutdown(ctx context.Context) error
+}
+
+// EnhancedTracer implements the enhanced tracing functionality
+type EnhancedTracer struct {
+	exporters []exporters.Exporter
+	config    Config
+	resolver  func(map[string]interface{}) (string, bool)
+}
+
+type Config struct {
+	SamplingRate     float64
+	UseSandboxID     bool
+	MaxSpansPerTrace int
+}
+
+func NewEnhancedTracer(exporters []exporters.Exporter, config Config, resolver func(map[string]interface{}) (string, bool)) *EnhancedTracer {
+	return &EnhancedTracer{
+		exporters: exporters,
+		config:    config,
+		resolver:  resolver,
+	}
+}
+
+func generateTraceID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err == nil {
+		return fmt.Sprintf("%x", b)
+	}
+	return fmt.Sprintf("%x", time.Now().UnixNano())
+}
+
+// GetAttribute returns the attribute value for the given key if it exists.
+func (s *EnhancedSpan) GetAttribute(key string) (interface{}, bool) {
+	if s == nil {
+		return nil, false
+	}
+	val, ok := s.attributes[key]
+	return val, ok
+}
+
+func (t *EnhancedTracer) StartSpan(ctx context.Context, operationName string, traceID string, attrs ...Attribute) (Span, context.Context) {
+	if traceID == "" {
+		traceID = generateTraceID()
+	}
+
+	enhancedSpan := &EnhancedSpan{
+		tracer:     t,
+		startTime:  time.Now(),
+		attributes: make(map[string]interface{}),
+		name:       operationName,
+		traceID:    traceID,
+		spanID:     generateSpanID(),
+	}
+
+	for _, attr := range attrs {
+		enhancedSpan.attributes[attr.Key] = attr.Value
+	}
+
+	newCtx := ContextWithSpan(ctx, enhancedSpan)
+	return enhancedSpan, newCtx
+}
+
+func (t *EnhancedTracer) ExportSpan(spanData exporters.SpanData) {
+	// Enrich missing sandbox.id; optionally override traceId with sandbox.id
+	if t.config.UseSandboxID {
+		var sbx string
+		if v, ok := spanData.Attributes["sandbox.id"]; ok {
+			if s, ok2 := v.(string); ok2 && s != "" {
+				sbx = s
+			}
+		}
+		if sbx == "" && t.resolver != nil {
+			if s, ok := t.resolver(spanData.Attributes); ok && s != "" {
+				sbx = s
+				if spanData.Attributes == nil {
+					spanData.Attributes = map[string]interface{}{}
+				}
+				spanData.Attributes["sandbox.id"] = sbx
+			}
+		}
+		if sbx != "" {
+			spanData.TraceID = sbx
+		}
+	}
+
+	if spanData.Attributes != nil {
+		copied := make(map[string]interface{}, len(spanData.Attributes))
+		for k, v := range spanData.Attributes {
+			copied[k] = v
+		}
+		spanData.Attributes = copied
+	}
+
+	for _, exporter := range t.exporters {
+		sd := spanData
+		go exporter.ExportSpan(context.Background(), sd)
+	}
+}
+
+func (t *EnhancedTracer) IsEnabled() bool {
+	return len(t.exporters) > 0
+}
+
+func (t *EnhancedTracer) Shutdown(ctx context.Context) error {
+	var errs []error
+	for _, exporter := range t.exporters {
+		if err := exporter.Shutdown(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("multiple errors during shutdown: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+func generateSpanID() string {
+	return fmt.Sprintf("%x", time.Now().UnixNano())
+}

--- a/pkg/tracing/exporters/factory.go
+++ b/pkg/tracing/exporters/factory.go
@@ -1,0 +1,32 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package exporters
+
+import "fmt"
+
+func CreateExporter(exporterType, endpoint string, options map[string]interface{}) (Exporter, error) {
+	switch exporterType {
+	case "file":
+		return NewFileExporter(endpoint, options)
+	case "zipkin":
+		return NewZipkinExporter(endpoint, options)
+	case "noop":
+		return NewNoopExporter(), nil
+	default:
+		return nil, fmt.Errorf("unknown exporter type: %s", exporterType)
+	}
+}

--- a/pkg/tracing/exporters/file_exporter.go
+++ b/pkg/tracing/exporters/file_exporter.go
@@ -1,0 +1,253 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package exporters
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/v2/pkg/tracing/common"
+)
+
+type FileExporterDefaults struct {
+	Directory   string
+	Format      string
+	ServiceName string
+	MaxFileSize int64
+}
+
+var DefaultFileExporterConfig = FileExporterDefaults{
+	Directory:   "/var/log/containerd/traces",
+	Format:      "json",
+	ServiceName: "containerd",
+	MaxFileSize: 100 * 1024 * 1024, // 100MB
+}
+
+type FileExporter struct {
+	file          *os.File
+	encoder       *json.Encoder
+	mu            sync.Mutex
+	filePath      string
+	format        string // "json" or "zipkin"
+	serviceName   string
+	maxFileSize   int64
+	currentSize   int64
+	rotationCount int
+}
+
+// ZipkinSpan represents the Zipkin V2 JSON format
+type ZipkinSpan struct {
+	TraceID        string             `json:"traceId"`
+	ID             string             `json:"id"`
+	ParentID       string             `json:"parentId,omitempty"`
+	Name           string             `json:"name"`
+	Timestamp      int64              `json:"timestamp"` // microseconds since epoch
+	Duration       int64              `json:"duration"`  // microseconds
+	Kind           string             `json:"kind,omitempty"`
+	LocalEndpoint  *ZipkinEndpoint    `json:"localEndpoint,omitempty"`
+	RemoteEndpoint *ZipkinEndpoint    `json:"remoteEndpoint,omitempty"`
+	Annotations    []ZipkinAnnotation `json:"annotations,omitempty"`
+	Tags           map[string]string  `json:"tags,omitempty"`
+	Debug          bool               `json:"debug,omitempty"`
+	Shared         bool               `json:"shared,omitempty"`
+}
+
+type ZipkinEndpoint struct {
+	ServiceName string `json:"serviceName"`
+	IPv4        string `json:"ipv4,omitempty"`
+	IPv6        string `json:"ipv6,omitempty"`
+	Port        int    `json:"port,omitempty"`
+}
+
+type ZipkinAnnotation struct {
+	Timestamp int64  `json:"timestamp"`
+	Value     string `json:"value"`
+}
+
+func NewFileExporter(filePath string, options map[string]interface{}) (*FileExporter, error) {
+	cfg := DefaultFileExporterConfig
+
+	if dir, ok := options["directory"].(string); ok && dir != "" {
+		cfg.Directory = dir
+	}
+	if fmtVal, ok := options["format"].(string); ok && fmtVal != "" {
+		cfg.Format = fmtVal
+	}
+	if svc, ok := options["service_name"].(string); ok && svc != "" {
+		cfg.ServiceName = svc
+	}
+	if sizeStr, ok := options["max_file_size"].(string); ok && sizeStr != "" {
+		if size, err := strconv.ParseInt(sizeStr, 10, 64); err == nil {
+			cfg.MaxFileSize = size
+		}
+	}
+
+	if err := os.MkdirAll(cfg.Directory, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create trace directory: %w", err)
+	}
+
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open trace file: %w", err)
+	}
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	exporter := &FileExporter{
+		file:        file,
+		encoder:     json.NewEncoder(file),
+		filePath:    filePath,
+		format:      cfg.Format,
+		serviceName: cfg.ServiceName,
+		maxFileSize: cfg.MaxFileSize,
+		currentSize: fileInfo.Size(),
+	}
+
+	return exporter, nil
+}
+
+func (e *FileExporter) ExportSpan(ctx context.Context, spanData SpanData) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Rotate file if needed
+	if e.currentSize >= e.maxFileSize {
+		if err := e.rotateFile(); err != nil {
+			return fmt.Errorf("failed to rotate file: %w", err)
+		}
+	}
+
+	var data interface{}
+	switch e.format {
+	case "zipkin":
+		data = e.convertToZipkinFormat(spanData)
+	default:
+		// For JSON lines; ensure duration is set
+		if spanData.Duration == 0 {
+			spanData.Duration = spanData.EndTime.Sub(spanData.StartTime)
+		}
+		data = spanData
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal span data: %w", err)
+	}
+
+	// Write one JSON per line
+	if _, err := e.file.Write(append(jsonData, '\n')); err != nil {
+		return err
+	}
+	e.currentSize += int64(len(jsonData) + 1)
+	return nil
+}
+
+func (e *FileExporter) convertToZipkinFormat(spanData SpanData) ZipkinSpan {
+	// Convert attributes to Zipkin tags
+	tags := make(map[string]string)
+	for key, value := range spanData.Attributes {
+		kv := common.KeyValue(key, value)
+		tags[string(kv.Key)] = kv.Value.Emit()
+	}
+
+	// Add standard containerd tags
+	tags["component"] = "containerd"
+	tags["container.runtime"] = "containerd"
+
+	// Determine span kind based on operation name
+	kind := e.determineSpanKind(spanData.Name)
+
+	// Convert times to microseconds
+	timestamp := spanData.StartTime.UnixNano() / 1000
+	duration := spanData.EndTime.Sub(spanData.StartTime).Microseconds()
+
+	zs := ZipkinSpan{
+		TraceID:   spanData.TraceID,
+		ID:        spanData.SpanID,
+		Name:      spanData.Name,
+		Timestamp: timestamp,
+		Duration:  duration,
+		Kind:      kind,
+		Tags:      tags,
+		LocalEndpoint: &ZipkinEndpoint{
+			ServiceName: e.serviceName,
+		},
+	}
+	zs.Annotations = e.createAnnotations(spanData)
+	return zs
+}
+
+func (e *FileExporter) determineSpanKind(operationName string) string {
+	switch operationName {
+	case "cri.create_container", "cri.start_container", "cri.stop_container",
+		"cri.remove_container", "cri.create_sandbox", "cri.start_sandbox",
+		"cri.stop_sandbox", "cri.remove_sandbox":
+		return "SERVER"
+	case "cni.setup_pod_network", "cni.teardown_pod_network":
+		return "CLIENT"
+	case "snapshot.prepare", "snapshot.commit", "mount.snapshot", "mount.unmount_snapshot":
+		return "PRODUCER"
+	default:
+		return ""
+	}
+}
+
+func (e *FileExporter) createAnnotations(spanData SpanData) []ZipkinAnnotation {
+	return []ZipkinAnnotation{
+		{Timestamp: spanData.StartTime.UnixNano() / 1000, Value: "start"},
+		{Timestamp: spanData.EndTime.UnixNano() / 1000, Value: "end"},
+	}
+}
+
+func (e *FileExporter) rotateFile() error {
+	if err := e.file.Close(); err != nil {
+		return err
+	}
+	timestamp := time.Now().Format("20060102-150405")
+	newFilePath := fmt.Sprintf("%s.%d.%s", e.filePath, e.rotationCount, timestamp)
+	e.rotationCount++
+
+	if err := os.Rename(e.filePath, newFilePath); err != nil {
+		return err
+	}
+
+	file, err := os.OpenFile(e.filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	e.file = file
+	e.encoder = json.NewEncoder(file)
+	e.currentSize = 0
+	return nil
+}
+
+func (e *FileExporter) Shutdown(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.file != nil {
+		return e.file.Close()
+	}
+	return nil
+}

--- a/pkg/tracing/exporters/interface.go
+++ b/pkg/tracing/exporters/interface.go
@@ -1,0 +1,38 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package exporters
+
+import (
+	"context"
+	"time"
+)
+
+type Exporter interface {
+	ExportSpan(ctx context.Context, spanData SpanData) error
+	Shutdown(ctx context.Context) error
+}
+
+type SpanData struct {
+	TraceID    string                 `json:"traceId"`
+	SpanID     string                 `json:"spanId"`
+	Name       string                 `json:"name"`
+	StartTime  time.Time              `json:"startTime"`
+	EndTime    time.Time              `json:"endTime"`
+	Duration   time.Duration          `json:"duration"`
+	Attributes map[string]interface{} `json:"attributes"`
+	Status     string                 `json:"status,omitempty"`
+}

--- a/pkg/tracing/exporters/noop_exporter.go
+++ b/pkg/tracing/exporters/noop_exporter.go
@@ -1,0 +1,34 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package exporters
+
+import "context"
+
+// noopExporter implements Exporter but performs no operations.
+type noopExporter struct{}
+
+func NewNoopExporter() Exporter {
+	return &noopExporter{}
+}
+
+func (n *noopExporter) ExportSpan(ctx context.Context, spanData SpanData) error {
+	return nil
+}
+
+func (n *noopExporter) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/pkg/tracing/exporters/zipkin_exporter.go
+++ b/pkg/tracing/exporters/zipkin_exporter.go
@@ -1,0 +1,100 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package exporters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type ZipkinExporter struct {
+	endpoint string
+	client   *http.Client
+	batch    []ZipkinSpan
+	mu       sync.Mutex
+}
+
+func NewZipkinExporter(endpoint string, options map[string]interface{}) (*ZipkinExporter, error) {
+	return &ZipkinExporter{
+		endpoint: endpoint,
+		client:   &http.Client{Timeout: 10 * time.Second},
+		batch:    make([]ZipkinSpan, 0),
+	}, nil
+}
+
+func (z *ZipkinExporter) ExportSpan(ctx context.Context, spanData SpanData) error {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+
+	zipkinSpan := z.convertToZipkin(spanData)
+	z.batch = append(z.batch, zipkinSpan)
+
+	// Simple batching threshold
+	if len(z.batch) >= 100 {
+		return z.flushBatch()
+	}
+	return nil
+}
+
+func (z *ZipkinExporter) convertToZipkin(spanData SpanData) ZipkinSpan {
+	tags := make(map[string]string)
+	for k, v := range spanData.Attributes {
+		tags[k] = fmt.Sprintf("%v", v)
+	}
+	return ZipkinSpan{
+		TraceID:   spanData.TraceID,
+		ID:        spanData.SpanID,
+		Name:      spanData.Name,
+		Timestamp: spanData.StartTime.UnixNano() / 1000,
+		Duration:  int64(spanData.Duration / time.Microsecond),
+		Tags:      tags,
+		LocalEndpoint: &ZipkinEndpoint{
+			ServiceName: "containerd",
+		},
+	}
+}
+
+func (z *ZipkinExporter) flushBatch() error {
+	if len(z.batch) == 0 {
+		return nil
+	}
+	jsonData, err := json.Marshal(z.batch)
+	if err != nil {
+		return err
+	}
+	resp, err := z.client.Post(z.endpoint, "application/json", bytes.NewReader(jsonData))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("zipkin export failed: %s", resp.Status)
+	}
+	z.batch = z.batch[:0]
+	return nil
+}
+
+func (z *ZipkinExporter) Shutdown(ctx context.Context) error {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	return z.flushBatch()
+}

--- a/pkg/tracing/log.go
+++ b/pkg/tracing/log.go
@@ -17,6 +17,7 @@
 package tracing
 
 import (
+	"github.com/containerd/containerd/v2/pkg/tracing/common"
 	"github.com/containerd/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -76,7 +77,7 @@ func (h *LogrusHook) Fire(entry *log.Entry) error {
 func logrusDataToAttrs(data map[string]any) []attribute.KeyValue {
 	attrs := make([]attribute.KeyValue, 0, len(data))
 	for k, v := range data {
-		attrs = append(attrs, keyValue(k, v))
+		attrs = append(attrs, common.KeyValue(k, v))
 	}
 	return attrs
 }

--- a/pkg/tracing/manager/manager.go
+++ b/pkg/tracing/manager/manager.go
@@ -1,0 +1,210 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/containerd/containerd/v2/pkg/tracing/enhanced"
+	"github.com/containerd/containerd/v2/pkg/tracing/exporters"
+)
+
+type Manager interface {
+	Shutdown(ctx context.Context) error
+	IsEnabled() bool
+	GetTracer() enhanced.Tracer
+}
+
+type TraceManager struct {
+	config    Config
+	exporters []exporters.Exporter
+	mu        sync.RWMutex
+	enabled   bool
+	tracer    *enhanced.EnhancedTracer
+}
+
+type Config struct {
+	Enabled          bool
+	SamplingRate     float64
+	UseSandboxID     bool
+	MaxSpansPerTrace int
+	Exporters        []ExporterConfig
+
+	// Resolver provides sandbox.id from span attributes when absent.
+	Resolver func(map[string]interface{}) (string, bool)
+}
+
+type ExporterConfig struct {
+	Type     string
+	Endpoint string
+	Options  map[string]interface{}
+}
+
+// NewTraceManager constructs a manager, instantiates exporters via factory,
+// and initializes an enhanced tracer when enabled and exporters are present.
+// The enhanced tracer is created using pkg/tracing/plugin/enhanced.go.
+func NewTraceManager(config Config) (*TraceManager, error) {
+	m := &TraceManager{
+		config: config,
+	}
+
+	var exps []exporters.Exporter
+	for _, ec := range config.Exporters {
+		exp, err := exporters.CreateExporter(ec.Type, ec.Endpoint, ec.Options)
+		if err != nil {
+			return nil, err
+		}
+		exps = append(exps, &traceIDNormalizingExporter{
+			inner:    exp,
+			resolver: config.Resolver,
+		})
+	}
+	m.exporters = exps
+
+	m.enabled = config.Enabled && len(exps) > 0
+	if m.enabled {
+		m.tracer = enhanced.NewEnhancedTracer(exps, enhanced.Config{
+			SamplingRate:     config.SamplingRate,
+			UseSandboxID:     config.UseSandboxID,
+			MaxSpansPerTrace: config.MaxSpansPerTrace,
+		}, config.Resolver)
+	}
+	return m, nil
+}
+
+func (m *TraceManager) Shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.tracer != nil {
+		_ = m.tracer.Shutdown(ctx)
+	}
+	for _, exporter := range m.exporters {
+		_ = exporter.Shutdown(ctx)
+	}
+	m.enabled = false
+	return nil
+}
+
+func (m *TraceManager) IsEnabled() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.enabled
+}
+
+// GetTracer returns the enhanced tracer instance if available.
+func (m *TraceManager) GetTracer() enhanced.Tracer {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.tracer
+}
+
+type NoopManager struct{}
+
+func (n *NoopManager) Start() error { return nil }
+
+func NewNoopManager() Manager {
+	return &NoopManager{}
+}
+
+func (n *NoopManager) Shutdown(ctx context.Context) error { return nil }
+func (n *NoopManager) IsEnabled() bool                    { return false }
+func (n *NoopManager) GetTracer() enhanced.Tracer         { return nil }
+
+type traceIDNormalizingExporter struct {
+	inner    exporters.Exporter
+	resolver func(map[string]interface{}) (string, bool)
+}
+
+func (w *traceIDNormalizingExporter) ExportSpan(ctx context.Context, sd exporters.SpanData) error {
+	if sd.Attributes == nil {
+		sd.Attributes = make(map[string]interface{})
+	}
+
+	original := sd.TraceID
+	if original != "" {
+		sd.Attributes["trace.id"] = original
+		sd.Attributes["trace.id.original"] = original
+	}
+
+	// Determine sandbox.id presence early for both normalization and "longest" tag
+	var sandbox string
+	if v, ok := sd.Attributes["sandbox.id"]; ok {
+		if s, ok2 := v.(string); ok2 && s != "" {
+			sandbox = s
+		}
+	}
+	if sandbox == "" && w.resolver != nil {
+		if s, ok := w.resolver(sd.Attributes); ok && s != "" {
+			sandbox = s
+			sd.Attributes["sandbox.id"] = s
+		}
+	}
+
+	// Save the longest of the available original identifiers as a tag
+	longest := original
+	if len(sandbox) > len(longest) {
+		longest = sandbox
+	}
+	if longest != "" {
+		sd.Attributes["trace.id.longest"] = longest
+	}
+
+	// Source for normalization priority: original -> sandbox -> default
+	source := strings.TrimSpace(original)
+	if source == "" {
+		source = sandbox
+	}
+	if source == "" {
+		source = "containerd-default-trace"
+	}
+
+	// Enforce 64-bit (16 lowercase hex) trace id
+	sd.TraceID = normalize64Hex(source)
+
+	return w.inner.ExportSpan(ctx, sd)
+}
+
+func (w *traceIDNormalizingExporter) Shutdown(ctx context.Context) error {
+	return w.inner.Shutdown(ctx)
+}
+
+func normalize64Hex(in string) string {
+	s := strings.ToLower(strings.TrimSpace(in))
+	if len(s) == 16 && isHex(s) {
+		return s
+	}
+	sum := sha256.Sum256([]byte(in))
+	return hex.EncodeToString(sum[:8])
+}
+
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsDigit(r) && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
@@ -27,106 +28,326 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/containerd/containerd/v2/pkg/tracing/common"
+	"github.com/containerd/containerd/v2/pkg/tracing/enhanced"
+	"github.com/containerd/containerd/v2/pkg/tracing/manager"
 )
+
+// globalTraceManager holds the global trace manager instance
+var (
+	globalTraceManager manager.Manager
+	globalTraceMutex   sync.RWMutex
+)
+
+// sandboxIDResolver is an optional global hook that can derive a sandboxID
+// from span attributes (e.g. via containerID -> sandboxID lookup).
+// It should return (sandboxID, true) if resolved, otherwise ("", false).
+var sandboxIDResolver func(attrs map[string]interface{}) (string, bool)
+
+type sandboxIDKey struct{}
+
+func ContextWithSandboxID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, sandboxIDKey{}, id)
+}
+
+// SetGlobalTraceManager sets the global trace manager for enhanced tracing
+func SetGlobalTraceManager(tm manager.Manager) {
+	globalTraceMutex.Lock()
+	defer globalTraceMutex.Unlock()
+	globalTraceManager = tm
+}
+
+// getGlobalTraceManager returns the global trace manager instance
+func getGlobalTraceManager() manager.Manager {
+	globalTraceMutex.RLock()
+	defer globalTraceMutex.RUnlock()
+	return globalTraceManager
+}
+
+// SetSandboxIDResolver installs a process-wide resolver used by enhanced tracer
+// to populate sandbox.id when it is missing on a span.
+func SetSandboxIDResolver(fn func(map[string]interface{}) (string, bool)) {
+	globalTraceMutex.Lock()
+	defer globalTraceMutex.Unlock()
+	sandboxIDResolver = fn
+}
+
+func getSandboxIDResolver() func(map[string]interface{}) (string, bool) {
+	globalTraceMutex.RLock()
+	defer globalTraceMutex.RUnlock()
+	return sandboxIDResolver
+}
+
+// isEnhancedTracingEnabled checks if enhanced tracing is enabled and available
+func isEnhancedTracingEnabled() bool {
+	tm := getGlobalTraceManager()
+	if tm == nil {
+		return false
+	}
+	return tm.IsEnabled()
+}
 
 // StartConfig defines configuration for a new span object.
 type StartConfig struct {
 	spanOpts []trace.SpanStartOption
 }
 
-type SpanOpt func(config *StartConfig)
+// SpanOpt is an interface to add an option to StartConfig.
+type SpanOpt func(*StartConfig)
 
-// WithAttribute appends attributes to a new created span.
-func WithAttribute(k string, v interface{}) SpanOpt {
-	return func(config *StartConfig) {
-		config.spanOpts = append(config.spanOpts,
-			trace.WithAttributes(Attribute(k, v)))
+// WithAttributes adds provided k/v attributes to a new span that is created.
+// This is a convenience helper to avoid repeatedly using trace.WithAttributes(Attribute(k, v))
+func WithAttributes(kv ...attribute.KeyValue) SpanOpt {
+	return func(cfg *StartConfig) {
+		cfg.spanOpts = append(cfg.spanOpts, trace.WithAttributes(kv...))
 	}
 }
 
-// UpdateHTTPClient updates the http client with the necessary otel transport
-func UpdateHTTPClient(client *http.Client, name string) {
-	client.Transport = otelhttp.NewTransport(
-		client.Transport,
-		otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
-			return name
-		}),
-	)
+// WithAttribute is a single key/value convenience wrapper kept for backward compatibility.
+func WithAttribute(k string, v any) SpanOpt {
+	return WithAttributes(Attribute(k, v))
 }
 
-// StartSpan starts child span in a context.
+// WithSpanOptions creates a SpanOpt to set trace.SpanStartOption(s).
+func WithSpanOptions(opts ...trace.SpanStartOption) SpanOpt {
+	return func(cfg *StartConfig) {
+		cfg.spanOpts = append(cfg.spanOpts, opts...)
+	}
+}
+
+// StartSpan creates a new Span and adds it to the context.
+// If this function is called inside the context of a parent span, its return
+// context holds the newly created span. Otherwise, it creates a span with implicit
+// parent referencing and returns the context holding the new span.
+// StartSpan creates a new Span and adds it to the context.
+// If this function is called inside the context of a parent span, its return
+// context holds the newly created span. Otherwise, it creates a span with implicit
+// parent referencing and returns the context holding the new span.
 func StartSpan(ctx context.Context, opName string, opts ...SpanOpt) (context.Context, *Span) {
 	config := StartConfig{}
 	for _, fn := range opts {
 		fn(&config)
 	}
+
 	tracer := otel.Tracer("")
 	if parent := trace.SpanFromContext(ctx); parent != nil && parent.SpanContext().IsValid() {
 		tracer = parent.TracerProvider().Tracer("")
 	}
-	ctx, span := tracer.Start(ctx, opName, config.spanOpts...)
-	return ctx, &Span{otelSpan: span}
+
+	// Create the OpenTelemetry span as before
+	ctx, otelSpan := tracer.Start(ctx, opName, config.spanOpts...)
+
+	// Create wrapper span that handles both OTEL and enhanced tracing
+	wrapperSpan := &Span{
+		otelSpan: otelSpan,
+	}
+
+	// If enhanced tracing is enabled, create enhanced span in background
+	if isEnhancedTracingEnabled() {
+		tm := getGlobalTraceManager()
+		enhancedSpan, enhancedCtx := enhanced.StartSpanFromOTEL(ctx, tm.GetTracer(), opName, otelSpan)
+		if enhancedSpan != nil {
+			wrapperSpan.enhancedSpan = enhancedSpan
+			ctx = enhancedCtx
+		}
+
+		// Apply sandbox ID resolver if span lacks sandbox.id
+		if resolver := getSandboxIDResolver(); resolver != nil && enhancedSpan != nil {
+			if esp, ok := enhancedSpan.(*enhanced.EnhancedSpan); ok {
+				if _, exists := esp.GetAttribute("sandbox.id"); !exists {
+					if sid, ok := resolver(map[string]interface{}{
+						"trace.name": opName,
+					}); ok && sid != "" {
+						esp.SetAttribute("sandbox.id", sid)
+					}
+				}
+			}
+		}
+
+	}
+
+	return ctx, wrapperSpan
 }
 
 // SpanFromContext returns the current Span from the context.
 func SpanFromContext(ctx context.Context) *Span {
-	return &Span{
-		otelSpan: trace.SpanFromContext(ctx),
+	otelSpan := trace.SpanFromContext(ctx)
+	if otelSpan == nil {
+		return nil
+	}
+
+	wrapperSpan := &Span{
+		otelSpan: otelSpan,
+	}
+
+	// If enhanced tracing is enabled, try to get enhanced span from context
+	if isEnhancedTracingEnabled() {
+		if enhancedSpan := enhanced.SpanFromContext(ctx); enhancedSpan != nil {
+			wrapperSpan.enhancedSpan = enhancedSpan
+		}
+	}
+
+	return wrapperSpan
+}
+
+// Span is wrapper around both otel trace.Span and enhanced span.
+type Span struct {
+	otelSpan     trace.Span
+	enhancedSpan enhanced.Span
+}
+
+// End completes both OTEL and enhanced spans.
+func (s *Span) End() {
+	if s.otelSpan != nil {
+		s.otelSpan.End()
+	}
+	if s.enhancedSpan != nil {
+		s.enhancedSpan.End()
 	}
 }
 
-// Span is wrapper around otel trace.Span.
-// Span is the individual component of a trace. It represents a
-// single named and timed operation of a workflow that is traced.
-type Span struct {
-	otelSpan trace.Span
-}
-
-// End completes the span.
-func (s *Span) End() {
-	s.otelSpan.End()
-}
-
-// AddEvent adds an event with provided name and options.
+// AddEvent adds an event to both OTEL and enhanced spans.
 func (s *Span) AddEvent(name string, attributes ...attribute.KeyValue) {
-	s.otelSpan.AddEvent(name, trace.WithAttributes(attributes...))
+	if s.otelSpan != nil {
+		s.otelSpan.AddEvent(name, trace.WithAttributes(attributes...))
+	}
+	if s.enhancedSpan != nil {
+		enhancedAttrs := convertToEnhancedAttributes(attributes)
+		s.enhancedSpan.AddEvent(name, enhancedAttrs...)
+	}
 }
 
 // RecordError will record err as an exception span event for this span
 func (s *Span) RecordError(err error, options ...trace.EventOption) {
-	s.otelSpan.RecordError(err, options...)
-}
-
-// SetStatus sets the status of the current span.
-// If an error is encountered, it records the error and sets span status to Error.
-func (s *Span) SetStatus(err error) {
-	if err != nil {
-		s.otelSpan.RecordError(err)
-		s.otelSpan.SetStatus(codes.Error, err.Error())
-	} else {
-		s.otelSpan.SetStatus(codes.Ok, "")
+	if s.otelSpan != nil {
+		s.otelSpan.RecordError(err, options...)
+	}
+	if s.enhancedSpan != nil {
+		s.enhancedSpan.RecordError(err)
 	}
 }
 
-// SetAttributes sets kv as attributes of the span.
+// SetStatus sets the status of both OTEL and enhanced spans.
+func (s *Span) SetStatus(err error) {
+	if s.otelSpan != nil {
+		if err != nil {
+			s.otelSpan.RecordError(err)
+			s.otelSpan.SetStatus(codes.Error, err.Error())
+		} else {
+			s.otelSpan.SetStatus(codes.Ok, "")
+		}
+	}
+	if s.enhancedSpan != nil {
+		if err != nil {
+			s.enhancedSpan.SetStatus(enhanced.StatusCodeError, err.Error())
+			s.enhancedSpan.RecordError(err)
+		} else {
+			s.enhancedSpan.SetStatus(enhanced.StatusCodeOk, "success")
+		}
+	}
+}
+
+// SetAttributes sets attributes on both OTEL and enhanced spans.
 func (s *Span) SetAttributes(kv ...attribute.KeyValue) {
-	s.otelSpan.SetAttributes(kv...)
+	if s.otelSpan != nil {
+		s.otelSpan.SetAttributes(kv...)
+	}
+	if s.enhancedSpan != nil {
+		enhancedAttrs := convertToEnhancedAttributes(kv)
+		s.enhancedSpan.SetAttributes(enhancedAttrs...)
+	}
+}
+
+// SetAttribute sets a single attribute on both OTEL and enhanced spans.
+func (s *Span) SetAttribute(key string, value interface{}) {
+	if s.otelSpan != nil {
+		s.otelSpan.SetAttributes(Attribute(key, value))
+	}
+	if s.enhancedSpan != nil {
+		s.enhancedSpan.SetAttribute(key, value)
+	}
 }
 
 const spanDelimiter = "."
 
 // Name sets the span name by joining a list of strings in dot separated format.
-func Name(names ...string) string {
-	return strings.Join(names, spanDelimiter)
+func Name(parts ...string) string {
+	return strings.Join(parts, spanDelimiter)
 }
 
-// Attribute takes a key value pair and returns attribute.KeyValue type.
+// SpanOperation returns a composite span operation name.
+func SpanOperation(parts ...string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, spanDelimiter)
+}
+
+// Attribute returns generic attribute.KeyValue type for any supported input types.
 func Attribute(k string, v any) attribute.KeyValue {
-	return keyValue(k, v)
+	return common.KeyValue(k, v)
 }
 
-// HTTPStatusCodeAttributes generates attributes of the HTTP namespace as specified by the OpenTelemetry
-// specification for a span.
+// HTTPStatusCodeAttributes returns the attributes list for the given status code.
 func HTTPStatusCodeAttributes(code int) []attribute.KeyValue {
 	return []attribute.KeyValue{semconv.HTTPStatusCodeKey.Int(code)}
+}
+
+// UpdateHTTPClient wraps the given http.Client's transport with otelhttp instrumentation
+// and returns a new client instance to avoid modifying the original.
+func UpdateHTTPClient(client *http.Client, _ ...string) *http.Client {
+	if client == nil {
+		return http.DefaultClient
+	}
+
+	// Copy to avoid side-effects
+	newClient := *client
+
+	rt := newClient.Transport
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+
+	newClient.Transport = otelhttp.NewTransport(rt)
+	return &newClient
+}
+
+// Helper function to convert OTEL attributes to enhanced attributes
+func convertToEnhancedAttributes(otelAttrs []attribute.KeyValue) []enhanced.Attribute {
+	var enhancedAttrs []enhanced.Attribute
+	for _, attr := range otelAttrs {
+		enhancedAttrs = append(enhancedAttrs, enhanced.Attribute{
+			Key:   string(attr.Key),
+			Value: attr.Value.AsInterface(),
+		})
+	}
+	return enhancedAttrs
+}
+
+// EnhancedSpan returns the underlying enhanced span if available
+func (s *Span) EnhancedSpan() enhanced.Span {
+	return s.enhancedSpan
+}
+
+// IsEnhancedTracingActive returns true if enhanced tracing is active
+func (s *Span) IsEnhancedTracingActive() bool {
+	return s.enhancedSpan != nil
+}
+
+// IsRecording reports whether either the underlying OTEL span or the enhanced span is still recording.
+func (s *Span) IsRecording() bool {
+	if s == nil {
+		return false
+	}
+	if s.otelSpan != nil && s.otelSpan.IsRecording() {
+		return true
+	}
+	if s.enhancedSpan != nil && s.enhancedSpan.IsRecording() {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This commit proposes a standardized tracing API for containerd CRI
entry points to improve observability of container lifecycle operations.

Highlights:
- Centralized tracing interfaces under pkg/tracing
- Configurable sampling and exporter support (otlp, zipkin, file)
- Standard CRI span names and attribute constants
- Initial instrumentation for container, sandbox, image, and
  internal operations (CNI, snapshotter, runtime tasks, mounts)
- File exporter implementation for local debugging

Phase 1 focuses on CRI operations with low overhead and clean
abstractions, providing a foundation for future extensions (CNI,
image service, runtime).