### PR TITLE
fix: Fix cleanup script

### DIFF
--- a/script/test/utils.sh
+++ b/script/test/utils.sh
@@ -306,20 +306,52 @@ test_setup() {
   run_crictl
 }
 
-# test_teardown kills containerd.
+# test_teardown kills containerd and associated shim processes, unmounts shm, and cleans up state.
 test_teardown() {
   if [ -n "${pid}" ]; then
     if [ $IS_WINDOWS -eq 1 ]; then
-      # Mark service for deletion. It will be deleted as soon as the service stops.
+      # Windows cleanup
       sc.exe delete containerd-test
       # Stop the service
       sc.exe stop containerd-test || true
     else
+      echo "[teardown] Stopping containerd for PID ${pid}..."
+
+      # Kill containerd process group
       pgid=$(ps -o pgid= -p "${pid}" || true)
-      if [ ! -z "${pgid}" ]; then
-        ${sudo} pkill -g ${pgid}
+      if [ -n "${pgid}" ]; then
+        ${sudo} pkill -g "${pgid}" || true
       else
-        echo "pid(${pid}) not found, skipping pkill"
+        echo "[teardown] pid(${pid}) not found, skipping pkill"
+      fi
+
+      # Kill only shims for particular containerd instance.
+      if [ -n "${CONTAINERD_STATE}" ]; then
+        echo "[teardown] Killing shims under ${CONTAINERD_STATE}..."
+        ${sudo} pkill -9 -f "containerd-shim.*${CONTAINERD_STATE}" || true
+
+        # Wait until shims are gone.
+        for i in $(seq 1 30); do
+          if ! pgrep -f "containerd-shim.*${CONTAINERD_STATE}" >/dev/null; then
+            echo "[teardown] All shims exited."
+            break
+          fi
+          echo "[teardown] Waiting for shims to exit..."
+          sleep 1
+        done
+
+        # Clean up shm mounts.
+        if [ -d "${CONTAINERD_STATE}" ]; then
+          echo "[teardown] Cleaning up shm mounts under ${CONTAINERD_STATE}..."
+          ${sudo} mount | grep "${CONTAINERD_STATE}.*shm" | awk '{print $3}' | while read -r shm_mount; do
+            if [ -n "${shm_mount}" ]; then
+              echo "[teardown] Unmounting ${shm_mount}"
+              ${sudo} umount "${shm_mount}" 2>/dev/null \
+                || ${sudo} umount -l "${shm_mount}" 2>/dev/null \
+                || true
+            fi
+          done 2>/dev/null || true
+        fi
       fi
     fi
   fi


### PR DESCRIPTION
The initial teardown process only kills `containerd`. In some cases, `containerd-shim` processes are left running, especially when tests are executed in parallel.

**Test teardown improvements:**

* Extends the `test_teardown` function to not only kill the containerd process, but also:
  - Kills associated containerd-shim processes related to the test instance, making it safer for parallel test execution.
  - Waits for all shim processes to exit before proceeding.
  - Cleans up any shared memory (shm) mounts under the containerd state directory, ensuring no leftover mounts remain after tests.

Fixes #12204 