### PR TITLE
fix: filter containers doesn't work if there are multiple id found

### DIFF
--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -379,7 +379,7 @@ func TestContainerListStatsWithIdSandboxIdFilter(t *testing.T) {
 	for id, config := range containerConfigMap {
 		require.NoError(t, Eventually(func() (bool, error) {
 			stats, err = runtimeService.ListContainerStats(
-				&runtime.ContainerStatsFilter{Id: id[:3], PodSandboxId: sb[:3]})
+				&runtime.ContainerStatsFilter{Id: id[:6], PodSandboxId: sb[:6]})
 			if err != nil {
 				return false, err
 			}

--- a/internal/cri/server/container_list_test.go
+++ b/internal/cri/server/container_list_test.go
@@ -158,7 +158,8 @@ func TestFilterContainers(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			filtered := c.filterCRIContainers(testContainers, test.filter)
+			filtered, err := c.filterCRIContainers(testContainers, test.filter)
+			assert.NoError(t, err)
 			assert.Equal(t, test.expect, filtered, test.desc)
 		})
 	}


### PR DESCRIPTION
I'm not sure whether return an error if multiple id found. @dmcgowan 
I change filter length to 6 ,it will have less change to happen.