### PR TITLE
Provide 'capability profiles' enabling the ability to run containers without certain capabilties such as NET_RAW

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -290,7 +290,7 @@ version = 3
           privileged_without_host_devices = false
           privileged_without_host_devices_all_devices_allowed = false
           cgroup_writable = false
-          capability_profile = 'default'
+          capability_profile = ''
           base_runtime_spec = ''
           cni_conf_dir = ''
           cni_max_conf_num = 0
@@ -579,9 +579,9 @@ version = 2
 
       # capability_profile selects the default set of Linux capabilities granted to containers.
       # Valid values are "default" (historical default, including CAP_NET_RAW) and "reduced" (drops
-      # CAP_NET_RAW, CAP_MKNOD, CAP_AUDIT_WRITE and CAP_SETFCAP). If unset, no profile override is
-      # applied and capabilities from base_runtime_spec (if set) are preserved.
-      capability_profile = 'default'
+      # CAP_NET_RAW, CAP_MKNOD, CAP_AUDIT_WRITE and CAP_SETFCAP). If unset (the default), no profile
+      # override is applied and capabilities from base_runtime_spec (if set) are preserved.
+      capability_profile = ''
 
       # base_runtime_spec is a file path to a JSON file with the OCI spec that will be used as the base spec that all
       # container's are created from.

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -290,6 +290,7 @@ version = 3
           privileged_without_host_devices = false
           privileged_without_host_devices_all_devices_allowed = false
           cgroup_writable = false
+          capability_profile = 'default'
           base_runtime_spec = ''
           cni_conf_dir = ''
           cni_max_conf_num = 0
@@ -575,6 +576,12 @@ version = 2
 
       # cgroup_writable field enables the support for writable cgroups in unprivileged containers with cgroup v2 enabled. When disabled, the cgroup interface (/sys/fs/cgroup) is mounted as read-only, preventing containers from managing their own cgroup hierarchies.
       cgroup_writable = false
+
+      # capability_profile selects the default set of Linux capabilities granted to containers.
+      # Valid values are "default" (historical default, including CAP_NET_RAW) and "reduced" (drops
+      # CAP_NET_RAW, CAP_MKNOD, CAP_AUDIT_WRITE and CAP_SETFCAP). If unset, no profile override is
+      # applied and capabilities from base_runtime_spec (if set) are preserved.
+      capability_profile = 'default'
 
       # base_runtime_spec is a file path to a JSON file with the OCI spec that will be used as the base spec that all
       # container's are created from.

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -427,7 +427,19 @@ type RuntimeConfig struct {
 	// IgnoreDeprecationWarnings is the list of the deprecation IDs (such as "io.containerd.deprecation/pull-schema-1-image")
 	// that should be ignored for checking "ContainerdHasNoDeprecationWarnings" condition.
 	IgnoreDeprecationWarnings []string `toml:"ignore_deprecation_warnings" json:"ignoreDeprecationWarnings"`
+
+	// CapabilityProfile indicates to use a more secure set of default capabilities
+	// when creating containers. This removes capabilities that are not typically
+	// needed for most workloads, such as NET_RAW, SETFCAP, MKNOD and AUDIT_WRITE.
+	CapabilityProfile string `toml:"capability_profile" json:"capabilityProfile"`
 }
+
+type CapabilityProfile string
+
+const (
+	CapabilityProfileDefault CapabilityProfile = "default"
+	CapabilityProfileReduced CapabilityProfile = "reduced"
+)
 
 // X509KeyPairStreaming contains the x509 configuration for streaming
 type X509KeyPairStreaming struct {

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -35,6 +35,7 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	"github.com/containerd/containerd/v2/internal/cri/opts"
 	"github.com/containerd/containerd/v2/pkg/deprecation"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/plugins"
 	streaming "k8s.io/cri-streaming/pkg/streaming"
 )
