### PR TITLE
ensure task delete when podsandbox run failed

### DIFF
--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -209,7 +209,8 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 			if cleanupErr = container.Delete(deferCtx, containerd.WithSnapshotCleanup); cleanupErr != nil {
 				log.G(ctx).WithError(cleanupErr).Errorf("Failed to delete containerd container %q", id)
 			}
-			podSandbox.Container = nil
+			// Can not set podSandbox.Container nil. When task Started, many failed scenarios, like timeout, ctx cancle .etc
+			// while cleanup task depend on container information, so it is necessary to keep container.
 		}
 	}()
 


### PR DESCRIPTION
Fix #12344

when executing NewTask in the `podsandbox run`, it may fail for various reasons, like timeout, ctx cancle .etc, and the shim process has already started.
During the defer cleanup, cleaning up the podsandbox.container only deletes the data in the store and cannot guarantee that the task is properly deleted. 
Therefore, it is necessary to retain the podsandbox.container, And task can be actively cleaned up through shutdown api. But the invocation of the task depends on the container information, so keep podsandbox.container even if cleanup done.

There is no guarantee that the NewTask operation is atomic. A failure does not mean that resources have been completely cleaned up. Therefore, it is reasonable to delegate cleanup to the upper caller
