### PR TITLE
cri: retry stopSandboxContainer if shim connection is closed

### DIFF
--- a/integration/sandbox_run_rollback_test.go
+++ b/integration/sandbox_run_rollback_test.go
@@ -112,8 +112,13 @@ func TestRunPodSandboxWithShimDeleteFailure(t *testing.T) {
 
 			t.Log("Inject Shim failpoint")
 			injectShimFailpoint(t, sbConfig, map[string]string{
-				"Start":  "1*error(failed to start shim)",
-				"Delete": "1*error(please retry)", // inject failpoint during rollback shim
+				"Start": "1*error(failed to start shim)",
+				// Kill invoked by Delete during rollback, we should block it instead of Delete
+				//
+				// NOTE: If we allow to Kill, there could be a race condition. The event handler
+				// will cleanup the sandbox record after Kill asynchronously. It could cause that
+				// ListPodSandbox returns empty.
+				"Kill": "1*error(please retry)",
 			})
 
 			t.Log("Create a sandbox")

--- a/internal/cri/server/podsandbox/helpers.go
+++ b/internal/cri/server/podsandbox/helpers.go
@@ -20,7 +20,10 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl/v2"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 
@@ -123,4 +126,13 @@ func getMetadata(ctx context.Context, container containerd.Container) (*sandboxs
 		return nil, fmt.Errorf("failed to convert the extension to sandbox metadata")
 	}
 	return meta, nil
+}
+
+// isShimTTRPCClosed returns true if the cause of error is ttrpc.ErrClosed from shim.
+func isShimTTRPCClosed(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errdefs.IsUnknown(err) && strings.HasSuffix(err.Error(), ttrpc.ErrClosed.Error())
 }


### PR DESCRIPTION
### Background:

The TestRunPodSandboxWithShimDeleteFailure test case validates that the sandbox can be properly cleaned up when RunPodSandbox returns an error.

This test simulates a RunPodSandbox failure by using a failpoint to inject an error during the startup of the sandbox container. It also blocks the first task deletion attempt within the deferred cleanup logic of RunPodSandbox. As a result, the sandbox remains after the failed RunPodSandbox call, allowing the test to verify the subsequent cleanup process.

### Race-condition causes flaky issue:

The defer cleanup invokes `task.Delete` with `containerd.WithProcessKill` option so that it will kill sandbox container first. Since we don't block `Kill` call, cleanup will kill sandbox container successfully, even if `task.Delete` fails.

https://github.com/containerd/containerd/blob/04fe0ff9d292d3fa29d239e6a7f312e8175415c8/internal/cri/server/podsandbox/sandbox_run.go#L248-L258


That podSandboxEventHandler.HandleEvent receives task exit event during defer cleanup of RunPodSandbox and then it will delete task. That `task.Delete` call could take few second to shutdown containerd-shim. It could bring race-condition if we invoke RemovePodSandbox.

https://github.com/containerd/containerd/blob/04fe0ff9d292d3fa29d239e6a7f312e8175415c8/internal/cri/server/podsandbox/events.go#L43-L61

If shim exits, that RemovePodSandbox could return error like

```
... failed to kill pod sandbox container: ttrpc: closed
```

### Retry and fix this transient issue:

If `a ttrpc: closed` error occurs, we should retry the operation. There’s no need to introduce a mutex for this, as the kubelet already has retry logic to ensure the sandbox is eventually cleaned up.

### Other flaky issue:

The event handle could be able to cleanup shim asynchronously. That
could cause ListPodSandbox returns empty, which is not expected. Updated
that test case with `Kill` failpoint instead of `Delete`.

```
    default:     sandbox_run_rollback_test.go:127:
    default:         	Error Trace:	/root/go/src/github.com/containerd/containerd/integration/sandbox_run_rollback_test.go:127
    default:         	Error:      	"[]" should have 1 item(s), but has 0
    default:         	Test:       	TestRunPodSandboxWithShimDeleteFailure/JustCleanup
```

Fixes: #11107
Close: #11967