### PR TITLE
Add conf.d include in the default config

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -138,6 +138,7 @@ func platformAgnosticDefaultConfig() *srvconfig.Config {
 		DisabledPlugins:  []string{},
 		RequiredPlugins:  []string{},
 		StreamProcessors: streamProcessors(),
+		Imports:          []string{defaults.DefaultConfigIncludePattern},
 	}
 }
 

--- a/defaults/defaults_unix.go
+++ b/defaults/defaults_unix.go
@@ -24,4 +24,7 @@ const (
 	// DefaultRootDir is the default location used by containerd to store
 	// persistent data
 	DefaultRootDir = "/var/lib/containerd"
+
+	// DefaultConfigIncludePattern is the default location for drop-in confiugration files.
+	DefaultConfigIncludePattern = "/etc/containerd/conf.d/*.toml"
 )

--- a/defaults/defaults_windows.go
+++ b/defaults/defaults_windows.go
@@ -31,6 +31,9 @@ var (
 
 	// DefaultConfigDir is the default location for config files.
 	DefaultConfigDir = filepath.Join(os.Getenv("programfiles"), "containerd")
+
+	// DefaultConfigIncludePattern is the default location for drop-in confiugration files.
+	DefaultConfigIncludePattern = filepath.Join(os.Getenv("programfiles"), "containerd\\conf.d\\*.toml")
 )
 
 const (


### PR DESCRIPTION
We've reworked config merging strategy in 2.0 - https://github.com/containerd/containerd/pull/9982

This change adds `/etc/containerd/conf.d/*.toml` to the default configuration to allow configs drop-ins without the need to change root configuration file. 

```bash
❯ bin/containerd config default
...
imports = ['/etc/containerd/conf.d/*.toml']
```