### PR TITLE
Set annotations parameter in CreateSandbox request

### DIFF
--- a/plugins/sandbox/controller.go
+++ b/plugins/sandbox/controller.go
@@ -157,11 +157,12 @@ func (c *controllerLocal) Create(ctx context.Context, info sandbox.Sandbox, opts
 	}
 
 	if _, err := svc.CreateSandbox(ctx, &runtimeAPI.CreateSandboxRequest{
-		SandboxID:  sandboxID,
-		BundlePath: shim.Bundle(),
-		Rootfs:     mount.ToProto(coptions.Rootfs),
-		Options:    typeurl.MarshalProto(coptions.Options),
-		NetnsPath:  coptions.NetNSPath,
+		SandboxID:   sandboxID,
+		BundlePath:  shim.Bundle(),
+		Rootfs:      mount.ToProto(coptions.Rootfs),
+		Options:     typeurl.MarshalProto(coptions.Options),
+		NetnsPath:   coptions.NetNSPath,
+		Annotations: coptions.Annotations,
 	}); err != nil {
 		c.cleanupShim(ctx, sandboxID, svc)
 		return fmt.Errorf("failed to create sandbox %s: %w", sandboxID, errgrpc.ToNative(err))


### PR DESCRIPTION
In the CreateSandbox request, which is part of the Sandbox Controller, we ignored the `Annotations` parameter which could have been set by the caller via `WithAnnotations` option.

This PR rectifies the same and adds the Annotations parameter to the request.

Issue: https://github.com/containerd/containerd/issues/12565