### PR TITLE
Defer removal of deprecated registry config fields to 2.3

### DIFF
--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -231,17 +231,17 @@ type Registry struct {
 	ConfigPath string `toml:"config_path" json:"configPath"`
 	// Mirrors are namespace to mirror mapping for all namespaces.
 	// This option will not be used when ConfigPath is provided.
-	// DEPRECATED: Use ConfigPath instead. Remove in containerd 2.2.
+	// DEPRECATED: Use ConfigPath instead. Remove in containerd 2.3.
 	// Supported in 1.x releases.
 	Mirrors map[string]Mirror `toml:"mirrors" json:"mirrors"`
 	// Configs are configs for each registry.
 	// The key is the domain name or IP of the registry.
-	// DEPRECATED: Use ConfigPath instead. Remove in containerd 2.2.
+	// DEPRECATED: Use ConfigPath instead. Remove in containerd 2.3.
 	// Supported in 1.x releases.
 	Configs map[string]RegistryConfig `toml:"configs" json:"configs"`
 	// Auths are registry endpoint to auth config mapping. The registry endpoint must
 	// be a valid url with host specified.
-	// DEPRECATED: Use ConfigPath instead. Remove in containerd 2.2.
+	// DEPRECATED: Use ConfigPath instead. Remove in containerd 2.3.
 	// Supported in 1.x releases.
 	Auths map[string]AuthConfig `toml:"auths" json:"auths"`
 	// Headers adds additional HTTP headers that get sent to all registries


### PR DESCRIPTION
Defer the removal of the deprecated registry configuration fields (`Mirrors`, `Configs`, and `Auths`) from 2.2 to 2.3.

These fields are still necessary for many users to authenticate with private and mirrored container registries. The current alternatives have the following limitations, like:

- The `ImagePullSecrets` feature does not work correctly with registry mirrors (#10996)
- Migrating to the v3 config is problematic for users who rely on both `tls` and `auth` configurations for a single registry (#11624)

If we defer removing these fields, we can still provide users with a stable config until the new authentication mechanisms are ready.