@@ -107,6 +108,13 @@ type Runtime struct {
 	PrivilegedWithoutHostDevicesAllDevicesAllowed bool `toml:"privileged_without_host_devices_all_devices_allowed" json:"privileged_without_host_devices_all_devices_allowed"`
 	// CgroupWritable enables writable cgroups in non-privileged containers
 	CgroupWritable bool `toml:"cgroup_writable" json:"cgroupWritable"`
+	// CapabilityProfile selects the default set of Linux capabilities granted
+	// to containers. Valid values are "default" (the historical default,
+	// including CAP_NET_RAW) and "reduced" (drops CAP_NET_RAW, CAP_MKNOD,
+	// CAP_AUDIT_WRITE and CAP_SETFCAP, matching the Kubernetes baseline Pod
+	// Security Standard). If unset, no profile is applied and capabilities
+	// granted by BaseRuntimeSpec (or the "default" profile if unset) are used.
+	CapabilityProfile string `toml:"capability_profile" json:"capabilityProfile"`
 	// BaseRuntimeSpec is a json file with OCI spec to use as base spec that all container's will be created from.
 	BaseRuntimeSpec string `toml:"base_runtime_spec" json:"baseRuntimeSpec"`
 	// NetworkPluginConfDir is a directory containing the CNI network information for the runtime class.
@@ -672,6 +680,9 @@ func ValidateRuntimeConfig(ctx context.Context, c *RuntimeConfig) ([]deprecation
 
 		if !r.PrivilegedWithoutHostDevices && r.PrivilegedWithoutHostDevicesAllDevicesAllowed {
 			return warnings, errors.New("`privileged_without_host_devices_all_devices_allowed` requires `privileged_without_host_devices` to be enabled")
+		}
+		if r.CapabilityProfile != "" && r.CapabilityProfile != oci.CapabilityProfileDefault && r.CapabilityProfile != oci.CapabilityProfileReduced {
+			return warnings, fmt.Errorf("runtime %s: invalid `capability_profile` %q, must be %q or %q", k, r.CapabilityProfile, oci.CapabilityProfileDefault, oci.CapabilityProfileReduced)
 		}
 		// If empty, use default podSandbox mode
 		if len(r.Sandboxer) == 0 {

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -113,6 +113,7 @@ type Runtime struct {
 	// CAP_NET_RAW) and "reduced" (drops CAP_NET_RAW, CAP_MKNOD,
 	// CAP_AUDIT_WRITE and CAP_SETFCAP). If unset, no profile override is applied
 	// and capabilities from BaseRuntimeSpec (if set) are preserved.
+	// unset is equivalent to "default"
 	CapabilityProfile string `toml:"capability_profile" json:"capabilityProfile"`
 	// BaseRuntimeSpec is a json file with OCI spec to use as base spec that all container's will be created from.
 	BaseRuntimeSpec string `toml:"base_runtime_spec" json:"baseRuntimeSpec"`

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -111,9 +111,11 @@ type Runtime struct {
 	// CapabilityProfile selects the default set of Linux capabilities granted
 	// to containers. Valid values are "default" (historical default, including
 	// CAP_NET_RAW) and "reduced" (drops CAP_NET_RAW, CAP_MKNOD,
-	// CAP_AUDIT_WRITE and CAP_SETFCAP). if this field is unset, the behavior is the same as "default"
-	// and capabilities from BaseRuntimeSpec (if set) are preserved.
-	// unset is equivalent to "default"
+	// CAP_AUDIT_WRITE and CAP_SETFCAP). This field only applies to containerd's
+	// internal default capability set: if left unset (empty string), no
+	// profile override is applied and capabilities from BaseRuntimeSpec (if
+	// set) are preserved. Setting "default" or "reduced" explicitly always
+	// overrides capabilities from BaseRuntimeSpec.
 	CapabilityProfile string `toml:"capability_profile" json:"capabilityProfile"`
 	// BaseRuntimeSpec is a json file with OCI spec to use as base spec that all container's will be created from.
 	BaseRuntimeSpec string `toml:"base_runtime_spec" json:"baseRuntimeSpec"`

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -109,11 +109,10 @@ type Runtime struct {
 	// CgroupWritable enables writable cgroups in non-privileged containers
 	CgroupWritable bool `toml:"cgroup_writable" json:"cgroupWritable"`
 	// CapabilityProfile selects the default set of Linux capabilities granted
-	// to containers. Valid values are "default" (the historical default,
-	// including CAP_NET_RAW) and "reduced" (drops CAP_NET_RAW, CAP_MKNOD,
-	// CAP_AUDIT_WRITE and CAP_SETFCAP, matching the Kubernetes baseline Pod
-	// Security Standard). If unset, no profile is applied and capabilities
-	// granted by BaseRuntimeSpec (or the "default" profile if unset) are used.
+	// to containers. Valid values are "default" (historical default, including
+	// CAP_NET_RAW) and "reduced" (drops CAP_NET_RAW, CAP_MKNOD,
+	// CAP_AUDIT_WRITE and CAP_SETFCAP). If unset, no profile override is applied
+	// and capabilities from BaseRuntimeSpec (if set) are preserved.
 	CapabilityProfile string `toml:"capability_profile" json:"capabilityProfile"`
 	// BaseRuntimeSpec is a json file with OCI spec to use as base spec that all container's will be created from.
 	BaseRuntimeSpec string `toml:"base_runtime_spec" json:"baseRuntimeSpec"`

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -111,7 +111,7 @@ type Runtime struct {
 	// CapabilityProfile selects the default set of Linux capabilities granted
 	// to containers. Valid values are "default" (historical default, including
 	// CAP_NET_RAW) and "reduced" (drops CAP_NET_RAW, CAP_MKNOD,
-	// CAP_AUDIT_WRITE and CAP_SETFCAP). If unset, no profile override is applied
+	// CAP_AUDIT_WRITE and CAP_SETFCAP). if this field is unset, the behavior is the same as "default"
 	// and capabilities from BaseRuntimeSpec (if set) are preserved.
 	// unset is equivalent to "default"
 	CapabilityProfile string `toml:"capability_profile" json:"capabilityProfile"`

--- a/internal/cri/config/config_unix.go
+++ b/internal/cri/config/config_unix.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/pelletier/go-toml/v2"
 )
 
@@ -91,9 +92,10 @@ func DefaultRuntimeConfig() RuntimeConfig {
 			DefaultRuntimeName: "runc",
 			Runtimes: map[string]Runtime{
 				"runc": {
-					Type:      "io.containerd.runc.v2",
-					Options:   m,
-					Sandboxer: string(ModePodSandbox),
+					Type:              "io.containerd.runc.v2",
+					Options:           m,
+					Sandboxer:         string(ModePodSandbox),
+					CapabilityProfile: oci.CapabilityProfileDefault,
 				},
 			},
 		},

--- a/internal/cri/config/config_unix.go
+++ b/internal/cri/config/config_unix.go
@@ -20,7 +20,6 @@ package config
 
 import (
 	"github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/pelletier/go-toml/v2"
 )
 
@@ -92,10 +91,9 @@ func DefaultRuntimeConfig() RuntimeConfig {
 			DefaultRuntimeName: "runc",
 			Runtimes: map[string]Runtime{
 				"runc": {
-					Type:              "io.containerd.runc.v2",
-					Options:           m,
-					Sandboxer:         string(ModePodSandbox),
-					CapabilityProfile: oci.CapabilityProfileDefault,
+					Type:      "io.containerd.runc.v2",
+					Options:   m,
+					Sandboxer: string(ModePodSandbox),
 				},
 			},
 		},

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -556,12 +556,19 @@ func (c *criService) runtimeSpec(id string, platform imagespec.Platform, baseSpe
 		return &spec, nil
 	}
 
-	spec, err := oci.GenerateSpecWithPlatform(ctx, nil, platforms.Format(platform), container, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate spec: %w", err)
+	if c.config.CapabilityProfile == string(criconfig.CapabilityProfileReduced) && platform.OS == "linux" {
+		spec, err := oci.GenerateSpecWithCapabilityProfileForLinux(ctx, nil, container, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate reduced spec: %w", err)
+		}
+		return spec, nil
+	} else {
+		spec, err := oci.GenerateSpecWithPlatform(ctx, nil, platforms.Format(platform), container, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate spec: %w", err)
+		}
+		return spec, nil
 	}
-
-	return spec, nil
 }
 
 const (

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -798,8 +798,13 @@ func (c *criService) buildLinuxSpec(
 		}
 	}
 
-	specOpts = append(specOpts, customopts.WithDevices(c.os, config, c.config.DeviceOwnershipFromSecurityContext),
-		customopts.WithCapabilities(securityContext, c.allCaps))
+	specOpts = append(specOpts, customopts.WithDevices(c.os, config, c.config.DeviceOwnershipFromSecurityContext))
+	if ociRuntime.CapabilityProfile != "" {
+		// Only override the base/default capability set when a profile is
+		// explicitly configured, so BaseRuntimeSpec capabilities are preserved otherwise.
+		specOpts = append(specOpts, oci.WithCapabilityProfile(ociRuntime.CapabilityProfile))
+	}
+	specOpts = append(specOpts, customopts.WithCapabilities(securityContext, c.allCaps))
 
 	if securityContext.GetPrivileged() {
 		if !sandboxConfig.GetLinux().GetSecurityContext().GetPrivileged() {

--- a/internal/cri/server/container_create_linux_test.go
+++ b/internal/cri/server/container_create_linux_test.go
@@ -1399,7 +1399,7 @@ func TestCapabilityProfile(t *testing.T) {
 		profile      string
 		expectNetRaw bool
 	}{
-		{desc: "unset defaults to the default profile", profile: "", expectNetRaw: true},
+		{desc: "unset does not override the base/default capability set", profile: "", expectNetRaw: true},
 		{desc: "explicit default profile", profile: oci.CapabilityProfileDefault, expectNetRaw: true},
 		{desc: "reduced profile drops CAP_NET_RAW", profile: oci.CapabilityProfileReduced, expectNetRaw: false},
 	} {

--- a/internal/cri/server/container_create_linux_test.go
+++ b/internal/cri/server/container_create_linux_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1384,6 +1385,32 @@ func TestBaseOCISpec(t *testing.T) {
 	assert.Len(t, spec.Process.Capabilities.Permitted, 1)
 
 	assert.Equal(t, *spec.Linux.Resources.Memory.Limit, containerConfig.Linux.Resources.MemoryLimitInBytes)
+}
+
+func TestCapabilityProfile(t *testing.T) {
+	c := newTestCRIService()
+	testSandboxID := "sandbox-id"
+	testContainerName := "container-name"
+	testPid := uint32(1234)
+	containerConfig, sandboxConfig, imageConfig, _ := getCreateContainerTestData()
+
+	for _, test := range []struct {
+		desc         string
+		profile      string
+		expectNetRaw bool
+	}{
+		{desc: "unset defaults to the default profile", profile: "", expectNetRaw: true},
+		{desc: "explicit default profile", profile: oci.CapabilityProfileDefault, expectNetRaw: true},
+		{desc: "reduced profile drops CAP_NET_RAW", profile: oci.CapabilityProfileReduced, expectNetRaw: false},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			ociRuntime := config.Runtime{CapabilityProfile: test.profile}
+			spec, err := c.buildContainerSpec(currentPlatform, t.Name(), testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime, nil)
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.expectNetRaw, slices.Contains(spec.Process.Capabilities.Bounding, "CAP_NET_RAW"))
+		})
+	}
 }
 
 func writeFilesToTempDir(t *testing.T, content []string) (string, error) {

--- a/internal/cri/server/container_create_linux_test.go
+++ b/internal/cri/server/container_create_linux_test.go
@@ -1364,27 +1364,47 @@ func TestBaseOCISpec(t *testing.T) {
 		},
 	}))
 
-	ociRuntime := config.Runtime{}
-	ociRuntime.BaseRuntimeSpec = "/etc/containerd/cri-base.json"
-
 	testID := "test-id"
 	testSandboxID := "sandbox-id"
 	testContainerName := "container-name"
 	testPid := uint32(1234)
-	containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
 
-	spec, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime, nil)
-	assert.NoError(t, err)
+	for _, test := range []struct {
+		desc               string
+		capabilityProfile  string
+		expectBaseSpecCaps bool
+	}{
+		{desc: "unset preserves BaseRuntimeSpec capabilities", capabilityProfile: "", expectBaseSpecCaps: true},
+		{desc: "default profile overrides BaseRuntimeSpec capabilities", capabilityProfile: oci.CapabilityProfileDefault, expectBaseSpecCaps: false},
+		{desc: "reduced profile overrides BaseRuntimeSpec capabilities", capabilityProfile: oci.CapabilityProfileReduced, expectBaseSpecCaps: false},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
 
-	specCheck(t, testID, testSandboxID, testPid, spec)
+			ociRuntime := config.Runtime{
+				BaseRuntimeSpec:   "/etc/containerd/cri-base.json",
+				CapabilityProfile: test.capabilityProfile,
+			}
 
-	assert.Contains(t, spec.Process.User.AdditionalGids, uint32(9999))
-	assert.Len(t, spec.Process.User.AdditionalGids, 3)
+			spec, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime, nil)
+			assert.NoError(t, err)
 
-	assert.Contains(t, spec.Process.Capabilities.Permitted, "CAP_SETUID")
-	assert.Len(t, spec.Process.Capabilities.Permitted, 1)
+			specCheck(t, testID, testSandboxID, testPid, spec)
 
-	assert.Equal(t, *spec.Linux.Resources.Memory.Limit, containerConfig.Linux.Resources.MemoryLimitInBytes)
+			assert.Contains(t, spec.Process.User.AdditionalGids, uint32(9999))
+			assert.Len(t, spec.Process.User.AdditionalGids, 3)
+
+			if test.expectBaseSpecCaps {
+				assert.Contains(t, spec.Process.Capabilities.Permitted, "CAP_SETUID")
+				assert.Len(t, spec.Process.Capabilities.Permitted, 1)
+			} else {
+				// the profile's full capability set replaces BaseRuntimeSpec's single-cap set.
+				assert.Greater(t, len(spec.Process.Capabilities.Permitted), 1)
+			}
+
+			assert.Equal(t, *spec.Linux.Resources.Memory.Limit, containerConfig.Linux.Resources.MemoryLimitInBytes)
+		})
+	}
 }
 
 func TestCapabilityProfile(t *testing.T) {

--- a/pkg/oci/spec.go
+++ b/pkg/oci/spec.go
@@ -120,8 +120,7 @@ func ApplyOpts(ctx context.Context, client Client, c *containers.Container, s *S
 const CapabilityProfileDefault = "default"
 
 // CapabilityProfileReduced is a capability profile that drops capabilities
-// that are not needed by most workloads and are disallowed by the Kubernetes
-// baseline Pod Security Standard, namely CAP_NET_RAW, CAP_MKNOD,
+// that are not needed by most workloads, namely CAP_NET_RAW, CAP_MKNOD,
 // CAP_AUDIT_WRITE and CAP_SETFCAP.
 const CapabilityProfileReduced = "reduced"
 

--- a/pkg/oci/spec.go
+++ b/pkg/oci/spec.go
@@ -115,6 +115,23 @@ func ApplyOpts(ctx context.Context, client Client, c *containers.Container, s *S
 	return nil
 }
 
+// CapabilityProfileDefault is the capability profile matching the historical
+// default capability set, including CAP_NET_RAW.
+const CapabilityProfileDefault = "default"
+
+// CapabilityProfileReduced is a capability profile that drops capabilities
+// that are not needed by most workloads and are disallowed by the Kubernetes
+// baseline Pod Security Standard, namely CAP_NET_RAW, CAP_MKNOD,
+// CAP_AUDIT_WRITE and CAP_SETFCAP.
+const CapabilityProfileReduced = "reduced"
+
+// capabilityProfiles maps a capability profile name to the set of
+// capabilities it grants by default.
+var capabilityProfiles = map[string]func() []string{
+	CapabilityProfileDefault: defaultUnixCaps,
+	CapabilityProfileReduced: defaultReducedUnixCaps,
+}
+
 func defaultUnixCaps() []string {
 	return []string{
 		"CAP_CHOWN",
@@ -132,6 +149,25 @@ func defaultUnixCaps() []string {
 		"CAP_KILL",
 		"CAP_AUDIT_WRITE",
 	}
+}
+
+// reducedCapsRemoved is the set of capabilities dropped from defaultUnixCaps
+// to form the reduced profile.
+var reducedCapsRemoved = []string{
+	"CAP_NET_RAW",
+	"CAP_MKNOD",
+	"CAP_AUDIT_WRITE",
+	"CAP_SETFCAP",
+}
+
+// defaultReducedUnixCaps derives the reduced profile by filtering
+// defaultUnixCaps, so the two stay in sync if defaultUnixCaps changes.
+func defaultReducedUnixCaps() []string {
+	caps := defaultUnixCaps()
+	for _, c := range reducedCapsRemoved {
+		removeCap(&caps, c)
+	}
+	return caps
 }
 
 func defaultUnixNamespaces() []specs.LinuxNamespace {

--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1076,6 +1076,23 @@ func WithCapabilities(caps []string) SpecOpts {
 	}
 }
 
+// WithCapabilityProfile sets Linux capabilities on the process from a named
+// capability profile (e.g. [CapabilityProfileDefault] or
+// [CapabilityProfileReduced]). An empty profile name is treated as
+// [CapabilityProfileDefault].
+func WithCapabilityProfile(profile string) SpecOpts {
+	if profile == "" {
+		profile = CapabilityProfileDefault
+	}
+	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
+		caps, ok := capabilityProfiles[profile]
+		if !ok {
+			return fmt.Errorf("unknown capability profile %q, must be %q or %q", profile, CapabilityProfileDefault, CapabilityProfileReduced)
+		}
+		return WithCapabilities(caps())(ctx, client, c, s)
+	}
+}
+
 func capsContain(caps []string, s string) bool {
 	return slices.Contains(caps, s)
 }

--- a/pkg/oci/spec_test.go
+++ b/pkg/oci/spec_test.go
@@ -235,14 +235,14 @@ func TestWithCapabilityProfile(t *testing.T) {
 	ctx := namespaces.WithNamespace(context.Background(), "testing")
 
 	for _, tc := range []struct {
-		name       string
-		profile    string
-		wantNetRaw bool
-		wantErr    bool
+		name        string
+		profile     string
+		wantRemoved bool
+		wantErr     bool
 	}{
-		{name: "unset", profile: "", wantNetRaw: true},
-		{name: CapabilityProfileDefault, profile: CapabilityProfileDefault, wantNetRaw: true},
-		{name: CapabilityProfileReduced, profile: CapabilityProfileReduced, wantNetRaw: false},
+		{name: "unset", profile: "", wantRemoved: false},
+		{name: CapabilityProfileDefault, profile: CapabilityProfileDefault, wantRemoved: false},
+		{name: CapabilityProfileReduced, profile: CapabilityProfileReduced, wantRemoved: true},
 		{name: "bogus", profile: "bogus", wantErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -261,9 +261,11 @@ func TestWithCapabilityProfile(t *testing.T) {
 			if runtime.GOOS != "linux" {
 				return
 			}
-			hasNetRaw := capsContain(s.Process.Capabilities.Bounding, "CAP_NET_RAW")
-			if hasNetRaw != tc.wantNetRaw {
-				t.Errorf("CAP_NET_RAW presence = %v, want %v", hasNetRaw, tc.wantNetRaw)
+			for _, cap := range reducedCapsRemoved {
+				removed := !capsContain(s.Process.Capabilities.Bounding, cap)
+				if removed != tc.wantRemoved {
+					t.Errorf("%s removed = %v, want %v", cap, removed, tc.wantRemoved)
+				}
 			}
 		})
 	}

--- a/pkg/oci/spec_test.go
+++ b/pkg/oci/spec_test.go
@@ -229,6 +229,46 @@ func TestWithCapabilitiesNil(t *testing.T) {
 	}
 }
 
+func TestWithCapabilityProfile(t *testing.T) {
+	t.Parallel()
+
+	ctx := namespaces.WithNamespace(context.Background(), "testing")
+
+	for _, tc := range []struct {
+		name       string
+		profile    string
+		wantNetRaw bool
+		wantErr    bool
+	}{
+		{name: "unset", profile: "", wantNetRaw: true},
+		{name: CapabilityProfileDefault, profile: CapabilityProfileDefault, wantNetRaw: true},
+		{name: CapabilityProfileReduced, profile: CapabilityProfileReduced, wantNetRaw: false},
+		{name: "bogus", profile: "bogus", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := GenerateSpec(ctx, nil, &containers.Container{ID: t.Name()},
+				WithCapabilityProfile(tc.profile),
+			)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error for unknown capability profile")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if runtime.GOOS != "linux" {
+				return
+			}
+			hasNetRaw := capsContain(s.Process.Capabilities.Bounding, "CAP_NET_RAW")
+			if hasNetRaw != tc.wantNetRaw {
+				t.Errorf("CAP_NET_RAW presence = %v, want %v", hasNetRaw, tc.wantNetRaw)
+			}
+		})
+	}
+}
+
 func TestPopulateDefaultWindowsSpec(t *testing.T) {
 	var (
 		c   = containers.Container{ID: "TestWithDefaultSpec"}


### PR DESCRIPTION
This PR resolves #10434 

We introduce 'capability profiles' and have two values. 
default (the exact same capabilities today)
reduced (we remove net_raw, audit_write, mknod, and setfcap) 

If not set we use the default. This is the alternative to just removing NET_RAW from the defaults. We eventually could make the 'reduced' profile the default if desired. Instead of 'reduced' we could call it the 'k8s' profile. 

People have referred to this as the "NET_RAW expliot" where containerd used net_raw as a default capability. I disagree this is an sort of exploit but it doesn't give it a good name. 

Tested with crictl:
reduced:  cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_sys_chroot=ep

default: 
cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap=ep
