### PR TITLE
bugfix:fix container logs lost because io close too quickly

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/exec.go
+++ b/cmd/containerd-shim-runc-v2/process/exec.go
@@ -35,6 +35,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
+	"github.com/containerd/log"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -111,7 +112,9 @@ func (e *execProcess) Delete(ctx context.Context) error {
 }
 
 func (e *execProcess) delete(ctx context.Context) error {
-	waitTimeout(ctx, &e.wg, 2*time.Second)
+	if err := waitTimeout(ctx, &e.wg, 10*time.Second); err != nil {
+		log.G(ctx).WithError(err).Errorf("failed to drain exec process %s io", e.id)
+	}
 	if e.io != nil {
 		for _, c := range e.closers {
 			c.Close()

--- a/cmd/containerd-shim-runc-v2/process/init.go
+++ b/cmd/containerd-shim-runc-v2/process/init.go
@@ -298,7 +298,9 @@ func (p *Init) Delete(ctx context.Context) error {
 }
 
 func (p *Init) delete(ctx context.Context) error {
-	waitTimeout(ctx, &p.wg, 2*time.Second)
+	if err := waitTimeout(ctx, &p.wg, 10*time.Second); err != nil {
+		log.G(ctx).WithError(err).Errorf("failed to drain init process %s io", p.id)
+	}
 	err := p.runtime.Delete(ctx, p.id, nil)
 	// ignore errors if a runtime has already deleted the process
 	// but we still hold metadata and pipes


### PR DESCRIPTION
fix  https://github.com/containerd/containerd/issues/12289
I find TestContainerExecLargeOutputWithTTY failed because of  container exec logs lost.
https://github.com/containerd/containerd/blob/v2.1.4/cmd/containerd-shim-runc-v2/process/exec.go#L108-L109
```
func (e *execProcess) delete(ctx context.Context) error {
	waitTimeout(ctx, &e.wg, 2*time.Second)
```
waitTimeout will return context.Canceled.
so default 2 second timeout  sometimes is not enough.

PTAL  thanks @fuweid  @cpuguy83  @AkihiroSuda @dmcgowan @djdongjin 
the ci failed is because of other reason. 😮‍💨
