### PR TITLE
feat: Add support for time namespaces

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -505,7 +505,8 @@ func validNamespace(ns string) bool {
 		specs.MountNamespace,
 		specs.UserNamespace,
 		specs.IPCNamespace,
-		specs.CgroupNamespace:
+		specs.CgroupNamespace,
+		specs.TimeNamespace:
 		return true
 	default:
 		return false

--- a/internal/cri/opts/spec_opts.go
+++ b/internal/cri/opts/spec_opts.go
@@ -353,6 +353,7 @@ func WithPodNamespaces(config *runtime.LinuxContainerSecurityContext, sandboxPid
 		oci.WithLinuxNamespace(runtimespec.LinuxNamespace{Type: runtimespec.NetworkNamespace, Path: GetNetworkNamespace(sandboxPid)}),
 		oci.WithLinuxNamespace(runtimespec.LinuxNamespace{Type: runtimespec.IPCNamespace, Path: GetIPCNamespace(sandboxPid)}),
 		oci.WithLinuxNamespace(runtimespec.LinuxNamespace{Type: runtimespec.UTSNamespace, Path: GetUTSNamespace(sandboxPid)}),
+		oci.WithLinuxNamespace(runtimespec.LinuxNamespace{Type: runtimespec.TimeNamespace, Path: GetTimeNamespace(sandboxPid)}),
 	}
 	if namespaces.GetPid() != runtime.NamespaceMode_CONTAINER {
 		opts = append(opts, oci.WithLinuxNamespace(runtimespec.LinuxNamespace{Type: runtimespec.PIDNamespace, Path: GetPIDNamespace(targetPid)}))
@@ -382,6 +383,8 @@ const (
 	pidNSFormat = "/proc/%v/ns/pid"
 	// userNSFormat is the format of user namespace of a process.
 	userNSFormat = "/proc/%v/ns/user"
+	// timeNSFormat is the format of time namespace of a process.
+	timeNSFormat = "/proc/%v/ns/time"
 )
 
 // GetNetworkNamespace returns the network namespace of a process.
@@ -407,4 +410,9 @@ func GetPIDNamespace(pid uint32) string {
 // GetUserNamespace returns the user namespace of a process.
 func GetUserNamespace(pid uint32) string {
 	return fmt.Sprintf(userNSFormat, pid)
+}
+
+// GetTimeNamespace returns the time namespace of a process.
+func GetTimeNamespace(pid uint32) string {
+	return fmt.Sprintf(timeNSFormat, pid)
 }

--- a/internal/cri/server/container_create_linux_test.go
+++ b/internal/cri/server/container_create_linux_test.go
@@ -167,6 +167,10 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 			Type: runtimespec.PIDNamespace,
 			Path: opts.GetPIDNamespace(sandboxPid),
 		})
+		assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
+			Type: runtimespec.TimeNamespace,
+			Path: opts.GetTimeNamespace(sandboxPid),
+		})
 
 		t.Logf("Check PodSandbox annotations")
 		assert.Contains(t, spec.Annotations, annotations.SandboxID)

--- a/internal/cri/server/podsandbox/sandbox_run_linux_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux_test.go
@@ -165,6 +165,9 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
 					Type: runtimespec.IPCNamespace,
 				})
+				assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
+					Type: runtimespec.TimeNamespace,
+				})
 				assert.Contains(t, spec.Linux.Sysctl["net.ipv4.ip_unprivileged_port_start"], "0")
 				if !userns.RunningInUserNS() {
 					assert.Contains(t, spec.Linux.Sysctl["net.ipv4.ping_group_range"], "0 2147483647")

--- a/pkg/oci/spec.go
+++ b/pkg/oci/spec.go
@@ -151,6 +151,9 @@ func defaultUnixNamespaces() []specs.LinuxNamespace {
 		{
 			Type: specs.NetworkNamespace,
 		},
+		{
+			Type: specs.TimeNamespace,
+		},
 	}
 }
 


### PR DESCRIPTION
### What type of PR is this?
/kind feature

### What this PR does / why we need it:
This PR adds support for Linux time namespaces to containerd. Time namespaces  allow containers to have their own view of system clocks (CLOCK_MONOTONIC and CLOCK_BOOTTIME) without affecting the host or other containers.

### Key Benefits:
Better isolation: Containers can change their time without affecting the host
Testing support: Enables testing of time-based services and scheduled jobs
Pod-level sharing: Time namespace is shared within a pod, ensuring consistent time view across containers in the same pod

### Which issue(s) this PR fixes:
Fixes #12517

### Testing
```
Running pkg/oci tests...
✓ PASS: pkg/oci tests passed
--- PASS: TestGenerateSpecWithPlatform (0.00s)
--- PASS: TestGenerateSpec (0.00s)
--- PASS: TestWithLinuxNamespace (0.00s)
PASS
```
```
# Container spec includes time namespace
$ sudo ctr run -d alpine:latest test sleep 3600
$ sudo ctr containers info test | grep -A 20 "namespaces"
"namespaces": [
    {"type": "pid"},
    {"type": "ipc"},
    {"type": "uts"},
    {"type": "mount"},
    {"type": "network"},
    {"type": "time"}  
]

# Namespace isolation verified
Host:      time:[4026531834]
Container: time:[4026532506]  
```