### PR TITLE
core/mount: Reject X-containerd.* options before kernel mount

### DIFF
--- a/core/mount/mount_linux_test.go
+++ b/core/mount/mount_linux_test.go
@@ -697,3 +697,23 @@ func TestGetCommonDirectory(t *testing.T) {
 		})
 	}
 }
+
+func TestXContainerdOptionsFiltered(t *testing.T) {
+	testutil.RequiresRoot(t)
+
+	target := filepath.Join(t.TempDir(), "mnt")
+	require.NoError(t, os.MkdirAll(target, 0755))
+
+	m := Mount{
+		Type:   "tmpfs",
+		Source: "tmpfs",
+		Options: []string{
+			"size=10M",
+			"X-containerd.custom=test-value",
+			"mode=0755",
+		},
+	}
+
+	err := m.Mount(target)
+	require.Error(t, err, "X-containerd.* options should cause an error")
+}


### PR DESCRIPTION
The X-containerd.* prefix is reserved for internal mount options that should be consumed by transformers (e.g., mkdir, mkfs) before reaching the core mount layer.

This change returns an error if any X-containerd.* options reach the mount syscall, making transformer bugs immediately visible rather than causing silent failures or kernel errors.