### PR TITLE
add SystemdCgroup to default runtime options

### DIFF
--- a/internal/cri/config/config_unix.go
+++ b/internal/cri/config/config_unix.go
@@ -65,6 +65,9 @@ func DefaultRuntimeConfig() RuntimeConfig {
 	# Root is the runc root directory.
 	Root = ""
 
+	# SystemdCgroup enables systemd cgroups.
+	SystemdCgroup = false
+
 	# CriuImagePath is the criu image path
 	CriuImagePath = ""
 


### PR DESCRIPTION
even though the SystemdCgroup key was used/respected by runtime options, it was not present as part of the default generated config.

Fixes: #12101 