### PR TITLE
feat: add additional metadata to image-verification plugin

### DIFF
--- a/core/images/mediatypes.go
+++ b/core/images/mediatypes.go
@@ -51,6 +51,10 @@ const (
 	MediaTypeContainerd1CheckpointRuntimeName    = "application/vnd.containerd.container.checkpoint.runtime.name"
 	MediaTypeContainerd1CheckpointRuntimeOptions = "application/vnd.containerd.container.checkpoint.runtime.options+proto"
 
+	// Image Verification Media Types
+
+	MediaTypeContainerd1ImageVerificationInput = "application/vnd.containerd.image-verifier.input.v1+json"
+
 	// MediaTypeDockerSchema1Manifest is the legacy Docker schema1 manifest
 	MediaTypeDockerSchema1Manifest = "application/vnd.docker.distribution.manifest.v1+prettyjws"
 

--- a/core/transfer/local/pull.go
+++ b/core/transfer/local/pull.go
@@ -80,6 +80,10 @@ func (ts *localTransferService) pull(ctx context.Context, ir transfer.ImageFetch
 			logger.WithError(err).Error("No judgement received from verifier")
 			return fmt.Errorf("blocking pull of %v with digest %v: image verifier %v returned error: %w", name, desc.Digest.String(), vfName, err)
 		}
+		if jdg == nil {
+			logger.Error("No judgement received from verifier")
+			return fmt.Errorf("blocking pull of %v with digest %v: image verifier %v returned no judgement", name, desc.Digest.String(), vfName)
+		}
 		logger = logger.WithFields(log.Fields{
 			"ok":     jdg.OK,
 			"reason": jdg.Reason,

--- a/docs/image-verification.md
+++ b/docs/image-verification.md
@@ -37,8 +37,8 @@ Currently, there are two media types:
 - If `verify_on_run` is disabled (default), the media type is `application/vnd.oci.descriptor.v1+json`.
   - This represents the OCI Content Descriptor of the image. See [the OCI specification](https://github.com/opencontainers/image-spec/blob/main/descriptor.md) for more details.
 - If `verify_on_run` is enabled, run-time verification uses `application/vnd.containerd.image-verifier.input.v1+json`.
-  - This wraps the OCI Content Descriptor with the `operation` and the `annotations` containerd assigns to the container, including the [well-known CRI keys](../internal/cri/annotations/annotations.go). All values originate from the runtime caller.
-  - This media type is defined in [the image verifier plugin code](../pkg/imageverifier/image_verifier.go) (see `VerifierInput`).
+  - This wraps the OCI Content Descriptor with the `operation` and the `annotations` containerd assigns to the container, including the [well-known CRI keys](../internal/cri/annotations/annotations.go). Some values are supplied by the runtime caller (e.g. request annotations), while others are set authoritatively by containerd (e.g. sandbox ID, container name, image name), so caller-supplied values should not be assumed trustworthy on their own.
+  - The media type constant is defined in [core/images/mediatypes.go](../core/images/mediatypes.go), and its payload structure in [pkg/imageverifier/image_verifier.go](../pkg/imageverifier/image_verifier.go) (see `VerifierInput`).
 
 ### Image Pull Judgement
 

--- a/docs/image-verification.md
+++ b/docs/image-verification.md
@@ -15,7 +15,7 @@ To enable image verification, add a stanza like the following to the containerd 
 
 All files in `bin_dir`, if it exists, must be verifier executables which conform to the following API.
 
-Verification always runs on image pull. When `verify_on_run` is enabled, verification will also run before the container starts and the verifier binary's standard input will include CRI context (See [Standard Input](#standard-input))
+Verification always runs on image pull. When `verify_on_run` is enabled, verification will also run at container creation (`operation=run`), and the verifier binary's standard input will include CRI request context (see [Standard Input](#standard-input)).
 
 ## Image Verifier Binary API
 

--- a/docs/image-verification.md
+++ b/docs/image-verification.md
@@ -10,9 +10,12 @@ To enable image verification, add a stanza like the following to the containerd 
     bin_dir = "/opt/containerd/image-verifier/bin"
     max_verifiers = 10
     per_verifier_timeout = "10s"
+    verify_on_run = false
 ```
 
 All files in `bin_dir`, if it exists, must be verifier executables which conform to the following API.
+
+Verification always runs on image pull. When `verify_on_run` is enabled, verification will also run before the container starts and the verifier binary's standard input will include CRI context (See [Standard Input](#standard-input))
 
 ## Image Verifier Binary API
 
@@ -21,16 +24,21 @@ All files in `bin_dir`, if it exists, must be verifier executables which conform
 - `-name`: The given reference to the image that may be pulled.
 - `-digest`: The resolved digest of the image that may be pulled.
 - `-stdin-media-type`: The media type of the JSON data passed to stdin.
+- `-operation`: The phase invoking verification, `pull` or `run`. Only passed when `verify_on_run` is enabled.
 
 ### Standard Input
 
 A JSON encoded payload is passed to the verifier binary's standard input. The
 media type of this payload is specified by the `-stdin-media-type` CLI
-argument, and may change in future versions of containerd. Currently, the
-payload has a media type of `application/vnd.oci.descriptor.v1+json` and
-represents the OCI Content Descriptor of the image that may be pulled. See
-[the OCI specification](https://github.com/opencontainers/image-spec/blob/main/descriptor.md)
-for more details.
+argument, and may change in future versions of containerd.
+
+Currently, there are two media types:
+
+- If `verify_on_run` is disabled (default), the media type is `application/vnd.oci.descriptor.v1+json`.
+  - This represents the OCI Content Descriptor of the image. See [the OCI specification](https://github.com/opencontainers/image-spec/blob/main/descriptor.md) for more details.
+- If `verify_on_run` is enabled, run-time verification uses `application/vnd.containerd.image-verifier.input.v1+json`.
+  - This wraps the OCI Content Descriptor with the `operation` and the `annotations` containerd assigns to the container, including the [well-known CRI keys](../internal/cri/annotations/annotations.go). All values originate from the runtime caller.
+  - This media type is defined in [the image verifier plugin code](../pkg/imageverifier/image_verifier.go) (see `VerifierInput`).
 
 ### Image Pull Judgement
 

--- a/docs/image-verification.md
+++ b/docs/image-verification.md
@@ -32,12 +32,13 @@ A JSON encoded payload is passed to the verifier binary's standard input. The
 media type of this payload is specified by the `-stdin-media-type` CLI
 argument, and may change in future versions of containerd.
 
-Currently, there are two media types:
+The media type depends on `verify_on_run` option:
 
-- If `verify_on_run` is disabled (default), the media type is `application/vnd.oci.descriptor.v1+json`.
+- If `verify_on_run` is disabled (default), the media type is `application/vnd.oci.descriptor.v1+json`
   - This represents the OCI Content Descriptor of the image. See [the OCI specification](https://github.com/opencontainers/image-spec/blob/main/descriptor.md) for more details.
-- If `verify_on_run` is enabled, run-time verification uses `application/vnd.containerd.image-verifier.input.v1+json`.
-  - This wraps the OCI Content Descriptor with the `operation` and the `annotations` containerd assigns to the container, including the [well-known CRI keys](../internal/cri/annotations/annotations.go). Some values are supplied by the runtime caller (e.g. request annotations), while others are set authoritatively by containerd (e.g. sandbox ID, container name, image name), so caller-supplied values should not be assumed trustworthy on their own.
+- If `verify_on_run` is enabled, both pull and run verification use `application/vnd.containerd.image-verifier.input.v1+json`
+  - This wraps the OCI Content Descriptor with the `operation` and the `annotations` containerd assigns to the container. Pull verification has no run context, so `annotations` is only populated for `run`.
+  - The annotations include the [well-known CRI keys](../internal/cri/annotations/annotations.go). Some values are supplied by the runtime caller (e.g. request annotations), while others are set authoritatively by containerd (e.g. sandbox ID, container name, image name), so caller-supplied values should not be assumed trustworthy on their own.
   - The media type constant is defined in [core/images/mediatypes.go](../core/images/mediatypes.go), and its payload structure in [pkg/imageverifier/image_verifier.go](../pkg/imageverifier/image_verifier.go) (see `VerifierInput`).
 
 ### Image Pull Judgement

--- a/internal/cri/annotations/annotations.go
+++ b/internal/cri/annotations/annotations.go
@@ -107,29 +107,40 @@ func DefaultCRIAnnotations(
 	config *runtime.PodSandboxConfig,
 	sandbox bool,
 ) []oci.SpecOpts {
-	opts := []oci.SpecOpts{
-		customopts.WithAnnotation(SandboxID, sandboxID),
-		customopts.WithAnnotation(SandboxNamespace, config.GetMetadata().GetNamespace()),
-		customopts.WithAnnotation(SandboxUID, config.GetMetadata().GetUid()),
-		customopts.WithAnnotation(SandboxName, config.GetMetadata().GetName()),
+	m := DefaultCRIAnnotationsMap(sandboxID, containerName, imageName, config, sandbox)
+	opts := make([]oci.SpecOpts, 0, len(m))
+	for k, v := range m {
+		opts = append(opts, customopts.WithAnnotation(k, v))
 	}
-	ctrType := ContainerTypeContainer
+	return opts
+}
+
+// DefaultCRIAnnotationsMap is DefaultCRIAnnotations as a map, for callers that
+// need the assembled annotations rather than spec-mutating options.
+func DefaultCRIAnnotationsMap(
+	sandboxID string,
+	containerName string,
+	imageName string,
+	config *runtime.PodSandboxConfig,
+	sandbox bool,
+) map[string]string {
+	m := map[string]string{
+		SandboxID:        sandboxID,
+		SandboxNamespace: config.GetMetadata().GetNamespace(),
+		SandboxUID:       config.GetMetadata().GetUid(),
+		SandboxName:      config.GetMetadata().GetName(),
+	}
 	if sandbox {
-		ctrType = ContainerTypeSandbox
+		m[ContainerType] = ContainerTypeSandbox
 		// Sandbox log dir and sandbox image name get passed for sandboxes, the other metadata always
 		// gets sent however.
-		opts = append(
-			opts,
-			customopts.WithAnnotation(SandboxLogDir, config.GetLogDirectory()),
-			customopts.WithAnnotation(SandboxImageName, imageName),
-		)
+		m[SandboxLogDir] = config.GetLogDirectory()
+		m[SandboxImageName] = imageName
 	} else {
+		m[ContainerType] = ContainerTypeContainer
 		// Image name and container name get passed for containers.
-		opts = append(
-			opts,
-			customopts.WithAnnotation(ContainerName, containerName),
-			customopts.WithAnnotation(ImageName, imageName),
-		)
+		m[ContainerName] = containerName
+		m[ImageName] = imageName
 	}
-	return append(opts, customopts.WithAnnotation(ContainerType, ctrType))
+	return m
 }

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -228,15 +229,18 @@ func (c *criService) verifyImageForRun(ctx context.Context, name string, desc im
 		return nil
 	}
 
-	opts := imageverifier.VerifyOptions{
-		Operation:   imageverifier.OperationRun,
-		Annotations: runVerifierAnnotations(sandboxID, containerName, name, containerConfig, sandboxConfig),
-	}
+	verifierAnnotations := runVerifierAnnotations(sandboxID, containerName, name, containerConfig, sandboxConfig)
 
 	for vfName, vf := range c.imageVerifiers {
 		cv, ok := vf.(imageverifier.ContextImageVerifier)
 		if !ok {
 			continue
+		}
+
+		// Give each verifier its own copy of the annotations so they cannot be modified
+		opts := imageverifier.VerifyOptions{
+			Operation:   imageverifier.OperationRun,
+			Annotations: maps.Clone(verifierAnnotations),
 		}
 
 		logger := log.G(ctx).WithFields(log.Fields{
@@ -250,6 +254,10 @@ func (c *criService) verifyImageForRun(ctx context.Context, name string, desc im
 		if err != nil {
 			logger.WithError(err).Error("No judgement received from verifier")
 			return fmt.Errorf("blocking run of %v with digest %v: image verifier %v returned error: %w", name, desc.Digest.String(), vfName, err)
+		}
+		if jdg == nil {
+			logger.Error("No judgement received from verifier")
+			return fmt.Errorf("blocking run of %v with digest %v: image verifier %v returned no judgement", name, desc.Digest.String(), vfName)
 		}
 		logger = logger.WithFields(log.Fields{
 			"ok":     jdg.OK,
@@ -271,15 +279,9 @@ func (c *criService) verifyImageForRun(ctx context.Context, name string, desc im
 // applied last so request annotations cannot spoof identity.
 func runVerifierAnnotations(sandboxID, containerName, imageName string, containerConfig *runtime.ContainerConfig, sandboxConfig *runtime.PodSandboxConfig) map[string]string {
 	ann := map[string]string{}
-	for k, v := range sandboxConfig.GetAnnotations() {
-		ann[k] = v
-	}
-	for k, v := range containerConfig.GetAnnotations() {
-		ann[k] = v
-	}
-	for k, v := range annotations.DefaultCRIAnnotationsMap(sandboxID, containerName, imageName, sandboxConfig, false) {
-		ann[k] = v
-	}
+	maps.Copy(ann, sandboxConfig.GetAnnotations())
+	maps.Copy(ann, containerConfig.GetAnnotations())
+	maps.Copy(ann, annotations.DefaultCRIAnnotationsMap(sandboxID, containerName, imageName, sandboxConfig, false))
 	return ann
 }
 

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -47,6 +47,7 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/containerd/v2/internal/registrar"
 	"github.com/containerd/containerd/v2/pkg/blockio"
+	"github.com/containerd/containerd/v2/pkg/imageverifier"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/pkg/tracing"
 )
@@ -189,6 +190,11 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		tracing.Attribute("container.image.ref", containerdImage.Name()),
 	)
 
+	// Verify the image for this run request. No-op unless a verifier opts in.
+	if err := c.verifyImageForRun(ctx, containerdImage.Name(), containerdImage.Target(), sandboxID, containerName, config, sandboxConfig); err != nil {
+		return nil, err
+	}
+
 	_, err = c.createContainer(
 		&createContainerRequest{
 			ctx:                   ctx,
@@ -213,6 +219,68 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 
 	return &runtime.CreateContainerResponse{ContainerId: id}, nil
+}
+
+// verifyImageForRun runs the configured image verifiers at container creation.
+// Only verifiers implementing imageverifier.ContextImageVerifier participate.
+func (c *criService) verifyImageForRun(ctx context.Context, name string, desc imagespec.Descriptor, sandboxID, containerName string, containerConfig *runtime.ContainerConfig, sandboxConfig *runtime.PodSandboxConfig) error {
+	if len(c.imageVerifiers) == 0 {
+		return nil
+	}
+
+	opts := imageverifier.VerifyOptions{
+		Operation:   imageverifier.OperationRun,
+		Annotations: runVerifierAnnotations(sandboxID, containerName, name, containerConfig, sandboxConfig),
+	}
+
+	for vfName, vf := range c.imageVerifiers {
+		cv, ok := vf.(imageverifier.ContextImageVerifier)
+		if !ok {
+			continue
+		}
+
+		logger := log.G(ctx).WithFields(log.Fields{
+			"name":     name,
+			"digest":   desc.Digest.String(),
+			"verifier": vfName,
+		})
+		logger.Debug("Verifying image for run")
+
+		jdg, err := cv.VerifyImageContext(ctx, name, desc, opts)
+		if err != nil {
+			logger.WithError(err).Error("No judgement received from verifier")
+			return fmt.Errorf("blocking run of %v with digest %v: image verifier %v returned error: %w", name, desc.Digest.String(), vfName, err)
+		}
+		logger = logger.WithFields(log.Fields{
+			"ok":     jdg.OK,
+			"reason": jdg.Reason,
+		})
+
+		if !jdg.OK {
+			logger.Warn("Image verifier blocked run")
+			return fmt.Errorf("image verifier %s blocked run of %v with digest %v for reason: %v", vfName, name, desc.Digest.String(), jdg.Reason)
+		}
+		logger.Debug("Image verifier allowed run")
+	}
+
+	return nil
+}
+
+// runVerifierAnnotations returns the sandbox and container request annotations,
+// overlaid with the well-known CRI keys (ex. io.kubernetes.cri.*). The CRI keys are
+// applied last so request annotations cannot spoof identity.
+func runVerifierAnnotations(sandboxID, containerName, imageName string, containerConfig *runtime.ContainerConfig, sandboxConfig *runtime.PodSandboxConfig) map[string]string {
+	ann := map[string]string{}
+	for k, v := range sandboxConfig.GetAnnotations() {
+		ann[k] = v
+	}
+	for k, v := range containerConfig.GetAnnotations() {
+		ann[k] = v
+	}
+	for k, v := range annotations.DefaultCRIAnnotationsMap(sandboxID, containerName, imageName, sandboxConfig, false) {
+		ann[k] = v
+	}
+	return ann
 }
 
 type createContainerRequest struct {

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -237,7 +237,8 @@ func (c *criService) verifyImageForRun(ctx context.Context, name string, desc im
 			continue
 		}
 
-		// Give each verifier its own copy of the annotations so they cannot be modified
+		// Give each verifier its own copy of the annotations so one cannot mutate
+		// what subsequent verifiers see.
 		opts := imageverifier.VerifyOptions{
 			Operation:   imageverifier.OperationRun,
 			Annotations: maps.Clone(verifierAnnotations),

--- a/internal/cri/server/container_create_verifier_test.go
+++ b/internal/cri/server/container_create_verifier_test.go
@@ -1,0 +1,222 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/internal/cri/annotations"
+	"github.com/containerd/containerd/v2/pkg/imageverifier"
+)
+
+// fakeContextVerifier implements imageverifier.ContextImageVerifier and records
+// the options it was called with.
+type fakeContextVerifier struct {
+	judgement  *imageverifier.Judgement
+	err        error
+	calledWith *imageverifier.VerifyOptions
+}
+
+func (f *fakeContextVerifier) VerifyImage(ctx context.Context, name string, desc imagespec.Descriptor) (*imageverifier.Judgement, error) {
+	return &imageverifier.Judgement{OK: true}, nil
+}
+
+func (f *fakeContextVerifier) VerifyImageContext(ctx context.Context, name string, desc imagespec.Descriptor, opts imageverifier.VerifyOptions) (*imageverifier.Judgement, error) {
+	o := opts
+	f.calledWith = &o
+	return f.judgement, f.err
+}
+
+// fakeLegacyVerifier implements only imageverifier.ImageVerifier and records
+// whether it was invoked, so we can assert it is skipped at run time.
+type fakeLegacyVerifier struct {
+	called bool
+}
+
+func (f *fakeLegacyVerifier) VerifyImage(ctx context.Context, name string, desc imagespec.Descriptor) (*imageverifier.Judgement, error) {
+	f.called = true
+	return &imageverifier.Judgement{OK: true}, nil
+}
+
+func runTestSandboxConfig() *runtime.PodSandboxConfig {
+	return &runtime.PodSandboxConfig{
+		Metadata: &runtime.PodSandboxMetadata{
+			Name:      "test-pod",
+			Uid:       "00000000-0000-0000-0000-000000000000",
+			Namespace: "test-namespace",
+		},
+		Labels:      map[string]string{"sandbox-label": "sval"},
+		Annotations: map[string]string{"sandbox-annotation": "saval"},
+	}
+}
+
+func runTestContainerConfig() *runtime.ContainerConfig {
+	return &runtime.ContainerConfig{
+		Metadata:    &runtime.ContainerMetadata{Name: "test-ctr"},
+		Labels:      map[string]string{"container-label": "cval"},
+		Annotations: map[string]string{"container-annotation": "caval"},
+	}
+}
+
+func TestVerifyImageForRun(t *testing.T) {
+	const (
+		imageName = "registry.example.com/image:abc"
+		digest    = "sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+		sandboxID = "sandbox-id-123"
+		ctrName   = "test-ctr"
+	)
+	desc := imagespec.Descriptor{Digest: digest}
+	ctx := context.Background()
+
+	verify := func(c *criService) error {
+		return c.verifyImageForRun(ctx, imageName, desc, sandboxID, ctrName, runTestContainerConfig(), runTestSandboxConfig())
+	}
+
+	t.Run("no verifiers configured is a no-op", func(t *testing.T) {
+		c := newTestCRIService()
+		assert.NoError(t, verify(c))
+	})
+
+	t.Run("context verifier allows run and receives pass-through annotations", func(t *testing.T) {
+		vf := &fakeContextVerifier{judgement: &imageverifier.Judgement{OK: true}}
+		c := newTestCRIService(func(s *criService) {
+			s.imageVerifiers = map[string]imageverifier.ImageVerifier{"ok": vf}
+		})
+
+		require.NoError(t, verify(c))
+		require.NotNil(t, vf.calledWith)
+
+		opts := vf.calledWith
+		assert.Equal(t, imageverifier.OperationRun, opts.Operation)
+
+		// Request annotations (sandbox + container) are passed through.
+		assert.Equal(t, "saval", opts.Annotations["sandbox-annotation"])
+		assert.Equal(t, "caval", opts.Annotations["container-annotation"])
+		// Well-known CRI identity annotations are present (reused from
+		// DefaultCRIAnnotations), carrying pod identity via standard keys.
+		assert.Equal(t, "test-namespace", opts.Annotations[annotations.SandboxNamespace])
+		assert.Equal(t, "test-pod", opts.Annotations[annotations.SandboxName])
+		assert.Equal(t, "00000000-0000-0000-0000-000000000000", opts.Annotations[annotations.SandboxUID])
+		assert.Equal(t, sandboxID, opts.Annotations[annotations.SandboxID])
+		assert.Equal(t, ctrName, opts.Annotations[annotations.ContainerName])
+		assert.Equal(t, imageName, opts.Annotations[annotations.ImageName])
+	})
+
+	t.Run("context verifier rejection blocks run", func(t *testing.T) {
+		vf := &fakeContextVerifier{judgement: &imageverifier.Judgement{OK: false, Reason: "not signed"}}
+		c := newTestCRIService(func(s *criService) {
+			s.imageVerifiers = map[string]imageverifier.ImageVerifier{"deny": vf}
+		})
+
+		err := verify(c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not signed")
+	})
+
+	t.Run("context verifier error blocks run", func(t *testing.T) {
+		vf := &fakeContextVerifier{err: errors.New("boom")}
+		c := newTestCRIService(func(s *criService) {
+			s.imageVerifiers = map[string]imageverifier.ImageVerifier{"err": vf}
+		})
+
+		err := verify(c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("legacy verifier is skipped at run time", func(t *testing.T) {
+		legacy := &fakeLegacyVerifier{}
+		c := newTestCRIService(func(s *criService) {
+			s.imageVerifiers = map[string]imageverifier.ImageVerifier{"legacy": legacy}
+		})
+
+		assert.NoError(t, verify(c))
+		assert.False(t, legacy.called, "legacy ImageVerifier must not be invoked at run time")
+	})
+
+	t.Run("one rejecting verifier among several blocks run", func(t *testing.T) {
+		ok := &fakeContextVerifier{judgement: &imageverifier.Judgement{OK: true}}
+		deny := &fakeContextVerifier{judgement: &imageverifier.Judgement{OK: false, Reason: "not signed"}}
+		c := newTestCRIService(func(s *criService) {
+			s.imageVerifiers = map[string]imageverifier.ImageVerifier{"ok": ok, "deny": deny}
+		})
+
+		err := verify(c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not signed")
+	})
+
+	t.Run("legacy and context verifiers together: only context runs", func(t *testing.T) {
+		legacy := &fakeLegacyVerifier{}
+		cv := &fakeContextVerifier{judgement: &imageverifier.Judgement{OK: true}}
+		c := newTestCRIService(func(s *criService) {
+			s.imageVerifiers = map[string]imageverifier.ImageVerifier{"legacy": legacy, "ctx": cv}
+		})
+
+		require.NoError(t, verify(c))
+		assert.False(t, legacy.called, "legacy ImageVerifier must not be invoked at run time")
+		assert.NotNil(t, cv.calledWith, "context verifier must be invoked at run time")
+	})
+}
+
+func TestRunVerifierAnnotations(t *testing.T) {
+	const (
+		imageName = "registry.example.com/image:abc"
+		sandboxID = "sandbox-id-123"
+		ctrName   = "test-ctr"
+	)
+
+	t.Run("container annotation overrides sandbox annotation", func(t *testing.T) {
+		sandboxConfig := runTestSandboxConfig()
+		sandboxConfig.Annotations["shared"] = "from-sandbox"
+		containerConfig := runTestContainerConfig()
+		containerConfig.Annotations["shared"] = "from-container"
+
+		ann := runVerifierAnnotations(sandboxID, ctrName, imageName, containerConfig, sandboxConfig)
+		assert.Equal(t, "from-container", ann["shared"], "container annotation should override sandbox annotation")
+	})
+
+	t.Run("well-known CRI keys override spoofed request annotations", func(t *testing.T) {
+		sandboxConfig := runTestSandboxConfig()
+		containerConfig := runTestContainerConfig()
+		// A workload tries to spoof its identity via request annotations.
+		sandboxConfig.Annotations[annotations.SandboxNamespace] = "spoofed-namespace"
+		containerConfig.Annotations[annotations.ImageName] = "spoofed-image"
+
+		ann := runVerifierAnnotations(sandboxID, ctrName, imageName, containerConfig, sandboxConfig)
+		assert.Equal(t, "test-namespace", ann[annotations.SandboxNamespace], "authoritative sandbox namespace must win over spoofed value")
+		assert.Equal(t, imageName, ann[annotations.ImageName], "authoritative image name must win over spoofed value")
+	})
+
+	t.Run("nil sandbox metadata and annotations do not panic", func(t *testing.T) {
+		sandboxConfig := &runtime.PodSandboxConfig{}  // nil Metadata, nil Annotations
+		containerConfig := &runtime.ContainerConfig{} // nil Annotations
+
+		ann := runVerifierAnnotations(sandboxID, ctrName, imageName, containerConfig, sandboxConfig)
+		// Identity keys are still assembled (with empty values where metadata is absent).
+		assert.Equal(t, imageName, ann[annotations.ImageName])
+		assert.Equal(t, ctrName, ann[annotations.ContainerName])
+		assert.Empty(t, ann[annotations.SandboxNamespace])
+	})
+}

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -54,6 +54,7 @@ import (
 	nriservice "github.com/containerd/containerd/v2/internal/nri"
 	"github.com/containerd/containerd/v2/internal/registrar"
 	"github.com/containerd/containerd/v2/pkg/deprecation"
+	"github.com/containerd/containerd/v2/pkg/imageverifier"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	osinterface "github.com/containerd/containerd/v2/pkg/os"
 	"github.com/containerd/containerd/v2/plugins"
@@ -161,6 +162,9 @@ type criService struct {
 	containerEventsQ eventq.EventQueue[*runtime.ContainerEventResponse]
 	// nri is used to hook NRI into CRI request processing.
 	nri *nri.API
+	// imageVerifiers are the loaded image verifier plugins, invoked at container
+	// creation for run-time verification.
+	imageVerifiers map[string]imageverifier.ImageVerifier
 	// sandboxService is the sandbox related service for CRI
 	sandboxService sandboxService
 	// runtimeHandlers contains runtime handler info
@@ -187,6 +191,9 @@ type CRIServiceOptions struct {
 
 	// SandboxControllers is a map of all the loaded sandbox controllers
 	SandboxControllers map[string]sandbox.Controller
+
+	// Verifiers are the loaded image verifier plugins, keyed by plugin name.
+	Verifiers map[string]imageverifier.ImageVerifier
 
 	// Client is the base containerd client used for accessing services,
 	//
@@ -223,6 +230,7 @@ func NewCRIService(options *CRIServiceOptions) (CRIService, runtime.RuntimeServi
 		runtimeHandlers:    make(map[string]*runtime.RuntimeHandler),
 		statsCollector:     statsCollector,
 		shimPath:           options.ShimPath,
+		imageVerifiers:     options.Verifiers,
 	}
 
 	// TODO: Make discard time configurable

--- a/pkg/imageverifier/bindir/bindir.go
+++ b/pkg/imageverifier/bindir/bindir.go
@@ -65,11 +65,11 @@ func (v *ImageVerifier) VerifyImage(ctx context.Context, name string, desc ocisp
 	return v.verify(ctx, name, desc, imageverifier.VerifyOptions{Operation: imageverifier.OperationPull}, v.config.VerifyOnRun)
 }
 
-// VerifyImageContext verifies an image with operation-scoped context
+// VerifyImageContext verifies an image with operation-scoped context.
 func (v *ImageVerifier) VerifyImageContext(ctx context.Context, name string, desc ocispec.Descriptor, opts imageverifier.VerifyOptions) (*imageverifier.Judgement, error) {
 	if opts.Operation != imageverifier.OperationRun {
 		// Only run-time verification is gated/contextual here; other operations
-		// fall back to the descriptor-only contract.
+		// fall back to the VerifyImage entrypoint.
 		return v.VerifyImage(ctx, name, desc)
 	}
 	if !v.config.VerifyOnRun {

--- a/pkg/imageverifier/bindir/bindir.go
+++ b/pkg/imageverifier/bindir/bindir.go
@@ -67,6 +67,11 @@ func (v *ImageVerifier) VerifyImage(ctx context.Context, name string, desc ocisp
 
 // VerifyImageContext verifies an image with operation-scoped context
 func (v *ImageVerifier) VerifyImageContext(ctx context.Context, name string, desc ocispec.Descriptor, opts imageverifier.VerifyOptions) (*imageverifier.Judgement, error) {
+	if opts.Operation != imageverifier.OperationRun {
+		// Only run-time verification is gated/contextual here; other operations
+		// fall back to the descriptor-only contract.
+		return v.VerifyImage(ctx, name, desc)
+	}
 	if !v.config.VerifyOnRun {
 		return &imageverifier.Judgement{
 			OK:     true,

--- a/pkg/imageverifier/bindir/bindir.go
+++ b/pkg/imageverifier/bindir/bindir.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/internal/tomlext"
 	"github.com/containerd/containerd/v2/pkg/imageverifier"
 	"github.com/containerd/log"
@@ -41,13 +42,17 @@ type Config struct {
 	BinDir             string           `toml:"bin_dir"`
 	MaxVerifiers       int              `toml:"max_verifiers"`
 	PerVerifierTimeout tomlext.Duration `toml:"per_verifier_timeout"`
+	VerifyOnRun        bool             `toml:"verify_on_run"`
 }
 
 type ImageVerifier struct {
 	config *Config
 }
 
-var _ imageverifier.ImageVerifier = (*ImageVerifier)(nil)
+var (
+	_ imageverifier.ImageVerifier        = (*ImageVerifier)(nil)
+	_ imageverifier.ContextImageVerifier = (*ImageVerifier)(nil)
+)
 
 func NewImageVerifier(c *Config) *ImageVerifier {
 	return &ImageVerifier{
@@ -55,7 +60,26 @@ func NewImageVerifier(c *Config) *ImageVerifier {
 	}
 }
 
+// VerifyImage verifies an image using the bare OCI descriptor
 func (v *ImageVerifier) VerifyImage(ctx context.Context, name string, desc ocispec.Descriptor) (*imageverifier.Judgement, error) {
+	return v.verify(ctx, name, desc, imageverifier.VerifyOptions{Operation: imageverifier.OperationPull}, false)
+}
+
+// VerifyImageContext verifies an image with operation-scoped context
+func (v *ImageVerifier) VerifyImageContext(ctx context.Context, name string, desc ocispec.Descriptor, opts imageverifier.VerifyOptions) (*imageverifier.Judgement, error) {
+	if !v.config.VerifyOnRun {
+		return &imageverifier.Judgement{
+			OK:     true,
+			Reason: "run-time image verification is disabled; skipping",
+		}, nil
+	}
+	return v.verify(ctx, name, desc, opts, true)
+}
+
+// verify runs the configured verifier binaries against the image. When
+// includeContext is true, verifiers receive the richer VerifierInput payload and
+// an -operation argument; otherwise the bare OCI descriptor.
+func (v *ImageVerifier) verify(ctx context.Context, name string, desc ocispec.Descriptor, opts imageverifier.VerifyOptions, includeContext bool) (*imageverifier.Judgement, error) {
 	// os.ReadDir sorts entries by name.
 	entries, err := os.ReadDir(v.config.BinDir)
 	if err != nil {
@@ -85,10 +109,10 @@ func (v *ImageVerifier) VerifyImage(ctx context.Context, name string, desc ocisp
 
 		bin := entry.Name()
 		start := time.Now()
-		exitCode, vr, err := v.runVerifier(ctx, bin, name, desc)
-		runtime := time.Since(start)
+		exitCode, vr, err := v.runVerifier(ctx, bin, name, desc, opts, includeContext)
+		elapsed := time.Since(start)
 		if err != nil {
-			return nil, fmt.Errorf("failed to call verifier %v (runtime %v): %w", bin, runtime, err)
+			return nil, fmt.Errorf("failed to call verifier %v (runtime %v): %w", bin, elapsed, err)
 		}
 
 		if exitCode != 0 {
@@ -110,15 +134,23 @@ func (v *ImageVerifier) VerifyImage(ctx context.Context, name string, desc ocisp
 	}, nil
 }
 
-func (v *ImageVerifier) runVerifier(ctx context.Context, bin string, imageName string, desc ocispec.Descriptor) (exitCode int, reason string, err error) {
+func (v *ImageVerifier) runVerifier(ctx context.Context, bin string, imageName string, desc ocispec.Descriptor, opts imageverifier.VerifyOptions, includeContext bool) (exitCode int, reason string, err error) {
 	ctx, cancel := context.WithTimeout(ctx, tomlext.ToStdTime(v.config.PerVerifierTimeout))
 	defer cancel()
 
 	binPath := filepath.Join(v.config.BinDir, bin)
+
+	stdinMediaType := ocispec.MediaTypeDescriptor
+	if includeContext {
+		stdinMediaType = images.MediaTypeContainerd1ImageVerificationInput
+	}
 	args := []string{
 		"-name", imageName,
 		"-digest", desc.Digest.String(),
-		"-stdin-media-type", ocispec.MediaTypeDescriptor,
+		"-stdin-media-type", stdinMediaType,
+	}
+	if includeContext {
+		args = append(args, "-operation", string(opts.Operation))
 	}
 
 	cmd := exec.CommandContext(ctx, binPath, args...)
@@ -169,7 +201,7 @@ func (v *ImageVerifier) runVerifier(ctx context.Context, bin string, imageName s
 	stdoutWrite.Close()
 	stderrWrite.Close()
 
-	// Write the descriptor to stdin.
+	// Write the descriptor (or the richer VerifierInput) to stdin.
 	go func() {
 		// Descriptors are usually small enough to fit in a pipe buffer (which is
 		// often 64 KiB on Linux) so this write usually won't block on the child
@@ -177,7 +209,17 @@ func (v *ImageVerifier) runVerifier(ctx context.Context, bin string, imageName s
 		// the parent to block if the descriptor is larger than the pipe buffer and
 		// the child process doesn't read stdin. Therefore, we write to stdin
 		// asynchronously, limited by the stdinWrite deadline set above.
-		err := json.NewEncoder(stdinWrite).Encode(desc)
+		var err error
+		if includeContext {
+			input := imageverifier.VerifierInput{
+				Descriptor:  &desc,
+				Operation:   opts.Operation,
+				Annotations: opts.Annotations,
+			}
+			err = json.NewEncoder(stdinWrite).Encode(input)
+		} else {
+			err = json.NewEncoder(stdinWrite).Encode(desc)
+		}
 		if err != nil {
 			// This may error out with a "broken pipe" error if the descriptor is
 			// larger than the pipe buffer and the child process does not read all

--- a/pkg/imageverifier/bindir/bindir.go
+++ b/pkg/imageverifier/bindir/bindir.go
@@ -60,9 +60,9 @@ func NewImageVerifier(c *Config) *ImageVerifier {
 	}
 }
 
-// VerifyImage verifies an image using the bare OCI descriptor
+// VerifyImage verifies an image using the OCI descriptor.
 func (v *ImageVerifier) VerifyImage(ctx context.Context, name string, desc ocispec.Descriptor) (*imageverifier.Judgement, error) {
-	return v.verify(ctx, name, desc, imageverifier.VerifyOptions{Operation: imageverifier.OperationPull}, false)
+	return v.verify(ctx, name, desc, imageverifier.VerifyOptions{Operation: imageverifier.OperationPull}, v.config.VerifyOnRun)
 }
 
 // VerifyImageContext verifies an image with operation-scoped context

--- a/pkg/imageverifier/bindir/bindir_test.go
+++ b/pkg/imageverifier/bindir/bindir_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/v2/internal/tomlext"
+	"github.com/containerd/containerd/v2/pkg/imageverifier"
 	"github.com/containerd/log"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
@@ -420,5 +421,100 @@ func TestBinDirVerifyImage(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, j.OK)
 		assert.NotEmpty(t, j.Reason)
+	})
+
+	t.Run("verify_on_run disabled is a no-op for VerifyImageContext", func(t *testing.T) {
+		binDir := newBinDir(t, allBinsDir,
+			"verifier_test_input_output_management",
+		)
+
+		v := NewImageVerifier(&Config{
+			BinDir:             binDir,
+			MaxVerifiers:       -1,
+			PerVerifierTimeout: tomlext.FromStdTime(5 * time.Second),
+			VerifyOnRun:        false,
+		})
+
+		j, err := v.VerifyImageContext(ctx, "registry.example.com/image:abc", ocispec.Descriptor{
+			Digest:    "sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+			MediaType: "application/vnd.docker.distribution.manifest.list.v2+json",
+			Size:      2048,
+		}, imageverifier.VerifyOptions{
+			Operation: imageverifier.OperationRun,
+		})
+		// With request context disabled, no verifier binaries run and the
+		// operation is allowed.
+		assert.NoError(t, err)
+		assert.True(t, j.OK)
+		assert.Contains(t, j.Reason, "disabled")
+	})
+
+	t.Run("verify_on_run enabled passes neutral context", func(t *testing.T) {
+		binDir := newBinDir(t, allBinsDir,
+			"verifier_test_input_output_management",
+		)
+
+		v := NewImageVerifier(&Config{
+			BinDir:             binDir,
+			MaxVerifiers:       -1,
+			PerVerifierTimeout: tomlext.FromStdTime(5 * time.Second),
+			VerifyOnRun:        true,
+		})
+
+		j, err := v.VerifyImageContext(ctx, "registry.example.com/image:abc", ocispec.Descriptor{
+			Digest:      "sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+			MediaType:   "application/vnd.docker.distribution.manifest.list.v2+json",
+			Size:        2048,
+			Annotations: map[string]string{"a": "b"},
+		}, imageverifier.VerifyOptions{
+			Operation:   imageverifier.OperationRun,
+			Annotations: map[string]string{"io.kubernetes.cri.sandbox-namespace": "test-namespace", "x": "y"},
+		})
+		assert.NoError(t, err)
+		assert.True(t, j.OK)
+
+		b, err := os.ReadFile(data.ArgsFile)
+		require.NoError(t, err)
+		assert.Equal(t, "-name registry.example.com/image:abc -digest sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 -stdin-media-type application/vnd.containerd.image-verifier.input.v1+json -operation run", string(b))
+
+		b, err = os.ReadFile(data.StdinFile)
+		require.NoError(t, err)
+		assert.Equal(t, `{"descriptor":{"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json","digest":"sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4","size":2048,"annotations":{"a":"b"}},"operation":"run","annotations":{"io.kubernetes.cri.sandbox-namespace":"test-namespace","x":"y"}}`, strings.TrimSpace(string(b)))
+	})
+
+	t.Run("verify_on_run enabled with rejecting verifier", func(t *testing.T) {
+		binDir := newBinDir(t, allBinsDir, "reject_reason_d")
+
+		v := NewImageVerifier(&Config{
+			BinDir:             binDir,
+			MaxVerifiers:       -1,
+			PerVerifierTimeout: tomlext.FromStdTime(5 * time.Second),
+			VerifyOnRun:        true,
+		})
+
+		j, err := v.VerifyImageContext(ctx, "registry.example.com/image:abc", ocispec.Descriptor{}, imageverifier.VerifyOptions{
+			Operation: imageverifier.OperationRun,
+		})
+		assert.NoError(t, err)
+		assert.False(t, j.OK)
+		assert.Equal(t, fmt.Sprintf("verifier verifier-0%[1]v rejected image (exit code 1): Reason D", exeIfWindows()), j.Reason)
+	})
+
+	t.Run("verify_on_run enabled with exec failure", func(t *testing.T) {
+		binDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(binDir, "bad.sh"), []byte("BAD"), 0744))
+
+		v := NewImageVerifier(&Config{
+			BinDir:             binDir,
+			MaxVerifiers:       -1,
+			PerVerifierTimeout: tomlext.FromStdTime(5 * time.Second),
+			VerifyOnRun:        true,
+		})
+
+		j, err := v.VerifyImageContext(ctx, "registry.example.com/image:abc", ocispec.Descriptor{}, imageverifier.VerifyOptions{
+			Operation: imageverifier.OperationRun,
+		})
+		assert.Error(t, err)
+		assert.Nil(t, j)
 	})
 }

--- a/pkg/imageverifier/bindir/bindir_test.go
+++ b/pkg/imageverifier/bindir/bindir_test.go
@@ -482,6 +482,38 @@ func TestBinDirVerifyImage(t *testing.T) {
 		assert.Equal(t, `{"descriptor":{"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json","digest":"sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4","size":2048,"annotations":{"a":"b"}},"operation":"run","annotations":{"io.kubernetes.cri.sandbox-namespace":"test-namespace","x":"y"}}`, strings.TrimSpace(string(b)))
 	})
 
+	t.Run("verify_on_run enabled sends operation on pull", func(t *testing.T) {
+		binDir := newBinDir(t, allBinsDir,
+			"verifier_test_input_output_management",
+		)
+
+		v := NewImageVerifier(&Config{
+			BinDir:             binDir,
+			MaxVerifiers:       -1,
+			PerVerifierTimeout: tomlext.FromStdTime(5 * time.Second),
+			VerifyOnRun:        true,
+		})
+
+		// The pull entrypoint (VerifyImage) with verify_on_run enabled uses the
+		// richer contract and signals the pull operation, without run context.
+		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{
+			Digest:      "sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4",
+			MediaType:   "application/vnd.docker.distribution.manifest.list.v2+json",
+			Size:        2048,
+			Annotations: map[string]string{"a": "b"},
+		})
+		assert.NoError(t, err)
+		assert.True(t, j.OK)
+
+		b, err := os.ReadFile(data.ArgsFile)
+		require.NoError(t, err)
+		assert.Equal(t, "-name registry.example.com/image:abc -digest sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 -stdin-media-type application/vnd.containerd.image-verifier.input.v1+json -operation pull", string(b))
+
+		b, err = os.ReadFile(data.StdinFile)
+		require.NoError(t, err)
+		assert.Equal(t, `{"descriptor":{"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json","digest":"sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4","size":2048,"annotations":{"a":"b"}},"operation":"pull"}`, strings.TrimSpace(string(b)))
+	})
+
 	t.Run("verify_on_run enabled with rejecting verifier", func(t *testing.T) {
 		binDir := newBinDir(t, allBinsDir, "reject_reason_d")
 

--- a/pkg/imageverifier/image_verifier.go
+++ b/pkg/imageverifier/image_verifier.go
@@ -26,6 +26,41 @@ type ImageVerifier interface {
 	VerifyImage(ctx context.Context, name string, desc ocispec.Descriptor) (*Judgement, error)
 }
 
+// Operation identifies the lifecycle phase a verifier is invoked from.
+type Operation string
+
+const (
+	// OperationPull is verification during an image pull.
+	OperationPull Operation = "pull"
+	// OperationRun is verification when a container is created from a pulled image.
+	OperationRun Operation = "run"
+)
+
+// VerifyOptions carries optional, operation-scoped context to verifiers.
+// Annotations is a plain string map so this package stays caller-agnostic; any
+// Kubernetes meaning lives in well-known keys (e.g. io.kubernetes.cri.*) and is
+// not validated by containerd.
+type VerifyOptions struct {
+	Operation   Operation
+	Annotations map[string]string
+}
+
+// ContextImageVerifier is an optional interface a verifier may implement to
+// receive operation-scoped context. Callers type-assert for it and fall back to
+// VerifyImage.
+type ContextImageVerifier interface {
+	ImageVerifier
+	VerifyImageContext(ctx context.Context, name string, desc ocispec.Descriptor, opts VerifyOptions) (*Judgement, error)
+}
+
+// VerifierInput is the stdin payload for the
+// images.MediaTypeContainerd1ImageVerificationInput media type.
+type VerifierInput struct {
+	Descriptor  *ocispec.Descriptor `json:"descriptor,omitempty"`
+	Operation   Operation           `json:"operation,omitempty"`
+	Annotations map[string]string   `json:"annotations,omitempty"`
+}
+
 type Judgement struct {
 	OK     bool
 	Reason string

--- a/plugins/cri/cri.go
+++ b/plugins/cri/cri.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/server"
 	"github.com/containerd/containerd/v2/internal/cri/server/images"
 	nriservice "github.com/containerd/containerd/v2/internal/nri"
+	"github.com/containerd/containerd/v2/pkg/imageverifier"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services/warning"
 	"github.com/containerd/containerd/v2/version"
@@ -58,6 +59,7 @@ func init() {
 			plugins.LeasePlugin,
 			plugins.SandboxStorePlugin,
 			plugins.TransferPlugin,
+			plugins.ImageVerifierPlugin,
 			plugins.WarningPlugin,
 			plugins.ShimPlugin,
 		},
@@ -147,6 +149,9 @@ func initCRIService(ic *plugin.InitContext) (any, error) {
 				break
 			}
 		}
+	verifiers, err := getImageVerifiers(ic)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get image verifiers from plugins: %w", err)
 	}
 
 	options := &server.CRIServiceOptions{
@@ -157,6 +162,7 @@ func initCRIService(ic *plugin.InitContext) (any, error) {
 		Client:             client,
 		SandboxControllers: sbControllers,
 		ShimPath:           shimPath,
+		Verifiers:          verifiers,
 	}
 	is := criImagePlugin.(imageService).GRPCService()
 
@@ -270,6 +276,22 @@ func getSandboxControllers(ic *plugin.InitContext) (map[string]sandbox.Controlle
 		sc[name] = p.(sandbox.Controller)
 	}
 	return sc, nil
+}
+
+// getImageVerifiers loads the registered image verifier plugins, keyed by name.
+func getImageVerifiers(ic *plugin.InitContext) (map[string]imageverifier.ImageVerifier, error) {
+	ps, err := ic.GetByType(plugins.ImageVerifierPlugin)
+	if err != nil {
+		return nil, err
+	}
+	if len(ps) == 0 {
+		return nil, nil
+	}
+	verifiers := make(map[string]imageverifier.ImageVerifier, len(ps))
+	for name, p := range ps {
+		verifiers[name] = p.(imageverifier.ImageVerifier)
+	}
+	return verifiers, nil
 }
 
 func configMigration(ctx context.Context, configVersion int, pluginConfigs map[string]any) error {

--- a/plugins/cri/cri.go
+++ b/plugins/cri/cri.go
@@ -150,6 +150,8 @@ func initCRIService(ic *plugin.InitContext) (any, error) {
 				break
 			}
 		}
+	}
+
 	verifiers, err := getImageVerifiers(ic)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image verifiers from plugins: %w", err)

--- a/plugins/cri/cri.go
+++ b/plugins/cri/cri.go
@@ -18,6 +18,7 @@ package cri
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -281,11 +282,9 @@ func getSandboxControllers(ic *plugin.InitContext) (map[string]sandbox.Controlle
 // getImageVerifiers loads the registered image verifier plugins, keyed by name.
 func getImageVerifiers(ic *plugin.InitContext) (map[string]imageverifier.ImageVerifier, error) {
 	ps, err := ic.GetByType(plugins.ImageVerifierPlugin)
-	if err != nil {
+	// No registered image verifier plugins is a valid configuration.
+	if err != nil && !errors.Is(err, plugin.ErrPluginNotFound) {
 		return nil, err
-	}
-	if len(ps) == 0 {
-		return nil, nil
 	}
 	verifiers := make(map[string]imageverifier.ImageVerifier, len(ps))
 	for name, p := range ps {


### PR DESCRIPTION
### What type of PR is this?

kind/feature

### What this PR does / why we need it:

The [ImageVerifier plugin](https://github.com/containerd/containerd/blob/main/docs/image-verification.md) allows containerd to make an external call to verify an image before pulling it.

This PR adds an optional extension to the ImageVerifier plugin that verifies an image at container creation, in addition to at image pull. Hooking in at this stage gives verifiers access to CRI request metadata, enabling more context-aware verification decisions.

### Which issue(s) this PR fixes:

This PR introduces the enhancements suggested in #12540 . 

### Special notes for your reviewer:

- I added special notes as code comments on code in this PR to make it easier to see what I am referring to.

### Does this PR introduce a user-facing change?

An extension, `verify_on_run`, is added to the `image-verification` plugin. However, this feature is disabled by default. Outside of this, there are no user-facing changes.