### PR TITLE
doc: add k8s 1.34 into support matrix

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -147,10 +147,10 @@ of containerd for every supported version of Kubernetes.
 
 | Kubernetes Version | containerd Version               | CRI Version     |
 |--------------------|----------------------------------|-----------------|
-| 1.30               | 2.1.0+, 2.0.0+, 1.7.13+, 1.6.28+ | v1              |
 | 1.31               | 2.1.0+, 2.0.0+, 1.7.20+, 1.6.34+ | v1              |
 | 1.32               | 2.1.0+, 2.0.1+, 1.7.24+, 1.6.36+ | v1              |
 | 1.33               | 2.1.0+, 2.0.4+, 1.7.24+, 1.6.36+ | v1              |
+| 1.34               | 2.1.3+, 2.0.6+, 1.7.28+, 1.6.39+ | v1              |
 
 Deprecated containerd and kubernetes versions
 


### PR DESCRIPTION
- add k8s 1.34 into support matrix
- remove k8s 1.30 as its EOL in upstream