### PR TITLE
fix: refactor ListPodSandboxMetrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,10 @@ linters:
   exclusions:
     generated: lax
     rules:
+      # Metric descriptors are currently only used for linux
+      - path: cri[\\/]server[\\/]list_metric_descriptors.go
+        linters:
+          - unused
       - path: cmd[\\/]containerd[\\/]builtins[\\/]
         text: 'blank-imports:'
       - path: contrib[\\/]fuzz[\\/]

--- a/internal/cri/server/container_stats_list_test.go
+++ b/internal/cri/server/container_stats_list_test.go
@@ -28,14 +28,15 @@ import (
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
 	"github.com/containerd/containerd/api/types"
-	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
-	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
-	"github.com/containerd/containerd/v2/pkg/protobuf"
 	"github.com/containerd/platforms"
 	"github.com/containerd/typeurl/v2"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/anypb"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+	"github.com/containerd/containerd/v2/pkg/protobuf"
 )
 
 func TestContainerMetricsCPUNanoCoreUsage(t *testing.T) {
@@ -243,12 +244,12 @@ func TestContainerMetricsMemory(t *testing.T) {
 
 	for _, test := range []struct {
 		desc     string
-		metrics  interface{}
+		metrics  cgroupMetrics
 		expected *runtime.MemoryUsage
 	}{
 		{
 			desc: "v1 metrics - no memory limit",
-			metrics: &v1.Metrics{
+			metrics: cgroupMetrics{v1: &v1.Metrics{
 				Memory: &v1.MemoryStat{
 					Usage: &v1.MemoryEntry{
 						Limit: math.MaxUint64, // no limit
@@ -259,7 +260,7 @@ func TestContainerMetricsMemory(t *testing.T) {
 					TotalPgMajFault:   12,
 					TotalInactiveFile: 500,
 				},
-			},
+			}},
 			expected: &runtime.MemoryUsage{
 				Timestamp:       timestamp.UnixNano(),
 				WorkingSetBytes: &runtime.UInt64Value{Value: 500},
@@ -272,7 +273,7 @@ func TestContainerMetricsMemory(t *testing.T) {
 		},
 		{
 			desc: "v1 metrics - memory limit",
-			metrics: &v1.Metrics{
+			metrics: cgroupMetrics{v1: &v1.Metrics{
 				Memory: &v1.MemoryStat{
 					Usage: &v1.MemoryEntry{
 						Limit: 5000,
@@ -283,7 +284,7 @@ func TestContainerMetricsMemory(t *testing.T) {
 					TotalPgMajFault:   12,
 					TotalInactiveFile: 500,
 				},
-			},
+			}},
 			expected: &runtime.MemoryUsage{
 				Timestamp:       timestamp.UnixNano(),
 				WorkingSetBytes: &runtime.UInt64Value{Value: 500},
@@ -296,7 +297,7 @@ func TestContainerMetricsMemory(t *testing.T) {
 		},
 		{
 			desc: "v2 metrics - memory limit",
-			metrics: &v2.Metrics{
+			metrics: cgroupMetrics{v2: &v2.Metrics{
 				Memory: &v2.MemoryStat{
 					Usage:        1000,
 					UsageLimit:   5000,
@@ -304,7 +305,7 @@ func TestContainerMetricsMemory(t *testing.T) {
 					Pgfault:      11,
 					Pgmajfault:   12,
 				},
-			},
+			}},
 			expected: &runtime.MemoryUsage{
 				Timestamp:       timestamp.UnixNano(),
 				WorkingSetBytes: &runtime.UInt64Value{Value: 1000},
@@ -317,7 +318,7 @@ func TestContainerMetricsMemory(t *testing.T) {
 		},
 		{
 			desc: "v2 metrics - no memory limit",
-			metrics: &v2.Metrics{
+			metrics: cgroupMetrics{v2: &v2.Metrics{
 				Memory: &v2.MemoryStat{
 					Usage:        1000,
 					UsageLimit:   math.MaxUint64, // no limit
@@ -325,7 +326,7 @@ func TestContainerMetricsMemory(t *testing.T) {
 					Pgfault:      11,
 					Pgmajfault:   12,
 				},
-			},
+			}},
 			expected: &runtime.MemoryUsage{
 				Timestamp:       timestamp.UnixNano(),
 				WorkingSetBytes: &runtime.UInt64Value{Value: 1000},

--- a/internal/cri/server/list_metric_descriptors.go
+++ b/internal/cri/server/list_metric_descriptors.go
@@ -16,6 +16,10 @@
 
 package server
 
+import (
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
 const (
 	CPUUsageMetrics      = "cpu"
 	MemoryUsageMetrics   = "memory"
@@ -25,4 +29,289 @@ const (
 	ProcessMetrics       = "process"
 	MiscellaneousMetrics = "misc"
 	ContainerSpecMetrics = "container_spec"
+)
+
+var (
+	baseLabelKeys    = []string{"pod", "namespace", "container", "id", "image"}
+	networkLabelKeys = append(baseLabelKeys, "interface")
+	diskLabelKeys    = append(baseLabelKeys, "device")
+)
+
+// CPU metrics
+var (
+	containerCPUUserSecondsTotal = &runtime.MetricDescriptor{
+		Name:      "container_cpu_user_seconds_total",
+		Help:      "Cumulative user CPU time consumed in seconds.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerCPUSystemSecondsTotal = &runtime.MetricDescriptor{
+		Name:      "container_cpu_system_seconds_total",
+		Help:      "Cumulative system CPU time consumed in seconds.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerCPUUsageSecondsTotal = &runtime.MetricDescriptor{
+		Name:      "container_cpu_usage_seconds_total",
+		Help:      "Cumulative CPU time consumed in seconds.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerCPUCfsPeriodsTotal = &runtime.MetricDescriptor{
+		Name:      "container_cpu_cfs_periods_total",
+		Help:      "Number of elapsed enforcement period intervals.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerCPUCfsThrottledPeriodsTotal = &runtime.MetricDescriptor{
+		Name:      "container_cpu_cfs_throttled_periods_total",
+		Help:      "Number of CPU throttled period intervals.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerCPUCfsThrottledSecondsTotal = &runtime.MetricDescriptor{
+		Name:      "container_cpu_cfs_throttled_seconds_total",
+		Help:      "Total time duration the container has been throttled.",
+		LabelKeys: baseLabelKeys,
+	}
+)
+
+// Memory metrics
+var (
+	containerMemoryCache = &runtime.MetricDescriptor{
+		Name:      "container_memory_cache",
+		Help:      "Number of bytes of memory used by the container for caching purposes.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerMemoryRss = &runtime.MetricDescriptor{
+		Name:      "container_memory_rss",
+		Help:      "Size of RSS in bytes, total anonymous memory and [swap cache memory used by the container.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerMemoryKernelUsage = &runtime.MetricDescriptor{
+		Name:      "container_memory_kernel_usage",
+		Help:      "Size of kernel memory allocated to the container in bytes, includes page tables, socket buffers...",
+		LabelKeys: baseLabelKeys,
+	}
+	containerMemoryMappedFile = &runtime.MetricDescriptor{
+		Name:      "container_memory_mapped_file",
+		Help:      "Size of container's memory mapped files in bytes.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerMemorySwap = &runtime.MetricDescriptor{
+		Name:      "container_memory_swap",
+		Help:      "Container swap usage in bytes.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerMemoryFailcnt = &runtime.MetricDescriptor{
+		Name:      "container_memory_failcnt",
+		Help:      "Number of times container memory usage has hit its cgroup v1 upper memory limit, for cg2 this value is not currently supported",
+		LabelKeys: baseLabelKeys,
+	}
+	containerMemoryUsageBytes = &runtime.MetricDescriptor{
+		Name:      "container_memory_usage_bytes",
+		Help:      "Current memory usage in bytes, including all memory regardless of when it was accessed",
+		LabelKeys: baseLabelKeys,
+	}
+	containerMemoryMaxUsageBytes = &runtime.MetricDescriptor{
+		Name:      "container_memory_max_usage_bytes",
+		Help:      "Maximum container memory usage recorded in bytes",
+		LabelKeys: baseLabelKeys,
+	}
+	containerMemoryWorkingSetBytes = &runtime.MetricDescriptor{
+		Name:      "container_memory_working_set_bytes",
+		Help:      "Amount of memory that is actively used by the container, excluding cached memory.",
+		LabelKeys: baseLabelKeys,
+	}
+	// additional added from cadvisor
+	containerMemoryTotalActiveFileBytes = &runtime.MetricDescriptor{
+		Name:      "container_memory_total_active_file_bytes",
+		Help:      "Amount of cache memory bytes, in use by the container, in file on disk.",
+		LabelKeys: baseLabelKeys,
+	}
+	// additional added from cadvisor
+	containerMemoryTotalInactiveFileBytes = &runtime.MetricDescriptor{
+		Name:      "container_memory_total_inactive_file_bytes",
+		Help:      "Amount of inactive cache memory bytes, for the container, in file on disk.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerMemoryFailuresTotal = &runtime.MetricDescriptor{
+		Name:      "container_memory_failures_total",
+		Help:      "Cumulative count of container memory allocation failures.",
+		LabelKeys: append(append([]string(nil), baseLabelKeys...), "failure_type", "scope"),
+	}
+	containerOomEventsTotal = &runtime.MetricDescriptor{
+		Name:      "container_oom_events_total",
+		Help:      "Count of out of memory events observed for the container",
+		LabelKeys: baseLabelKeys,
+	}
+)
+
+// Disk metrics
+var (
+	containerFsInodesFree = &runtime.MetricDescriptor{
+		Name:      "container_fs_inodes_free",
+		Help:      "Number of available Inodes",
+		LabelKeys: diskLabelKeys,
+	}
+	containerFsInodesTotal = &runtime.MetricDescriptor{
+		Name:      "container_fs_inodes_total",
+		Help:      "Number of Inodes",
+		LabelKeys: diskLabelKeys,
+	}
+	containerFsLimitBytes = &runtime.MetricDescriptor{
+		Name:      "container_fs_limit_bytes",
+		Help:      "Number of bytes that can be consumed by the container on this filesystem.",
+		LabelKeys: diskLabelKeys,
+	}
+	containerFsUsageBytes = &runtime.MetricDescriptor{
+		Name:      "container_fs_usage_bytes",
+		Help:      "Number of bytes that are consumed by the container on this filesystem.",
+		LabelKeys: diskLabelKeys,
+	}
+)
+
+// Disk IO metrics
+var (
+	containerFsReadsBytesTotal = &runtime.MetricDescriptor{
+		Name:      "container_fs_reads_bytes_total",
+		Help:      "Cumulative count of bytes read",
+		LabelKeys: diskLabelKeys,
+	}
+	containerFsReadsTotal = &runtime.MetricDescriptor{
+		Name:      "container_fs_reads_total",
+		Help:      "Cumulative count of reads completed",
+		LabelKeys: diskLabelKeys,
+	}
+	containerFsWritesBytesTotal = &runtime.MetricDescriptor{
+		Name:      "container_fs_writes_bytes_total",
+		Help:      "Cumulative count of bytes written",
+		LabelKeys: diskLabelKeys,
+	}
+	containerFsWritesTotal = &runtime.MetricDescriptor{
+		Name:      "container_fs_writes_total",
+		Help:      "Cumulative count of writes completed",
+		LabelKeys: diskLabelKeys,
+	}
+	containerBlkioDeviceUsageTotal = &runtime.MetricDescriptor{
+		Name:      "container_blkio_device_usage_total",
+		Help:      "Blkio device bytes usage",
+		LabelKeys: append(append([]string(nil), diskLabelKeys...), "major", "minor", "operation"),
+	}
+)
+
+// Network metrics
+var (
+	containerNetworkReceiveBytesTotal = &runtime.MetricDescriptor{
+		Name:      "container_network_receive_bytes_total",
+		Help:      "Cumulative count of bytes received",
+		LabelKeys: networkLabelKeys,
+	}
+	containerNetworkReceivePacketsTotal = &runtime.MetricDescriptor{
+		Name:      "container_network_receive_packets_total",
+		Help:      "Cumulative count of packets received",
+		LabelKeys: networkLabelKeys,
+	}
+	containerNetworkReceivePacketsDroppedTotal = &runtime.MetricDescriptor{
+		Name:      "container_network_receive_packets_dropped_total",
+		Help:      "Cumulative count of packets dropped while receiving",
+		LabelKeys: networkLabelKeys,
+	}
+	containerNetworkReceiveErrorsTotal = &runtime.MetricDescriptor{
+		Name:      "container_network_receive_errors_total",
+		Help:      "Cumulative count of errors encountered while receiving",
+		LabelKeys: networkLabelKeys,
+	}
+	containerNetworkTransmitBytesTotal = &runtime.MetricDescriptor{
+		Name:      "container_network_transmit_bytes_total",
+		Help:      "Cumulative count of bytes transmitted",
+		LabelKeys: networkLabelKeys,
+	}
+	containerNetworkTransmitPacketsTotal = &runtime.MetricDescriptor{
+		Name:      "container_network_transmit_packets_total",
+		Help:      "Cumulative count of packets transmitted",
+		LabelKeys: networkLabelKeys,
+	}
+	containerNetworkTransmitPacketsDroppedTotal = &runtime.MetricDescriptor{
+		Name:      "container_network_transmit_packets_dropped_total",
+		Help:      "Cumulative count of packets dropped while transmitting",
+		LabelKeys: networkLabelKeys,
+	}
+	containerNetworkTransmitErrorsTotal = &runtime.MetricDescriptor{
+		Name:      "container_network_transmit_errors_total",
+		Help:      "Cumulative count of errors encountered while transmitting",
+		LabelKeys: networkLabelKeys,
+	}
+)
+
+// Process metrics
+var (
+	containerProcesses = &runtime.MetricDescriptor{
+		Name:      "container_processes",
+		Help:      "Number of processes running inside the container.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerFileDescriptors = &runtime.MetricDescriptor{
+		Name:      "container_file_descriptors",
+		Help:      "Number of open file descriptors for the container.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerSockets = &runtime.MetricDescriptor{
+		Name:      "container_sockets",
+		Help:      "Number of open sockets for the container.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerThreadsMax = &runtime.MetricDescriptor{
+		Name:      "container_threads_max",
+		Help:      "Maximum number of threads allowed inside the container, infinity if value is zero",
+		LabelKeys: baseLabelKeys,
+	}
+	containerThreads = &runtime.MetricDescriptor{
+		Name:      "container_threads",
+		Help:      "Number of threads running inside the container",
+		LabelKeys: baseLabelKeys,
+	}
+	containerUlimitsSoft = &runtime.MetricDescriptor{
+		Name:      "container_ulimits_soft",
+		Help:      "Soft ulimit values for the container root process. Unlimited if -1, except priority and nice",
+		LabelKeys: append(append([]string(nil), baseLabelKeys...), "ulimit"),
+	}
+)
+
+// Miscellaneous metrics
+var (
+	containerLastSeen = &runtime.MetricDescriptor{
+		Name:      "container_last_seen",
+		Help:      "Last time a container was seen by the exporter",
+		LabelKeys: baseLabelKeys,
+	}
+	containerStartTimeSeconds = &runtime.MetricDescriptor{
+		Name:      "container_start_time_seconds",
+		Help:      "Start time of the container since unix epoch in seconds",
+		LabelKeys: baseLabelKeys,
+	}
+)
+
+// Container spec metrics
+var (
+	containerSpecCPUPeriod = &runtime.MetricDescriptor{
+		Name:      "container_spec_cpu_period",
+		Help:      "CPU period of the container",
+		LabelKeys: baseLabelKeys,
+	}
+	containerSpecCPUShares = &runtime.MetricDescriptor{
+		Name:      "container_spec_cpu_shares",
+		Help:      "CPU share of the container",
+		LabelKeys: baseLabelKeys,
+	}
+	containerSpecMemoryLimitBytes = &runtime.MetricDescriptor{
+		Name:      "container_spec_memory_limit_bytes",
+		Help:      "Memory limit for the container",
+		LabelKeys: baseLabelKeys,
+	}
+	containerSpecMemoryReservationLimitBytes = &runtime.MetricDescriptor{
+		Name:      "container_spec_memory_reservation_limit_bytes",
+		Help:      "Memory reservation limit for the container",
+		LabelKeys: baseLabelKeys,
+	}
+	containerSpecMemorySwapLimitBytes = &runtime.MetricDescriptor{
+		Name:      "container_spec_memory_swap_limit_bytes",
+		Help:      "Memory swap limit for the container",
+		LabelKeys: baseLabelKeys,
+	}
 )

--- a/internal/cri/server/list_metric_descriptors_linux.go
+++ b/internal/cri/server/list_metric_descriptors_linux.go
@@ -22,8 +22,6 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-var baseLabelKeys = []string{"id", "name"}
-
 func (c *criService) ListMetricDescriptors(context.Context, *runtime.ListMetricDescriptorsRequest) (*runtime.ListMetricDescriptorsResponse, error) {
 	descriptors := c.getMetricDescriptors()
 
@@ -33,313 +31,74 @@ func (c *criService) ListMetricDescriptors(context.Context, *runtime.ListMetricD
 	}
 
 	return &runtime.ListMetricDescriptorsResponse{Descriptors: metricDescriptors}, nil
-
 }
 
 func (c *criService) getMetricDescriptors() map[string][]*runtime.MetricDescriptor {
 	descriptors := map[string][]*runtime.MetricDescriptor{
 		CPUUsageMetrics: {
-			{
-				Name:      "container_cpu_user_seconds_total",
-				Help:      "Cumulative user CPU time consumed in seconds.",
-				LabelKeys: baseLabelKeys,
-			}, {
-				Name:      "container_cpu_system_seconds_total",
-				Help:      "Cumulative system CPU time consumed in seconds.",
-				LabelKeys: baseLabelKeys,
-			}, {
-				Name:      "container_cpu_usage_seconds_total",
-				Help:      "Cumulative CPU time consumed in seconds.",
-				LabelKeys: baseLabelKeys,
-			}, {
-				Name:      "container_cpu_cfs_periods_total",
-				Help:      "Number of elapsed enforcement period intervals.",
-				LabelKeys: baseLabelKeys,
-			}, {
-				Name:      "container_cpu_cfs_throttled_periods_total",
-				Help:      "Number of throttled period intervals.",
-				LabelKeys: baseLabelKeys,
-			}, {
-				Name:      "container_cpu_cfs_throttled_seconds_total",
-				Help:      "Total time duration the container has been throttled.",
-				LabelKeys: baseLabelKeys,
-			},
+			containerCPUUserSecondsTotal,
+			containerCPUSystemSecondsTotal,
+			containerCPUUsageSecondsTotal,
+			containerCPUCfsPeriodsTotal,
+			containerCPUCfsThrottledPeriodsTotal,
+			containerCPUCfsThrottledSecondsTotal,
 		},
 		MemoryUsageMetrics: {
-			{
-				Name:      "container_memory_cache",
-				Help:      "Number of bytes of page cache memory.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_memory_rss",
-				Help:      "Size of RSS in bytes.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_memory_kernel_usage",
-				Help:      "Size of kernel memory allocated in bytes.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_memory_mapped_file",
-				Help:      "Size of memory mapped files in bytes.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_memory_swap",
-				Help:      "Container swap usage in bytes.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_memory_failcnt",
-				Help:      "Number of times container memory usage has hit its cgroup v1 upper memory limit, for cg2 this value is not currently supported",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_memory_usage_bytes",
-				Help:      "Current memory usage in bytes, including all memory regardless of when it was accessed",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_memory_max_usage_bytes",
-				Help:      "Maximum memory usage recorded in bytes",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_memory_working_set_bytes",
-				Help:      "Current working set in bytes.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				// additional added from cadvisor
-				Name:      "container_memory_total_active_file_bytes",
-				Help:      "Current total active cache memory in file on disk, in bytes.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				// additional added from cadvisor
-				Name:      "container_memory_total_inactive_file_bytes",
-				Help:      "Current total inactive cache memory in file, in bytes.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_memory_failures_total",
-				Help:      "Cumulative count of memory allocation failures.",
-				LabelKeys: append(baseLabelKeys, "failure_type", "scope"),
-			},
-			{
-				Name:      "container_oom_events_total",
-				Help:      "Count of out of memory events observed for the container",
-				LabelKeys: baseLabelKeys,
-			},
+			containerMemoryCache,
+			containerMemoryRss,
+			containerMemoryKernelUsage,
+			containerMemoryMappedFile,
+			containerMemorySwap,
+			containerMemoryFailcnt,
+			containerMemoryUsageBytes,
+			containerMemoryMaxUsageBytes,
+			containerMemoryWorkingSetBytes,
+			containerMemoryTotalActiveFileBytes,
+			containerMemoryTotalInactiveFileBytes,
+			containerMemoryFailuresTotal,
+			containerOomEventsTotal,
 		},
 		NetworkUsageMetrics: {
-			{
-				Name:      "container_network_receive_bytes_total",
-				Help:      "Cumulative count of bytes received",
-				LabelKeys: append(baseLabelKeys, "interface"),
-			},
-			{
-				Name:      "container_network_receive_packets_total",
-				Help:      "Cumulative count of packets received",
-				LabelKeys: append(baseLabelKeys, "interface"),
-			},
-			{
-				Name:      "container_network_receive_packets_dropped_total",
-				Help:      "Cumulative count of packets dropped while receiving",
-				LabelKeys: append(baseLabelKeys, "interface"),
-			},
-			{
-				Name:      "container_network_receive_errors_total",
-				Help:      "Cumulative count of errors encountered while receiving",
-				LabelKeys: append(baseLabelKeys, "interface"),
-			},
-			{
-				Name:      "container_network_transmit_bytes_total",
-				Help:      "Cumulative count of bytes transmitted",
-				LabelKeys: append(baseLabelKeys, "interface"),
-			},
-			{
-				Name:      "container_network_transmit_packets_total",
-				Help:      "Cumulative count of packets transmitted",
-				LabelKeys: append(baseLabelKeys, "interface"),
-			},
-			{
-				Name:      "container_network_transmit_packets_dropped_total",
-				Help:      "Cumulative count of packets dropped while transmitting",
-				LabelKeys: append(baseLabelKeys, "interface"),
-			},
-			{
-				Name:      "container_network_transmit_errors_total",
-				Help:      "Cumulative count of errors encountered while transmitting",
-				LabelKeys: append(baseLabelKeys, "interface"),
-			},
+			containerNetworkReceiveBytesTotal,
+			containerNetworkReceivePacketsTotal,
+			containerNetworkReceivePacketsDroppedTotal,
+			containerNetworkReceiveErrorsTotal,
+			containerNetworkTransmitBytesTotal,
+			containerNetworkTransmitPacketsTotal,
+			containerNetworkTransmitPacketsDroppedTotal,
+			containerNetworkTransmitErrorsTotal,
 		},
 		DiskUsageMetrics: {
-			{
-				Name:      "container_fs_inodes_free",
-				Help:      "Number of available Inodes",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_inodes_total",
-				Help:      "Number of Inodes",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_limit_bytes",
-				Help:      "Number of bytes that can be consumed by the container on this filesystem.",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_usage_bytes",
-				Help:      "Number of bytes that are consumed by the container on this filesystem.",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
+			containerFsInodesFree,
+			containerFsInodesTotal,
+			containerFsLimitBytes,
+			containerFsUsageBytes,
 		},
 		DiskIOMetrics: {
-			{
-				Name:      "container_fs_reads_bytes_total",
-				Help:      "Cumulative count of bytes read",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_reads_total",
-				Help:      "Cumulative count of reads completed",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_sector_reads_total",
-				Help:      "Cumulative count of sector reads completed",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_reads_merged_total",
-				Help:      "Cumulative count of reads merged",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_read_seconds_total",
-				Help:      "Cumulative count of seconds spent reading",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_writes_bytes_total",
-				Help:      "Cumulative count of bytes written",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_writes_total",
-				Help:      "Cumulative count of writes completed",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_sector_writes_total",
-				Help:      "Cumulative count of sector writes completed",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_writes_merged_total",
-				Help:      "Cumulative count of writes merged",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_write_seconds_total",
-				Help:      "Cumulative count of seconds spent writing",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_io_current",
-				Help:      "Number of I/Os currently in progress",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_io_time_seconds_total",
-				Help:      "Cumulative count of seconds spent doing I/Os",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_fs_io_time_weighted_seconds_total",
-				Help:      "Cumulative weighted I/O time in seconds",
-				LabelKeys: append(baseLabelKeys, "device"),
-			},
-			{
-				Name:      "container_blkio_device_usage_total",
-				Help:      "Blkio device bytes usage",
-				LabelKeys: append(baseLabelKeys, "device", "major", "minor", "operation"),
-			},
+			containerFsReadsBytesTotal,
+			containerFsReadsTotal,
+			containerFsWritesBytesTotal,
+			containerFsWritesTotal,
+			containerBlkioDeviceUsageTotal,
 		},
 		ProcessMetrics: {
-			{
-				Name:      "container_processes",
-				Help:      "Number of processes running inside the container.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_file_descriptors",
-				Help:      "Number of open file descriptors for the container.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_sockets",
-				Help:      "Number of open sockets for the container.",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_threads_max",
-				Help:      "Maximum number of threads allowed inside the container, infinity if value is zero",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_threads",
-				Help:      "Number of threads running inside the container",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_ulimits_soft",
-				Help:      "Soft ulimit values for the container root process. Unlimited if -1, except priority and nice",
-				LabelKeys: append(baseLabelKeys, "ulimit"),
-			},
+			containerProcesses,
+			containerFileDescriptors,
+			containerSockets,
+			containerThreadsMax,
+			containerThreads,
+			containerUlimitsSoft,
 		},
 		MiscellaneousMetrics: {
-			{
-				Name:      "container_last_seen",
-				Help:      "Last time a container was seen by the exporter",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_start_time_seconds",
-				Help:      "Start time of the container since unix epoch in seconds",
-				LabelKeys: baseLabelKeys,
-			},
+			containerLastSeen,
+			containerStartTimeSeconds,
 		},
 		ContainerSpecMetrics: {
-			{
-				Name:      "container_spec_cpu_period",
-				Help:      "CPU period of the container",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_spec_cpu_shares",
-				Help:      "CPU share of the container",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_spec_memory_limit_bytes",
-				Help:      "Memory limit for the container",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_spec_memory_reservation_limit_bytes",
-				Help:      "Memory reservation limit for the container",
-				LabelKeys: baseLabelKeys,
-			},
-			{
-				Name:      "container_spec_memory_swap_limit_bytes",
-				Help:      "Memory swap limit for the container",
-				LabelKeys: baseLabelKeys,
-			},
+			containerSpecCPUPeriod,
+			containerSpecCPUShares,
+			containerSpecMemoryLimitBytes,
+			containerSpecMemoryReservationLimitBytes,
+			containerSpecMemorySwapLimitBytes,
 		},
 	}
 	return descriptors

--- a/internal/cri/server/sandbox_stats.go
+++ b/internal/cri/server/sandbox_stats.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	cg1 "github.com/containerd/cgroups/v3/cgroup1/stats"
+	cg2 "github.com/containerd/cgroups/v3/cgroup2/stats"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -33,11 +35,15 @@ func (c *criService) PodSandboxStats(
 		return nil, fmt.Errorf("an error occurred when trying to find sandbox %s: %w", r.GetPodSandboxId(), err)
 	}
 
-	// issue 12279: this is tautologically true where interface is stubbed out.
-	podSandboxStats, err := c.podSandboxStats(ctx, sandbox) //nolint: staticcheck
-	if err != nil {                                         //nolint: staticcheck
+	podSandboxStats, err := c.podSandboxStats(ctx, sandbox)
+	if err != nil {
 		return nil, fmt.Errorf("failed to decode pod sandbox metrics %s: %w", r.GetPodSandboxId(), err)
 	}
 
 	return &runtime.PodSandboxStatsResponse{Stats: podSandboxStats}, nil
+}
+
+type cgroupMetrics struct {
+	v1 *cg1.Metrics
+	v2 *cg2.Metrics
 }


### PR DESCRIPTION
This PR improves https://github.com/containerd/containerd/pull/10691. As far as we can tell, this code never actually worked with e.g. Kubelet, and the original PR was merged without unit tests or even manual tests with a Prometheus server.

```
21:48:31.065239 cri_metrics.go:113] "Error getting CRI prometheus metric" err="inconsistent label cardinality: expected 5 label values but got 4 in []string{\"foo\", \"foo\", \"default\", \"a7a6fbfcfd90a6b5dc08e30e3e45c19aad2e5dd541cc1356c2883009a4b9b04e\"}" descriptor="Desc{fqName: \"container_fs_inodes_free\", help: \"[INTERNAL] Number of available Inodes\", constLabels: {}, variableLabels: {id,name,device}}"
```

Some extra scrutiny probably won't hurt, this PR only fixes the most critical issues.