### PR TITLE
bugfix: sync parent dir to ensure blob entry is reliably stored

### DIFF
--- a/plugins/content/local/writer.go
+++ b/plugins/content/local/writer.go
@@ -139,6 +139,9 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 		return err
 	}
 
+	if err := syncDir(filepath.Dir(target)); err != nil {
+		return err
+	}
 	// Enable content blob integrity verification if supported
 
 	if w.s.integritySupported {

--- a/plugins/content/local/writer_unix.go
+++ b/plugins/content/local/writer_unix.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import (
+	"fmt"
+	"os"
+)
+
+func syncDir(dir string) error {
+	dirF, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("failed to open dir %s: %w", dir, err)
+	}
+	err = dirF.Sync()
+	dirF.Close()
+	if err != nil {
+		return fmt.Errorf("failed to sync dir %s: %w", dir, err)
+	}
+	return nil
+}

--- a/plugins/content/local/writer_windows.go
+++ b/plugins/content/local/writer_windows.go
@@ -1,0 +1,22 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+// sync dir doesn't support in windows
+func syncDir(dir string) error {
+	return nil
+}


### PR DESCRIPTION
fix https://github.com/containerd/containerd/issues/12302

According to https://man7.org/linux/man-pages/man2/fsync.2.html, we need to sync parent dir to ensure blob entry is stored.

       Calling fsync() does not necessarily ensure that the entry in the
       directory containing the file has also reached disk.  For that an
       explicit fsync() on a file descriptor for the directory is also
       needed.

updated by @fuweid 