### PR TITLE
fix migrated cri image config when using registry

### DIFF
--- a/internal/cri/config/config_unix.go
+++ b/internal/cri/config/config_unix.go
@@ -32,9 +32,7 @@ func DefaultImageConfig() ImageConfig {
 		Snapshotter:                defaults.DefaultSnapshotter,
 		DisableSnapshotAnnotations: true,
 		MaxConcurrentDownloads:     3,
-		Registry: Registry{
-			ConfigPath: "/etc/containerd/certs.d:/etc/docker/certs.d",
-		},
+		Registry:                   Registry{},
 		ImageDecryption: ImageDecryption{
 			KeyModel: KeyModelNode,
 		},

--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -61,6 +61,16 @@ func init() {
 			}
 			mdb := m.(*metadata.DB)
 
+			// only set the default value of config path, if both mirrors and
+			// config path are empty and we are on Linux.
+			// This also makes sure that if the loaded config already contains both config path and mirrors
+			// the validation will fail.
+			if runtime.GOOS == "linux" {
+				if config.Registry.ConfigPath == "" && len(config.Registry.Mirrors) == 0 {
+					config.Registry.ConfigPath = "/etc/containerd/certs.d:/etc/docker/certs.d"
+				}
+			}
+
 			if warnings, err := criconfig.ValidateImageConfig(ic.Context, &config); err != nil {
 				return nil, fmt.Errorf("invalid cri image config: %w", err)
 			} else if len(warnings) > 0 {
@@ -208,18 +218,6 @@ func migrateConfig(dst, src map[string]interface{}) {
 	} {
 		if val, ok := src[key]; ok {
 			dst[key] = val
-		}
-	}
-	if runtime.GOOS == "linux" {
-		if value, ok := dst["registry"]; ok {
-			regMap := value.(map[string]any)
-			if configPath, ok := regMap["config_path"]; ok {
-				if configPath == "" {
-					// Fill in default from config_unix.go (DefaultImageConfig)
-					regMap["config_path"] = "/etc/containerd/certs.d:/etc/docker/certs.d"
-				}
-			}
-			dst["registry"] = regMap
 		}
 	}
 


### PR DESCRIPTION
when config has registry.mirrors from config version 2, after migration, config_path should be set to empty and not be the default value

move setting the config_path from default image config to plugin init.
This makes sure that when both mirrors and config_path are set, mirrors
are given preference and does not cause an error with CRI plugin

Fixes: #12612 