### PR TITLE
ctr run: dump OCI config to a file

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -19,14 +19,19 @@ package run
 import (
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/containerd/console"
 	gocni "github.com/containerd/go-cni"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
@@ -35,8 +40,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cio"
 	clabels "github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
 )
 
 func withMounts(cliContext *cli.Context) oci.SpecOpts {
@@ -131,6 +134,10 @@ var Command = &cli.Command{
 			Name:  "sync-fs",
 			Usage: "Synchronize the underlying filesystem containing files when unpack images, false by default",
 		},
+		&cli.StringFlag{
+			Name:  "dump-config",
+			Usage: "Dump the generated OCI config to a file",
+		},
 	}, append(platformRunFlags,
 		append(commands.RuntimeFlags,
 			append(append(commands.SnapshotterFlags, []cli.Flag{commands.SnapshotterLabels}...),
@@ -184,6 +191,23 @@ var Command = &cli.Command{
 					log.L.WithError(err).Error("failed to cleanup container")
 				}
 			}()
+		}
+		if cliContext.IsSet("dump-config") {
+			filename := cliContext.String("dump-config")
+			if filename == "" {
+				return errors.New("file name is required with --dump-config")
+			}
+			spec, err := container.Spec(ctx)
+			if err != nil {
+				return err
+			}
+			specBytes, err := json.MarshalIndent(spec, "", "  ")
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(filename, specBytes, 0o666); err != nil {
+				return err
+			}
 		}
 		var con console.Console
 		if tty {


### PR DESCRIPTION
New flag allows `ctr` to dump the generated OCI spec to a file.  This is useful when debugging failures at the runtime layer when containerd cleans up the bundle directory inside `/var/run/containerd/io.containerd.runtiem.v2.task/<namespace>/<container>`.