### PR TITLE
fix: correct pointer assignment

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1601,7 +1601,7 @@ func WithPidsLimit(limit int64) SpecOpts {
 		if s.Linux.Resources.Pids == nil {
 			s.Linux.Resources.Pids = &specs.LinuxPids{}
 		}
-		s.Linux.Resources.Pids.Limit = limit
+		s.Linux.Resources.Pids.Limit = &limit
 		return nil
 	}
 }


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
This PR fixes an assignment error (`int64` to `*int64`).

### Which issue(s) this PR fixes:
Build error occurred during unit testing.