### PR TITLE
WIP RFC: erofs-snapshotter: support .erofs+{zstd|gzip} images

### DIFF
--- a/core/images/mediatypes.go
+++ b/core/images/mediatypes.go
@@ -102,6 +102,18 @@ func DiffCompression(ctx context.Context, mediaType string) (string, error) {
 		}
 		return "", nil
 	default:
+		// Keep this in default so vendor-prefixed EROFS media types still resolve their suffix compression.
+		if strings.HasSuffix(base, ".erofs") {
+			if len(ext) > 0 {
+				switch ext[len(ext)-1] {
+				case "gzip":
+					return "gzip", nil
+				case "zstd":
+					return "zstd", nil
+				}
+			}
+			return "", nil
+		}
 		return "", fmt.Errorf("unrecognised mediatype %s: %w", mediaType, errdefs.ErrNotImplemented)
 	}
 }


### PR DESCRIPTION
Goal:

The current implementation does not support erofs images that are compressed into .erofs+{zstd|gzip} images. Erofs itself supports compression natively, and so the current implementation has three options:

- use erofs images w/out native compression (uncompressed during image pulls, uncompressed on disk), or
- use erfos images w native compression (compressed during image pulls, compressed on disk), or
- use overlayfs+zstd images and convert to erofs images on apply (compressed during image pulls, converted at unpack time, uncompressed on disk)

The option that would be give us the fastest startup + best runtime performance is:
- using erofs images (so that we don't wait to convert from overlayfs to erofs on apply)
- that are compressed when we're pulling (for fast pulls), and
- decompressed on disk (for fast reads at runtime)

That corresponds to .erofs layers that are natively uncompressed, but compressed / decompressed by the diff processor.

-----
Initial experimentation:

I created a small cli tool for converting existing overlayfs images to .erofs+zstd images. I converted some images to .erofs+zstd, then uploaded them to a registry, and then timed the pull + unpack. I saw 1.5-2x faster pulls over the "overlayfs + convert to erofs at unpack" path.

-----
Looking for feedback:

I'm looking for some quick feedback-- does this approach make sense?

In particular, I'm curious for more context on this comment:
```
// Since `images.DiffCompression` doesn't support arbitrary media types,
// disallow non-empty suffixes for now.
```
My code changes images.DiffCompression to support this-- does that change makes sense, or is there a reason why it shouldn't support arbitrary media types?

The code here is a draft; if this approach is sound I can polish the code, run some more principled experiments & add a test.