### PR TITLE
Update pkg/oci to use fs.FS interface and os.OpenRoot

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -29,7 +30,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/continuity/fs"
 	"github.com/containerd/platforms"
 	"github.com/moby/sys/user"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -653,9 +653,9 @@ func WithUser(userstr string) SpecOpts {
 				s.Process.User.UID, s.Process.User.GID = uid, gid
 				return nil
 			}
-			f := func(root string) error {
+			f := func(root fs.FS) error {
 				if username != "" {
-					usr, err := UserFromPath(root, func(u user.User) bool {
+					usr, err := UserFromFS(root, func(u user.User) bool {
 						return u.Name == username
 					})
 					if err != nil {
@@ -664,7 +664,7 @@ func WithUser(userstr string) SpecOpts {
 					uid = uint32(usr.Uid)
 				}
 				if groupname != "" {
-					gid, err = GIDFromPath(root, func(g user.Group) bool {
+					gid, err = GIDFromFS(root, func(g user.Group) bool {
 						return g.Name == groupname
 					})
 					if err != nil {
@@ -678,7 +678,12 @@ func WithUser(userstr string) SpecOpts {
 				if !isRootfsAbs(s.Root.Path) {
 					return errors.New("rootfs absolute path is required")
 				}
-				return f(s.Root.Path)
+				rootfs, err := os.OpenRoot(s.Root.Path)
+				if err != nil {
+					return err
+				}
+				defer rootfs.Close()
+				return f(rootfs.FS())
 			}
 			if c.Snapshotter == "" {
 				return errors.New("no snapshotter set for container")
@@ -696,7 +701,14 @@ func WithUser(userstr string) SpecOpts {
 			// from the container's rootfs. Since the option does read operation
 			// only, we append ReadOnly mount option to prevent the Linux kernel
 			// from syncing whole filesystem in umount syscall.
-			return mount.WithReadonlyTempMount(ctx, mounts, f)
+			return mount.WithReadonlyTempMount(ctx, mounts, func(root string) error {
+				rootfs, err := os.OpenRoot(root)
+				if err != nil {
+					return err
+				}
+				defer rootfs.Close()
+				return f(rootfs.FS())
+			})
 		default:
 			return fmt.Errorf("invalid USER value %s", userstr)
 		}
@@ -724,8 +736,8 @@ func WithUserID(uid uint32) SpecOpts {
 		defer ensureAdditionalGids(s)
 		setProcess(s)
 		s.Process.User.AdditionalGids = nil
-		setUser := func(root string) error {
-			usr, err := UserFromPath(root, func(u user.User) bool {
+		setUser := func(root fs.FS) error {
+			usr, err := UserFromFS(root, func(u user.User) bool {
 				return u.Uid == int(uid)
 			})
 			if err != nil {
@@ -742,7 +754,12 @@ func WithUserID(uid uint32) SpecOpts {
 			if !isRootfsAbs(s.Root.Path) {
 				return errors.New("rootfs absolute path is required")
 			}
-			return setUser(s.Root.Path)
+			rootfs, err := os.OpenRoot(s.Root.Path)
+			if err != nil {
+				return err
+			}
+			defer rootfs.Close()
+			return setUser(rootfs.FS())
 		}
 		if c.Snapshotter == "" {
 			return errors.New("no snapshotter set for container")
@@ -760,7 +777,14 @@ func WithUserID(uid uint32) SpecOpts {
 		// from the container's rootfs. Since the option does read operation
 		// only, we append ReadOnly mount option to prevent the Linux kernel
 		// from syncing whole filesystem in umount syscall.
-		return mount.WithReadonlyTempMount(ctx, mounts, setUser)
+		return mount.WithReadonlyTempMount(ctx, mounts, func(root string) error {
+			rootfs, err := os.OpenRoot(root)
+			if err != nil {
+				return err
+			}
+			defer rootfs.Close()
+			return setUser(rootfs.FS())
+		})
 	}
 }
 
@@ -776,8 +800,8 @@ func WithUsername(username string) SpecOpts {
 		setProcess(s)
 		s.Process.User.AdditionalGids = nil
 		if s.Linux != nil {
-			setUser := func(root string) error {
-				usr, err := UserFromPath(root, func(u user.User) bool {
+			setUser := func(root fs.FS) error {
+				usr, err := UserFromFS(root, func(u user.User) bool {
 					return u.Name == username
 				})
 				if err != nil {
@@ -790,7 +814,12 @@ func WithUsername(username string) SpecOpts {
 				if !isRootfsAbs(s.Root.Path) {
 					return errors.New("rootfs absolute path is required")
 				}
-				return setUser(s.Root.Path)
+				rootfs, err := os.OpenRoot(s.Root.Path)
+				if err != nil {
+					return err
+				}
+				defer rootfs.Close()
+				return setUser(rootfs.FS())
 			}
 			if c.Snapshotter == "" {
 				return errors.New("no snapshotter set for container")
@@ -808,7 +837,14 @@ func WithUsername(username string) SpecOpts {
 			// from the container's rootfs. Since the option does read operation
 			// only, we append ReadOnly mount option to prevent the Linux kernel
 			// from syncing whole filesystem in umount syscall.
-			return mount.WithReadonlyTempMount(ctx, mounts, setUser)
+			return mount.WithReadonlyTempMount(ctx, mounts, func(root string) error {
+				rootfs, err := os.OpenRoot(root)
+				if err != nil {
+					return err
+				}
+				defer rootfs.Close()
+				return setUser(rootfs.FS())
+			})
 		} else if s.Windows != nil {
 			s.Process.User.Username = username
 		} else {
@@ -829,12 +865,12 @@ func WithAdditionalGIDs(userstr string) SpecOpts {
 		}
 		setProcess(s)
 		s.Process.User.AdditionalGids = nil
-		setAdditionalGids := func(root string) error {
+		setAdditionalGids := func(root fs.FS) error {
 			defer ensureAdditionalGids(s)
 			var username string
 			uid, err := strconv.Atoi(userstr)
 			if err == nil {
-				usr, err := UserFromPath(root, func(u user.User) bool {
+				usr, err := UserFromFS(root, func(u user.User) bool {
 					return u.Uid == uid
 				})
 				if err != nil {
@@ -847,7 +883,7 @@ func WithAdditionalGIDs(userstr string) SpecOpts {
 			} else {
 				username = userstr
 			}
-			gids, err := getSupplementalGroupsFromPath(root, func(g user.Group) bool {
+			gids, err := getSupplementalGroupsFromFS(root, func(g user.Group) bool {
 				// we only want supplemental groups
 				if g.Name == username {
 					return false
@@ -872,7 +908,12 @@ func WithAdditionalGIDs(userstr string) SpecOpts {
 			if !isRootfsAbs(s.Root.Path) {
 				return errors.New("rootfs absolute path is required")
 			}
-			return setAdditionalGids(s.Root.Path)
+			rootfs, err := os.OpenRoot(s.Root.Path)
+			if err != nil {
+				return err
+			}
+			defer rootfs.Close()
+			return setAdditionalGids(rootfs.FS())
 		}
 		if c.Snapshotter == "" {
 			return errors.New("no snapshotter set for container")
@@ -890,7 +931,14 @@ func WithAdditionalGIDs(userstr string) SpecOpts {
 		// from the container's rootfs. Since the option does read operation
 		// only, we append ReadOnly mount option to prevent the Linux kernel
 		// from syncing whole filesystem in umount syscall.
-		return mount.WithReadonlyTempMount(ctx, mounts, setAdditionalGids)
+		return mount.WithReadonlyTempMount(ctx, mounts, func(root string) error {
+			rootfs, err := os.OpenRoot(root)
+			if err != nil {
+				return err
+			}
+			defer rootfs.Close()
+			return setAdditionalGids(rootfs.FS())
+		})
 	}
 }
 
@@ -903,16 +951,21 @@ func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 			return nil
 		}
 		setProcess(s)
-		setAdditionalGids := func(root string) error {
+		setAdditionalGids := func(root fs.FS) error {
 			defer ensureAdditionalGids(s)
-			gpath, err := fs.RootPath(root, "/etc/group")
-			if err != nil {
-				return err
-			}
-			ugroups, groupErr := user.ParseGroupFile(gpath)
-			if groupErr != nil && !os.IsNotExist(groupErr) {
+
+			var ugroups []user.Group
+			f, groupErr := root.Open("etc/group")
+			if groupErr == nil {
+				defer f.Close()
+				ugroups, groupErr = user.ParseGroup(f)
+				if groupErr != nil {
+					return groupErr
+				}
+			} else if !os.IsNotExist(groupErr) {
 				return groupErr
 			}
+
 			groupMap := make(map[string]user.Group)
 			for _, group := range ugroups {
 				groupMap[group.Name] = group
@@ -940,7 +993,12 @@ func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 			if !filepath.IsAbs(s.Root.Path) {
 				return errors.New("rootfs absolute path is required")
 			}
-			return setAdditionalGids(s.Root.Path)
+			rootfs, err := os.OpenRoot(s.Root.Path)
+			if err != nil {
+				return err
+			}
+			defer rootfs.Close()
+			return setAdditionalGids(rootfs.FS())
 		}
 		if c.Snapshotter == "" {
 			return errors.New("no snapshotter set for container")
@@ -958,7 +1016,14 @@ func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 		// from the container's rootfs. Since the option does read operation
 		// only, we append ReadOnly mount option to prevent the Linux kernel
 		// from syncing whole filesystem in umount syscall.
-		return mount.WithReadonlyTempMount(ctx, mounts, setAdditionalGids)
+		return mount.WithReadonlyTempMount(ctx, mounts, func(root string) error {
+			rootfs, err := os.OpenRoot(root)
+			if err != nil {
+				return err
+			}
+			defer rootfs.Close()
+			return setAdditionalGids(rootfs.FS())
+		})
 	}
 }
 
@@ -1065,11 +1130,23 @@ var ErrNoUsersFound = errors.New("no users found")
 // UserFromPath inspects the user object using /etc/passwd in the specified rootfs.
 // filter can be nil.
 func UserFromPath(root string, filter func(user.User) bool) (user.User, error) {
-	ppath, err := fs.RootPath(root, "/etc/passwd")
+	r, err := os.OpenRoot(root)
 	if err != nil {
 		return user.User{}, err
 	}
-	users, err := user.ParsePasswdFileFilter(ppath, filter)
+	defer r.Close()
+	return UserFromFS(r.FS(), filter)
+}
+
+// UserFromFS inspects the user object using /etc/passwd in the specified fs.FS.
+// filter can be nil.
+func UserFromFS(root fs.FS, filter func(user.User) bool) (user.User, error) {
+	f, err := root.Open("etc/passwd")
+	if err != nil {
+		return user.User{}, err
+	}
+	defer f.Close()
+	users, err := user.ParsePasswdFilter(f, filter)
 	if err != nil {
 		return user.User{}, err
 	}
@@ -1085,11 +1162,23 @@ var ErrNoGroupsFound = errors.New("no groups found")
 // GIDFromPath inspects the GID using /etc/group in the specified rootfs.
 // filter can be nil.
 func GIDFromPath(root string, filter func(user.Group) bool) (gid uint32, err error) {
-	gpath, err := fs.RootPath(root, "/etc/group")
+	r, err := os.OpenRoot(root)
 	if err != nil {
 		return 0, err
 	}
-	groups, err := user.ParseGroupFileFilter(gpath, filter)
+	defer r.Close()
+	return GIDFromFS(r.FS(), filter)
+}
+
+// GIDFromFS inspects the GID using /etc/group in the specified fs.FS.
+// filter can be nil.
+func GIDFromFS(root fs.FS, filter func(user.Group) bool) (gid uint32, err error) {
+	f, err := root.Open("etc/group")
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	groups, err := user.ParseGroupFilter(f, filter)
 	if err != nil {
 		return 0, err
 	}
@@ -1100,12 +1189,13 @@ func GIDFromPath(root string, filter func(user.Group) bool) (gid uint32, err err
 	return uint32(g.Gid), nil
 }
 
-func getSupplementalGroupsFromPath(root string, filter func(user.Group) bool) ([]uint32, error) {
-	gpath, err := fs.RootPath(root, "/etc/group")
+func getSupplementalGroupsFromFS(root fs.FS, filter func(user.Group) bool) ([]uint32, error) {
+	f, err := root.Open("etc/group")
 	if err != nil {
 		return []uint32{}, err
 	}
-	groups, err := user.ParseGroupFileFilter(gpath, filter)
+	defer f.Close()
+	groups, err := user.ParseGroupFilter(f, filter)
 	if err != nil {
 		return []uint32{}, err
 	}

--- a/pkg/oci/spec_opts_linux_test.go
+++ b/pkg/oci/spec_opts_linux_test.go
@@ -23,14 +23,15 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/containerd/containerd/v2/core/containers"
-	"github.com/containerd/containerd/v2/pkg/cap"
-	"github.com/containerd/containerd/v2/pkg/testutil"
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/pkg/cap"
+	"github.com/containerd/containerd/v2/pkg/testutil"
 )
 
 //nolint:gosec
@@ -739,7 +740,7 @@ func TestWithAppendAdditionalGroupsNoEtcGroup(t *testing.T) {
 		{
 			name:     "no additional gids, append root group",
 			groups:   []string{"root"},
-			err:      fmt.Sprintf("unable to find group root: open %s: no such file or directory", filepath.Join(td, "etc", "group")),
+			err:      "unable to find group root: openat etc/group: no such file or directory",
 			expected: []uint32{0},
 		},
 		{


### PR DESCRIPTION
Switch to use fs.FS interface over directly requiring path string. This interface allows the filesystem operations to be further abstracted, then we can use any library which can return an FS from mounts without requiring an active mount. This is useful for supporting erofs on hosts which cannot directly mount it.

Using os.OpenRoot over continuity's RootPath is the preferred solution going forward as it is part of the standard library and able to leverage the openat syscall. Switching with this package first is the safest since it does not resolve user provided paths against the root.