### PR TITLE
install-runhcs-shim: fetch target commit instead of tags 

### DIFF
--- a/script/setup/install-runhcs-shim
+++ b/script/setup/install-runhcs-shim
@@ -37,9 +37,10 @@ then
     cd "$tmpdir"
     git init .
     git remote add origin "$RUNHCS_REPO"
-    git fetch --tags --depth=1 origin ${RUNHCS_VERSION}
+    git fetch --depth 1 origin ${RUNHCS_VERSION}
+    git checkout FETCH_HEAD
 else
     cd "${HCSSHIM_SRC}"
+    git checkout "refs/tags/${RUNHCS_VERSION}" || git checkout "refs/heads/${RUNHCS_VERSION}" || git checkout "${RUNHCS_VERSION}"
 fi
-git checkout "refs/tags/${RUNHCS_VERSION}" || git checkout "refs/heads/${RUNHCS_VERSION}" || git checkout "${RUNHCS_VERSION}"
 GO111MODULE=on go build -mod=vendor -o "${DESTDIR}/containerd-shim-runhcs-v1.exe" ./cmd/containerd-shim-runhcs-v1


### PR DESCRIPTION
No idea why it blames lock during fetching.

```bash
...
 * [new tag]           v0.9.9           -> v0.9.9
error: cannot lock ref 'refs/tags/v0.6.3': Unable to create 'C:/Users/runneradmin/AppData/Local/Temp/tmp.N2FTxfARN9/.git/refs/tags/v0.6.3.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
+ cleanup
+ rm -rf /tmp/tmp.N2FTxfARN9
```