### PR TITLE
[release/2.1] Update GHA runners to use latest images for basic binaries build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         go-version: ["1.23.12", "1.24.9", "1.25.3"]
         exclude:
           - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}


### PR DESCRIPTION
Backports https://github.com/containerd/containerd/pull/12469

Follow-up to https://github.com/containerd/containerd/pull/12468

(cherry picked from commit f72025d050ca1edbaf375ac8f3523a40e5b12838)