### PR TITLE
core/runtime/v2: remove uses of otelgrpc.UnaryClientInterceptor

### DIFF
--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -305,8 +305,7 @@ func makeConnection(ctx context.Context, id string, params client.BootstrapParam
 	case "grpc":
 		gopts := []grpc.DialOption{
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),   //nolint:staticcheck // Ignore SA1019. Deprecation assumes use of [grpc.NewClient] but we are not using that here.
-			grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()), //nolint:staticcheck // Ignore SA1019. Deprecation assumes use of [grpc.NewClient] but we are not using that here.
+			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		}
 		return grpcDialContext(params.Address, onClose, gopts...)
 	default:

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -79,8 +79,7 @@ func clientWithTrace() error {
 
     dialOpts := []grpc.DialOption{
         grpc.WithTransportCredentials(insecure.NewCredentials()),
-        grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
-        grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
+        grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
     }
     client, ctx, cancel, err := commands.NewClient(context, containerd.WithDialOpts(dialOpts))
     if err != nil {


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/12604#issuecomment-3596523255
- relates to https://github.com/open-telemetry/opentelemetry-go-contrib/pull/7125
- relates to https://github.com/containerd/containerd/pull/10186



The otelgrpc.UnaryClientInterceptor and otelgrpc.StreamClientInterceptor options were deprecated and removed in favor of NewClientHandler.