### PR TITLE
Fix integ-test: looking for sleep inf as longCommand

### DIFF
--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -2403,8 +2403,8 @@ func initContainerAndCheckChildrenDieOnKill(t *testing.T, opts ...oci.SpecOpts) 
 		t.Fatal(err)
 	}
 
-	// The container is using longCommand, which contains sleep 1 on Linux, and ping -t localhost on Windows.
-	if strings.Contains(string(b), "sleep 1") || strings.Contains(string(b), "ping -t localhost") {
+	// The container is using longCommand, which contains sleep inf on Linux, and ping -t localhost on Windows.
+	if strings.Contains(string(b), "sleep inf") || strings.Contains(string(b), "ping -t localhost") {
 		t.Fatalf("killing init didn't kill all its children:\n%v", string(b))
 	}
 


### PR DESCRIPTION
The tests should check `sleep inf` rather than `sleep 1`.

The `longCommand` is defined as
https://github.com/containerd/containerd/blob/1b613badfaa659eec5d57d57e21cf3b51ba24f17/integration/client/client_unix_test.go#L58

But the tests are looking for `sleep 1` in the process list.

This change fixes it.