### PR TITLE
Ensure layer is deactivated before converting scratch to read-only in Windows

### DIFF
--- a/plugins/snapshots/windows/windows.go
+++ b/plugins/snapshots/windows/windows.go
@@ -289,6 +289,14 @@ func (s *wcowSnapshotter) convertScratchToReadOnlyLayer(ctx context.Context, sna
 	}
 
 	parentLayerPaths := s.parentIDsToParentPaths(snapshot.ParentIDs)
+
+	// Ensure the layer is deactivated
+	// This handles the case where the layer is still active from container execution
+	// Calling deactivate layer multiple times won't cause error
+	if err := hcsshim.DeactivateLayer(s.info, filepath.Base(path)); err != nil {
+		return fmt.Errorf("failed to deactivate layer: %w", err)
+	}
+
 	reader, writer := io.Pipe()
 
 	go func() {


### PR DESCRIPTION
When building image with buildkit enabled in Windows, error with occur:

```
> docker buildx build .
[+] Building 0.2s (6/6) FINISHED                                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                             0.0s
 => => transferring dockerfile: 138B                                                                                                                                                             0.0s
 => [internal] load metadata for mcr.microsoft.com/windows/nanoserver:ltsc2022                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                  0.0s
 => [1/3] FROM mcr.microsoft.com/windows/nanoserver:ltsc2022@sha256:98171699808fbf48b5e04158948a3414d1e5a8828b8cbfd92e178c48f9dad8e8                                                             0.0s
 => => resolve mcr.microsoft.com/windows/nanoserver:ltsc2022@sha256:98171699808fbf48b5e04158948a3414d1e5a8828b8cbfd92e178c48f9dad8e8                                                             0.0s
 => CACHED [2/3] RUN echo "hello world"                                                                                                                                                          0.0s
 => ERROR [3/3] RUN curl.exe -I 1.1.1.1                                                                                                                                                          0.0s
------
 > [3/3] RUN curl.exe -I 1.1.1.1:
------
Dockerfile:3
--------------------
   1 |     FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
   2 |     RUN echo "hello world"
   3 | >>> RUN curl.exe -I 1.1.1.1
   4 |
--------------------
ERROR: failed to build: failed to solve: failed to commit rfu2euv46cfh0d6vvodjsxqdt to x7t3phuztsubpx8xnfd5e43iv during finalize: failed to reimport snapshot: hcsshim::ActivateLayer failed in Win32: The process cannot access the file because it is being used by another process. (0x20)
```

This issue fixes it by ensuring layer is deactivated before converting scratch to read-only.

This prevents issues when the layer is still active from container execution. The deactivation call is safe to repeat without causing errors.