### PR TITLE
Add plugins for server listeners

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -440,12 +440,11 @@ The daemon's configuration file, commonly located in `/etc/containerd/config.tom
 is versioned and backwards compatible.  The `version` field in the config
 file specifies the config's version.  If no version number is specified inside
 the config file then it is assumed to be a version `1` config and parsed as such.
-The latest version is `version = 2`. The `main` branch is being prepared to support
-the next config version `3`. The configuration is automatically migrated to the
-latest version on each startup, leaving the configuration file unchanged. To avoid
-the migration and optimize the daemon startup time, use `containerd config migrate`
-to output the configuration as the latest version. Version `1` is no longer deprecated
-and is supported by migration, however, it is recommended to use at least version `2`.
+The latest version is `version = 4`. The configuration is automatically migrated to
+the latest version on each startup, leaving the configuration file unchanged. To
+avoid the migration and optimize the daemon startup time, use `containerd config
+migrate` to output the configuration as the latest version. All prior versions are
+supported by migration.
 
 Migrating a configuration to the latest version will limit the prior versions
 of containerd in which the configuration can be used. It is suggested not to
@@ -459,6 +458,7 @@ each configuration version.
 | 1                     | v1.0.0                     |
 | 2                     | v1.3.0                     |
 | 3                     | v2.0.0                     |
+| 4                     | v2.3.0                     |
 
 ### Not Covered
 

