### PR TITLE
Prepare release notes for api/v1.10.0-beta.0

### DIFF
--- a/api/releases/v1.10.0-beta.toml
+++ b/api/releases/v1.10.0-beta.toml
@@ -1,0 +1,16 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+sub_path = "api"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "api/v1.9.0"
+
+pre_release = true
+
+preface = """\
+The 11th release for the containerd 1.x API aligns with the containerd 2.2 release.
+"""


### PR DESCRIPTION
Prepare release notes for api/v1.10.0-beta.0 now that there is an api change to go into the 2.2 release. 

----

containerd api/v1.10.0-beta.0

Welcome to the api/v1.10.0-beta.0 release of containerd!  
*This is a pre-release of containerd*

The 11th release for the containerd 1.x API aligns with the containerd 2.2 release.

### Highlights

* Add mount manager ([#12063](https://github.com/containerd/containerd/pull/12063))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Wei Fu

### Changes
<details><summary>4 commits</summary>
<p>

* Add mount manager ([#12063](https://github.com/containerd/containerd/pull/12063))
  * [`8db301086`](https://github.com/containerd/containerd/commit/8db3010865ae9926aed6c5e476a7c6b2413b44d5) Add mounts api service
  * [`67fbf9db9`](https://github.com/containerd/containerd/commit/67fbf9db9cbf6ae83df58d18a19f32b28ebc0017) Generate and vendor proto changes
  * [`c5097ac63`](https://github.com/containerd/containerd/commit/c5097ac63fd704213c507a2b712fa2db7744090b) Add mount manager to protobuf services and types
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [api/v1.9.0](https://github.com/containerd/containerd/releases/tag/api/v1.9.0)
