### PR TITLE
Update 2.1 branch to no longer build as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,4 +163,4 @@ jobs:
           files: |
             builds/release-tars-**/*
             containerd-*-attestation.intoto.jsonl
-          make_latest: true
+          make_latest: false


### PR DESCRIPTION
2.2 release will now build as latest, change this to false to prevent overwriting 2.2 builds.