### PR TITLE
Add Readonly setup to EROFS mount loop handler

### DIFF
--- a/plugins/mount/erofs/plugin_linux.go
+++ b/plugins/mount/erofs/plugin_linux.go
@@ -72,6 +72,7 @@ func (erofsMountHandler) Mount(ctx context.Context, m mount.Mount, mp string, _ 
 		// Never try to mount with raw files anymore if tried
 		forceloop = true
 		params := mount.LoopParams{
+			Readonly:  true,
 			Autoclear: true,
 		}
 		// set up all loop devices


### PR DESCRIPTION
Close #12451 

Loop devices should be unconditionally readonly for EROFS layers.
It is usually unnecessary since there is no write in all workloads but fsverity explicitly check this, e.g.:
ext4_file_open() -> fsverity_file_open() -> __fsverity_file_open():

```c
int __fsverity_file_open(struct inode *inode, struct file *filp)
{
        if (filp->f_mode & FMODE_WRITE)
                return -EPERM;
        return ensure_verity_info(inode);
}
EXPORT_SYMBOL_GPL(__fsverity_file_open);
```
