### PR TITLE
docker: fix addQuery with multiple calls

### DIFF
--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -554,12 +554,12 @@ func (r *request) authorize(ctx context.Context, req *http.Request) error {
 func (r *request) addQuery(key, value string) (err error) {
 	var q url.Values
 	// Parse query
-	if i := strings.IndexByte(r.path, '?'); i > 0 {
-		r.path = r.path[:i+1]
-		q, err = url.ParseQuery(r.path[i+1:])
+	if p, query, ok := strings.Cut(r.path, "?"); ok {
+		q, err = url.ParseQuery(query)
 		if err != nil {
 			return
 		}
+		r.path = p + "?"
 	} else {
 		r.path = r.path + "?"
 		q = url.Values{}

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -645,6 +645,28 @@ func TestResolveProxyFallback(t *testing.T) {
 	}
 }
 
+func TestAddQuery(t *testing.T) {
+	req := &request{path: "/foo"}
+	if err := req.addQuery("bar", "123"); err != nil {
+		t.Fatal(err)
+	}
+	if exp := "/foo?bar=123"; req.path != exp {
+		t.Fatalf("unexpected path %q, expected %q", req.path, exp)
+	}
+	if err := req.addQuery("baz", "456"); err != nil {
+		t.Fatal(err)
+	}
+	if exp := "/foo?bar=123&baz=456"; req.path != exp {
+		t.Fatalf("unexpected path %q, expected %q", req.path, exp)
+	}
+	if err := req.addQuery("baz", "789"); err != nil {
+		t.Fatal(err)
+	}
+	if exp := "/foo?bar=123&baz=456&baz=789"; req.path != exp {
+		t.Fatalf("unexpected path %q, expected %q", req.path, exp)
+	}
+}
+
 func flipLocalhost(host string) string {
 	if strings.HasPrefix(host, "127.0.0.1") {
 		return "localhost" + host[9:]


### PR DESCRIPTION
In previous implementation every call would
replace the whole query instead of adding to it.