### PR TITLE
docs: Update 1.7 LTS support timeline

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -128,11 +128,13 @@ to all committers.
 | [1.4](https://github.com/containerd/containerd/releases/tag/v1.4.13) | End of Life   | August 17, 2020                | March 3, 2022                  |                        |
 | [1.5](https://github.com/containerd/containerd/releases/tag/v1.5.18) | End of Life   | May 3, 2021                    | February 28, 2023              |                        |
 | [1.6](https://github.com/containerd/containerd/releases/tag/v1.6.0)  | Extended      | February 15, 2022              | August 23, 2025                | @containerd/committers |
-| [1.7](https://github.com/containerd/containerd/releases/tag/v1.7.0)  | LTS           | March 10, 2023                 | March 10, 2026                 | @containerd/committers |
+| [1.7](https://github.com/containerd/containerd/releases/tag/v1.7.0)  | LTS           | March 10, 2023                 | September 2026*                | @containerd/committers |
 | [2.0](https://github.com/containerd/containerd/releases/tag/v2.0.0)  | Active        | November 5, 2024               | November 7, 2025               | @containerd/committers |
 | [2.1](https://github.com/containerd/containerd/releases/tag/v2.1.0)  | Active        | May 7, 2025                    | May 5, 2026 (_tentative_)      | @containerd/committers |
 | [2.2](https://github.com/containerd/containerd/milestone/49)         | _Future_      | November 5, 2025 (_tentative_) | November 6, 2026 (_tentative_) | _TBD_                  |
 | [2.3](https://github.com/containerd/containerd/milestone/50)         | _Future_      | May 6, 2026 (_tentative_)      | _TBD_                          | _TBD_                  |
+
+\* Support for the 1.7 release branch is provided by @containerd/committers until March 10, 2026. Extended support through September 2026 is provided by @chrishenzie and @samuelkarp.
 
 ### Kubernetes Support
 


### PR DESCRIPTION
Extend the LTS support window for the 1.7 release branch to September 2026. The footnote asterisk is escaped to ensure correct rendering on the hugo site.

This change reflects the decision made during the community meeting, where @samuelkarp and I volunteered to provide extended support beyond the standard two-year LTS period. The existing support from @containerd/committers remains in place until March 2026.