### PR TITLE
Update GHA runners to use latest images for basic binaries build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         go-version: ["1.24.9", "1.25.3"]
         exclude:
           - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}


### PR DESCRIPTION
Similar to https://github.com/containerd/containerd/pull/11933, the binaries CI job spot checks the binaries can compile without issue. This job is not used to produce the final artifacts used for release.