### PR TITLE
cri: retry stop container if there is connection closed

### DIFF
--- a/internal/cri/server/container_remove.go
+++ b/internal/cri/server/container_remove.go
@@ -68,7 +68,7 @@ func (c *criService) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 	if state == runtime.ContainerState_CONTAINER_RUNNING ||
 		state == runtime.ContainerState_CONTAINER_UNKNOWN {
 		log.L.Infof("Forcibly stopping container %q", id)
-		if err := c.stopContainer(ctx, container, 0); err != nil {
+		if err := c.stopContainerRetryOnConnectionClosed(ctx, container, 0); err != nil {
 			return nil, fmt.Errorf("failed to forcibly stop container %q: %w", id, err)
 		}
 

--- a/internal/cri/server/nri_linux.go
+++ b/internal/cri/server/nri_linux.go
@@ -31,5 +31,5 @@ func (i *criImplementation) UpdateContainerResources(ctx context.Context, ctr cs
 }
 
 func (i *criImplementation) StopContainer(ctx context.Context, ctr cstore.Container, timeout time.Duration) error {
-	return i.c.stopContainer(ctx, ctr, timeout)
+	return i.c.stopContainerRetryOnConnectionClosed(ctx, ctr, timeout)
 }

--- a/internal/cri/server/podsandbox/helpers.go
+++ b/internal/cri/server/podsandbox/helpers.go
@@ -20,10 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 
-	"github.com/containerd/errdefs"
-	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl/v2"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 
@@ -126,13 +123,4 @@ func getMetadata(ctx context.Context, container containerd.Container) (*sandboxs
 		return nil, fmt.Errorf("failed to convert the extension to sandbox metadata")
 	}
 	return meta, nil
-}
-
-// isShimTTRPCClosed returns true if the cause of error is ttrpc.ErrClosed from shim.
-func isShimTTRPCClosed(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	return errdefs.IsUnknown(err) && strings.HasSuffix(err.Error(), ttrpc.ErrClosed.Error())
 }

--- a/internal/cri/server/podsandbox/helpers_linux_test.go
+++ b/internal/cri/server/podsandbox/helpers_linux_test.go
@@ -18,17 +18,12 @@ package podsandbox
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/containerd/errdefs/pkg/errgrpc"
-	"github.com/containerd/ttrpc"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
@@ -107,45 +102,5 @@ func TestEnsureRemoveAllWithMount(t *testing.T) {
 
 	if _, err := os.Stat(dir1); !os.IsNotExist(err) {
 		t.Fatalf("expected %q to not exist", dir1)
-	}
-}
-
-func TestIsShimTTRPCClosed(t *testing.T) {
-	tests := []struct {
-		name     string
-		err      error
-		expected bool
-	}{
-		{
-			name:     "nil error",
-			err:      nil,
-			expected: false,
-		},
-		{
-			name:     "ttrpc closed error text",
-			err:      fmt.Errorf("ttrpc: closed"),
-			expected: true,
-		},
-		{
-			name:     "ttrpc closed error",
-			err:      ttrpc.ErrClosed,
-			expected: true,
-		},
-		{
-			name:     "wrapped ttrpc closed error",
-			err:      fmt.Errorf("some context: %w", ttrpc.ErrClosed),
-			expected: true,
-		},
-		{
-			name:     "non-ttrpc error",
-			err:      fmt.Errorf("some other error"),
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, isShimTTRPCClosed(errgrpc.ToNative(tt.err)))
-		})
 	}
 }

--- a/internal/cri/server/podsandbox/sandbox_stop.go
+++ b/internal/cri/server/podsandbox/sandbox_stop.go
@@ -47,14 +47,7 @@ func (c *Controller) Stop(ctx context.Context, sandboxID string, _ ...sandbox.St
 	}
 	state := podSandbox.Status.Get().State
 	if state == sandboxstore.StateReady || state == sandboxstore.StateUnknown {
-		err = c.stopSandboxContainer(ctx, podSandbox)
-		if err != nil && isShimTTRPCClosed(err) {
-			log.G(ctx).WithError(err).
-				Warnf("Shim ttrpc connection closed when stopping sandbox container %q in %q state, retrying", sandboxID, state)
-
-			err = c.stopSandboxContainer(ctx, podSandbox)
-		}
-		if err != nil {
+		if err := c.stopSandboxContainerRetryOnConnectionClosed(ctx, podSandbox); err != nil {
 			return fmt.Errorf("failed to stop sandbox container %q in %q state: %w", sandboxID, state, err)
 		}
 	}
@@ -62,6 +55,30 @@ func (c *Controller) Stop(ctx context.Context, sandboxID string, _ ...sandbox.St
 		return fmt.Errorf("failed to cleanup sandbox files: %w", err)
 	}
 	return nil
+}
+
+func (c *Controller) stopSandboxContainerRetryOnConnectionClosed(ctx context.Context, podSandbox *types.PodSandbox) error {
+	const maxRetries = 3
+
+	var err error
+	for i := 1; i <= maxRetries; i++ {
+		err = c.stopSandboxContainer(ctx, podSandbox)
+		if err == nil {
+			return nil
+		}
+
+		if !ctrdutil.IsShimTTRPCClosed(err) {
+			return err
+		}
+
+		if i+1 <= maxRetries {
+			retryAfter := time.Duration(100*i*i) * time.Millisecond
+			log.G(ctx).WithError(err).
+				Warnf("Shim ttrpc connection closed when stopping sandbox container %q, retry after %s", podSandbox.ID, retryAfter)
+			time.Sleep(retryAfter)
+		}
+	}
+	return err
 }
 
 // stopSandboxContainer kills the sandbox container.

--- a/internal/cri/server/sandbox_stop.go
+++ b/internal/cri/server/sandbox_stop.go
@@ -74,7 +74,7 @@ func (c *criService) stopPodSandbox(ctx context.Context, sandbox sandboxstore.Sa
 		}
 		// Forcibly stop the container. Do not use `StopContainer`, because it introduces a race
 		// if a container is removed after list.
-		if err := c.stopContainer(ctx, container, 0); err != nil {
+		if err := c.stopContainerRetryOnConnectionClosed(ctx, container, 0); err != nil {
 			return fmt.Errorf("failed to stop container %q: %w", container.ID, err)
 		}
 	}

--- a/internal/cri/util/util.go
+++ b/internal/cri/util/util.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -30,7 +31,9 @@ import (
 	clabels "github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/timeout"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/ttrpc"
 )
 
 // deferCleanupTimeoutKey is used to retrieve the configurable timeout for containerd cleanup operations in defer.
@@ -135,4 +138,13 @@ func GenerateUserString(username string, uid, gid *runtime.Int64Value) (string, 
 		userstr = userstr + ":" + groupstr
 	}
 	return userstr, nil
+}
+
+// IsShimTTRPCClosed returns true if the cause of error is ttrpc.ErrClosed from shim.
+func IsShimTTRPCClosed(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errdefs.IsUnknown(err) && strings.HasSuffix(err.Error(), ttrpc.ErrClosed.Error())
 }


### PR DESCRIPTION
In critest, a lot of containers will exit automatically. It could be race condition between event handler and StopPodSandbox goroutines. The StopPodSandbox could encounter `ttrpc: closed` error. It's retryable. To fix flaky CI issue, add new function as wrapper to retry stopContainer call.

REF: #12396