### PR TITLE
Revert "Implement io.ReaderAt on docker fetch reader"

### DIFF
--- a/core/remotes/docker/httpreadseeker.go
+++ b/core/remotes/docker/httpreadseeker.go
@@ -103,36 +103,6 @@ func (hrs *httpReadSeeker) Close() error {
 	return nil
 }
 
-func (hrs *httpReadSeeker) ReadAt(p []byte, offset int64) (n int, err error) {
-	if hrs.closed {
-		return 0, fmt.Errorf("httpReadSeeker.ReadAt: closed: %w", errdefs.ErrUnavailable)
-	}
-
-	if offset < 0 {
-		return 0, fmt.Errorf("httpReadSeeker.ReadAt: negative offset: %w", errdefs.ErrInvalidArgument)
-	}
-
-	if hrs.size != -1 && offset >= hrs.size {
-		return 0, io.EOF
-	}
-
-	if hrs.open == nil {
-		return 0, fmt.Errorf("httpReadSeeker.ReadAt: cannot open: %w", errdefs.ErrNotImplemented)
-	}
-
-	rc, err := hrs.open(offset)
-	if err != nil {
-		return 0, fmt.Errorf("httpReadSeeker.ReadAt: failed to open at offset %d: %w", offset, err)
-	}
-	defer func() {
-		if closeErr := rc.Close(); closeErr != nil {
-			log.L.WithError(closeErr).Error("httpReadSeeker.ReadAt: failed to close ReadCloser")
-		}
-	}()
-
-	return io.ReadFull(rc, p)
-}
-
 func (hrs *httpReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	if hrs.closed {
 		return 0, fmt.Errorf("Fetcher.Seek: closed: %w", errdefs.ErrUnavailable)


### PR DESCRIPTION
- https://github.com/containerd/containerd/pull/11981


This reverts commit 4bf1705a880261a4cebd0766824a5a4548b4a947.

This caused issues for downstream clients who were wrapping the type contingent on it implementing io.ReaderAt.
Consequently this is causing headaches due to increased round trips with the remote.

Meanwhile I only added this as a convenience for implementing content.Provider in the remote which can done even without the original change, just... less conveniently.

In hindsight, this was just a bad change as it has a rather wide impact and the actual implementation isn't an optimized ReaderAt.

Related to moby/buildkit#6366, moby/buildkit#6359