### PR TITLE
Update Go requirements in BUILDING

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,7 +25,7 @@ A codespace will open in a web-based version of Visual Studio Code. The [dev con
 
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
-* Go 1.22.x or above
+* Go compiler (download from https://go.dev/dl/). The two most recent major Go versions are supported. For example, if Go 1.25 is the latest, then 1.25 and 1.24 are supported.
 * Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/protocolbuffers/protobuf/releases))
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 


### PR DESCRIPTION
Updates wording `BUILDING.md` around required Go version to specify that the project supports the two most recent major Go versions, rather than hardcoding "1.22.x or above" (which we don't support).

This way the documentation doesn't become outdated when new Go versions are released.