### PR TITLE
bugfix:add lock to protect task delete and task kill

### DIFF
--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -46,7 +46,7 @@ func init() {
 
 func testContext(t testing.TB) (context.Context, context.CancelFunc) {
 	// This needs work to convert from context.Background() to t.Context().
-	ctx, cancel := context.WithCancel(context.Background())  //nolint:all
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:all
 	ctx = namespaces.WithNamespace(ctx, testNamespace)
 	if t != nil {
 		ctx = logtest.WithT(ctx, t)

--- a/plugins/services/tasks/local.go
+++ b/plugins/services/tasks/local.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/api/types/runc/options"
 	"github.com/containerd/containerd/api/types/task"
+	"github.com/containerd/containerd/v2/internal/kmutex"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/log"
@@ -129,6 +130,7 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 		publisher:  ep.(events.Publisher),
 		monitor:    monitor.(runtime.TaskMonitor),
 		v2Runtime:  v2r.(runtime.PlatformRuntime),
+		locker:     kmutex.New(),
 	}
 
 	v2Tasks, err := l.v2Runtime.Tasks(ic.Context, true)
@@ -156,6 +158,8 @@ type local struct {
 
 	monitor   runtime.TaskMonitor
 	v2Runtime runtime.PlatformRuntime
+	// todo use rwlock
+	locker kmutex.KeyedLocker
 }
 
 func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.CallOption) (*api.CreateTaskResponse, error) {
@@ -295,6 +299,8 @@ func (l *local) Start(ctx context.Context, r *api.StartRequest, _ ...grpc.CallOp
 }
 
 func (l *local) Delete(ctx context.Context, r *api.DeleteTaskRequest, _ ...grpc.CallOption) (*api.DeleteResponse, error) {
+	l.locker.Lock(context.Background(), r.ContainerID)
+	defer l.locker.Unlock(r.ContainerID)
 	container, err := l.getContainer(ctx, r.ContainerID)
 	if err != nil {
 		return nil, err
@@ -450,6 +456,8 @@ func (l *local) Resume(ctx context.Context, r *api.ResumeTaskRequest, _ ...grpc.
 }
 
 func (l *local) Kill(ctx context.Context, r *api.KillRequest, _ ...grpc.CallOption) (*ptypes.Empty, error) {
+	l.locker.Lock(context.Background(), r.ContainerID)
+	defer l.locker.Unlock(r.ContainerID)
 	t, err := l.getTask(ctx, r.ContainerID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
task delete will stop shim ttrpc service. if this time call task kill will return ttrpc closed. 

```
func (l *local) Delete(ctx context.Context, r *api.DeleteTaskRequest, _ ...grpc.CallOption
will call  func (m *TaskManager) Delete(ctx context.Context, taskID string)
then call
	exit, err := shimTask.delete(ctx, sandboxed, func(ctx context.Context, id string) {
		m.manager.shims.Delete(ctx, id)
	})
```
we should add lock to protect   getTaskFromContainer in Kill func(maybe other func also need ) and local delete
```
func (l *local) getTaskFromContainer(ctx context.Context, container *containers.Container) (runtime.Task, error) {
	l.locker.Lock(context.Background(), container.ID)
	defer l.locker.Unlock(container.ID)
	t, err := l.v2Runtime.Get(ctx, container.ID)
	if err != nil {
		return nil, status.Errorf(codes.NotFound, "task %v not found", container.ID)
	}
	return t, nil
}
```
this pr will fix https://github.com/containerd/containerd/issues/11107 
to make sure task exist. PTAL @dmcgowan  @fuweid   @mikebrow 