--- a/cmd/containerd/builtins/builtins.go
+++ b/cmd/containerd/builtins/builtins.go
@@ -30,6 +30,8 @@ import (
 	_ "github.com/containerd/containerd/v2/plugins/restart"
 	_ "github.com/containerd/containerd/v2/plugins/sandbox"
 	_ "github.com/containerd/containerd/v2/plugins/server/debug"
+	_ "github.com/containerd/containerd/v2/plugins/server/grpc"
+	_ "github.com/containerd/containerd/v2/plugins/server/ttrpc"
 	_ "github.com/containerd/containerd/v2/plugins/services/containers"
 	_ "github.com/containerd/containerd/v2/plugins/services/content"
 	_ "github.com/containerd/containerd/v2/plugins/services/diff"

--- a/cmd/containerd/builtins/builtins.go
+++ b/cmd/containerd/builtins/builtins.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/containerd/containerd/v2/plugins/nri"
 	_ "github.com/containerd/containerd/v2/plugins/restart"
 	_ "github.com/containerd/containerd/v2/plugins/sandbox"
+	_ "github.com/containerd/containerd/v2/plugins/server/debug"
 	_ "github.com/containerd/containerd/v2/plugins/services/containers"
 	_ "github.com/containerd/containerd/v2/plugins/services/content"
 	_ "github.com/containerd/containerd/v2/plugins/services/diff"

--- a/cmd/containerd/builtins/builtins.go
+++ b/cmd/containerd/builtins/builtins.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/containerd/containerd/v2/plugins/sandbox"
 	_ "github.com/containerd/containerd/v2/plugins/server/debug"
 	_ "github.com/containerd/containerd/v2/plugins/server/grpc"
+	_ "github.com/containerd/containerd/v2/plugins/server/metrics"
 	_ "github.com/containerd/containerd/v2/plugins/server/ttrpc"
 	_ "github.com/containerd/containerd/v2/plugins/services/containers"
 	_ "github.com/containerd/containerd/v2/plugins/services/content"

--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -125,18 +125,20 @@ func dumpConfig(cliContext *cli.Context) error {
 
 func platformAgnosticDefaultConfig() *srvconfig.Config {
 	return &srvconfig.Config{
-		Version: version.ConfigVersion,
-		Root:    defaults.DefaultRootDir,
-		State:   defaults.DefaultStateDir,
-		GRPC: srvconfig.GRPCConfig{
-			Address:        defaults.DefaultAddress,
-			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
-			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
-		},
+		Version:          version.ConfigVersion,
+		Root:             defaults.DefaultRootDir,
+		State:            defaults.DefaultStateDir,
 		DisabledPlugins:  []string{},
 		RequiredPlugins:  []string{},
 		StreamProcessors: streamProcessors(),
 		Imports:          []string{defaults.DefaultConfigIncludePattern},
+		Plugins: map[string]any{
+			"io.containerd.server.v1.grpc": map[string]any{
+				"address":               defaults.DefaultAddress,
+				"max_recv_message_size": defaults.DefaultMaxRecvMsgSize,
+				"max_send_message_size": defaults.DefaultMaxSendMsgSize,
+			},
+		},
 	}
 }
 

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -34,7 +34,6 @@ import (
 	_ "github.com/containerd/containerd/v2/core/metrics" // import containerd build info
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/errdefs"
@@ -165,16 +164,6 @@ can be used and modified as necessary as a custom configuration.`
 			return err
 		}
 
-		if config.GRPC.Address == "" {
-			return fmt.Errorf("grpc address cannot be empty: %w", errdefs.ErrInvalidArgument)
-		}
-		if config.TTRPC.Address == "" {
-			// If TTRPC was not explicitly configured, use defaults based on GRPC.
-			config.TTRPC.Address = config.GRPC.Address + ".ttrpc"
-			config.TTRPC.UID = config.GRPC.UID
-			config.TTRPC.GID = config.GRPC.GID
-		}
-
 		// Make sure top-level directories are created early.
 		if err := server.CreateTopLevelDirectories(config); err != nil {
 			return err
@@ -229,6 +218,7 @@ can be used and modified as necessary as a custom configuration.`
 		go func() {
 			defer close(chsrv)
 
+			// TODO: When to set grpc address from flag? Migration should be done first
 			server, err := server.New(ctx, config)
 			if err != nil {
 				select {
@@ -270,6 +260,8 @@ can be used and modified as necessary as a custom configuration.`
 		if err := server.Start(ctx); err != nil {
 			return err
 		}
+
+		// TODO: Move to server.Start(ctx) error
 		if config.Metrics.Address != "" {
 			l, err := net.Listen("tcp", config.Metrics.Address)
 			if err != nil {
@@ -277,26 +269,8 @@ can be used and modified as necessary as a custom configuration.`
 			}
 			serve(ctx, l, server.ServeMetrics)
 		}
-		// setup the ttrpc endpoint
-		tl, err := sys.GetLocalListener(config.TTRPC.Address, config.TTRPC.UID, config.TTRPC.GID)
-		if err != nil {
-			return fmt.Errorf("failed to get listener for main ttrpc endpoint: %w", err)
-		}
-		serve(ctx, tl, server.ServeTTRPC)
 
-		if config.GRPC.TCPAddress != "" {
-			l, err := net.Listen("tcp", config.GRPC.TCPAddress)
-			if err != nil {
-				return fmt.Errorf("failed to get listener for TCP grpc endpoint: %w", err)
-			}
-			serve(ctx, l, server.ServeTCP)
-		}
-		// setup the main grpc endpoint
-		l, err := sys.GetLocalListener(config.GRPC.Address, config.GRPC.UID, config.GRPC.GID)
-		if err != nil {
-			return fmt.Errorf("failed to get listener for main endpoint: %w", err)
-		}
-		serve(ctx, l, server.ServeGRPC)
+		// end s.Start
 
 		readyC := make(chan struct{})
 		go func() {
@@ -351,10 +325,6 @@ func applyFlags(cliContext *cli.Context, config *srvconfig.Config) error {
 			name: "state",
 			d:    &config.State,
 		},
-		{
-			name: "address",
-			d:    &config.GRPC.Address,
-		},
 	} {
 		if s := cliContext.String(v.name); s != "" {
 			*v.d = s
@@ -365,6 +335,35 @@ func applyFlags(cliContext *cli.Context, config *srvconfig.Config) error {
 				}
 				*v.d = absPath
 			}
+		}
+	}
+
+	if s := cliContext.String("address"); s != "" {
+		var (
+			grpcConfig  map[string]any
+			ttrpcConfig map[string]any
+		)
+		v, ok := config.Plugins["io.containerd.server.v1.grpc"]
+		if !ok {
+			grpcConfig = make(map[string]any)
+		} else if grpcConfig, ok = v.(map[string]any); !ok {
+			return fmt.Errorf("grpc plugin has invalid configuration: %w", errdefs.ErrInvalidArgument)
+		}
+		grpcConfig["address"] = s
+		config.Plugins["io.containerd.server.v1.grpc"] = grpcConfig
+
+		_, ok = config.Plugins["io.containerd.server.v1.ttrpc"]
+		if !ok {
+			ttrpcConfig = map[string]any{
+				"address": s + ".ttrpc",
+			}
+			if uid, ok := grpcConfig["uid"]; ok {
+				ttrpcConfig["uid"] = uid
+			}
+			if gid, ok := grpcConfig["gid"]; ok {
+				ttrpcConfig["gid"] = gid
+			}
+			config.Plugins["io.containerd.server.v1.ttrpc"] = ttrpcConfig
 		}
 	}
 

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -267,18 +267,8 @@ can be used and modified as necessary as a custom configuration.`
 		case serverC <- server:
 		}
 
-		if config.Debug.Address != "" {
-			var l net.Listener
-			if isLocalAddress(config.Debug.Address) {
-				if l, err = sys.GetLocalListener(config.Debug.Address, config.Debug.UID, config.Debug.GID); err != nil {
-					return fmt.Errorf("failed to get listener for debug endpoint: %w", err)
-				}
-			} else {
-				if l, err = net.Listen("tcp", config.Debug.Address); err != nil {
-					return fmt.Errorf("failed to get listener for debug endpoint: %w", err)
-				}
-			}
-			serve(ctx, l, server.ServeDebug)
+		if err := server.Start(ctx); err != nil {
+			return err
 		}
 		if config.Metrics.Address != "" {
 			l, err := net.Listen("tcp", config.Metrics.Address)

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"iter"
-	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -261,17 +260,6 @@ can be used and modified as necessary as a custom configuration.`
 			return err
 		}
 
-		// TODO: Move to server.Start(ctx) error
-		if config.Metrics.Address != "" {
-			l, err := net.Listen("tcp", config.Metrics.Address)
-			if err != nil {
-				return fmt.Errorf("failed to get listener for metrics endpoint: %w", err)
-			}
-			serve(ctx, l, server.ServeMetrics)
-		}
-
-		// end s.Start
-
 		readyC := make(chan struct{})
 		go func() {
 			server.Wait()
@@ -290,17 +278,6 @@ can be used and modified as necessary as a custom configuration.`
 		return nil
 	}
 	return app
-}
-
-func serve(ctx context.Context, l net.Listener, serveFunc func(net.Listener) error) {
-	path := l.Addr().String()
-	log.G(ctx).WithField("address", path).Info("serving...")
-	go func() {
-		defer l.Close()
-		if err := serveFunc(l); err != nil {
-			log.G(ctx).WithError(err).WithField("address", path).Fatal("serve failure")
-		}
-	}()
 }
 
 func applyFlags(cliContext *cli.Context, config *srvconfig.Config) error {

--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -21,7 +21,6 @@ package command
 import (
 	"context"
 	"os"
-	"path/filepath"
 
 	"github.com/containerd/containerd/v2/cmd/containerd/server"
 	"github.com/containerd/log"
@@ -71,8 +70,4 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 		}
 	}()
 	return done
-}
-
-func isLocalAddress(path string) bool {
-	return filepath.IsAbs(path)
 }

--- a/cmd/containerd/command/main_windows.go
+++ b/cmd/containerd/command/main_windows.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"unsafe"
 
 	"github.com/Microsoft/go-winio/pkg/etw"
@@ -114,8 +113,4 @@ func init() {
 			log.L.Error(err)
 		}
 	}
-}
-
-func isLocalAddress(path string) bool {
-	return strings.HasPrefix(path, `\\.\pipe\`)
 }

--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -65,10 +65,6 @@ type Config struct {
 	State string `toml:"state"`
 	// TempDir is the path to a directory where to place containerd temporary files
 	TempDir string `toml:"temp"`
-	// GRPC configuration settings
-	GRPC GRPCConfig `toml:"grpc"`
-	// TTRPC configuration settings
-	TTRPC TTRPCConfig `toml:"ttrpc"`
 	// Debug log settings
 	Debug Debug `toml:"debug"`
 	// Metrics and monitoring settings
@@ -95,6 +91,19 @@ type Config struct {
 	Imports []string `toml:"imports"`
 	// StreamProcessors configuration
 	StreamProcessors map[string]StreamProcessor `toml:"stream_processors"`
+
+	// Deprecated fields must remain but should not be output when generating default or migrated configs.
+	// These fields are automatically migrated to the corresponding server plugin
+	// configuration blocks on startup (see serviceMigrate). In version 4 configs,
+	// server settings are configured directly under [plugins."<plugin-id>"].
+
+	// Deprecated: use server plugins io.containerd.server.v1.grpc and io.containerd.server.v1.grpc-tcp
+	GRPC GRPCConfig `toml:"grpc,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.ttrpc.
+	// In configs prior to version 4, an unset TTRPC address is derived from
+	// the GRPC address (grpcAddress + ".ttrpc") and inherits GRPC's UID/GID.
+	// In version 4, the TTRPC plugin uses its own defaults independently.
+	TTRPC TTRPCConfig `toml:"ttrpc,omitempty"`
 }
 
 // StreamProcessor provides configuration for diff content processors
@@ -206,6 +215,15 @@ func v1Migrate(ctx context.Context, c *Config) error {
 	return nil
 }
 
+// serviceMigrate moves server properties (GRPC, TTRPC, Debug, Metrics) from
+// top-level config fields into their corresponding plugin configuration blocks
+// for version 4.
+//
+// For configs prior to version 4, if the TTRPC address is not explicitly set
+// it is derived from the GRPC address (grpcAddress + ".ttrpc") and inherits
+// GRPC's UID/GID. In version 4, each server plugin is independently
+// configured; the TTRPC plugin will use its own default address if its
+// plugin block is omitted, regardless of the GRPC plugin's address.
 func serviceMigrate(ctx context.Context, c *Config) error {
 	if c.Debug.Address != "" && c.Plugins["io.containerd.server.v1.debug"] == nil {
 		c.Plugins["io.containerd.server.v1.debug"] = map[string]any{
@@ -217,28 +235,94 @@ func serviceMigrate(ctx context.Context, c *Config) error {
 		c.Debug.UID = 0
 		c.Debug.GID = 0
 	}
+	// Capture legacy GRPC values up front so both grpc and grpc-tcp
+	// migrations see the same values, and so migrations that don't key on
+	// an address (uid/gid/max message sizes) are not dropped.
+	grpcAddress := c.GRPC.Address
+	grpcUID := c.GRPC.UID
+	grpcGID := c.GRPC.GID
+	grpcMaxRecv := c.GRPC.MaxRecvMsgSize
+	grpcMaxSend := c.GRPC.MaxSendMsgSize
+	grpcHasLegacy := grpcAddress != "" || grpcUID != 0 || grpcGID != 0 || grpcMaxRecv != 0 || grpcMaxSend != 0
+	if grpcHasLegacy && c.Plugins["io.containerd.server.v1.grpc"] == nil {
+		c.Plugins["io.containerd.server.v1.grpc"] = map[string]any{
+			"address":               grpcAddress,
+			"uid":                   grpcUID,
+			"gid":                   grpcGID,
+			"max_recv_message_size": grpcMaxRecv,
+			"max_send_message_size": grpcMaxSend,
+		}
+	}
+	if c.GRPC.TCPAddress != "" && c.Plugins["io.containerd.server.v1.grpc-tcp"] == nil {
+		c.Plugins["io.containerd.server.v1.grpc-tcp"] = map[string]any{
+			"address":               c.GRPC.TCPAddress,
+			"tls_ca":                c.GRPC.TCPTLSCA,
+			"tls_cert":              c.GRPC.TCPTLSCert,
+			"tls_key":               c.GRPC.TCPTLSKey,
+			"tls_common_name":       c.GRPC.TCPTLSCName,
+			"max_recv_message_size": grpcMaxRecv,
+			"max_send_message_size": grpcMaxSend,
+		}
+	}
+	if grpcHasLegacy || c.GRPC.TCPAddress != "" {
+		c.GRPC = GRPCConfig{}
+	}
+	if c.Plugins["io.containerd.server.v1.ttrpc"] == nil {
+		ttrpcAddress := c.TTRPC.Address
+		ttrpcUID := c.TTRPC.UID
+		ttrpcGID := c.TTRPC.GID
+		if ttrpcAddress == "" && grpcAddress != "" {
+			ttrpcAddress = grpcAddress + ".ttrpc"
+			if ttrpcUID == 0 {
+				ttrpcUID = grpcUID
+			}
+			if ttrpcGID == 0 {
+				ttrpcGID = grpcGID
+			}
+		}
+		if ttrpcAddress != "" || ttrpcUID != 0 || ttrpcGID != 0 {
+			c.Plugins["io.containerd.server.v1.ttrpc"] = map[string]any{
+				"address": ttrpcAddress,
+				"uid":     ttrpcUID,
+				"gid":     ttrpcGID,
+			}
+			c.TTRPC.Address = ""
+			c.TTRPC.UID = 0
+			c.TTRPC.GID = 0
+		}
+	}
 	return nil
 }
 
 // GRPCConfig provides GRPC configuration for the socket
 type GRPCConfig struct {
-	Address        string `toml:"address"`
-	TCPAddress     string `toml:"tcp_address"`
-	TCPTLSCA       string `toml:"tcp_tls_ca"`
-	TCPTLSCert     string `toml:"tcp_tls_cert"`
-	TCPTLSKey      string `toml:"tcp_tls_key"`
-	UID            int    `toml:"uid"`
-	GID            int    `toml:"gid"`
-	MaxRecvMsgSize int    `toml:"max_recv_message_size"`
-	MaxSendMsgSize int    `toml:"max_send_message_size"`
-	TCPTLSCName    string `toml:"tcp_tls_common_name"`
+	// Deprecated: use server plugin io.containerd.server.v1.grpc
+	Address string `toml:"address,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.grpc-tcp
+	TCPAddress string `toml:"tcp_address,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.grpc-tcp
+	TCPTLSCA string `toml:"tcp_tls_ca,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.grpc-tcp
+	TCPTLSCert string `toml:"tcp_tls_cert,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.grpc-tcp
+	TCPTLSKey string `toml:"tcp_tls_key,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.grpc
+	UID int `toml:"uid,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.grpc
+	GID int `toml:"gid,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.grpc
+	MaxRecvMsgSize int `toml:"max_recv_message_size,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.grpc
+	MaxSendMsgSize int `toml:"max_send_message_size,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.grpc-tcp
+	TCPTLSCName string `toml:"tcp_tls_common_name,omitempty"`
 }
 
 // TTRPCConfig provides TTRPC configuration for the socket
 type TTRPCConfig struct {
-	Address string `toml:"address"`
-	UID     int    `toml:"uid"`
-	GID     int    `toml:"gid"`
+	Address string `toml:"address,omitempty"`
+	UID     int    `toml:"uid,omitempty"`
+	GID     int    `toml:"gid,omitempty"`
 }
 
 // Debug provides debug configuration
@@ -258,8 +342,9 @@ type Debug struct {
 
 // MetricsConfig provides metrics configuration
 type MetricsConfig struct {
-	Address       string `toml:"address"`
-	GRPCHistogram bool   `toml:"grpc_histogram"`
+	Address string `toml:"address"`
+	// Deprecated: use metrics plugin io.containerd.metrics.v1.grpc-prometheus
+	GRPCHistogram bool `toml:"grpc_histogram,omitempty"`
 }
 
 // CgroupConfig provides cgroup configuration

--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -226,6 +226,9 @@ func v1Migrate(ctx context.Context, c *Config) error {
 // configured; the TTRPC plugin will use its own default address if its
 // plugin block is omitted, regardless of the GRPC plugin's address.
 func serviceMigrate(ctx context.Context, c *Config) error {
+	if c.Plugins == nil {
+		c.Plugins = make(map[string]any)
+	}
 	if c.Debug.Address != "" && c.Plugins["io.containerd.server.v1.debug"] == nil {
 		c.Plugins["io.containerd.server.v1.debug"] = map[string]any{
 			"address": c.Debug.Address,

--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -47,9 +47,10 @@ import (
 
 // migrations hold the migration functions for every prior containerd config version
 var migrations = []func(context.Context, *Config) error{
-	nil,       // Version 0 is not defined, treated at version 1
-	v1Migrate, // Version 1 plugins renamed to URI for version 2
-	nil,       // Version 2 has only plugin changes to version 3
+	nil,            // Version 0 is not defined, treated at version 1
+	v1Migrate,      // Version 1 plugins renamed to URI for version 2
+	nil,            // Version 2 has only plugin changes to version 3
+	serviceMigrate, // Version 3 has server properties moved to plugins for version 4
 }
 
 // NOTE: Any new map fields added also need to be handled in mergeConfig.
@@ -68,7 +69,7 @@ type Config struct {
 	GRPC GRPCConfig `toml:"grpc"`
 	// TTRPC configuration settings
 	TTRPC TTRPCConfig `toml:"ttrpc"`
-	// Debug and profiling settings
+	// Debug log settings
 	Debug Debug `toml:"debug"`
 	// Metrics and monitoring settings
 	Metrics MetricsConfig `toml:"metrics"`
@@ -205,6 +206,20 @@ func v1Migrate(ctx context.Context, c *Config) error {
 	return nil
 }
 
+func serviceMigrate(ctx context.Context, c *Config) error {
+	if c.Debug.Address != "" && c.Plugins["io.containerd.server.v1.debug"] == nil {
+		c.Plugins["io.containerd.server.v1.debug"] = map[string]any{
+			"address": c.Debug.Address,
+			"uid":     c.Debug.UID,
+			"gid":     c.Debug.GID,
+		}
+		c.Debug.Address = ""
+		c.Debug.UID = 0
+		c.Debug.GID = 0
+	}
+	return nil
+}
+
 // GRPCConfig provides GRPC configuration for the socket
 type GRPCConfig struct {
 	Address        string `toml:"address"`
@@ -228,13 +243,17 @@ type TTRPCConfig struct {
 
 // Debug provides debug configuration
 type Debug struct {
-	Address string `toml:"address"`
-	UID     int    `toml:"uid"`
-	GID     int    `toml:"gid"`
-	Level   string `toml:"level"`
+	Level string `toml:"level"`
 	// Format represents the logging format. Supported values are 'text' and 'json'.
 	Format     string `toml:"format"`
 	LogTraceID bool   `toml:"log_trace_id"`
+
+	// Deprecated: use server plugin io.containerd.server.v1.debug
+	Address string `toml:"address,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.debug
+	UID int `toml:"uid,omitempty"`
+	// Deprecated: use server plugin io.containerd.server.v1.debug
+	GID int `toml:"gid,omitempty"`
 }
 
 // MetricsConfig provides metrics configuration

--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -67,8 +67,6 @@ type Config struct {
 	TempDir string `toml:"temp"`
 	// Debug log settings
 	Debug Debug `toml:"debug"`
-	// Metrics and monitoring settings
-	Metrics MetricsConfig `toml:"metrics"`
 	// DisabledPlugins are IDs of plugins to disable. Disabled plugins won't be
 	// initialized and started.
 	// DisabledPlugins must use a fully qualified plugin URI.
@@ -104,6 +102,9 @@ type Config struct {
 	// the GRPC address (grpcAddress + ".ttrpc") and inherits GRPC's UID/GID.
 	// In version 4, the TTRPC plugin uses its own defaults independently.
 	TTRPC TTRPCConfig `toml:"ttrpc,omitempty"`
+	// Metrics and monitoring settings
+	// Deprecated: use server plugin io.containerd.server.v1.metrics
+	Metrics MetricsConfig `toml:"metrics,omitempty"`
 }
 
 // StreamProcessor provides configuration for diff content processors
@@ -291,6 +292,18 @@ func serviceMigrate(ctx context.Context, c *Config) error {
 			c.TTRPC.GID = 0
 		}
 	}
+	if c.Metrics.GRPCHistogram && c.Plugins["io.containerd.metrics.v1.grpc-prometheus"] == nil {
+		c.Plugins["io.containerd.metrics.v1.grpc-prometheus"] = map[string]any{
+			"grpc_histogram": c.Metrics.GRPCHistogram,
+		}
+		c.Metrics.GRPCHistogram = false
+	}
+	if c.Metrics.Address != "" && c.Plugins["io.containerd.server.v1.metrics"] == nil {
+		c.Plugins["io.containerd.server.v1.metrics"] = map[string]any{
+			"address": c.Metrics.Address,
+		}
+		c.Metrics.Address = ""
+	}
 	return nil
 }
 
@@ -342,7 +355,8 @@ type Debug struct {
 
 // MetricsConfig provides metrics configuration
 type MetricsConfig struct {
-	Address string `toml:"address"`
+	// Deprecated: use server plugin io.containerd.server.v1.metrics
+	Address string `toml:"address,omitempty"`
 	// Deprecated: use metrics plugin io.containerd.metrics.v1.grpc-prometheus
 	GRPCHistogram bool `toml:"grpc_histogram,omitempty"`
 }

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -470,3 +470,195 @@ func testMergeConfig(t *testing.T, inputs []string, expected string, comparePlug
 	}
 	assert.Equal(t, strings.TrimLeft(expected, "\n"), buf.String())
 }
+
+func TestServiceMigrate(t *testing.T) {
+	ctx := logtest.WithT(context.Background(), t)
+
+	t.Run("FullMigration", func(t *testing.T) {
+		c := &Config{
+			Debug: Debug{
+				Address: "/run/containerd/debug.sock",
+				UID:     1000,
+				GID:     1000,
+			},
+			GRPC: GRPCConfig{
+				Address:        "/run/containerd/containerd.sock",
+				TCPAddress:     "127.0.0.1:1234",
+				TCPTLSCA:       "/etc/ca.pem",
+				TCPTLSCert:     "/etc/cert.pem",
+				TCPTLSKey:      "/etc/key.pem",
+				TCPTLSCName:    "containerd",
+				UID:            0,
+				GID:            0,
+				MaxRecvMsgSize: 32 * 1024 * 1024,
+				MaxSendMsgSize: 32 * 1024 * 1024,
+			},
+			TTRPC: TTRPCConfig{
+				Address: "/run/containerd/containerd.sock.ttrpc",
+				UID:     500,
+				GID:     500,
+			},
+			Metrics: MetricsConfig{
+				Address:       "127.0.0.1:9090",
+				GRPCHistogram: true,
+			},
+		}
+		err := serviceMigrate(ctx, c)
+		assert.NoError(t, err)
+
+		// Debug plugin
+		debugPlugin := c.Plugins["io.containerd.server.v1.debug"].(map[string]any)
+		assert.Equal(t, "/run/containerd/debug.sock", debugPlugin["address"])
+		assert.Equal(t, 1000, debugPlugin["uid"])
+		assert.Equal(t, 1000, debugPlugin["gid"])
+
+		// GRPC plugin
+		grpcPlugin := c.Plugins["io.containerd.server.v1.grpc"].(map[string]any)
+		assert.Equal(t, "/run/containerd/containerd.sock", grpcPlugin["address"])
+		assert.Equal(t, 0, grpcPlugin["uid"])
+		assert.Equal(t, 0, grpcPlugin["gid"])
+		assert.Equal(t, 32*1024*1024, grpcPlugin["max_recv_message_size"])
+		assert.Equal(t, 32*1024*1024, grpcPlugin["max_send_message_size"])
+
+		// GRPC TCP plugin
+		tcpPlugin := c.Plugins["io.containerd.server.v1.grpc-tcp"].(map[string]any)
+		assert.Equal(t, "127.0.0.1:1234", tcpPlugin["address"])
+		assert.Equal(t, "/etc/ca.pem", tcpPlugin["tls_ca"])
+		assert.Equal(t, "/etc/cert.pem", tcpPlugin["tls_cert"])
+		assert.Equal(t, "/etc/key.pem", tcpPlugin["tls_key"])
+		assert.Equal(t, "containerd", tcpPlugin["tls_common_name"])
+
+		// TTRPC plugin
+		ttrpcPlugin := c.Plugins["io.containerd.server.v1.ttrpc"].(map[string]any)
+		assert.Equal(t, "/run/containerd/containerd.sock.ttrpc", ttrpcPlugin["address"])
+		assert.Equal(t, 500, ttrpcPlugin["uid"])
+		assert.Equal(t, 500, ttrpcPlugin["gid"])
+
+		// Metrics plugin
+		metricsPlugin := c.Plugins["io.containerd.server.v1.metrics"].(map[string]any)
+		assert.Equal(t, "127.0.0.1:9090", metricsPlugin["address"])
+
+		// GRPC prometheus plugin
+		promPlugin := c.Plugins["io.containerd.metrics.v1.grpc-prometheus"].(map[string]any)
+		assert.Equal(t, true, promPlugin["grpc_histogram"])
+
+		// Legacy fields should be cleared
+		assert.Empty(t, c.Debug.Address)
+		assert.Zero(t, c.Debug.UID)
+		assert.Zero(t, c.Debug.GID)
+		assert.Empty(t, c.GRPC.Address)
+		assert.Empty(t, c.GRPC.TCPAddress)
+		assert.Empty(t, c.TTRPC.Address)
+		assert.Empty(t, c.Metrics.Address)
+		assert.False(t, c.Metrics.GRPCHistogram)
+	})
+
+	t.Run("TTRPCDefaultsToGRPC", func(t *testing.T) {
+		c := &Config{
+			GRPC: GRPCConfig{
+				Address: "/run/containerd/containerd.sock",
+				UID:     1000,
+				GID:     1000,
+			},
+		}
+		err := serviceMigrate(ctx, c)
+		assert.NoError(t, err)
+
+		ttrpcPlugin := c.Plugins["io.containerd.server.v1.ttrpc"].(map[string]any)
+		assert.Equal(t, "/run/containerd/containerd.sock.ttrpc", ttrpcPlugin["address"])
+		assert.Equal(t, 1000, ttrpcPlugin["uid"])
+		assert.Equal(t, 1000, ttrpcPlugin["gid"])
+	})
+
+	t.Run("TTRPCExplicitUIDGIDNotOverridden", func(t *testing.T) {
+		c := &Config{
+			GRPC: GRPCConfig{
+				Address: "/run/containerd/containerd.sock",
+				UID:     1000,
+				GID:     1000,
+			},
+			TTRPC: TTRPCConfig{
+				UID: 500,
+				GID: 500,
+			},
+		}
+		err := serviceMigrate(ctx, c)
+		assert.NoError(t, err)
+
+		ttrpcPlugin := c.Plugins["io.containerd.server.v1.ttrpc"].(map[string]any)
+		assert.Equal(t, "/run/containerd/containerd.sock.ttrpc", ttrpcPlugin["address"])
+		assert.Equal(t, 500, ttrpcPlugin["uid"])
+		assert.Equal(t, 500, ttrpcPlugin["gid"])
+	})
+
+	t.Run("ExistingPluginConfigNotOverwritten", func(t *testing.T) {
+		c := &Config{
+			Plugins: map[string]any{
+				"io.containerd.server.v1.grpc": map[string]any{
+					"address": "/custom/path.sock",
+				},
+			},
+			GRPC: GRPCConfig{
+				Address: "/run/containerd/containerd.sock",
+			},
+		}
+		err := serviceMigrate(ctx, c)
+		assert.NoError(t, err)
+
+		// Existing plugin config should be preserved
+		grpcPlugin := c.Plugins["io.containerd.server.v1.grpc"].(map[string]any)
+		assert.Equal(t, "/custom/path.sock", grpcPlugin["address"])
+	})
+
+	t.Run("EmptyConfig", func(t *testing.T) {
+		c := &Config{}
+		err := serviceMigrate(ctx, c)
+		assert.NoError(t, err)
+
+		// No plugins should be created for empty config
+		assert.Nil(t, c.Plugins["io.containerd.server.v1.debug"])
+		assert.Nil(t, c.Plugins["io.containerd.server.v1.grpc"])
+		assert.Nil(t, c.Plugins["io.containerd.server.v1.grpc-tcp"])
+		assert.Nil(t, c.Plugins["io.containerd.server.v1.ttrpc"])
+		assert.Nil(t, c.Plugins["io.containerd.server.v1.metrics"])
+	})
+}
+
+func TestV3MigrateTTRPCDerivedFromGRPC(t *testing.T) {
+	ctx := logtest.WithT(context.Background(), t)
+
+	data := `
+version = 3
+
+[grpc]
+  address = "/custom/containerd.sock"
+  uid = 1000
+  gid = 1000
+`
+	path := filepath.Join(t.TempDir(), "config.toml")
+	err := os.WriteFile(path, []byte(data), 0o600)
+	assert.NoError(t, err)
+
+	var out Config
+	err = LoadConfig(context.Background(), path, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, out.Version)
+
+	err = out.MigrateConfig(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, out.Version)
+
+	// TTRPC plugin should be created with address derived from GRPC
+	ttrpcPlugin := out.Plugins["io.containerd.server.v1.ttrpc"].(map[string]any)
+	assert.Equal(t, "/custom/containerd.sock.ttrpc", ttrpcPlugin["address"])
+	assert.Equal(t, 1000, ttrpcPlugin["uid"])
+	assert.Equal(t, 1000, ttrpcPlugin["gid"])
+
+	// GRPC plugin should have the configured address
+	grpcPlugin := out.Plugins["io.containerd.server.v1.grpc"].(map[string]any)
+	assert.Equal(t, "/custom/containerd.sock", grpcPlugin["address"])
+
+	// Legacy fields should be cleared
+	assert.Empty(t, out.GRPC.Address)
+	assert.Empty(t, out.TTRPC.Address)
+}

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -301,7 +301,7 @@ func TestDecodePluginInV1Config(t *testing.T) {
 
 	err = out.MigrateConfig(ctx)
 	assert.NoError(t, err)
-	assert.Equal(t, 3, out.Version)
+	assert.Equal(t, 4, out.Version)
 
 	pluginConfig := map[string]any{}
 	_, err = out.Decode(ctx, "io.containerd.runtime.v2.task", &pluginConfig)

--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -21,8 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -31,7 +29,6 @@ import (
 	"time"
 
 	"github.com/containerd/log"
-	"github.com/docker/go-metrics"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
@@ -267,17 +264,6 @@ type Server struct {
 	ready   sync.WaitGroup
 }
 
-// ServeMetrics provides a prometheus endpoint for exposing metrics
-func (s *Server) ServeMetrics(l net.Listener) error {
-	m := http.NewServeMux()
-	m.Handle("/v1/metrics", metrics.Handler())
-	srv := &http.Server{
-		Handler:           m,
-		ReadHeaderTimeout: 5 * time.Minute, // "G112: Potential Slowloris Attack (gosec)"; not a real concern for our use, so setting a long timeout.
-	}
-	return trapClosedConnErr(srv.Serve(l))
-}
-
 // Start the services, this will normally start listening on sockets
 // and serving requests.
 func (s *Server) Start(ctx context.Context) error {
@@ -460,11 +446,4 @@ func readString(properties map[string]any, key ...string) string {
 		}
 	}
 	return ""
-}
-
-func trapClosedConnErr(err error) error {
-	if err == nil || errors.Is(err, net.ErrClosed) {
-		return nil
-	}
-	return err
 }

--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -21,12 +21,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"expvar"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"net/http/pprof"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -302,6 +300,15 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 		}
 
 		delete(required, id)
+		if p.Type == plugins.ServerPlugin {
+			srv, ok := instance.(server)
+			if !ok {
+				log.G(ctx).WithField("id", id).Warn("plugin does not implement server interface, will not be started")
+			} else {
+				s.servers = append(s.servers, srv)
+			}
+		}
+
 		// check for grpc services that should be registered with the server
 		if src, ok := instance.(grpcService); ok {
 			grpcServices = append(grpcServices, src)
@@ -367,12 +374,17 @@ func recordConfigDeprecations(ctx context.Context, config *srvconfig.Config, set
 	_ = warn
 }
 
+type server interface {
+	Start(context.Context) error
+}
+
 // Server is the containerd main daemon
 type Server struct {
 	prometheusServerMetrics *grpc_prometheus.ServerMetrics
 	grpcServer              *grpc.Server
 	ttrpcServer             *ttrpc.Server
 	tcpServer               *grpc.Server
+	servers                 []server
 	config                  *srvconfig.Config
 	plugins                 []*plugin.Plugin
 	ready                   sync.WaitGroup
@@ -406,22 +418,15 @@ func (s *Server) ServeTCP(l net.Listener) error {
 	return trapClosedConnErr(s.tcpServer.Serve(l))
 }
 
-// ServeDebug provides a debug endpoint
-func (s *Server) ServeDebug(l net.Listener) error {
-	// don't use the default http server mux to make sure nothing gets registered
-	// that we don't want to expose via containerd
-	m := http.NewServeMux()
-	m.Handle("/debug/vars", expvar.Handler())
-	m.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
-	m.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-	m.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-	m.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-	m.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
-	srv := &http.Server{
-		Handler:           m,
-		ReadHeaderTimeout: 5 * time.Minute, // "G112: Potential Slowloris Attack (gosec)"; not a real concern for our use, so setting a long timeout.
+// Start the services, this will normally start listening on sockets
+// and serving requests.
+func (s *Server) Start(ctx context.Context) error {
+	for _, srv := range s.servers {
+		if err := srv.Start(ctx); err != nil {
+			return err
+		}
 	}
-	return trapClosedConnErr(srv.Serve(l))
+	return nil
 }
 
 // Stop the containerd server canceling any open connections

--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -18,8 +18,6 @@ package server
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
@@ -33,15 +31,11 @@ import (
 	"time"
 
 	"github.com/containerd/log"
-	"github.com/containerd/ttrpc"
 	"github.com/docker/go-metrics"
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
@@ -58,7 +52,6 @@ import (
 	sbproxy "github.com/containerd/containerd/v2/core/sandbox/proxy"
 	ssproxy "github.com/containerd/containerd/v2/core/snapshots/proxy"
 	"github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/containerd/v2/internal/wintls"
 	"github.com/containerd/containerd/v2/pkg/dialer"
 	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/containerd/v2/pkg/timeout"
@@ -146,105 +139,21 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 	for id, p := range config.StreamProcessors {
 		diff.RegisterProcessor(diff.BinaryHandler(id, p.Returns, p.Accepts, p.Path, p.Args, p.Env))
 	}
-
-	var prometheusServerMetricsOpts []grpc_prometheus.ServerMetricsOption
-	if config.Metrics.GRPCHistogram {
-		// Enable grpc time histograms to measure rpc latencies
-		prometheusServerMetricsOpts = append(prometheusServerMetricsOpts, grpc_prometheus.WithServerHandlingTimeHistogram())
-	}
-
-	prometheusServerMetrics := grpc_prometheus.NewServerMetrics(prometheusServerMetricsOpts...)
-	prometheus.MustRegister(prometheusServerMetrics)
-
-	serverOpts := []grpc.ServerOption{
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
-		grpc.ChainStreamInterceptor(
-			streamNamespaceInterceptor,
-			prometheusServerMetrics.StreamServerInterceptor(),
-		),
-		grpc.ChainUnaryInterceptor(
-			unaryNamespaceInterceptor,
-			prometheusServerMetrics.UnaryServerInterceptor(),
-		),
-	}
-	if config.GRPC.MaxRecvMsgSize > 0 {
-		serverOpts = append(serverOpts, grpc.MaxRecvMsgSize(config.GRPC.MaxRecvMsgSize))
-	}
-	if config.GRPC.MaxSendMsgSize > 0 {
-		serverOpts = append(serverOpts, grpc.MaxSendMsgSize(config.GRPC.MaxSendMsgSize))
-	}
-	ttrpcServer, err := newTTRPCServer()
-	if err != nil {
-		return nil, err
-	}
-	tcpServerOpts := serverOpts
-	if config.GRPC.TCPTLSCert != "" {
-		log.G(ctx).Info("setting up tls on tcp GRPC services...")
-
-		tlsCert, err := tls.LoadX509KeyPair(config.GRPC.TCPTLSCert, config.GRPC.TCPTLSKey)
-		if err != nil {
-			return nil, err
-		}
-		tlsConfig := &tls.Config{Certificates: []tls.Certificate{tlsCert}}
-
-		if config.GRPC.TCPTLSCA != "" {
-			caCertPool := x509.NewCertPool()
-			caCert, err := os.ReadFile(config.GRPC.TCPTLSCA)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load CA file: %w", err)
-			}
-			caCertPool.AppendCertsFromPEM(caCert)
-			tlsConfig.ClientCAs = caCertPool
-			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-		}
-		tcpServerOpts = append(tcpServerOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
-	} else if config.GRPC.TCPTLSCName != "" {
-		tlsConfig, CA, res, err :=
-			wintls.SetupTLSFromWindowsCertStore(ctx, config.GRPC.TCPTLSCName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to setup TLS from Windows cert store: %w", err)
-		}
-		// Cache resource for cleanup (Windows only)
-		setTLSResource(res)
-		if CA != nil {
-			tlsConfig.ClientCAs = CA
-			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-		}
-		tcpServerOpts = append(tcpServerOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
-	}
-
-	// grpcService allows GRPC services to be registered with the underlying server
-	type grpcService interface {
-		Register(*grpc.Server) error
-	}
-
-	// tcpService allows GRPC services to be registered with the underlying tcp server
-	type tcpService interface {
-		RegisterTCP(*grpc.Server) error
-	}
-
-	// ttrpcService allows TTRPC services to be registered with the underlying server
-	type ttrpcService interface {
-		RegisterTTRPC(*ttrpc.Server) error
-	}
-
 	var (
-		grpcServer = grpc.NewServer(serverOpts...)
-		tcpServer  = grpc.NewServer(tcpServerOpts...)
-
-		grpcServices  []grpcService
-		tcpServices   []tcpService
-		ttrpcServices []ttrpcService
-		s             = &Server{
-			prometheusServerMetrics: prometheusServerMetrics,
-			grpcServer:              grpcServer,
-			tcpServer:               tcpServer,
-			ttrpcServer:             ttrpcServer,
-			config:                  config,
+		s = &Server{
+			config: config,
 		}
-		initialized = plugin.NewPluginSet()
-		required    = make(map[string]struct{})
+		initialized  = plugin.NewPluginSet()
+		required     = make(map[string]struct{})
+		grpcAddress  = readString(config.Plugins, "io.containerd.server.v1.grpc", "address")
+		ttrpcAddress = readString(config.Plugins, "io.containerd.server.v1.ttrpc", "address")
 	)
+	if grpcAddress == "" {
+		grpcAddress = defaults.DefaultAddress
+	}
+	if ttrpcAddress == "" {
+		ttrpcAddress = defaults.DefaultAddress + ".ttrpc"
+	}
 	for _, r := range config.RequiredPlugins {
 		required[r] = struct{}{}
 	}
@@ -260,8 +169,8 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 			map[string]string{
 				plugins.PropertyRootDir:      filepath.Join(config.Root, id),
 				plugins.PropertyStateDir:     filepath.Join(config.State, id),
-				plugins.PropertyGRPCAddress:  config.GRPC.Address,
-				plugins.PropertyTTRPCAddress: config.TTRPC.Address,
+				plugins.PropertyGRPCAddress:  grpcAddress,
+				plugins.PropertyTTRPCAddress: ttrpcAddress,
 			},
 		)
 		initContext.RegisterReadiness = func() func() {
@@ -309,17 +218,6 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 			}
 		}
 
-		// check for grpc services that should be registered with the server
-		if src, ok := instance.(grpcService); ok {
-			grpcServices = append(grpcServices, src)
-		}
-		if src, ok := instance.(ttrpcService); ok {
-			ttrpcServices = append(ttrpcServices, src)
-		}
-		if service, ok := instance.(tcpService); ok {
-			tcpServices = append(tcpServices, service)
-		}
-
 		s.plugins = append(s.plugins, result)
 	}
 	if len(required) != 0 {
@@ -328,23 +226,6 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 			missing = append(missing, id)
 		}
 		return nil, fmt.Errorf("required plugin %s not included", missing)
-	}
-
-	// register services after all plugins have been initialized
-	for _, service := range grpcServices {
-		if err := service.Register(grpcServer); err != nil {
-			return nil, err
-		}
-	}
-	for _, service := range ttrpcServices {
-		if err := service.RegisterTTRPC(ttrpcServer); err != nil {
-			return nil, err
-		}
-	}
-	for _, service := range tcpServices {
-		if err := service.RegisterTCP(tcpServer); err != nil {
-			return nil, err
-		}
 	}
 
 	recordConfigDeprecations(ctx, config, initialized)
@@ -380,25 +261,10 @@ type server interface {
 
 // Server is the containerd main daemon
 type Server struct {
-	prometheusServerMetrics *grpc_prometheus.ServerMetrics
-	grpcServer              *grpc.Server
-	ttrpcServer             *ttrpc.Server
-	tcpServer               *grpc.Server
-	servers                 []server
-	config                  *srvconfig.Config
-	plugins                 []*plugin.Plugin
-	ready                   sync.WaitGroup
-}
-
-// ServeGRPC provides the containerd grpc APIs on the provided listener
-func (s *Server) ServeGRPC(l net.Listener) error {
-	s.prometheusServerMetrics.InitializeMetrics(s.grpcServer)
-	return trapClosedConnErr(s.grpcServer.Serve(l))
-}
-
-// ServeTTRPC provides the containerd ttrpc APIs on the provided listener
-func (s *Server) ServeTTRPC(l net.Listener) error {
-	return trapClosedConnErr(s.ttrpcServer.Serve(context.Background(), l))
+	servers []server
+	config  *srvconfig.Config
+	plugins []*plugin.Plugin
+	ready   sync.WaitGroup
 }
 
 // ServeMetrics provides a prometheus endpoint for exposing metrics
@@ -410,12 +276,6 @@ func (s *Server) ServeMetrics(l net.Listener) error {
 		ReadHeaderTimeout: 5 * time.Minute, // "G112: Potential Slowloris Attack (gosec)"; not a real concern for our use, so setting a long timeout.
 	}
 	return trapClosedConnErr(srv.Serve(l))
-}
-
-// ServeTCP allows services to serve over tcp
-func (s *Server) ServeTCP(l net.Listener) error {
-	s.prometheusServerMetrics.InitializeMetrics(s.tcpServer)
-	return trapClosedConnErr(s.tcpServer.Serve(l))
 }
 
 // Start the services, this will normally start listening on sockets
@@ -431,9 +291,6 @@ func (s *Server) Start(ctx context.Context) error {
 
 // Stop the containerd server canceling any open connections
 func (s *Server) Stop() {
-	s.grpcServer.Stop()
-	// Clean up TLS resources (Windows only)
-	cleanupTLSResources()
 	for i := len(s.plugins) - 1; i >= 0; i-- {
 		p := s.plugins[i]
 		instance, err := p.Instance()
@@ -578,6 +435,31 @@ func (pc *proxyClients) getClient(address string) (*grpc.ClientConn, error) {
 	pc.clients[address] = conn
 
 	return conn, nil
+}
+
+func readString(properties map[string]any, key ...string) string {
+	for i, k := range key {
+		v, ok := properties[k]
+		if !ok {
+			return ""
+		}
+		if i < len(key)-1 {
+			properties, ok = v.(map[string]any)
+			if !ok {
+				return ""
+			}
+			continue
+		}
+		switch v := v.(type) {
+		case string:
+			return v
+		case fmt.Stringer:
+			return v.String()
+		case []byte:
+			return string(v)
+		}
+	}
+	return ""
 }
 
 func trapClosedConnErr(err error) error {

--- a/cmd/containerd/server/server_linux.go
+++ b/cmd/containerd/server/server_linux.go
@@ -24,11 +24,8 @@ import (
 	cgroup1 "github.com/containerd/cgroups/v3/cgroup1"
 	cgroupsv2 "github.com/containerd/cgroups/v3/cgroup2"
 	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
-	"github.com/containerd/containerd/v2/internal/wintls"
 	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/log"
-	"github.com/containerd/otelttrpc"
-	"github.com/containerd/ttrpc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -66,14 +63,3 @@ func apply(ctx context.Context, config *srvconfig.Config) error {
 	}
 	return nil
 }
-
-func newTTRPCServer() (*ttrpc.Server, error) {
-	return ttrpc.NewServer(
-		ttrpc.WithServerHandshaker(ttrpc.UnixSocketRequireSameUser()),
-		ttrpc.WithUnaryServerInterceptor(otelttrpc.UnaryServerInterceptor()),
-	)
-}
-
-// TLS resource helpers are no-ops on Linux.
-func setTLSResource(r wintls.CertResource) {}
-func cleanupTLSResources()                 {}

--- a/cmd/containerd/server/server_other.go
+++ b/cmd/containerd/server/server_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !windows && !solaris
+//go:build !linux
 
 /*
    Copyright The containerd Authors.
@@ -22,18 +22,8 @@ import (
 	"context"
 
 	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
-	"github.com/containerd/containerd/v2/internal/wintls"
-	"github.com/containerd/ttrpc"
 )
 
 func apply(_ context.Context, _ *srvconfig.Config) error {
 	return nil
 }
-
-func newTTRPCServer() (*ttrpc.Server, error) {
-	return ttrpc.NewServer()
-}
-
-// TLS resource helpers are no-ops on other unsupported platforms.
-func setTLSResource(r wintls.CertResource) {}
-func cleanupTLSResources()                 {}

--- a/contrib/fuzz/daemon.go
+++ b/contrib/fuzz/daemon.go
@@ -24,9 +24,7 @@ import (
 	"github.com/containerd/containerd/v2/cmd/containerd/server"
 	"github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/log"
 )
 
 const (
@@ -71,18 +69,11 @@ func startDaemon() {
 			return
 		}
 
-		l, err := sys.GetLocalListener(srvconfig.GRPC.Address, srvconfig.GRPC.UID, srvconfig.GRPC.GID)
-		if err != nil {
+		defer server.Stop()
+		if err := server.Start(ctx); err != nil {
 			errC <- err
 			return
 		}
-
-		go func() {
-			defer l.Close()
-			if err := server.ServeGRPC(l); err != nil {
-				log.G(ctx).WithError(err).WithField("address", srvconfig.GRPC.Address).Fatal("serve failure")
-			}
-		}()
 
 		server.Wait()
 	}()

--- a/contrib/fuzz/daemon.go
+++ b/contrib/fuzz/daemon.go
@@ -54,10 +54,12 @@ func startDaemon() {
 			Debug: config.Debug{
 				Level: "debug",
 			},
-			GRPC: config.GRPCConfig{
-				Address:        defaultAddress,
-				MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
-				MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
+			Plugins: map[string]any{
+				"io.containerd.server.v1.grpc": map[string]any{
+					"address":               defaultAddress,
+					"max_recv_message_size": defaults.DefaultMaxRecvMsgSize,
+					"max_send_message_size": defaults.DefaultMaxSendMsgSize,
+				},
 			},
 			DisabledPlugins: []string{},
 			RequiredPlugins: []string{},

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -26,8 +26,8 @@ settings.
 **version**
 : The version field in the config file specifies the config’s version. If no
 version number is specified inside the config file then it is assumed to be a
-version 1 config and parsed as such. Please use version = 2 to enable version 2
-config as version 1 has been deprecated.
+version 1 config and parsed as such. Version 4 is the latest config version.
+Older configs are automatically migrated on startup.
 
 **root**
 : The root directory for containerd metadata. (Default: "/var/lib/containerd")
@@ -38,8 +38,11 @@ config as version 1 has been deprecated.
 **plugin_dir**
 : The directory for dynamic plugins to be stored
 
-**[grpc]**
-: Section for gRPC socket listener settings. Contains the following properties:
+**[grpc]** *(deprecated in version 4)*
+: Section for gRPC socket listener settings. In version 4, use the server
+plugins **io.containerd.server.v1.grpc** and **io.containerd.server.v1.grpc-tcp**
+instead. Existing configs are migrated automatically. Contains the following
+properties:
 
 - **address** (Default: "/run/containerd/containerd.sock")
 - **tcp_address**
@@ -50,15 +53,21 @@ config as version 1 has been deprecated.
 - **max_recv_message_size**
 - **max_send_message_size**
 
-**[ttrpc]**
-: Section for TTRPC settings. Contains properties:
+**[ttrpc]** *(deprecated in version 4)*
+: Section for TTRPC settings. In version 4, use the server plugin
+**io.containerd.server.v1.ttrpc** instead. In prior versions, when the TTRPC
+address was not explicitly set it was derived from the GRPC address
+(grpcAddress + ".ttrpc") and inherited GRPC’s UID/GID. In version 4, each
+server plugin is independently configured; the TTRPC plugin uses its own
+defaults when its configuration block is omitted. Contains properties:
 
 - **address** (Default: "")
 - **uid** (Default: 0)
 - **gid** (Default: 0)
 
-**[debug]**
-: Section to enable and configure a debug socket listener. Contains four properties:
+**[debug]** *(deprecated in version 4)*
+: Section to enable and configure a debug socket listener. In version 4, use the
+server plugin **io.containerd.server.v1.debug** instead. Contains properties:
 
 - **address** (Default: "/run/containerd/debug.sock")
 - **uid** (Default: 0)
@@ -67,8 +76,9 @@ config as version 1 has been deprecated.
   "trace", "debug", "info", "warn", "error", "fatal", "panic"
 - **format** (Default: "text") sets log format. Supported formats are "text" and "json"
 
-**[metrics]**
-: Section to enable and configure a metrics listener. Contains two properties:
+**[metrics]** *(deprecated in version 4)*
+: Section to enable and configure a metrics listener. In version 4, use the
+server plugin **io.containerd.server.v1.metrics** instead. Contains properties:
 
 - **address** (Default: "") Metrics endpoint does not listen by default
 - **grpc_histogram** (Default: false) Turn on or off gRPC histogram metrics
@@ -87,6 +97,33 @@ The following plugins are enabled by default and their settings are shown below.
 Plugins that are not enabled by default will provide their own configuration values
 documentation.
 
+- **[plugins."io.containerd.server.v1.grpc"]** configures the main gRPC server listener (version 4):
+  - **address** (Default: "/run/containerd/containerd.sock")
+  - **uid** (Default: effective UID)
+  - **gid** (Default: effective GID)
+  - **max_recv_message_size** (Default: 16777216)
+  - **max_send_message_size** (Default: 16777216)
+- **[plugins."io.containerd.server.v1.grpc-tcp"]** configures the TCP gRPC server listener (version 4).
+  Skipped if address is empty:
+  - **address** (Default: "")
+  - **tls_cert**, **tls_key**, **tls_ca**, **tls_common_name**
+  - **max_recv_message_size** (Default: 16777216)
+  - **max_send_message_size** (Default: 16777216)
+- **[plugins."io.containerd.server.v1.ttrpc"]** configures the TTRPC server listener (version 4).
+  In version 4, this plugin is configured independently from the gRPC plugin.
+  If the plugin block is omitted, the TTRPC server binds to its own default
+  address rather than deriving one from the gRPC address:
+  - **address** (Default: "/run/containerd/containerd.sock.ttrpc")
+  - **uid** (Default: effective UID)
+  - **gid** (Default: effective GID)
+- **[plugins."io.containerd.server.v1.debug"]** configures the debug server listener (version 4).
+  Skipped if address is empty:
+  - **address** (Default: "")
+  - **uid** (Default: 0)
+  - **gid** (Default: 0)
+- **[plugins."io.containerd.server.v1.metrics"]** configures the metrics HTTP listener (version 4).
+  Skipped if address is empty:
+  - **address** (Default: "")
 - **[plugins."io.containerd.monitor.v1.cgroups"]** has one option __no_prometheus__ (Default: **false**)
 - **[plugins."io.containerd.service.v1.diff-service"]** has one option __default__, a list by default set to **["walking"]**
 - **[plugins."io.containerd.gc.v1.scheduler"]** has several options that perform advanced tuning for the scheduler:
@@ -162,32 +199,28 @@ the main config.
 
 ## EXAMPLES
 
-### Complete Configuration
+### Version 4 Configuration
 
-The following is a complete **config.toml** default configuration example:
+The following is a **config.toml** example using version 4, where server
+settings are configured as plugins:
 
 ```toml
-version = 2
+version = 4
 
 root = "/var/lib/containerd"
 state = "/run/containerd"
 oom_score = 0
 imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
 
-[grpc]
+[plugins."io.containerd.server.v1.grpc"]
   address = "/run/containerd/containerd.sock"
-  uid = 0
-  gid = 0
 
-[debug]
+[plugins."io.containerd.server.v1.ttrpc"]
+  address = "/run/containerd/containerd.sock.ttrpc"
+
+[plugins."io.containerd.server.v1.debug"]
   address = "/run/containerd/debug.sock"
-  uid = 0
-  gid = 0
   level = "info"
-
-[metrics]
-  address = ""
-  grpc_histogram = false
 
 [cgroup]
   path = ""

--- a/integration/client/restart_monitor_test.go
+++ b/integration/client/restart_monitor_test.go
@@ -63,7 +63,10 @@ func newDaemonWithConfig(t *testing.T, configTOML string) (*Client, *daemon, fun
 		t.Fatal(err)
 	}
 
-	address := configTOMLDecoded.GRPC.Address
+	var address string
+	if grpcPlugin, ok := configTOMLDecoded.Plugins["io.containerd.server.v1.grpc"].(map[string]any); ok {
+		address, _ = grpcPlugin["address"].(string)
+	}
 	if address == "" {
 		if runtime.GOOS == "windows" {
 			address = fmt.Sprintf(`\\.\pipe\containerd-containerd-test-%s`, filepath.Base(tempDir))

--- a/plugins/server/debug/plugin.go
+++ b/plugins/server/debug/plugin.go
@@ -1,0 +1,102 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/pkg/sys"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/server/internal"
+
+	// Also register the internal pprof plugin, this can be separated
+	// if pprof moves out of internal
+	_ "github.com/containerd/containerd/v2/internal/pprof"
+)
+
+type config struct {
+	Address string `toml:"address"`
+	UID     int    `toml:"uid"`
+	GID     int    `toml:"gid"`
+}
+
+func init() {
+	registry.Register(&plugin.Registration{
+		Type: plugins.ServerPlugin,
+		ID:   "debug",
+		Requires: []plugin.Type{
+			plugins.HTTPHandler,
+		},
+		Config: &config{},
+		InitFn: func(ic *plugin.InitContext) (any, error) {
+			c := ic.Config.(*config)
+			if c.Address == "" {
+				return nil, plugin.ErrSkipPlugin
+			}
+
+			p, err := ic.GetByID(plugins.HTTPHandler, "pprof")
+			if err != nil {
+				if errors.Is(err, plugin.ErrPluginNotFound) {
+					log.G(ic.Context).Warn("debug server is specified but pprof plugin not found, skipping debug server")
+					return nil, plugin.ErrSkipPlugin
+				}
+				return nil, err
+			}
+
+			return server{
+				handler: p.(*http.Server),
+				config:  *c,
+			}, nil
+		},
+	})
+}
+
+type server struct {
+	handler *http.Server
+	config  config
+}
+
+func (s server) Start(ctx context.Context) error {
+	var (
+		l   net.Listener
+		err error
+	)
+	if internal.IsLocalAddress(s.config.Address) {
+		if l, err = sys.GetLocalListener(s.config.Address, s.config.UID, s.config.GID); err != nil {
+			return fmt.Errorf("failed to get listener for debug endpoint: %w", err)
+		}
+	} else {
+		if l, err = net.Listen("tcp", s.config.Address); err != nil {
+			return fmt.Errorf("failed to get listener for debug endpoint: %w", err)
+		}
+	}
+	internal.Serve(ctx, l, s.handler.Serve)
+
+	return nil
+}
+
+func (s server) Close() error {
+	return s.handler.Close()
+}

--- a/plugins/server/grpc/metrics.go
+++ b/plugins/server/grpc/metrics.go
@@ -1,0 +1,67 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package grpc
+
+import (
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+
+	"github.com/containerd/containerd/v2/plugins"
+)
+
+type metricsConfig struct {
+	GRPCHistogram bool `toml:"grpc_histogram"`
+}
+
+func init() {
+	registry.Register(&plugin.Registration{
+		Type: plugins.MetricsPlugin,
+		ID:   "grpc-prometheus",
+		Requires: []plugin.Type{
+			plugins.GRPCPlugin,
+		},
+		Config: &metricsConfig{
+			GRPCHistogram: false,
+		},
+		InitFn: func(ic *plugin.InitContext) (any, error) {
+			c := ic.Config.(*metricsConfig)
+			var prometheusServerMetricsOpts []grpc_prometheus.ServerMetricsOption
+			if c.GRPCHistogram {
+				// Enable grpc time histograms to measure rpc latencies
+				prometheusServerMetricsOpts = append(prometheusServerMetricsOpts, grpc_prometheus.WithServerHandlingTimeHistogram())
+			}
+
+			prometheusServerMetrics := grpc_prometheus.NewServerMetrics(prometheusServerMetricsOpts...)
+			prometheus.MustRegister(prometheusServerMetrics)
+
+			return prometheusServerMetrics, nil
+		},
+	})
+	registry.Register(&plugin.Registration{
+		Type: plugins.MetricsPlugin,
+		ID:   "grpc-otel",
+		Requires: []plugin.Type{
+			plugins.GRPCPlugin,
+		},
+		InitFn: func(ic *plugin.InitContext) (any, error) {
+			return otelgrpc.NewServerHandler(), nil
+		},
+	})
+}

--- a/plugins/server/grpc/namespace.go
+++ b/plugins/server/grpc/namespace.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package server
+package grpc
 
 import (
 	"context"

--- a/plugins/server/grpc/plugin.go
+++ b/plugins/server/grpc/plugin.go
@@ -159,7 +159,6 @@ func init() {
 				prometheusServerMetrics = p.(*grpc_prometheus.ServerMetrics)
 				streamOpts = append(streamOpts, prometheusServerMetrics.StreamServerInterceptor())
 				unaryOpts = append(unaryOpts, prometheusServerMetrics.UnaryServerInterceptor())
-				prometheusServerMetrics.InitializeMetrics(nil)
 			}
 
 			if p, err := ic.GetByID(plugins.MetricsPlugin, "grpc-otel"); err == nil {

--- a/plugins/server/grpc/plugin.go
+++ b/plugins/server/grpc/plugin.go
@@ -69,6 +69,8 @@ func init() {
 		},
 		Config: &config{
 			Address:        defaults.DefaultAddress,
+			UID:            os.Geteuid(),
+			GID:            os.Getegid(),
 			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
 			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
 		},

--- a/plugins/server/grpc/plugin.go
+++ b/plugins/server/grpc/plugin.go
@@ -1,0 +1,292 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/stats"
+
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/containerd/v2/internal/wintls"
+	"github.com/containerd/containerd/v2/pkg/sys"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/server/internal"
+)
+
+type config struct {
+	Address        string `toml:"address"`
+	UID            int    `toml:"uid"`
+	GID            int    `toml:"gid"`
+	MaxRecvMsgSize int    `toml:"max_recv_message_size"`
+	MaxSendMsgSize int    `toml:"max_send_message_size"`
+}
+
+type tcpConfig struct {
+	Address        string `toml:"address"`
+	TLSCA          string `toml:"tls_ca"`
+	TLSCert        string `toml:"tls_cert"`
+	TLSKey         string `toml:"tls_key"`
+	TLSCName       string `toml:"tls_common_name"`
+	MaxRecvMsgSize int    `toml:"max_recv_message_size"`
+	MaxSendMsgSize int    `toml:"max_send_message_size"`
+}
+
+func init() {
+	registry.Register(&plugin.Registration{
+		Type: plugins.ServerPlugin,
+		ID:   "grpc",
+		Requires: []plugin.Type{
+			plugins.GRPCPlugin,
+			plugins.MetricsPlugin,
+		},
+		Config: &config{
+			Address:        defaults.DefaultAddress,
+			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
+			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
+		},
+		InitFn: func(ic *plugin.InitContext) (any, error) {
+			c := ic.Config.(*config)
+			if c.Address == "" {
+				return nil, fmt.Errorf("grpc address cannot be empty: %w", errdefs.ErrInvalidArgument)
+			}
+
+			var (
+				streamOpts              = []grpc.StreamServerInterceptor{streamNamespaceInterceptor}
+				unaryOpts               = []grpc.UnaryServerInterceptor{unaryNamespaceInterceptor}
+				serverOpts              = []grpc.ServerOption{}
+				prometheusServerMetrics *grpc_prometheus.ServerMetrics // This should be grpc handler
+			)
+
+			if p, err := ic.GetByID(plugins.MetricsPlugin, "grpc-prometheus"); err == nil {
+				prometheusServerMetrics = p.(*grpc_prometheus.ServerMetrics)
+				streamOpts = append(streamOpts, prometheusServerMetrics.StreamServerInterceptor())
+				unaryOpts = append(unaryOpts, prometheusServerMetrics.UnaryServerInterceptor())
+			}
+
+			if p, err := ic.GetByID(plugins.MetricsPlugin, "grpc-otel"); err == nil {
+				serverOpts = append(serverOpts, grpc.StatsHandler(p.(stats.Handler)))
+			}
+
+			serverOpts = append(serverOpts, grpc.ChainStreamInterceptor(streamOpts...))
+			serverOpts = append(serverOpts, grpc.ChainUnaryInterceptor(unaryOpts...))
+			if c.MaxRecvMsgSize > 0 {
+				serverOpts = append(serverOpts, grpc.MaxRecvMsgSize(c.MaxRecvMsgSize))
+			}
+			if c.MaxSendMsgSize > 0 {
+				serverOpts = append(serverOpts, grpc.MaxSendMsgSize(c.MaxSendMsgSize))
+			}
+
+			// grpcService allows GRPC services to be registered with the underlying server
+			type grpcService interface {
+				Register(*grpc.Server) error
+			}
+
+			s := grpc.NewServer(serverOpts...)
+			ps, err := ic.GetByType(plugins.GRPCPlugin) // ensure grpc plugin is initialized
+			if err != nil && !errors.Is(err, plugin.ErrPluginNotFound) {
+				return nil, err
+			}
+			for _, p := range ps {
+				if gs, ok := p.(grpcService); ok {
+					if err := gs.Register(s); err != nil {
+						return nil, fmt.Errorf("failed to register grpc service: %w", err)
+					}
+				}
+			}
+			if prometheusServerMetrics != nil {
+				prometheusServerMetrics.InitializeMetrics(s)
+			}
+			return grpcServer{
+				Server: s,
+				config: *c,
+			}, nil
+		},
+	})
+
+	registry.Register(&plugin.Registration{
+		Type: plugins.ServerPlugin,
+		ID:   "grpc-tcp",
+		Requires: []plugin.Type{
+			plugins.GRPCPlugin,
+			plugins.MetricsPlugin,
+		},
+		Config: &tcpConfig{
+			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
+			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
+		},
+		InitFn: func(ic *plugin.InitContext) (any, error) {
+			c := ic.Config.(*tcpConfig)
+			if c.Address == "" {
+				return nil, plugin.ErrSkipPlugin
+			}
+
+			var (
+				streamOpts              = []grpc.StreamServerInterceptor{streamNamespaceInterceptor}
+				unaryOpts               = []grpc.UnaryServerInterceptor{unaryNamespaceInterceptor}
+				serverOpts              = []grpc.ServerOption{}
+				prometheusServerMetrics *grpc_prometheus.ServerMetrics // This should be grpc handler
+			)
+
+			if p, err := ic.GetByID(plugins.MetricsPlugin, "grpc-prometheus"); err == nil {
+				prometheusServerMetrics = p.(*grpc_prometheus.ServerMetrics)
+				streamOpts = append(streamOpts, prometheusServerMetrics.StreamServerInterceptor())
+				unaryOpts = append(unaryOpts, prometheusServerMetrics.UnaryServerInterceptor())
+				prometheusServerMetrics.InitializeMetrics(nil)
+			}
+
+			if p, err := ic.GetByID(plugins.MetricsPlugin, "grpc-otel"); err == nil {
+				serverOpts = append(serverOpts, grpc.StatsHandler(p.(stats.Handler)))
+			}
+
+			serverOpts = append(serverOpts, grpc.ChainStreamInterceptor(streamOpts...))
+			serverOpts = append(serverOpts, grpc.ChainUnaryInterceptor(unaryOpts...))
+
+			if c.MaxRecvMsgSize > 0 {
+				serverOpts = append(serverOpts, grpc.MaxRecvMsgSize(c.MaxRecvMsgSize))
+			}
+			if c.MaxSendMsgSize > 0 {
+				serverOpts = append(serverOpts, grpc.MaxSendMsgSize(c.MaxSendMsgSize))
+			}
+
+			if c.TLSCert != "" {
+				log.G(ic.Context).Info("setting up tls on tcp GRPC services...")
+
+				tlsCert, err := tls.LoadX509KeyPair(c.TLSCert, c.TLSKey)
+				if err != nil {
+					return nil, err
+				}
+				tlsConfig := &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+
+				if c.TLSCA != "" {
+					caCertPool := x509.NewCertPool()
+					caCert, err := os.ReadFile(c.TLSCA)
+					if err != nil {
+						return nil, fmt.Errorf("failed to load CA file: %w", err)
+					}
+					caCertPool.AppendCertsFromPEM(caCert)
+					tlsConfig.ClientCAs = caCertPool
+					tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+				}
+				serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
+			} else if c.TLSCName != "" {
+				tlsConfig, CA, res, err :=
+					wintls.SetupTLSFromWindowsCertStore(ic.Context, c.TLSCName)
+				if err != nil {
+					return nil, fmt.Errorf("failed to setup TLS from Windows cert store: %w", err)
+				}
+				// Cache resource for cleanup (Windows only)
+				setTLSResource(res)
+				if CA != nil {
+					tlsConfig.ClientCAs = CA
+					tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+				}
+				serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
+			}
+
+			// tcpService allows GRPC services to be registered with the underlying tcp server
+			type tcpService interface {
+				RegisterTCP(*grpc.Server) error
+			}
+
+			s := grpc.NewServer(serverOpts...)
+			ps, err := ic.GetByType(plugins.GRPCPlugin) // ensure grpc plugin is initialized
+			if err != nil && !errors.Is(err, plugin.ErrPluginNotFound) {
+				return nil, err
+			}
+			var hasService bool
+			for _, p := range ps {
+				if gs, ok := p.(tcpService); ok {
+					if err := gs.RegisterTCP(s); err != nil {
+						return nil, fmt.Errorf("failed to register grpc service: %w", err)
+					}
+					hasService = true
+				}
+			}
+			if !hasService {
+				return nil, fmt.Errorf("no tcp grpc services configured: %w", plugin.ErrSkipPlugin)
+			}
+			if prometheusServerMetrics != nil {
+				prometheusServerMetrics.InitializeMetrics(s)
+			}
+			return tcpServer{
+				Server: s,
+				config: *c,
+			}, nil
+		},
+	})
+}
+
+type grpcServer struct {
+	*grpc.Server
+	config config
+}
+
+func (s grpcServer) Start(ctx context.Context) error {
+	log.G(ctx).WithField("address", s.config.Address).WithField("uid", s.config.UID).WithField("gid", s.config.GID).Info("starting GRPC server")
+	l, err := sys.GetLocalListener(s.config.Address, s.config.UID, s.config.GID)
+	if err != nil {
+		return fmt.Errorf("failed to get listener for main endpoint: %w", err)
+	}
+
+	internal.Serve(ctx, l, s.Serve)
+
+	return nil
+}
+func (s grpcServer) Close() error {
+	s.Stop()
+
+	return nil
+}
+
+type tcpServer struct {
+	*grpc.Server
+	config tcpConfig
+}
+
+func (s tcpServer) Start(ctx context.Context) error {
+	l, err := net.Listen("tcp", s.config.Address)
+	if err != nil {
+		return fmt.Errorf("failed to get listener for TCP grpc endpoint: %w", err)
+	}
+
+	internal.Serve(ctx, l, s.Serve)
+
+	return nil
+}
+
+func (s tcpServer) Close() error {
+	s.Stop()
+
+	// Clean up TLS resources (Windows only)
+	cleanupTLSResources()
+
+	return nil
+}

--- a/plugins/server/grpc/tls_other.go
+++ b/plugins/server/grpc/tls_other.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /*
    Copyright The containerd Authors.
 
@@ -14,28 +16,13 @@
    limitations under the License.
 */
 
-package server
+package grpc
 
 import (
-	"context"
-
-	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/containerd/v2/internal/wintls"
-	"github.com/containerd/otelttrpc"
-	"github.com/containerd/ttrpc"
 )
 
-func apply(_ context.Context, _ *srvconfig.Config) error {
-	return nil
-}
-
-// TLS resource helpers are no-ops on Solaris.
+// TLS resource helpers are no-ops on other unsupported platforms.
 func setTLSResource(r wintls.CertResource) {}
-func cleanupTLSResources()                 {}
 
-// newTTRPCServer provides the ttrpc server for Solaris builds.
-func newTTRPCServer() (*ttrpc.Server, error) {
-	return ttrpc.NewServer(
-		ttrpc.WithUnaryServerInterceptor(otelttrpc.UnaryServerInterceptor()),
-	)
-}
+func cleanupTLSResources() {}

--- a/plugins/server/grpc/tls_windows.go
+++ b/plugins/server/grpc/tls_windows.go
@@ -14,16 +14,11 @@
    limitations under the License.
 */
 
-package server
+package grpc
 
 import (
-	"context"
-
-	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/containerd/v2/internal/wintls"
 	"github.com/containerd/log"
-	"github.com/containerd/otelttrpc"
-	"github.com/containerd/ttrpc"
 )
 
 // tlsResource holds Windows-specific TLS resources for cleanup on Stop.
@@ -40,15 +35,4 @@ func cleanupTLSResources() {
 		}
 		tlsResource = nil
 	}
-}
-
-// Windows-specific apply and TTRPC server constructor
-func apply(_ context.Context, _ *srvconfig.Config) error {
-	return nil
-}
-
-func newTTRPCServer() (*ttrpc.Server, error) {
-	return ttrpc.NewServer(
-		ttrpc.WithUnaryServerInterceptor(otelttrpc.UnaryServerInterceptor()),
-	)
 }

--- a/plugins/server/internal/listen_unix.go
+++ b/plugins/server/internal/listen_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import "path/filepath"
+
+func IsLocalAddress(path string) bool {
+	return filepath.IsAbs(path)
+}

--- a/plugins/server/internal/listen_windows.go
+++ b/plugins/server/internal/listen_windows.go
@@ -1,0 +1,23 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import "strings"
+
+func IsLocalAddress(path string) bool {
+	return strings.HasPrefix(path, `\\.\pipe\`)
+}

--- a/plugins/server/internal/serve.go
+++ b/plugins/server/internal/serve.go
@@ -1,0 +1,37 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/containerd/log"
+)
+
+func Serve(ctx context.Context, l net.Listener, serveFunc func(net.Listener) error) {
+	path := l.Addr().String()
+	log.G(ctx).WithField("address", path).Info("serving...")
+	go func() {
+		defer l.Close()
+
+		if err := serveFunc(l); err != nil && !errors.Is(err, net.ErrClosed) {
+			log.G(ctx).WithError(err).WithField("address", path).Fatal("serve failure")
+		}
+	}()
+}

--- a/plugins/server/metrics/plugin.go
+++ b/plugins/server/metrics/plugin.go
@@ -1,0 +1,85 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	"github.com/docker/go-metrics"
+
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/server/internal"
+)
+
+type config struct {
+	Address string `toml:"address"`
+}
+
+func init() {
+	registry.Register(&plugin.Registration{
+		Type:   plugins.ServerPlugin,
+		ID:     "metrics",
+		Config: &config{},
+		InitFn: func(ic *plugin.InitContext) (any, error) {
+			c := ic.Config.(*config)
+			if c.Address == "" {
+				return nil, plugin.ErrSkipPlugin
+			}
+
+			m := http.NewServeMux()
+			m.Handle("/v1/metrics", metrics.Handler())
+
+			return &server{
+				handler: m,
+				address: c.Address,
+			}, nil
+		},
+	})
+}
+
+type server struct {
+	handler http.Handler
+	address string
+	srv     *http.Server
+}
+
+func (s *server) Start(ctx context.Context) error {
+	l, err := net.Listen("tcp", s.address)
+	if err != nil {
+		return fmt.Errorf("failed to get listener for metrics endpoint: %w", err)
+	}
+	s.srv = &http.Server{
+		Handler:           s.handler,
+		ReadHeaderTimeout: 5 * time.Minute, // "G112: Potential Slowloris Attack (gosec)"; not a real concern for our use, so setting a long timeout.
+	}
+	internal.Serve(ctx, l, s.srv.Serve)
+
+	return nil
+}
+
+func (s *server) Close() error {
+	if s.srv == nil {
+		return nil
+	}
+	return s.srv.Close()
+}

--- a/plugins/server/ttrpc/plugin.go
+++ b/plugins/server/ttrpc/plugin.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/sys"
@@ -57,6 +58,8 @@ func init() {
 		},
 		Config: &config{
 			Address: defaultAddress,
+			UID:     os.Geteuid(),
+			GID:     os.Getegid(),
 		},
 		InitFn: func(ic *plugin.InitContext) (any, error) {
 			c := ic.Config.(*config)

--- a/plugins/server/ttrpc/plugin.go
+++ b/plugins/server/ttrpc/plugin.go
@@ -1,0 +1,128 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ttrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/containerd/v2/pkg/sys"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/server/internal"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	"github.com/containerd/ttrpc"
+)
+
+type config struct {
+	Address string `toml:"address"`
+	UID     int    `toml:"uid"`
+	GID     int    `toml:"gid"`
+}
+
+func (c *config) GetAddress() string {
+	return c.Address
+}
+
+func (c *config) SetAddress(s string) {
+	c.Address = s
+}
+
+func init() {
+	// Keep the default the same for compatibility
+	defaultAddress := defaults.DefaultAddress + ".ttrpc"
+	registry.Register(&plugin.Registration{
+		Type: plugins.ServerPlugin,
+		ID:   "ttrpc",
+		Requires: []plugin.Type{
+			plugins.TTRPCPlugin,
+			plugins.GRPCPlugin,
+		},
+		Config: &config{
+			Address: defaultAddress,
+		},
+		InitFn: func(ic *plugin.InitContext) (any, error) {
+			c := ic.Config.(*config)
+			if c.Address == "" {
+				return nil, plugin.ErrSkipPlugin
+			}
+
+			s, err := newTTRPCServer()
+			if err != nil {
+				return nil, err
+			}
+			// ttrpcService allows TTRPC services to be registered with the underlying server
+			type ttrpcService interface {
+				RegisterTTRPC(*ttrpc.Server) error
+			}
+			var hasService bool
+			ps, err := ic.GetByType(plugins.TTRPCPlugin) // ensure grpc plugin is initialized
+			if err != nil && !errors.Is(err, plugin.ErrPluginNotFound) {
+				return nil, err
+			}
+			for _, p := range ps {
+				if gs, ok := p.(ttrpcService); ok {
+					if err := gs.RegisterTTRPC(s); err != nil {
+						return nil, fmt.Errorf("failed to register ttrpc service: %w", err)
+					}
+					hasService = true
+				}
+			}
+			ps, err = ic.GetByType(plugins.GRPCPlugin) // ensure grpc plugin is initialized
+			if err != nil && !errors.Is(err, plugin.ErrPluginNotFound) {
+				return nil, err
+			}
+			for _, p := range ps {
+				if gs, ok := p.(ttrpcService); ok {
+					if err := gs.RegisterTTRPC(s); err != nil {
+						return nil, fmt.Errorf("failed to register ttrpc service: %w", err)
+					}
+					hasService = true
+				}
+			}
+			if !hasService {
+				return nil, fmt.Errorf("no ttrpc services configured: %w", plugin.ErrSkipPlugin)
+			}
+			return server{
+				Server: s,
+				config: *c,
+			}, nil
+		},
+	})
+}
+
+type server struct {
+	*ttrpc.Server
+	config config
+}
+
+func (s server) Start(ctx context.Context) error {
+	// setup the ttrpc endpoint
+	tl, err := sys.GetLocalListener(s.config.Address, s.config.UID, s.config.GID)
+	if err != nil {
+		return fmt.Errorf("failed to get listener for main ttrpc endpoint: %w", err)
+	}
+
+	internal.Serve(ctx, tl, func(l net.Listener) error {
+		return s.Serve(context.WithoutCancel(ctx), l)
+	})
+
+	return nil
+}

--- a/plugins/server/ttrpc/server_otel.go
+++ b/plugins/server/ttrpc/server_otel.go
@@ -1,3 +1,5 @@
+//go:build windows || solaris
+
 /*
    Copyright The containerd Authors.
 
@@ -14,26 +16,16 @@
    limitations under the License.
 */
 
-package internal
+package ttrpc
 
 import (
-	"context"
-	"errors"
-	"net"
-	"net/http"
-
-	"github.com/containerd/log"
+	"github.com/containerd/otelttrpc"
 	"github.com/containerd/ttrpc"
 )
 
-func Serve(ctx context.Context, l net.Listener, serveFunc func(net.Listener) error) {
-	path := l.Addr().String()
-	log.G(ctx).WithField("address", path).Info("serving...")
-	go func() {
-		defer l.Close()
-
-		if err := serveFunc(l); err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, ttrpc.ErrServerClosed) {
-			log.G(ctx).WithError(err).WithField("address", path).Fatal("serve failure")
-		}
-	}()
+// ttrpc server with otel interceptor
+func newTTRPCServer() (*ttrpc.Server, error) {
+	return ttrpc.NewServer(
+		ttrpc.WithUnaryServerInterceptor(otelttrpc.UnaryServerInterceptor()),
+	)
 }

--- a/plugins/server/ttrpc/server_other.go
+++ b/plugins/server/ttrpc/server_other.go
@@ -1,3 +1,5 @@
+//go:build !linux && !windows && !solaris
+
 /*
    Copyright The containerd Authors.
 
@@ -14,26 +16,12 @@
    limitations under the License.
 */
 
-package internal
+package ttrpc
 
 import (
-	"context"
-	"errors"
-	"net"
-	"net/http"
-
-	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
 )
 
-func Serve(ctx context.Context, l net.Listener, serveFunc func(net.Listener) error) {
-	path := l.Addr().String()
-	log.G(ctx).WithField("address", path).Info("serving...")
-	go func() {
-		defer l.Close()
-
-		if err := serveFunc(l); err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, ttrpc.ErrServerClosed) {
-			log.G(ctx).WithError(err).WithField("address", path).Fatal("serve failure")
-		}
-	}()
+func newTTRPCServer() (*ttrpc.Server, error) {
+	return ttrpc.NewServer()
 }

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -57,6 +57,8 @@ const (
 	StreamingPlugin plugin.Type = "io.containerd.streaming.v1"
 	// TracingProcessorPlugin implements an open telemetry span processor
 	TracingProcessorPlugin plugin.Type = "io.containerd.tracing.processor.v1"
+	// MetricsPlugin implements a metrics handler
+	MetricsPlugin plugin.Type = "io.containerd.metrics.v1"
 	// NRIApiPlugin implements the NRI adaptation interface for containerd.
 	NRIApiPlugin plugin.Type = "io.containerd.nri.v1"
 	// TransferPlugin implements a transfer service

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -77,6 +77,8 @@ const (
 	ShimPlugin plugin.Type = "io.containerd.shim.v1"
 	// HTTPHandler implements an http handler
 	HTTPHandler plugin.Type = "io.containerd.http.v1"
+	// ServerPlugin implements a server that starts with the main process, e.g. API listeners
+	ServerPlugin plugin.Type = "io.containerd.server.v1"
 	// MountManagerPlugin implements the mount manager interface
 	MountManagerPlugin plugin.Type = "io.containerd.mount-manager.v1"
 	// MountHandlerPlugin implements the mount handler interface

--- a/version/version.go
+++ b/version/version.go
@@ -38,4 +38,4 @@ var (
 // This version is used by the main configuration as well as all plugins.
 // Any configuration less than this version which has structural changes
 // should migrate the configuration structures used by this version.
-const ConfigVersion = 3
+const ConfigVersion = 4


### PR DESCRIPTION
Add new plugin types for server listeners and metrics (which are used by the servers).
- Simplifies server startup
- Relies on plugin lifecycle for all long running processes
- Allows extending containerd's set of listeners and their dependencies
- Separates the server configuration based on the listeners