### PR TITLE
Set default run platform in ctr

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -97,6 +97,24 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 		id = cliContext.Args().Get(1)
 	}
 
+	platform := cliContext.String("platform")
+	if platform == "" {
+		plat := platforms.DefaultSpec()
+		switch plat.OS {
+		case "linux":
+		case "freebsd":
+			// TODO: freebsd support is under development, allow platform to remain unchanged.
+			// A freebsd spec generator must be implemented to make use of it, until then,
+			// either a spec must be provided or the runtime can convert from the linux spec.
+		default:
+			// Other OSes do not have a supported container runtime, to use experimental runtimes,
+			// specs must be explicitly provided. Once there is a support spec generator, then
+			// the default platform can be added above to not default to linux.
+			plat.OS = "linux"
+		}
+		platform = platforms.FormatAll(plat)
+	}
+
 	var (
 		opts  []oci.SpecOpts
 		cOpts []containerd.NewContainerOpts
@@ -116,7 +134,7 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			// for container's id is Args[1]
 			args = cliContext.Args().Slice()[2:]
 		)
-		opts = append(opts, oci.WithDefaultSpec(), oci.WithDefaultUnixDevices)
+		opts = append(opts, oci.WithDefaultSpecForPlatform(platform), oci.WithDefaultUnixDevices)
 		if ef := cliContext.String("env-file"); ef != "" {
 			opts = append(opts, oci.WithEnvFile(ef))
 		}


### PR DESCRIPTION
Currently run will generate invalid specifications on non-Linux Unix platforms. Linux should be the default container platform for run when the platform is not explicitly provided.