### PR TITLE
Pass all labels to CNI Plugin

### DIFF
--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -419,6 +419,7 @@ func cniNamespaceOpts(id string, config *runtime.PodSandboxConfig) ([]cni.Namesp
 	opts := []cni.NamespaceOpts{
 		cni.WithLabels(toCNILabels(id, config)),
 		cni.WithCapability(annotations.PodAnnotations, config.Annotations),
+		cni.WithLabels(config.Labels),
 	}
 
 	portMappings := toCNIPortMappings(config.GetPortMappings())
@@ -450,13 +451,22 @@ func cniNamespaceOpts(id string, config *runtime.PodSandboxConfig) ([]cni.Namesp
 
 // toCNILabels adds pod metadata into CNI labels.
 func toCNILabels(id string, config *runtime.PodSandboxConfig) map[string]string {
-	return map[string]string{
+	labels := map[string]string{
 		"K8S_POD_NAMESPACE":          config.GetMetadata().GetNamespace(),
 		"K8S_POD_NAME":               config.GetMetadata().GetName(),
 		"K8S_POD_INFRA_CONTAINER_ID": id,
 		"K8S_POD_UID":                config.GetMetadata().GetUid(),
 		"IgnoreUnknown":              "1",
 	}
+
+	// Merge PodSandboxConfig labels, skip if key already exists
+	for k, v := range config.GetLabels() {
+		if _, exists := labels[k]; !exists {
+			labels[k] = v
+		}
+	}
+
+	return labels
 }
 
 // toCNIBandWidth converts CRI annotations to CNI bandwidth.


### PR DESCRIPTION
Currently, we do not pass all the labels to the CNI plugin. It is common across the main CNI plugins to use the kubeclient to reach out to the api-server to get labels. This may reduce the need for this. It is possible that labels have been updated between the scheduling and the CNI add. 