### PR TITLE
…

### DIFF
--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -83,10 +83,6 @@ func CreateTopLevelDirectories(config *srvconfig.Config) error {
 	if err := sys.MkdirAllWithACL(config.Root, 0o700); err != nil {
 		return err
 	}
-	// chmod is needed for upgrading from an older release that created the dir with 0o711
-	if err := os.Chmod(config.Root, 0o700); err != nil {
-		return err
-	}
 
 	// For supporting userns-remapped containers, the state dir cannot be just mkdired with 0o700.
 	// Each of plugins creates a dedicated directory beneath the state dir with appropriate permission bits.
@@ -105,10 +101,6 @@ func CreateTopLevelDirectories(config *srvconfig.Config) error {
 
 	if config.TempDir != "" {
 		if err := sys.MkdirAllWithACL(config.TempDir, 0o700); err != nil {
-			return err
-		}
-		// chmod is needed for upgrading from an older release that created the dir with 0o711
-		if err := os.Chmod(config.Root, 0o700); err != nil {
 			return err
 		}
 		if runtime.GOOS == "windows" {


### PR DESCRIPTION
A regression was introduced in 910171e90ec3a402c6669333483fbec9d0b414d7 wherein containers operating containerd without root permissions would receive a permissions denied error when attempting to os.Chmod() config.Root.