### PR TITLE
Fix nil pointer dereference in container spec memory metrics

### DIFF
--- a/internal/cri/server/list_pod_sandbox_metrics_linux.go
+++ b/internal/cri/server/list_pod_sandbox_metrics_linux.go
@@ -991,48 +991,54 @@ func (c *criService) extractContainerSpecMetrics(ctx context.Context, containerI
 	}
 
 	if cpuResource := resource.CPU; cpuResource != nil {
-		metrics = append(metrics, []*runtime.Metric{
-			{
+		if cpuResource.Period != nil {
+			metrics = append(metrics, &runtime.Metric{
 				Name:        "container_spec_cpu_period",
 				Timestamp:   timestamp,
 				MetricType:  runtime.MetricType_GAUGE,
 				LabelValues: labels,
 				Value:       &runtime.UInt64Value{Value: *cpuResource.Period},
-			},
-			{
+			})
+		}
+		if cpuResource.Shares != nil {
+			metrics = append(metrics, &runtime.Metric{
 				Name:        "container_spec_cpu_shares",
 				Timestamp:   timestamp,
 				MetricType:  runtime.MetricType_GAUGE,
 				LabelValues: labels,
 				Value:       &runtime.UInt64Value{Value: *cpuResource.Shares},
-			},
-		}...)
+			})
+		}
 	}
 
 	if memoryResource := resource.Memory; memoryResource != nil {
-		metrics = append(metrics, []*runtime.Metric{
-			{
+		if memoryResource.Limit != nil {
+			metrics = append(metrics, &runtime.Metric{
 				Name:        "container_spec_memory_limit_bytes",
 				Timestamp:   timestamp,
 				MetricType:  runtime.MetricType_GAUGE,
 				LabelValues: labels,
 				Value:       &runtime.UInt64Value{Value: uint64(*memoryResource.Limit)},
-			},
-			{
+			})
+		}
+		if memoryResource.Reservation != nil {
+			metrics = append(metrics, &runtime.Metric{
 				Name:        "container_spec_memory_reservation_limit_bytes",
 				Timestamp:   timestamp,
 				MetricType:  runtime.MetricType_GAUGE,
 				LabelValues: labels,
 				Value:       &runtime.UInt64Value{Value: uint64(*memoryResource.Reservation)},
-			},
-			{
+			})
+		}
+		if memoryResource.Swap != nil {
+			metrics = append(metrics, &runtime.Metric{
 				Name:        "container_spec_memory_swap_limit_bytes",
 				Timestamp:   timestamp,
 				MetricType:  runtime.MetricType_GAUGE,
 				LabelValues: labels,
 				Value:       &runtime.UInt64Value{Value: uint64(*memoryResource.Swap)},
-			},
-		}...)
+			})
+		}
 	}
 	return metrics, nil
 }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

This PR fixes a potential nil pointer dereference panic in `extractContainerSpecMetrics` when collecting container resource metrics.

The issue occurs when memory resource fields (`Limit`, `Reservation`, `Swap`) are nil, which can happen when:
- Container doesn't have memory limits set
- Only some memory constraints are configured
- `Reservation` is not set (it's only set via NRI plugins)

## Which issue(s) this PR fixes:

Fixes potential panic when collecting metrics from containers without full memory limit configuration.

## Special notes for your reviewer:

This fix makes the memory resource handling consistent with:
1. CPU resource handling in the same function (lines 993-1012)
2. Memory resource handling in `helpers.go` (lines 296-303)

Each pointer field now has an independent nil check before dereferencing.

## Does this PR introduce a user-facing change?

```release-note
Fix potential panic in ListPodSandboxMetrics when containers don't have all memory limits configured