### PR TITLE
[release/2.0] Disable event subscriber during task cleanup

### DIFF
--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -76,6 +76,7 @@ var Command = &cli.Command{
 		execCommand,
 		startCommand,
 		stateCommand,
+		shutdownCommand,
 		pprofCommand,
 	},
 }
@@ -110,6 +111,47 @@ var deleteCommand = &cli.Command{
 			return err
 		}
 		fmt.Printf("container deleted and returned exit status %d\n", r.ExitStatus)
+		return nil
+	},
+}
+
+var shutdownCommand = &cli.Command{
+	Name:  "shutdown",
+	Usage: "Shutdown shim if there is no active container",
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:  "api-version",
+			Usage: "shim API version {2,3}",
+			Value: 3,
+			Action: func(c *cli.Context, v int) error {
+				if v != 2 && v != 3 {
+					return fmt.Errorf("api-version must be 2 or 3")
+				}
+				return nil
+			},
+		},
+	},
+	Action: func(cliContext *cli.Context) error {
+		switch cliContext.Int("api-version") {
+		case 2:
+			service, err := getTaskServiceV2(cliContext)
+			if err != nil {
+				return err
+			}
+			_, err = service.Shutdown(context.Background(), &taskv2.ShutdownRequest{})
+			if err != nil {
+				return err
+			}
+		default:
+			service, err := getTaskService(cliContext)
+			if err != nil {
+				return err
+			}
+			_, err = service.Shutdown(context.Background(), &task.ShutdownRequest{})
+			if err != nil {
+				return err
+			}
+		}
 		return nil
 	},
 }

--- a/integration/restart_linux_test.go
+++ b/integration/restart_linux_test.go
@@ -17,11 +17,15 @@
 package integration
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -75,4 +79,48 @@ func TestContainerdRestartSandboxRecover(t *testing.T) {
 		}
 	}
 	assert.True(t, foundUnkownSb)
+}
+
+func TestReload100Pods(t *testing.T) {
+	workDir := t.TempDir()
+
+	currentReleaseCtrdDefaultConfig(t, workDir)
+
+	ctrd := newCtrdProc(t, *containerdBin, workDir, []string{})
+
+	logPath := ctrd.logPath()
+	t.Cleanup(func() {
+		if t.Failed() {
+			dumpFileContent(t, logPath)
+		}
+
+		t.Log("Ensure there is no leaky state dir after test")
+		assert.NoError(t, os.Remove(filepath.Join(workDir, "state", "io.containerd.runtime.v2.task", "k8s.io")))
+	})
+	require.NoError(t, ctrd.isReady())
+
+	podCtxs := []*podTCtx{}
+	defer func() {
+		for _, p := range podCtxs {
+			p.stop(true)
+		}
+		assert.NoError(t, ctrd.kill(syscall.SIGTERM))
+		assert.NoError(t, ctrd.wait(5*time.Minute))
+	}()
+
+	for i := 0; i < 100; i++ {
+		podCtx := newPodTCtx(t,
+			ctrd.criRuntimeService(t),
+			fmt.Sprintf("test-restart-%d", i),
+			"sandbox",
+			WithHostNetwork)
+
+		podCtxs = append(podCtxs, podCtx)
+	}
+
+	assert.NoError(t, ctrd.kill(syscall.SIGTERM))
+	assert.NoError(t, ctrd.wait(5*time.Minute))
+
+	ctrd = newCtrdProc(t, *containerdBin, workDir, []string{})
+	require.NoError(t, ctrd.isReady())
 }

--- a/integration/sandbox_run_linux_test.go
+++ b/integration/sandbox_run_linux_test.go
@@ -1,0 +1,44 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPodSandboxController_ShouldBackoffExitEventWhenFail(t *testing.T) {
+	t.Logf("Inject Shim failpoint")
+
+	sbConfig := PodSandboxConfig(t.Name(), "failpoint")
+	injectShimFailpoint(t, sbConfig, map[string]string{
+		"Delete": "1*error(retry)",
+	})
+
+	t.Log("Create a sandbox")
+	sbID, err := runtimeService.RunPodSandbox(sbConfig, failpointRuntimeHandler)
+	require.NoError(t, err)
+
+	t.Log("Stop the sandbox")
+	err = runtimeService.StopPodSandbox(sbID)
+	require.NoError(t, err)
+
+	t.Log("Delete sandbox")
+	err = runtimeService.RemovePodSandbox(sbID)
+	require.NoError(t, err)
+}

