### PR TITLE
Update plugin config migration to run on load

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"iter"
 	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"time"
 
 	"github.com/containerd/containerd/v2/cmd/containerd/server"
@@ -36,6 +38,8 @@ import (
 	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
 	"github.com/urfave/cli/v2"
 	"google.golang.org/grpc/grpclog"
 )
@@ -138,7 +142,11 @@ can be used and modified as necessary as a custom configuration.`
 		configPath := cliContext.String("config")
 		_, err := os.Stat(configPath)
 		if !os.IsNotExist(err) || cliContext.IsSet("config") {
-			if err := srvconfig.LoadConfig(ctx, configPath, config); err != nil {
+			g := registry.Graph(func(*plugin.Registration) bool { return false })
+			plugins := func() iter.Seq[plugin.Registration] {
+				return slices.Values(g)
+			}
+			if err := srvconfig.LoadConfigWithPlugins(ctx, configPath, plugins, config); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Perform the plugin migrations on load to allow stepping through plugin migration versions to happen alongside migration of the global configuration object. When the configuration migrations happen separately, the version in the config can get increasd on load and cause plugin migration not to occur. This does not cause issues today because global config migrations only occur for version 0 and 1, which was before plugin config migration was introduced. Any new version which does migrations either cannot get called on load or will break plugin migration later.

This change simplifies configuration load and migration, preventing the need to migrate the configurations on load and again later when plugins are loaded. This also allows includes to work at different versions, which may currently break or cause inconsistent results.

***Note*** this will now call the plugin graph twice, once without any filter to perform all migrations, and later with the disabled filter. Since the disabled filter is part of the global configuration, it does not make sense to utilize it during configuration load.
Currently the plugin load has an inefficiency which is solved by https://github.com/containerd/plugin/pull/8 and https://github.com/containerd/plugin/pull/13 which together is a 300x improvement in `Graph` call time and 99% reduction in memory allocation, making the extra call to `Graph` negligible. 