### PR TITLE
Fix transfer plugin to honor config_path for registry hosts configuration

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -72,7 +72,8 @@ var (
 			Usage: "Refresh token for authorization server",
 		},
 		&cli.StringFlag{
-			Name: "hosts-dir",
+			Name:  "hosts-dir",
+			Value: "/etc/containerd/certs.d",
 			// compatible with "/etc/docker/certs.d"
 			Usage: "Custom hosts configuration directory",
 		},

--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -304,10 +304,10 @@ func WritePidFile(path string, pid int) error {
 // Returns:
 //   - The config_path value (e.g., "/etc/containerd/certs.d") if the plugin exists and exports it
 //   - Empty string in the following cases:
-//     - Introspection query fails (daemon communication error)
-//     - Plugin "io.containerd.transfer.v1.local" is not found
-//     - Multiple plugins match (should never happen with exact ID match)
-//     - Plugin doesn't export "config_path" field
+//   - Introspection query fails (daemon communication error)
+//   - Plugin "io.containerd.transfer.v1.local" is not found
+//   - Multiple plugins match (should never happen with exact ID match)
+//   - Plugin doesn't export "config_path" field
 //
 // The function returns empty string instead of an error to allow graceful fallback
 // to CLI flag defaults when daemon configuration is unavailable.

--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -298,8 +298,19 @@ func WritePidFile(path string, pid int) error {
 }
 
 // GetRegistryConfigPath queries the transfer plugin's config_path via introspection.
-// Returns empty string if the plugin is not found or doesn't export config_path.
+//
 // This allows CLI commands to respect daemon configuration instead of relying solely on flags.
+//
+// Returns:
+//   - The config_path value (e.g., "/etc/containerd/certs.d") if the plugin exists and exports it
+//   - Empty string in the following cases:
+//     - Introspection query fails (daemon communication error)
+//     - Plugin "io.containerd.transfer.v1.local" is not found
+//     - Multiple plugins match (should never happen with exact ID match)
+//     - Plugin doesn't export "config_path" field
+//
+// The function returns empty string instead of an error to allow graceful fallback
+// to CLI flag defaults when daemon configuration is unavailable.
 func GetRegistryConfigPath(ctx context.Context, client interface{ IntrospectionService() introspection.Service }) string {
 	resp, err := client.IntrospectionService().Plugins(ctx, "id==io.containerd.transfer.v1.local")
 	if err != nil {

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -165,11 +165,11 @@ command. As part of this process, we do the following:
 			// Otherwise, try to get config_path from daemon's transfer plugin configuration.
 			// If that's not available either, fallback to CLI flag default.
 			if cliContext.IsSet("hosts-dir") {
-				opts = append(opts, registry.WithHostDir(cliContext.String("hosts-dir")))
+				opts = append(opts, registry.WithConfigPath(cliContext.String("hosts-dir")))
 			} else if daemonConfigPath := commands.GetRegistryConfigPath(ctx, client); daemonConfigPath != "" {
 				opts = append(opts, registry.WithConfigPath(daemonConfigPath))
 			} else {
-				opts = append(opts, registry.WithHostDir(cliContext.String("hosts-dir")))
+				opts = append(opts, registry.WithConfigPath(cliContext.String("hosts-dir")))
 			}
 
 			if cliContext.Bool("plain-http") {

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -159,8 +159,19 @@ command. As part of this process, we do the following:
 
 			opts := []registry.Opt{
 				registry.WithCredentials(ch),
-				registry.WithHostDir(cliContext.String("hosts-dir")),
 			}
+
+			// If --hosts-dir is explicitly set, use it.
+			// Otherwise, try to get config_path from daemon's transfer plugin configuration.
+			// If that's not available either, fallback to CLI flag default.
+			if cliContext.IsSet("hosts-dir") {
+				opts = append(opts, registry.WithHostDir(cliContext.String("hosts-dir")))
+			} else if daemonConfigPath := commands.GetRegistryConfigPath(ctx, client); daemonConfigPath != "" {
+				opts = append(opts, registry.WithConfigPath(daemonConfigPath))
+			} else {
+				opts = append(opts, registry.WithHostDir(cliContext.String("hosts-dir")))
+			}
+
 			if cliContext.Bool("plain-http") {
 				opts = append(opts, registry.WithDefaultScheme("http"))
 			}

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -121,11 +121,11 @@ var pushCommand = &cli.Command{
 			// Otherwise, try to get config_path from daemon's transfer plugin configuration.
 			// If that's not available either, fallback to CLI flag default.
 			if cliContext.IsSet("hosts-dir") {
-				opts = append(opts, registry.WithHostDir(cliContext.String("hosts-dir")))
+				opts = append(opts, registry.WithConfigPath(cliContext.String("hosts-dir")))
 			} else if daemonConfigPath := commands.GetRegistryConfigPath(ctx, client); daemonConfigPath != "" {
 				opts = append(opts, registry.WithConfigPath(daemonConfigPath))
 			} else {
-				opts = append(opts, registry.WithHostDir(cliContext.String("hosts-dir")))
+				opts = append(opts, registry.WithConfigPath(cliContext.String("hosts-dir")))
 			}
 
 			if cliContext.Bool("plain-http") {

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -114,7 +114,20 @@ var pushCommand = &cli.Command{
 			if local == "" {
 				local = ref
 			}
-			opts := []registry.Opt{registry.WithCredentials(ch), registry.WithHostDir(cliContext.String("hosts-dir"))}
+
+			opts := []registry.Opt{registry.WithCredentials(ch)}
+
+			// If --hosts-dir is explicitly set, use it.
+			// Otherwise, try to get config_path from daemon's transfer plugin configuration.
+			// If that's not available either, fallback to CLI flag default.
+			if cliContext.IsSet("hosts-dir") {
+				opts = append(opts, registry.WithHostDir(cliContext.String("hosts-dir")))
+			} else if daemonConfigPath := commands.GetRegistryConfigPath(ctx, client); daemonConfigPath != "" {
+				opts = append(opts, registry.WithConfigPath(daemonConfigPath))
+			} else {
+				opts = append(opts, registry.WithHostDir(cliContext.String("hosts-dir")))
+			}
+
 			if cliContext.Bool("plain-http") {
 				opts = append(opts, registry.WithDefaultScheme("http"))
 			}

--- a/core/transfer/registry/registry.go
+++ b/core/transfer/registry/registry.go
@@ -133,7 +133,8 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
 		}
 	}
 
-	// Determine the effective host directory: use hostDir if specified, otherwise configPath
+	// Determine the effective host directory.
+	// Priority: WithHostDir (explicit) > WithConfigPath (daemon config) > empty (use default resolver)
 	hostDir := ropts.hostDir
 	if hostDir == "" && ropts.configPath != "" {
 		hostDir = ropts.configPath

--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -18,6 +18,7 @@ package transfer
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
@@ -236,5 +237,6 @@ func defaultConfig() *transferConfig {
 		MaxConcurrentUploadedLayers: 3,
 		MaxConcurrentUnpacks:        1,
 		CheckPlatformSupported:      false,
+		RegistryConfigPath:          filepath.Join(defaults.DefaultConfigDir, "certs.d"),
 	}
 }

--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -182,6 +182,9 @@ func init() {
 			lc.RegistryConfigPath = config.RegistryConfigPath
 			lc.DuplicationSuppressor = kmutex.New()
 
+			// Export config_path so clients can query it via introspection
+			ic.Meta.Exports["config_path"] = config.RegistryConfigPath
+
 			return local.NewTransferService(ms.ContentStore(), metadata.NewImageStore(ms), lc), nil
 		},
 	})


### PR DESCRIPTION
## Summary

Fixes #12550

The transfer plugin was reading `config_path` from configuration, but never actually applied it when creating OCI registries.
As a result, `ctr` ignored custom `hosts.toml` configurations unless `--hosts-dir` was explicitly provided, leading to confusing and inconsistent behavior.

This change ensures that `config_path` is honored by default and aligns `ctr` behavior with the CRI plugin and user expectations.

## Problem

The transfer plugin parsed `config_path` correctly, but the value was never used when creating registries.
Because of this, `ctr images pull` did not respect `hosts.toml` unless the user manually passed `--hosts-dir` every time.

This resulted in:

* Custom registry configurations being silently ignored
* Confusion for users who had already configured `/etc/containerd/certs.d`
* Inconsistent behavior between `ctr` and the CRI plugin

## Changes

### 1. Set default `config_path` in transfer plugin

* Added `/etc/containerd/certs.d` as the default `config_path`
* Uses `filepath.Join()` for platform-independent path handling
* Appears in `containerd config default` output

### 2. Add `WithConfigPath` option to registry package

* Introduced a new option to specify a fallback config path
* Used when `hostDir` is not explicitly provided
* Preserves backward compatibility: `WithHostDir` still takes precedence

### 3. Set default `--hosts-dir` for `ctr`

* Added default value `/etc/containerd/certs.d` to the `--hosts-dir` flag
* Eliminates the need for users to specify it explicitly
* Aligns `ctr` behavior with the CRI plugin

### 4. Code quality improvements

* Removed duplicate host directory resolution logic
* Introduced a single variable to track the effective host directory
* Improved comments for clarity and maintainability

## Behavior

### Before

```bash
# hosts.toml exists at /etc/containerd/certs.d/docker.io
ctr images pull docker.io/library/nginx:latest
# ❌ hosts.toml is ignored

ctr images pull --hosts-dir=/etc/containerd/certs.d docker.io/library/nginx:latest
# ✅ works, but requires explicit flag
```

```bash
# hosts.toml exists at /etc/containerd/certs.d/docker.io
ctr images pull docker.io/library/nginx:latest
# ✅ hosts.toml is respected by default

ctr images pull --hosts-dir=/custom/path docker.io/library/nginx:latest
# ✅ custom path still overrides default
```

## Configuration

Default output now includes:

```toml
[plugins."io.containerd.transfer.v1.local"]
  config_path = "/etc/containerd/certs.d"
```

Matches CRI plugin behavior:

```toml
[plugins."io.containerd.cri.v1.images".registry]
  config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
```

## Testing

* ✅ Build succeeded
* ✅ `containerd config default` shows correct `config_path`
* ✅ `ctr images pull --help` shows default `--hosts-dir`
* ✅ No behavior changes when `--hosts-dir` is explicitly set
* ✅ No breaking changes

## Result

This change:

* Makes `ctr` honor registry configuration by default
* Matches CRI behavior
* Eliminates unnecessary user friction
* Fixes a real configuration bug, not just a usability issue