### PR TITLE
Prevent goroutine hangs during ProgressTracker shutdown

### DIFF
--- a/core/transfer/local/progress.go
+++ b/core/transfer/local/progress.go
@@ -260,8 +260,12 @@ func (j *ProgressTracker) Add(desc ocispec.Descriptor) {
 	if j == nil {
 		return
 	}
-	j.added <- jobUpdate{
+	up := jobUpdate{
 		desc: desc,
+	}
+	select {
+	case j.added <- up:
+	case <-j.waitC:
 	}
 }
 
@@ -269,11 +273,14 @@ func (j *ProgressTracker) MarkExists(desc ocispec.Descriptor) {
 	if j == nil {
 		return
 	}
-	j.added <- jobUpdate{
+	up := jobUpdate{
 		desc:   desc,
 		exists: true,
 	}
-
+	select {
+	case j.added <- up:
+	case <-j.waitC:
+	}
 }
 
 // AddChildren adds hierarchy information
@@ -293,9 +300,13 @@ func (j *ProgressTracker) ExtractProgress(desc ocispec.Descriptor, progress int6
 	if j == nil {
 		return
 	}
-	j.extraction <- extractionUpdate{
+	up := extractionUpdate{
 		desc:     desc,
 		progress: progress,
+	}
+	select {
+	case j.extraction <- up:
+	case <-j.waitC:
 	}
 }
 


### PR DESCRIPTION
This PR prevents goroutine hangs during ProgressTracker shutdown.

I noticed the image pull occasionally hangs on progress updates because `ProgressTracker.HandleProgress` could return early (due to canceled context).

This can be reproduced by repeatedly performing image pulls using `ctr` and kill the operation in the middle. Eventually the process hangs.