### PR TITLE
[release/2.0] CI: skip ubuntu-24.04-arm on private repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2025]
+        exclude:
+          - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
 
 
     steps:
@@ -190,6 +192,8 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022]
         go-version: ["1.23.12", "1.24.6"]
+        exclude:
+          - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-go
@@ -375,6 +379,8 @@ jobs:
         runc: [runc]  # crun can be added here to debug crun issues
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
         cgroup_driver: [cgroupfs, systemd]
+        exclude:
+          - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
 
     env:
       GOTEST: gotestsum --


### PR DESCRIPTION
Cherrypick (not clean):
- #12419