### PR TITLE
cri/nri: short-circuit nil adjustment.

### DIFF
--- a/internal/cri/nri/nri_api_linux.go
+++ b/internal/cri/nri/nri_api_linux.go
@@ -336,6 +336,9 @@ func (a *API) WithContainerAdjustment() containerd.NewContainerOpts {
 		if err != nil {
 			return fmt.Errorf("failed to get NRI adjustment for container: %w", err)
 		}
+		if adjust == nil {
+			return nil
+		}
 
 		sgen := generate.Generator{Config: spec}
 		ngen := nrigen.SpecGenerator(&sgen, generatorOptions...)


### PR DESCRIPTION
Skip processing early if we get a nil adjustment from NRI instead of going through the motions.