### PR TITLE
core/mount.test: should not call removeLoop when set autoclear

### DIFF
--- a/core/mount/loopback_handler_linux.go
+++ b/core/mount/loopback_handler_linux.go
@@ -18,6 +18,7 @@ package mount
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -79,7 +80,7 @@ func (loopbackHandler) Unmount(ctx context.Context, path string) error {
 	defer loop.Close()
 
 	if err := setLoopAutoclear(loop, true); err != nil {
-		return err
+		return fmt.Errorf("failed to set auto clear on loop device %q: %w", loopdev, err)
 	}
 
 	if err := os.Remove(path); err != nil {


### PR DESCRIPTION
In CI we run make root-test via gotestsum, which executes multiple package tests concurrently. TestAutoclearTrueLoop attempts to invoke LOOP_CLR_FD using a device name, which introduces a race condition.

Example race:

Process P1 represents mount.test which runs TestAutoclearTrueLoop Process P2 represents manager.test which runs TestLoopbackMount

T1: P1 closes fd of loop-device (loop3) (kernel unsets backing-file on close)
T2: P2 gets loop3 from /dev/loop-control
T3: P2 configures loop3 with backing file successfully
T4: P1 invokes removeLoop to clear backing file for loop3

You might see that failure like this

```
=== FAIL: core/mount/manager TestLoopbackMount (0.05s)
    log_hook.go:47: time="2025-10-23T21:49:22.532811960Z" level=debug msg="activating mount" func="manager.(*mountManager).Activate" file="/home/runner/work/containerd/containerd/core/mount/manager/manager.go:134" mounts="[{loop /tmp/TestLoopbackMount989607109/001/fs-1621892597  []} {format/ext4 {{ mount 0 }}  []}]" name=id1 testcase=TestLoopbackMount
    helpers.go:100: unmount /tmp/TestLoopbackMount989607109/001/test-mount-3030342351
    manager_linux_test.go:80:
        	Error Trace:	/home/runner/work/containerd/containerd/core/mount/manager/manager_linux_test.go:80
        	            				/home/runner/work/containerd/containerd/core/mount/manager/manager_linux_test.go:105
        	Error:      	Received unexpected error:
        	            	failed to get loop device info: no such device or address
        	Test:       	TestLoopbackMount
```

To fix this, the test now compares backing-file's inode directly and does not call removeLoop when autoclear is set.