### PR TITLE
Add EROFS layer media type

### DIFF
--- a/core/images/mediatypes.go
+++ b/core/images/mediatypes.go
@@ -59,6 +59,9 @@ const (
 	MediaTypeImageLayerEncrypted     = ocispec.MediaTypeImageLayer + "+encrypted"
 	MediaTypeImageLayerGzipEncrypted = ocispec.MediaTypeImageLayerGzip + "+encrypted"
 
+	// EROFS media type
+	MediaTypeErofsLayer = "application/vnd.erofs.layer.v1"
+
 	// In-toto attestation
 	MediaTypeInToto = "application/vnd.in-toto+json"
 )
@@ -139,10 +142,13 @@ func IsLayerType(mt string) bool {
 		return true
 	}
 
-	// Parse Docker media types, strip off any + suffixes first
 	switch base, _ := parseMediaTypes(mt); base {
+	// Parse Docker media types, strip off any + suffixes first
 	case MediaTypeDockerSchema2Layer, MediaTypeDockerSchema2LayerGzip,
 		MediaTypeDockerSchema2LayerForeign, MediaTypeDockerSchema2LayerForeignGzip, MediaTypeDockerSchema2LayerZstd:
+		return true
+	// Allow EROFS native layers for efficient container image distribution.
+	case MediaTypeErofsLayer:
 		return true
 	}
 	return false

--- a/plugins/diff/erofs/differ.go
+++ b/plugins/diff/erofs/differ.go
@@ -89,8 +89,6 @@ func NewErofsDiffer(store content.Store, opts ...DifferOpt) differ {
 	return d
 }
 
-// A valid EROFS native layer media type should end with ".erofs".
-//
 // Please avoid using any +suffix to list the algorithms used inside EROFS
 // blobs, since:
 //   - Each EROFS layer can use multiple compression algorithms;
@@ -100,11 +98,11 @@ func NewErofsDiffer(store content.Store, opts ...DifferOpt) differ {
 // Since `images.DiffCompression` doesn't support arbitrary media types,
 // disallow non-empty suffixes for now.
 func isErofsMediaType(mt string) bool {
-	mediaType, _, hasExt := strings.Cut(mt, "+")
-	if hasExt {
+	if !strings.HasSuffix(mt, ".erofs") && !strings.HasPrefix(mt, "application/vnd.erofs.layer") {
 		return false
 	}
-	return strings.HasSuffix(mediaType, ".erofs")
+	_, _, hasExt := strings.Cut(mt, "+")
+	return !hasExt
 }
 
 func (s erofsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (d ocispec.Descriptor, err error) {


### PR DESCRIPTION
It introduces "application/vnd.erofs.layer.v1" to add support for EROFS native layers, so that containerd can fetch EROFS native container images directly.
E.g. `ctr run --snapshotter erofs -t quay.io/chengyuzhu6/ubuntu:20.04-erofs test /bin/bash`