### PR TITLE
[CI] Prevents triggering of an inactive issue/PR check for forked repository.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,8 @@ permissions: read-all
 
 jobs:
   stale:
+    # Prevents triggering on forks or other repos
+    if: github.repository == 'containerd/containerd'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
https://github.com/wzshiming/containerd/actions/workflows/stale.yml

This isn't really useful for forked repositories. Perhaps we could add a check for that.