### PR TITLE
Prepare release notes for api/v1.10.0

### DIFF
--- a/api/releases/v1.10.0.toml
+++ b/api/releases/v1.10.0.toml
@@ -9,7 +9,7 @@ ignore_deps = [ "github.com/containerd/containerd" ]
 # previous release
 previous = "api/v1.9.0"
 
-pre_release = true
+pre_release = false
 
 preface = """\
 The 11th release for the containerd 1.x API aligns with the containerd 2.2 release.


### PR DESCRIPTION
First step in v2.2.0 release process. Once the API tag is out, the main module go module can be updated. 

See generated notes

----

containerd api/v1.10.0

Welcome to the api/v1.10.0 release of containerd!

The 11th release for the containerd 1.x API aligns with the containerd 2.2 release.

### Highlights

* Add mount manager ([#12063](https://github.com/containerd/containerd/pull/12063))

#### Image Distribution

* Add parallel unpack support ([#12332](https://github.com/containerd/containerd/pull/12332))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Akihiro Suda
* Henry Wang
* Phil Estes
* Wei Fu

### Changes
<details><summary>13 commits</summary>
<p>

  * [`69c855bb5`](https://github.com/containerd/containerd/commit/69c855bb54f53311cd5f8854719d8428dd692f96) Prepare release notes for api/v1.10.0
* api/go.mod: golang.org/x/net v0.38.0 ([#12430](https://github.com/containerd/containerd/pull/12430))
  * [`4c7b94fce`](https://github.com/containerd/containerd/commit/4c7b94fce7bd19abce9b78538e3218b572f98127) api/go.mod: golang.org/x/net v0.38.0
* Prepare release notes for api/v1.10.0-rc.0 ([#12408](https://github.com/containerd/containerd/pull/12408))
  * [`fbc7848f2`](https://github.com/containerd/containerd/commit/fbc7848f2378afa2cf58c868bfcab1467f3ccccd) Prepare release notes for api/v1.10.0-rc.0
* Add parallel unpack support ([#12332](https://github.com/containerd/containerd/pull/12332))
  * [`0198b87fc`](https://github.com/containerd/containerd/commit/0198b87fcfb31492c23de83059291efc0f06a1f9) Implement parallel unpack
* Prepare release notes for api/v1.10.0-beta.0 ([#12346](https://github.com/containerd/containerd/pull/12346))
  * [`aa571f63c`](https://github.com/containerd/containerd/commit/aa571f63c6529d827bfef02956a8db9bee57ab8c) Prepare release notes for api/v1.10.0-beta.0
* Add mount manager ([#12063](https://github.com/containerd/containerd/pull/12063))
  * [`8db301086`](https://github.com/containerd/containerd/commit/8db3010865ae9926aed6c5e476a7c6b2413b44d5) Add mounts api service
  * [`67fbf9db9`](https://github.com/containerd/containerd/commit/67fbf9db9cbf6ae83df58d18a19f32b28ebc0017) Generate and vendor proto changes
  * [`c5097ac63`](https://github.com/containerd/containerd/commit/c5097ac63fd704213c507a2b712fa2db7744090b) Add mount manager to protobuf services and types
</p>
</details>

### Dependency Changes

* **golang.org/x/net**  v0.37.0 -> v0.38.0

Previous release can be found at [api/v1.9.0](https://github.com/containerd/containerd/releases/tag/api/v1.9.0)

