### PR TITLE
[release/1.7] CI: skip ubuntu-24.04-arm on private repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2025]
+        exclude:
+          - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -193,6 +195,8 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022]
         go-version: ["1.23.12", "1.24.8", "1.25.2"]
+        exclude:
+          - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-go
@@ -380,6 +384,8 @@ jobs:
         runc: [runc, crun]
         enable_cri_sandboxes: ["", "sandboxed"]
         os: [ubuntu-24.04, ubuntu-24.04-arm]
+        exclude:
+          - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
 
     env:
       GOTEST: gotestsum --


### PR DESCRIPTION
Cherrypick (not clean):
- #12419