### PR TITLE
Make E2E workflow a required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,6 +727,10 @@ jobs:
             *-junit.xml
             *-gotest.json
 
+  node-e2e:
+    name: E2E
+    uses: ./.github/workflows/node-e2e.yml
+
   # Currently Github actions UI supports no masks to mark matrix jobs as required to pass status checks.
   # This means that every time version of Go, containerd, or OS is changed, a corresponding job should
   # be added to the list of required checks. Which is not very convenient.
@@ -738,7 +742,7 @@ jobs:
     name: Report required job statuses
     runs-on: ubuntu-latest
     # List job dependencies which are required to pass status checks in order to be merged via merge queue.
-    needs: [linters, project, protos, binaries, integration-linux, integration-windows, tests-cri-in-userns, tests-mac-os]
+    needs: [linters, project, protos, binaries, integration-linux, integration-windows, tests-cri-in-userns, tests-mac-os, node-e2e]
     if: ${{ always() }}
     steps:
       - run: exit 1

--- a/.github/workflows/node-e2e.yml
+++ b/.github/workflows/node-e2e.yml
@@ -1,9 +1,6 @@
 name: E2E
 on:
-  pull_request:
-    branches: ['main', 'release/1.7', 'release/2.0', 'release/2.1']
-  merge_group:
-    branches: ['main', 'release/1.7', 'release/2.0', 'release/2.1']
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
The Kubernetes Node E2E workflow has proven to be stable:
https://github.com/containerd/containerd/actions/workflows/node-e2e.yml

To ensure these tests pass before merging, this change integrates the workflow into the required CI checks.