--- a/internal/cri/server/events.go
+++ b/internal/cri/server/events.go
@@ -66,7 +66,7 @@ func (c *criService) startSandboxExitMonitor(ctx context.Context, id string, exi
 				ExitedAt:   protobuf.ToTimestamp(exitedAt),
 			}
 
-			log.L.Infof("received exit event %+v", e)
+			log.L.WithField("monitor_name", "criService").Infof("received sandbox container exit event %+v", e)
 
 			err = func() error {
 				dctx := ctrdutil.NamespacedContext()
@@ -135,7 +135,7 @@ func (c *criService) startContainerExitMonitor(ctx context.Context, id string, p
 				ExitedAt:    protobuf.ToTimestamp(exitedAt),
 			}
 
-			log.L.Infof("received exit event %+v", e)
+			log.L.Infof("received container exit event %+v", e)
 
 			err = func() error {
 				dctx := ctrdutil.NamespacedContext()

--- a/internal/cri/server/events/events_test.go
+++ b/internal/cri/server/events/events_test.go
@@ -28,6 +28,41 @@ import (
 	testingclock "k8s.io/utils/clock/testing"
 )
 
+type noopEventHandler struct {
+	t       *testing.T
+	eventCh chan any
+}
+
+func (h *noopEventHandler) HandleEvent(any interface{}) error {
+	h.t.Logf("NoopEventHandler: %v", any)
+	h.eventCh <- any
+	return nil
+}
+
+func TestEventMonitor_SubscribeNothing(t *testing.T) {
+	eventCh := make(chan any, 100)
+	backOffEvent := &eventtypes.TaskOOM{ContainerID: "testContainer"}
+
+	em := NewEventMonitor(&noopEventHandler{t: t, eventCh: eventCh})
+	errCh := em.Start()
+
+	em.backOff.enBackOff(backOffEvent.ContainerID, backOffEvent)
+	select {
+	case <-time.After(30 * time.Second):
+		t.Error("No events received as expected")
+	case ev := <-eventCh:
+		assert.Equal(t, backOffEvent, ev)
+	}
+
+	em.Stop()
+	select {
+	case <-time.After(10 * time.Second):
+		t.Error("No error received as expected")
+	case err := <-errCh:
+		assert.NoError(t, err)
+	}
+}
+
 // TestBackOff tests the logic of backOff struct.
 func TestBackOff(t *testing.T) {
 	testStartTime := time.Now()

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -88,13 +88,15 @@ func init() {
 				store:          NewStore(),
 			}
 
-			eventMonitor := events.NewEventMonitor(&podSandboxEventHandler{
-				controller: &c,
-			})
-			eventMonitor.Subscribe(client, []string{`topic=="/tasks/exit"`})
-			eventMonitor.Start()
-			c.eventMonitor = eventMonitor
-
+			// There is no need to subscribe to the exit event for the pause container,
+			// as a dedicated goroutine already monitors the sandbox exit event.
+			// The eventMonitor handles the backoff mechanism in case the pause container cleanup fails.
+			c.eventMonitor = events.NewEventMonitor(
+				&podSandboxEventHandler{
+					controller: &c,
+				},
+			)
+			c.eventMonitor.Start()
 			return &c, nil
 		},
 	})
@@ -173,11 +175,23 @@ func (c *Controller) waitSandboxExit(ctx context.Context, p *types.PodSandbox, e
 			exitStatus = unknownExitCode
 			exitedAt = time.Now()
 		}
+
 		dctx := ctrdutil.NamespacedContext()
 		dctx, dcancel := context.WithTimeout(dctx, handleEventTimeout)
 		defer dcancel()
