### PR TITLE
[release/1.7] cri:prevent to generate unnecessary log when delete pod

### DIFF
--- a/pkg/cri/server/sandbox_remove.go
+++ b/pkg/cri/server/sandbox_remove.go
@@ -110,6 +110,9 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 		log.G(ctx).WithError(err).Errorf("NRI pod removal notification failed")
 	}
 
+	// Send CONTAINER_DELETED event with both ContainerId and SandboxId equal to SandboxId.
+	c.generateAndSendContainerEvent(ctx, id, id, runtime.ContainerEventType_CONTAINER_DELETED_EVENT)
+
 	// Remove sandbox from sandbox store. Note that once the sandbox is successfully
 	// deleted:
 	// 1) ListPodSandbox will not include this sandbox.
@@ -119,10 +122,6 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 
 	// Release the sandbox name reserved for the sandbox.
 	c.sandboxNameIndex.ReleaseByKey(id)
-
-	// Send CONTAINER_DELETED event with both ContainerId and SandboxId equal to SandboxId.
-	c.generateAndSendContainerEvent(ctx, id, id, runtime.ContainerEventType_CONTAINER_DELETED_EVENT)
-
 	sandboxRemoveTimer.WithValues(sandbox.RuntimeHandler).UpdateSince(start)
 
 	return &runtime.RemovePodSandboxResponse{}, nil


### PR DESCRIPTION
from issue  https://github.com/containerd/containerd/issues/12390
I find many logs as follows 
```
level=warning msg="Failed to get podSandbox status for container event for sandboxID \"360a74da53eb4a1fb0c61863550961c033ac7880d16d370a5c0f447fbcd974f6\": an error occurred when try to find sandbox: not found. Sending the event with nil podSandboxStatus."
```
because 
c.generateAndSendContainerEvent(ctx, id, id, runtime.ContainerEventType_CONTAINER_DELETED_EVENT)
run after c.sandboxStore.Delete(id)
containerd2.x doesn't have this issue.  @fuweid @mxpv @mikebrow 