### PR TITLE
Add rebase capability to erofs to support parallel unpack

### DIFF
--- a/plugins/snapshots/erofs/plugin/plugin.go
+++ b/plugins/snapshots/erofs/plugin/plugin.go
@@ -88,6 +88,7 @@ func init() {
 			}
 
 			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
+			ic.Meta.Capabilities = append(ic.Meta.Capabilities, "rebase")
 			return erofs.NewSnapshotter(root, opts...)
 		},
 	})


### PR DESCRIPTION
Adds support for parallel unpack when using erofs snapshotter. The erofs snapshotter already unpacks layers independently so just needs to be enabled.