### PR TITLE
bugfix:retry task delete and task kill when ttrpc closed

### DIFF
--- a/internal/cri/server/podsandbox/helpers.go
+++ b/internal/cri/server/podsandbox/helpers.go
@@ -20,10 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 
-	"github.com/containerd/errdefs"
-	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl/v2"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 
@@ -126,13 +123,4 @@ func getMetadata(ctx context.Context, container containerd.Container) (*sandboxs
 		return nil, fmt.Errorf("failed to convert the extension to sandbox metadata")
 	}
 	return meta, nil
-}
-
-// isShimTTRPCClosed returns true if the cause of error is ttrpc.ErrClosed from shim.
-func isShimTTRPCClosed(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	return errdefs.IsUnknown(err) && strings.HasSuffix(err.Error(), ttrpc.ErrClosed.Error())
 }

--- a/internal/cri/server/podsandbox/helpers_linux_test.go
+++ b/internal/cri/server/podsandbox/helpers_linux_test.go
@@ -18,17 +18,12 @@ package podsandbox
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/containerd/errdefs/pkg/errgrpc"
-	"github.com/containerd/ttrpc"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
@@ -107,45 +102,5 @@ func TestEnsureRemoveAllWithMount(t *testing.T) {
 
 	if _, err := os.Stat(dir1); !os.IsNotExist(err) {
 		t.Fatalf("expected %q to not exist", dir1)
-	}
-}
-
-func TestIsShimTTRPCClosed(t *testing.T) {
-	tests := []struct {
-		name     string
-		err      error
-		expected bool
-	}{
-		{
-			name:     "nil error",
-			err:      nil,
-			expected: false,
-		},
-		{
-			name:     "ttrpc closed error text",
-			err:      fmt.Errorf("ttrpc: closed"),
-			expected: true,
-		},
-		{
-			name:     "ttrpc closed error",
-			err:      ttrpc.ErrClosed,
-			expected: true,
-		},
-		{
-			name:     "wrapped ttrpc closed error",
-			err:      fmt.Errorf("some context: %w", ttrpc.ErrClosed),
-			expected: true,
-		},
-		{
-			name:     "non-ttrpc error",
-			err:      fmt.Errorf("some other error"),
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, isShimTTRPCClosed(errgrpc.ToNative(tt.err)))
-		})
 	}
 }

--- a/internal/cri/server/podsandbox/sandbox_stop.go
+++ b/internal/cri/server/podsandbox/sandbox_stop.go
@@ -47,14 +47,7 @@ func (c *Controller) Stop(ctx context.Context, sandboxID string, _ ...sandbox.St
 	}
 	state := podSandbox.Status.Get().State
 	if state == sandboxstore.StateReady || state == sandboxstore.StateUnknown {
-		err = c.stopSandboxContainer(ctx, podSandbox)
-		if err != nil && isShimTTRPCClosed(err) {
-			log.G(ctx).WithError(err).
-				Warnf("Shim ttrpc connection closed when stopping sandbox container %q in %q state, retrying", sandboxID, state)
-
-			err = c.stopSandboxContainer(ctx, podSandbox)
-		}
-		if err != nil {
+		if err := c.stopSandboxContainer(ctx, podSandbox); err != nil {
 			return fmt.Errorf("failed to stop sandbox container %q in %q state: %w", sandboxID, state, err)
 		}
 	}


### PR DESCRIPTION
try to fix  https://github.com/containerd/containerd/issues/12344
after retry  r is nill will cause panic.

```
func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStatus, error) {
      ....
	if errDelete != nil && isShimTTRPCClosed(errDelete) {
		log.G(ctx).WithError(err).Warnf("Shim ttrpc connection closed when deleting container %q, retrying", t.id)
		r, errDelete = t.client.TaskService().Delete(ctx, &tasks.DeleteTaskRequest{
			ContainerID: t.id,
		})
		if errDelete != nil {
			return nil, errgrpc.ToNative(errDelete)
		}
	}
	// Only cleanup the IO after a successful Delete
	if t.io != nil {
		t.io.Close()
	}
	return &ExitStatus{code: r.ExitStatus, exitedAt: protobuf.FromTimestamp(r.ExitedAt)}, nil
}
```
 @fuweid 