### PR TITLE
CI: skip ubuntu-24.04-arm on private repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        exclude:
+          - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
 
 
     steps:
@@ -190,6 +192,8 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022]
         go-version: ["1.24.8", "1.25.2"]
+        exclude:
+          - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/install-go
@@ -375,6 +379,8 @@ jobs:
         runc: [runc]  # crun can be added here to debug crun issues
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
         cgroup_driver: [cgroupfs, systemd]
+        exclude:
+          - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
 
     env:
       GOTEST: gotestsum --


### PR DESCRIPTION
ubuntu-24.04-arm runners are not available for private repositories.