### PR TITLE
Fix sandbox controller dependencies

### DIFF
--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -53,6 +53,7 @@ func init() {
 			plugins.EventPlugin,
 			plugins.LeasePlugin,
 			plugins.SandboxStorePlugin,
+			plugins.TransferPlugin,
 			plugins.CRIServicePlugin,
 			plugins.ServicePlugin,
 			plugins.WarningPlugin,


### PR DESCRIPTION
- The sandbox controller should only error out if it cannot find any
sandbox controllers. If it requires the pod sandbox controller to be
initialized, that creates an implicit dependency on all CRI plugins
being initialized. The sandbox controller API can be used without CRI
and therefore should not have this dependency.

- The pod sandbox controller currently initializes an entire client which
requires the transfer service to be initialized. If a plugin which
transitively depended on the transfer service is disabled, this could
lead to the pod sandbox controller failing to initialize as the transfer
service may be registered after. This dependency should be explicit in
the requires field.