### PR TITLE
snapshot: check parent's kind before commit

### DIFF
--- a/core/snapshots/storage/bolt.go
+++ b/core/snapshots/storage/bolt.go
@@ -412,6 +412,10 @@ func CommitActive(ctx context.Context, key, name string, usage snapshots.Usage, 
 			}
 			pid := readID(spbkt)
 
+			if pkind := readKind(spbkt); pkind != snapshots.KindCommitted {
+				return fmt.Errorf("parent %q is not committed: %w", si.Parent, errdefs.ErrFailedPrecondition)
+			}
+
 			// Updates parent back link to use new key
 			if err := pbkt.Put(parentKey(pid, id), []byte(name)); err != nil {
 				return fmt.Errorf("failed to update parent link %q from %q to %q: %w", pid, key, name, err)

--- a/core/snapshots/storage/metastore_test.go
+++ b/core/snapshots/storage/metastore_test.go
@@ -658,6 +658,7 @@ func testRebase(ctx context.Context, t *testing.T, ms *MetaStore) {
 		{"rebase-active-2", "rebase-committed-2", "committed-1", "committed-1", false},
 		{"rebase-active-3", "rebase-committed-3", "", "nonexist", true},
 		{"rebase-active-4", "rebase-committed-4", "committed-1", "", false},
+		{"rebase-active-5", "rebase-committed-5", "", "active-1", true},
 	}
 
 	for _, tc := range testcases {

--- a/plugins/snapshots/overlay/overlay_test.go
+++ b/plugins/snapshots/overlay/overlay_test.go
@@ -140,6 +140,11 @@ func testOverlayCommit(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 		t.Fatal(err)
 	}
 
+	activeParent := "active-parent"
+	if _, err := o.Prepare(ctx, activeParent, ""); err != nil {
+		t.Fatal(err)
+	}
+
 	// test rebase
 	testCases := []struct {
 		oldParent string
@@ -171,6 +176,11 @@ func testOverlayCommit(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 			newParent: "new",
 			expError:  true,
 		},
+		{
+			oldParent: "",
+			newParent: activeParent,
+			expError:  true,
+		},
 	}
 	for i, tc := range testCases {
 		key := fmt.Sprintf("/tmp/test-%d", i)
@@ -183,6 +193,7 @@ func testOverlayCommit(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 			if !tc.expError {
 				t.Fatal(err)
 			}
+			t.Logf("expected error received: %v", err)
 		} else if tc.expError {
 			t.Fatal("expected error but commit succeeded")
 		}


### PR DESCRIPTION
We should reject commit request if target parent is not committed. 
Just in case we rebase active snapshot on active one.