### PR TITLE
remotes: fix possible panic from WithMediaTypeKeyPrefix

### DIFF
--- a/core/remotes/handlers.go
+++ b/core/remotes/handlers.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 	"sync"
 
@@ -45,6 +46,7 @@ func WithMediaTypeKeyPrefix(ctx context.Context, mediaType, prefix string) conte
 	var values map[string]string
 	if v := ctx.Value(refKeyPrefix{}); v != nil {
 		values = v.(map[string]string)
+		values = maps.Clone(values)
 	} else {
 		values = make(map[string]string)
 	}


### PR DESCRIPTION
As the same instance of a map is used in context and mutated directly, this leads toa  situation where:
- Calling WithMediaTypeKeyPrefix from parallel goroutines where the context was based on the same base context can trigger a panic.
- A subcontext calling WithMediaTypeKeyPrefix changes the value for another context when they both originate from the same base context.


@dmcgowan @cpuguy83 @AkihiroSuda 