### PR TITLE
Fix gha api release file path

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -77,4 +77,4 @@ jobs:
           draft: false
           make_latest: false
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
-          body_path: ./builds/containerd-release-notes/release-notes.md
+          body_path: ./builds/release-notes.md


### PR DESCRIPTION
The switch to actions/download-artifacts v5.0.0 changed the output path to no longer include the name specified by upload.

See the WhatsNew section https://github.com/actions/download-artifact?tab=readme-ov-file#v5---whats-new for description of the behavior change.

Note that the regular non-api release still works because that uses multiple artifacts, which did not have a behavior change.

Run without fix:
[API Release](https://github.com/dmcgowan/containerd/actions/runs/18326085735)

Run with fix:
[API Release](https://github.com/dmcgowan/containerd/actions/runs/18326830075)