### PR TITLE
[github-action] release - Empty allowedSignersFile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Check signature
         run: |
+          # git tag -v requires an allowedSignersFile to be configured and exist for ssh signature verification
+          touch ${{ runner.temp }}/empty-allowedSignersFile
+          git config --global gpg.ssh.allowedSignersFile ${{ runner.temp }}/empty-allowedSignersFile
           releasever=${{ github.ref }}
           releasever="${releasever#refs/tags/}"
           TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||


### PR DESCRIPTION
Howdy! Likely you don't hit this upstream and it looks like the tags are currently signed with GPG based keys. However, on forks if you try to push a tag, this action fails if the signature is signed with an SSH key. As such, I'm offering this change upstream so you all could support future SSH signed git tags too. I've tested this on our fork and it seems to work with tags signed using my `ed25519` key & leaving the `allowedSignersFile` file empty. Without this, the CI job fails with:

```
Output: error: gpg.ssh.allowedSignersFile needs to be configured and exist for ssh signature verification
```

If you're open to this change and willing to backport it to the 2.1 release branch, that'd be swell! Thanks for considering!