### PR TITLE
[cri] Allow configuration of the manifest limit

### DIFF
--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -345,6 +345,11 @@ type ImageConfig struct {
 	// When transfer service is used to pull images, pull related configs, like max_concurrent_downloads
 	// and unpack_config are configured under [plugins."io.containerd.transfer.v1.local"]
 	UseLocalImagePull bool `toml:"use_local_image_pull" json:"useLocalImagePull"`
+
+	// Limit the number of manifests that will be unpacked during image pulls.
+	// The default is to unpack all the manifests that match the current platform
+	// but this can help limit the amount of returned manifests further
+	ManifestLimit int `toml:"manifest_limit" json:"manifestLimit"`
 }
 
 // RuntimeConfig contains toml config related to CRI plugin,

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -304,6 +304,7 @@ func (c *CRIImageService) pullImageWithTransferService(
 	sopts = append(sopts, transferimage.WithPlatforms(platforms.DefaultSpec()))
 	sopts = append(sopts, transferimage.WithUnpack(platforms.DefaultSpec(), snapshotter))
 	sopts = append(sopts, transferimage.WithImageLabels(labels))
+	sopts = append(sopts, transferimage.WithManifestLimit(c.config.ManifestLimit))
 	is := transferimage.NewStore(ref, sopts...)
 	log.G(ctx).Debugf("Getting new CRI credentials")
 	ch := newCRICredentials(ref, credentials)


### PR DESCRIPTION
Limit the number of manifests that will be unpacked during image pulls. The default is to unpack all the manifests that match the current platform but this can help limit the amount of returned manifests further. In particular this is useful in the case of index manifests with multiple image that match the same architecture. Limiting the manifests to 1 there will ensure it's always the same manifest that gets unpacked.