### PR TITLE
shim: add log after shim shutdown

### DIFF
--- a/pkg/shutdown/shutdown.go
+++ b/pkg/shutdown/shutdown.go
@@ -19,9 +19,11 @@ package shutdown
 import (
 	"context"
 	"errors"
+	"os"
 	"sync"
 	"time"
 
+	"github.com/containerd/log"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -92,6 +94,7 @@ func (s *shutdownService) Shutdown() {
 		s.err = err
 		close(s.doneC)
 		s.mu.Unlock()
+		log.G(ctx).Infof("shim shutdown successfully with pid %d", os.Getpid())
 	}(s.callbacks)
 }
 


### PR DESCRIPTION
because of https://github.com/containerd/containerd/issues/12344 this issue, containerd failed to shutdown shim(shim doesn't call shutdown func). so it is necessary to check shim status.
or should I  return an error ?
@fuweid   @henry118 