### PR TITLE
[release/2.0] Backport userns container image volume with copy-up fixes

### DIFF
--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containerd/log"
 )
@@ -101,6 +102,25 @@ func RemoveVolatileOption(mounts []Mount) []Mount {
 		return out
 	}
 
+	return mounts
+}
+
+// RemoveIDMapOption copies and removes the uidmap/gidmap options on any of the mounts using it.
+func RemoveIDMapOption(mounts []Mount) []Mount {
+	var out []Mount
+	for i, m := range mounts {
+		for j, opt := range m.Options {
+			if strings.HasPrefix(opt, "uidmap") || strings.HasPrefix(opt, "gidmap") {
+				if out == nil {
+					out = copyMounts(mounts)
+				}
+				out[i].Options = append(out[i].Options[:j], out[i].Options[j+1:]...)
+			}
+		}
+	}
+	if out != nil {
+		return out
+	}
 	return mounts
 }
 

--- a/internal/cri/opts/container.go
+++ b/internal/cri/opts/container.go
@@ -76,6 +76,11 @@ func WithVolumes(volumeMounts map[string]string, platform imagespec.Platform) co
 		}
 		mounts = mount.RemoveVolatileOption(mounts)
 
+		// Always copy files without UID/GID transformations.
+		// The ID transformations are only needed when running inside a userns, that is not
+		// the case here.
+		mounts = mount.RemoveIDMapOption(mounts)
+
 		root, err := os.MkdirTemp("", "ctd-volume")
 		if err != nil {
 			return err


### PR DESCRIPTION
This backports: https://github.com/containerd/containerd/pull/12218

Fixes: https://github.com/containerd/containerd/issues/11852 in the 2.0 branch