### PR TITLE
Update referrers interface to support more options

### DIFF
--- a/core/remotes/docker/referrers_test.go
+++ b/core/remotes/docker/referrers_test.go
@@ -89,7 +89,7 @@ func runReferrersTest(t *testing.T, name string, sf func(h http.Handler) (string
 		}
 	}
 
-	refs, err = rf.FetchReferrers(ctx, d.Digest, "application/vnd.test.sig")
+	refs, err = rf.FetchReferrers(ctx, d.Digest, remotes.WithReferrerArtifactTypes("application/vnd.test.sig"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Updates the fetch referrers interface to support more generic options than just artifact types. This will future proof the interface as the referrers API changes or allow sending filters to the API. This was added only in main so we can still fix the interface before the 2.2 release.