### PR TITLE
Add EROFS mount handler plugin

### DIFF
--- a/cmd/containerd/builtins/builtins_linux.go
+++ b/cmd/containerd/builtins/builtins_linux.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/containerd/containerd/v2/core/metrics/cgroups/v2"
 	_ "github.com/containerd/containerd/v2/plugins/diff/erofs/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/diff/walking/plugin"
+	_ "github.com/containerd/containerd/v2/plugins/mount/erofs"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/blockfile/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/erofs/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/native/plugin"

--- a/core/mount/loopback_handler_linux.go
+++ b/core/mount/loopback_handler_linux.go
@@ -43,7 +43,7 @@ func (loopbackHandler) Mount(ctx context.Context, m Mount, mp string, _ []Active
 	// TODO: Handle direct io
 
 	t := time.Now()
-	loop, err := setupLoop(m.Source, params)
+	loop, err := SetupLoop(m.Source, params)
 	if err != nil {
 		return ActiveMount{}, err
 	}

--- a/core/mount/losetup_linux.go
+++ b/core/mount/losetup_linux.go
@@ -151,7 +151,7 @@ func setupLoopDev(backingFile, loopDev string, param LoopParams) (_ *os.File, re
 	return loop, nil
 }
 
-// setupLoop looks for (and possibly creates) a free loop device, and
+// SetupLoop looks for (and possibly creates) a free loop device, and
 // then attaches backingFile to it.
 //
 // When autoclear is true, caller should take care to close it when
@@ -165,7 +165,7 @@ func setupLoopDev(backingFile, loopDev string, param LoopParams) (_ *os.File, re
 // the loop device when done with it.
 //
 // Upon success, the file handle to the loop device is returned.
-func setupLoop(backingFile string, param LoopParams) (*os.File, error) {
+func SetupLoop(backingFile string, param LoopParams) (*os.File, error) {
 	for retry := 1; retry < 100; retry++ {
 		num, err := getFreeLoopDev()
 		if err != nil {
@@ -227,7 +227,7 @@ func removeLoop(loopdev string) error {
 
 // AttachLoopDevice attaches a specified backing file to a loop device
 func AttachLoopDevice(backingFile string) (string, error) {
-	file, err := setupLoop(backingFile, LoopParams{})
+	file, err := SetupLoop(backingFile, LoopParams{})
 	if err != nil {
 		return "", err
 	}

--- a/core/mount/losetup_linux_test.go
+++ b/core/mount/losetup_linux_test.go
@@ -47,7 +47,7 @@ func TestNonExistingLoop(t *testing.T) {
 	testutil.RequiresRoot(t)
 
 	backingFile := "setup-loop-test-no-such-file"
-	_, err := setupLoop(backingFile, LoopParams{})
+	_, err := SetupLoop(backingFile, LoopParams{})
 	if err == nil {
 		t.Fatalf("setupLoop with non-existing file should fail")
 	}
@@ -58,7 +58,7 @@ func TestRoLoop(t *testing.T) {
 
 	backingFile := createTempFile(t)
 
-	file, err := setupLoop(backingFile, LoopParams{Readonly: true, Autoclear: true})
+	file, err := SetupLoop(backingFile, LoopParams{Readonly: true, Autoclear: true})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		file.Close()
@@ -74,7 +74,7 @@ func TestRwLoop(t *testing.T) {
 
 	backingFile := createTempFile(t)
 
-	file, err := setupLoop(backingFile, LoopParams{Autoclear: true})
+	file, err := SetupLoop(backingFile, LoopParams{Autoclear: true})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		file.Close()
@@ -103,7 +103,7 @@ func TestAutoclearTrueLoop(t *testing.T) {
 	dev := func() string {
 		backingFile := createTempFile(t)
 
-		file, err := setupLoop(backingFile, LoopParams{Autoclear: true})
+		file, err := SetupLoop(backingFile, LoopParams{Autoclear: true})
 		require.NoError(t, err)
 		dev := file.Name()
 		file.Close()
@@ -125,7 +125,7 @@ func TestAutoclearFalseLoop(t *testing.T) {
 	dev := func() string {
 		backingFile := createTempFile(t)
 
-		file, err := setupLoop(backingFile, LoopParams{Autoclear: false})
+		file, err := SetupLoop(backingFile, LoopParams{Autoclear: false})
 		require.NoError(t, err)
 		dev := file.Name()
 		file.Close()

--- a/core/mount/mount_linux.go
+++ b/core/mount/mount_linux.go
@@ -159,7 +159,7 @@ func (m *Mount) mount(target string) (err error) {
 		// or remount with changed data
 		source := m.Source
 		if opt.losetup {
-			loFile, err := setupLoop(m.Source, loopParams)
+			loFile, err := SetupLoop(m.Source, loopParams)
 			if err != nil {
 				return err
 			}

--- a/plugins/mount/erofs/plugin_linux.go
+++ b/plugins/mount/erofs/plugin_linux.go
@@ -1,0 +1,135 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofs
+
+import (
+	"context"
+	"errors"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/containerd/platforms"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/errdefs"
+
+	"golang.org/x/sys/unix"
+)
+
+var forceloop bool
+
+type erofsMountHandler struct {
+}
+
+func newErofsMountHandler() mount.Handler {
+	return erofsMountHandler{}
+}
+
+func (erofsMountHandler) Mount(ctx context.Context, m mount.Mount, mp string, _ []mount.ActiveMount) (mount.ActiveMount, error) {
+	if m.Type != "erofs" {
+		return mount.ActiveMount{}, errdefs.ErrNotImplemented
+	}
+
+	// Ignore the loop option which is specified if the dedicated mount handler is available
+	for i, v := range m.Options {
+		if v == "loop" {
+			m.Options = append(m.Options[:i], m.Options[i+1:]...)
+			break
+		}
+	}
+
+	if err := os.MkdirAll(mp, 0700); err != nil {
+		return mount.ActiveMount{}, err
+	}
+
+	var err error = unix.ENOTBLK
+	if !forceloop {
+		// Try to use file-backed mount feature if available (Linux 6.12+) first
+		err = m.Mount(mp)
+	}
+	if errors.Is(err, unix.ENOTBLK) {
+		var loops []*os.File
+
+		// Never try to mount with raw files anymore if tried
+		forceloop = true
+		params := mount.LoopParams{
+			Autoclear: true,
+		}
+		// set up all loop devices
+		loop, err := mount.SetupLoop(m.Source, params)
+		if err != nil {
+			return mount.ActiveMount{}, err
+		}
+		m.Source = loop.Name()
+		loops = append(loops, loop)
+		defer func() {
+			for _, loop := range loops {
+				loop.Close()
+			}
+		}()
+
+		for i, v := range m.Options {
+			// Convert raw files in `device=` into loop devices too
+			if strings.HasPrefix(v, "device=") {
+				loop, err := mount.SetupLoop(strings.TrimPrefix(v, "device="), params)
+				if err != nil {
+					return mount.ActiveMount{}, err
+				}
+				m.Options[i] = "device=" + loop.Name()
+			}
+		}
+		err = m.Mount(mp)
+		if err != nil {
+			return mount.ActiveMount{}, err
+		}
+	} else if err != nil {
+		return mount.ActiveMount{}, err
+	}
+
+	t := time.Now()
+	return mount.ActiveMount{
+		Mount:      m,
+		MountedAt:  &t,
+		MountPoint: mp,
+	}, nil
+}
+
+func (erofsMountHandler) Unmount(ctx context.Context, path string) error {
+	return mount.Unmount(path, 0)
+}
+
+type Config struct{}
+
+func init() {
+	registry.Register(&plugin.Registration{
+		Type:   plugins.MountHandlerPlugin,
+		ID:     "erofs",
+		Config: &Config{},
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			p := platforms.DefaultSpec()
+			p.OS = runtime.GOOS
+			ic.Meta.Platforms = append(ic.Meta.Platforms, p)
+
+			return newErofsMountHandler(), nil
+		},
+	})
+}


### PR DESCRIPTION
Commit ee8ae9d56933 ("Update erofs snapshotter to use mount manager") temporarily removed the file-backed mount feature to adapt to the new mount manager infrastructure as a quick start.

After the mount manager was introduced, a specific mount type can be handled with a mount handler plugin to provide a dedicated mount process (e.g. setup loopback devices in advance or calling external mount helper binaries).

This commit adds a default EROFS mount handler for the Linux hosts to set up loop devices for mount sources and "device=" external file blobs if necessary (i.e. when file-backed mounts are unavailable), allowing common runtimes such as runC to work directly, e.g.
 ``` sh
 mount -t erofs /var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/1/layer.erofs \
  /run/containerd/io.containerd.mount-manager.v1.bolt/t/346/1
 ```
 will be handled as
 ``` sh
 mount -t erofs /dev/loop1 /run/containerd/io.containerd.mount-manager.v1.bolt/t/346/1
 ```
and
 ``` sh
 mount -t erofs /var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/7/fsmeta.erofs \
   -odevice=/var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/1/layer.erofs,\
     device=/var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/2/layer.erofs,\
     ...
     device=/var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/7/layer.erofs
   /run/containerd/io.containerd.mount-manager.v1.bolt/t/335/1
 ```
 will be handled as
 ``` sh
 mount -t erofs /dev/loop1 -odevice=/dev/loop2,device=/dev/loop3,... \
   /run/containerd/io.containerd.mount-manager.v1.bolt/t/335/1
 ```
if file-backed mounts are unavailable.

For other host platforms (e.g. Darwin hosts) or specific runtimes that require EROFS raw mounts instead of parsed mounts, this plugin can be explicitly masked off by users.