### PR TITLE
Update Darwin defaults to useable values

### DIFF
--- a/defaults/defaults_darwin.go
+++ b/defaults/defaults_darwin.go
@@ -17,6 +17,23 @@
 package defaults
 
 const (
-	// DefaultRuntime would be a multiple of choices, thus empty
-	DefaultRuntime = ""
+	// DefaultRuntime is the default darwin runtime for running containers
+	DefaultRuntime = "io.containerd.nerdbox.v1"
+	// DefaultAddress is the default unix socket address
+	DefaultAddress = "/var/run/containerd/containerd.sock"
+	// DefaultDebugAddress is the default unix socket address for pprof data
+	DefaultDebugAddress = "/var/run/containerd/debug.sock"
+	// DefaultFIFODir is the default location used by client-side cio library
+	// to store FIFOs.
+	DefaultFIFODir = "/var/run/containerd/fifo"
+	// DefaultSnapshotter will set the default snapshotter for the platform.
+	// Since mounts are not supported on Darwin, use erofs as the default
+	// which does not require mount support.
+	DefaultSnapshotter = "erofs"
+	// DefaultStateDir is the default location used by containerd to store
+	// transient data
+	DefaultStateDir = "/var/run/containerd"
+	// DefaultDiffer will set the default differ for the platform, use the
+	// erofs differ which does not require mount support.
+	DefaultDiffer = "erofs"
 )

--- a/defaults/defaults_unix_other.go
+++ b/defaults/defaults_unix_other.go
@@ -1,4 +1,4 @@
-//go:build unix && !linux
+//go:build unix && !linux && !darwin
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
The current Darwin defaults are not supported on Darwin and do not allow for successfully pulling or running containers. Switch to defaults that will work on Darwin based on new features in containerd 2.2.

With this change
```
$ ctr image pull --platform linux/arm64 docker.io/library/alpine:latest
$ ctr run -t --rm docker.io/library/alpine:latest test /bin/sh
```
will work with [nerdbox](https://github.com/containerd/nerdbox) installed and setup

```release-note
* **Darwin Support** ___experimental___

  Linux images can be pulled and run with containerd directly running on macOS. This is achieved
  using the improvements to the EROFS snapshotter, the new mount manager service, and the
  experimental [nerdbox runtime](https://github.com/containerd/nerdbox).
```