### PR TITLE
fix: ci TestContainerListStatsWithIdSandboxIdFilter

### DIFF
--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -379,7 +379,7 @@ func TestContainerListStatsWithIdSandboxIdFilter(t *testing.T) {
 	for id, config := range containerConfigMap {
 		require.NoError(t, Eventually(func() (bool, error) {
 			stats, err = runtimeService.ListContainerStats(
-				&runtime.ContainerStatsFilter{Id: id[:3], PodSandboxId: sb[:3]})
+				&runtime.ContainerStatsFilter{Id: id[:6], PodSandboxId: sb[:6]})
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
listcontainer with id filter  will return nil, if muti containers matched.
so I have to change the filter id lenth from 3 to 6, it will have less chance to happen.
// TODO: we should return nil , an error or multiple containers. (need to discuss in another pr https://github.com/containerd/containerd/pull/12454)
```
root@nmx-Swift-SF314-512:/home/nmx/containerd# crictl ps
CONTAINER           IMAGE               CREATED             STATE               NAME                ATTEMPT             POD ID              POD                 NAMESPACE
d4a4973d5e85b       busybox             About an hour ago   Running             busybox             0                   f5949c8dbacc5       unknown             unknown
310b294b6f60c       busybox             About an hour ago   Running             busybox             0                   d363d2907ac1a       unknown             unknown
56808746c0d60       busybox             About an hour ago   Running             busybox             0                   828ffa4c51bce       unknown             unknown
b8dbaa2d22239       busybox             About an hour ago   Running             busybox             0                   a76d796ef6b4a       unknown             unknown
6fb9c79e7a8ec       busybox             About an hour ago   Running             busybox             0                   7f30bb2afb0cc       unknown             unknown
1331c647216ff       busybox             About an hour ago   Running             busybox             0                   30dfde83ea686       unknown             unknown
dca499af8362c       busybox             About an hour ago   Running             busybox             0                   1b1e228db7a89       unknown             unknown
a74cad52b2c12       busybox             About an hour ago   Running             busybox             0                   9ff1fdb8f1a4e       unknown             unknown
4cb8cb7bb34d8       busybox             About an hour ago   Running             busybox             0                   c83ca9c7a1242       unknown             unknown
a0c9f68d04798       busybox             About an hour ago   Running             busybox             0                   1758e6dac8c84       unknown             unknown
9d75bf613f877       busybox             About an hour ago   Running             busybox             0                   93210b5e3c7a1       unknown             unknown
b7d5b39d7318e       busybox             About an hour ago   Running             busybox             0                   76a91fd144e06       unknown             unknown

```
use  crictl ps --id b show nothing.
```
root@nmx-Swift-SF314-512:/home/nmx/containerd# crictl  ps -id b
CONTAINER           IMAGE               CREATED             STATE               NAME                ATTEMPT             POD ID              POD                 NAMESPACE
```
@akhilerm 

Fixes: #12440 