### PR TITLE
Ensure errContentRangeIgnored error when range-get request is ignored

### DIFF
--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -459,7 +459,7 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 	if err := r.Acquire(ctx, 1); err != nil {
 		return nil, err
 	}
-	resp, err := req.doWithRetries(ctx, lastHost, withErrorCheck, withOffsetCheck(offset))
+	resp, err := req.doWithRetries(ctx, lastHost, withErrorCheck, withOffsetCheck(offset, parallelism))
 	switch err {
 	case nil:
 		// all good

--- a/core/remotes/docker/fetcher_test.go
+++ b/core/remotes/docker/fetcher_test.go
@@ -247,6 +247,7 @@ func TestFetcherOpenParallel(t *testing.T) {
 	sendContentLength = true
 
 	ignoreContentRange = true
+	checkReader(0)
 	checkReader(25)
 	ignoreContentRange = false
 

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -659,9 +659,9 @@ func withErrorCheck(r *request, resp *http.Response) error {
 
 var errContentRangeIgnored = errors.New("content range requests ignored")
 
-func withOffsetCheck(offset int64) doChecks {
+func withOffsetCheck(offset, parallelism int64) doChecks {
 	return func(r *request, resp *http.Response) error {
-		if offset == 0 {
+		if parallelism <= 1 && offset == 0 {
 			return nil
 		}
 		if resp.StatusCode == http.StatusPartialContent {


### PR DESCRIPTION
Fixed an issue where pulling image fails when `concurrent_layer_fetch_buffer` is small.

### Repro steps:
1. Configure containerd with
```
[plugins]
  [plugins.'io.containerd.transfer.v1.local']
    max_concurrent_downloads = 20
    concurrent_layer_fetch_buffer = 518
```

2. Pull image:
```
# ctr i pull docker.io/library/hello-world:latest
docker.io/library/hello world:latest            fetching image content
└──index (a0dfb02aac21)                         downloading     |++++++++++++++++++++++++++++++++++++++|        12.1 KiB/12.1 KiB
application/vnd.oci.image.index.v1+json sha256:a0dfb02aac212703bfcb339d77d47ec32c8706ff250850ecc0e19c8737b18567
Pulling from OCI Registry (docker.io/library/hello-world:latest)        elapsed: 1.6 s  total:  12.1 K  (7.5 KiB/s)
ctr: failed commit on ref "index-sha256:a0dfb02aac212703bfcb339d77d47ec32c8706ff250850ecc0e19c8737b18567": "index-sha256:a0dfb02aac212703bfcb339d77d47ec32c8706ff250850ecc0e19c8737b18567" failed size validation: 12432 != 12341: failed precondition
```

Here is the dump of the HTTP response, the registry did not return `content-range` in the response header:

```
Sep 09 19:01:36 ip-172-31-63-131 containerd[293664]: time="2025-09-09T19:01:36.846936961Z" level=debug msg="fetch response received" digest="sha256:a0dfb02aac212703bfcb339d77d47ec32c8706ff250850ecc0e19c8737b18567" mediatype=application/vnd.oci.image.index.v1+json response.header.connection=keep-alive response.header.content-length=12341 response.header.content-type=application/vnd.oci.image.index.v1+json response.header.date="Tue, 09 Sep 2025 19:01:36 GMT" response.header.docker-content-digest="sha256:a0dfb02aac212703bfcb339d77d47ec32c8706ff250850ecc0e19c8737b18567" response.header.docker-distribution-api-version=registry/2.0 response.header.docker-ratelimit-source=35.88.37.181 response.header.etag="\"sha256:a0dfb02aac212703bfcb339d77d47ec32c8706ff250850ecc0e19c8737b18567\"" response.header.ratelimit-limit="100;w=21600" response.header.ratelimit-remaining="70;w=21600" response.header.strict-transport-security="max-age=31536000" response.status="200 OK" size=12341 url="https://registry-1.docker.io/v2/library/hello-world/manifests/sha256:a0dfb02aac212703bfcb339d77d47ec32c8706ff250850ecc0e19c8737b18567"
```

### Fix
The Fetcher sets the `Range` header if `parallelism > 1` or `offset > 0`. 

https://github.com/containerd/containerd/blob/1843b237f6ccd52062857555ad851b51907409a6/core/remotes/docker/fetcher.go#L455-L457

But `withOffsetCheck` returns `nil` for error when `offset == 0` only.

https://github.com/containerd/containerd/blob/1843b237f6ccd52062857555ad851b51907409a6/core/remotes/docker/resolver.go#L664-L666

This logic cannot handle the scenario when a registry ignores the range-get request for small layers. The correct logic should return `errContentRangeIgnored` in this case.
