### PR TITLE
Update RELEASES.md to set 2.0 to EOL

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -127,9 +127,9 @@ to all committers.
 | [1.3](https://github.com/containerd/containerd/releases/tag/v1.3.10) | End of Life   | September 26, 2019             | March 4, 2021                  |                        |
 | [1.4](https://github.com/containerd/containerd/releases/tag/v1.4.13) | End of Life   | August 17, 2020                | March 3, 2022                  |                        |
 | [1.5](https://github.com/containerd/containerd/releases/tag/v1.5.18) | End of Life   | May 3, 2021                    | February 28, 2023              |                        |
-| [1.6](https://github.com/containerd/containerd/releases/tag/v1.6.0)  | End of Life   | February 15, 2022              | August 23, 2025                | @containerd/committers |
+| [1.6](https://github.com/containerd/containerd/releases/tag/v1.6.39) | End of Life   | February 15, 2022              | August 23, 2025                | @containerd/committers |
 | [1.7](https://github.com/containerd/containerd/releases/tag/v1.7.0)  | LTS           | March 10, 2023                 | September 2026*                | @containerd/committers |
-| [2.0](https://github.com/containerd/containerd/releases/tag/v2.0.0)  | Active        | November 5, 2024               | November 7, 2025               | @containerd/committers |
+| [2.0](https://github.com/containerd/containerd/releases/tag/v2.0.7)  | End of Life   | November 5, 2024               | November 7, 2025               | @containerd/committers |
 | [2.1](https://github.com/containerd/containerd/releases/tag/v2.1.0)  | Active        | May 7, 2025                    | May 5, 2026                    | @containerd/committers |
 | [2.2](https://github.com/containerd/containerd/releases/tag/v2.2.0)  | Active        | November 5, 2025               | November 6, 2026               | @containerd/committers |
 | [2.3](https://github.com/containerd/containerd/milestone/50)         | _Future_      | May 6, 2026 (_tentative_)      | _TBD_                          | _TBD_                  |


### PR DESCRIPTION
Mark 2.0 as end of life.
Set 1.6 and 2.0 links to the final release tag in that line (like the previous EOL lines)