-		event := &eventtypes.TaskExit{ExitStatus: exitStatus, ExitedAt: protobuf.ToTimestamp(exitedAt)}
+
+		event := &eventtypes.TaskExit{
+			ID:          p.ID,
+			ContainerID: p.ID,
+			ExitStatus:  exitStatus,
+			ExitedAt:    protobuf.ToTimestamp(exitedAt),
+		}
+
+		log.G(ctx).WithField("monitor_name", "podsandbox").
+			Infof("received sandbox exit event %+v", event)
+
 		if err := handleSandboxTaskExit(dctx, p, event); err != nil {
+			log.G(ctx).WithError(err).Errorf("failed to handle sandbox exit event %+v", event)
 			c.eventMonitor.Backoff(p.ID, event)
 		}
 		return nil


### PR DESCRIPTION
We have individual goroutine for each sandbox container. If there is any error in handler, that goroutine will put event in that backoff queue. So we don't need event subscriber for podsandbox. Otherwise, there will be two goroutines to cleanup sandbox container.

```
>>>> From EventMonitor
  time="2025-10-23T19:30:59.626254404Z" level=debug msg="Received containerd event timestamp - 2025-10-23 19:30:59.624494674 +0000 UTC, namespace - \"k8s.io\", topic - \"/tasks/exit\""
  time="2025-10-23T19:30:59.626301912Z" level=debug msg="TaskExit event in podsandbox handler container_id:\"22e15114133e4d461ab380654fb76f3e73d3e0323989c422fa17882762979ccf\" id:\"22e15114133e4d461ab380654fb76f3e73d3e0323989c422fa17882762979ccf\" pid:203121 exit_status:137 exited_at:{seconds:1761247859 nanos:624467824}"

>>> If EventMonitor handles task exit well, it will close ttrpc
connection and then waitSandboxExit could encounter ttrpc-closed error

  time="2025-10-23T19:30:59.688031150Z" level=error msg="failed to delete task" error="ttrpc: closed" id=22e15114133e4d461ab380654fb76f3e73d3e0323989c422fa17882762979ccf
```

If both task.Delete calls fail but the shim has already been shut down, it could trigger a new task.Exit event sent by cleanupAfterDeadShim. This would result in three events in the EventMonitor's backoff queue, which is unnecessary and could cause confusion due to duplicate events.

The worst-case scenario caused by two concurrent task.Delete calls is a shim leak. The timeline for this scenario is as follows:

| Timestamp | Component       | Action                        | Result                                                                                           |
| ------    | -----------     | --------                      | --------                                                                                         |
| T1        | EventMonitor    | Sends `task.Delete`           | Marked as Req-1                                                                                  |
| T2        | waitSandboxExit | Sends `task.Delete`           | Marked as Req-2                                                                                  |
| T3        | containerd-shim | Handles Req-2                 | Container transitions from stopped to deleted                                                    |
| T4        | containerd-shim | Handles Req-1                 | Fails - container already deleted<br>Returns error: `cannot delete a deleted process: not found` |
| T5        | EventMonitor    | Receives `not found` error    | -                                                                                                |
| T6        | EventMonitor    | Sends `shim.Shutdown` request | No-op (active container record still exists)                                                     |
| T7        | EventMonitor    | Closes ttrpc connection       | Clean container state dir                                                                        |
| T8        | containerd-shim | Handles Req-2                 | Removes container record from memory                                                             |
| T9        | waitSandboxExit | Receives error                | Error: `ttrpc: closed`                                                                           |
| T10       | waitSandboxExit | Sends `shim.Shutdown` request | Fails (connection already closed)                                                                |
| T11       | waitSandboxExit | Closes ttrpc connection       | No-op (already closed)                                                                           |

The containerd-shim is still running because shim.Shutdown was sent at T6 before T8. Because container's state dir is deleted at T7, it's unable to clean it up after containerd restarted.

We should avoid concurrent task.Delete calls here.

I also add subcommand - shutdown - in `ctr shim` for debug.

Fixed: #12344
Cherry-picked: #12400


(cherry picked from commit 2042e805b821873a35194ef159f3b5f8850ab2ff)