### PR TITLE
Add size check to referrers response

### DIFF
--- a/core/remotes/docker/referrers.go
+++ b/core/remotes/docker/referrers.go
@@ -45,6 +45,11 @@ func (r dockerFetcher) FetchReferrers(ctx context.Context, dgst digest.Digest, o
 		return nil, err
 	}
 	defer rc.Close()
+	if size < 0 {
+		size = MaxManifestSize
+	} else if size > MaxManifestSize {
+		return nil, fmt.Errorf("referrers index size %d exceeds maximum allowed %d: %w", size, MaxManifestSize, errdefs.ErrNotFound)
+	}
 
 	var index ocispec.Index
 	dec := json.NewDecoder(io.LimitReader(rc, size))

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -927,6 +927,7 @@ type testContent struct {
 	mediaType    string
 	artifactType string
 	content      []byte
+	skipLength   bool
 }
 
 type contentOpt func(*testContent)
@@ -963,7 +964,11 @@ func (tc testContent) Digest() digest.Digest {
 
 func (tc testContent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", tc.mediaType)
-	w.Header().Add("Content-Length", strconv.Itoa(len(tc.content)))
+	if !tc.skipLength {
+		w.Header().Add("Content-Length", strconv.Itoa(len(tc.content)))
+	} else {
+		w.Header().Set("Content-Length", "")
+	}
 	w.Header().Add("Docker-Content-Digest", tc.Digest().String())
 	w.WriteHeader(http.StatusOK)
 	w.Write(tc.content)


### PR DESCRIPTION
Size bound the referrers response similar to other manifest requests. Unlike other manifest requests, we don't need to keep the file size when it is unknown, just respect the limits.

Similar to manifests, when the size is too large, return not found to attempt retry elsewhere.

Close #12452