### PR TITLE
tracing: shim traces not always exported on shutdown

### DIFF
--- a/cmd/containerd-shim-runc-v2/main_tracing.go
+++ b/cmd/containerd-shim-runc-v2/main_tracing.go
@@ -19,6 +19,12 @@
 package main
 
 import (
+	"os"
+
 	_ "github.com/containerd/containerd/v2/internal/pprof"
 	_ "github.com/containerd/containerd/v2/pkg/tracing/plugin"
 )
+
+func init() {
+	os.Setenv("OTEL_SERVICE_NAME", "containerd-shim-runc-v2")
+}


### PR DESCRIPTION
During container/task kill and deletion, the shim actions can complete fast enough such that the shim process exits and otel spans (via the shim_tracing build tag) are not exported yet. This registers a call back function on shutdown to forcibly shutdown the tracing provider so that any remaining spans are flushed before the shim process exits.