### PR TITLE
[WIP] Re-enable ResourceMetrics for node-e2e tests

### DIFF
--- a/.github/workflows/node-e2e.yml
+++ b/.github/workflows/node-e2e.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Checkout Kubernetes
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
-          repository: kubernetes/kubernetes
+          repository: dims/kubernetes
+          ref: add-logs-to-kubelet-metrics
           path: src/k8s.io/kubernetes
 
       - name: Install Go
@@ -88,12 +89,10 @@ jobs:
       - name: Run Node E2E Tests
         working-directory: ./src/k8s.io/kubernetes
         run: |
-          # TODO: Remove "ResourceMetrics" feature skip once containerd supports ListMetricDescriptors:
-          # https://github.com/kubernetes/kubernetes/blob/v1.33.2/test/e2e_node/resource_metrics_test.go#L67-L71
           sudo make test-e2e-node \
             FOCUS='\[NodeConformance\]|\[Feature:.+\]|\[Feature\]' \
-            SKIP='\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:UserNamespacesSupport\]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:ResourceMetrics\]|\[Alpha\]' \
-            TEST_ARGS='--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
+            SKIP='\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:UserNamespacesSupport\]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Alpha\]' \
+            TEST_ARGS='--feature-gates=PodAndContainerStatsFromCRI=true --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --feature-gates=PodAndContainerStatsFromCRI=true"'
 
       - name: Collect Logs on Failure
         if: failure()

--- a/internal/cri/server/stats_collector.go
+++ b/internal/cri/server/stats_collector.go
@@ -1,0 +1,290 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/containerd/cgroups/v3"
+	"github.com/containerd/cgroups/v3/cgroup1"
+	cg1 "github.com/containerd/cgroups/v3/cgroup1/stats"
+	cgroupsv2 "github.com/containerd/cgroups/v3/cgroup2"
+	cg2 "github.com/containerd/cgroups/v3/cgroup2/stats"
+	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+
+	"github.com/containerd/containerd/api/services/tasks/v1"
+	"github.com/containerd/containerd/v2/internal/cri/store/stats"
+	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
+)
+
+const (
+	// defaultCollectionInterval is how often the collector fetches metrics.
+	// This matches cAdvisor's default housekeeping interval.
+	defaultCollectionInterval = 1 * time.Second
+
+	// defaultStatsAge is how long stats samples are retained.
+	defaultStatsAge = 2 * time.Minute
+
+	// defaultMaxSamples is the maximum number of samples to keep per container.
+	// 120 samples at 1s interval = 2 minutes of history
+	defaultMaxSamples = 120
+)
+
+// StatsCollector periodically collects CPU stats for containers and sandboxes,
+// storing them in TimedStores. This allows UsageNanoCores to be calculated
+// from historical samples, similar to how cAdvisor works.
+type StatsCollector struct {
+	mu sync.RWMutex
+	// stores maps container/sandbox ID to their TimedStore
+	stores map[string]*stats.TimedStore
+	// interval is how often to collect stats
+	interval time.Duration
+	// statsAge is how long to keep samples
+	statsAge time.Duration
+	// maxSamples is the max number of samples per container
+	maxSamples int
+	// stopCh is used to stop the collection loop
+	stopCh chan struct{}
+	// service provides access to task metrics
+	service *criService
+}
+
+// NewStatsCollector creates a new StatsCollector.
+func NewStatsCollector(service *criService) *StatsCollector {
+	return &StatsCollector{
+		stores:     make(map[string]*stats.TimedStore),
+		interval:   defaultCollectionInterval,
+		statsAge:   defaultStatsAge,
+		maxSamples: defaultMaxSamples,
+		stopCh:     make(chan struct{}),
+		service:    service,
+	}
+}
+
+// Start begins the background stats collection loop.
+func (c *StatsCollector) Start() {
+	go c.collectLoop()
+}
+
+// Stop stops the background stats collection loop.
+func (c *StatsCollector) Stop() {
+	close(c.stopCh)
+}
+
+// collectLoop periodically collects stats for all containers and sandboxes.
+func (c *StatsCollector) collectLoop() {
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	// Do an initial collection immediately
+	c.collect()
+
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			c.collect()
+		}
+	}
+}
+
+// collect fetches metrics for all containers and sandboxes and stores them.
+func (c *StatsCollector) collect() {
+	// Use namespaced context to access containers in the k8s.io namespace
+	ctx := ctrdutil.NamespacedContext()
+
+	// Collect container stats
+	c.collectContainerStats(ctx)
+
+	// Collect sandbox stats (Linux only, uses cgroup metrics)
+	c.collectSandboxStats(ctx)
+}
+
+// collectContainerStats fetches metrics for all containers.
+func (c *StatsCollector) collectContainerStats(ctx context.Context) {
+	containers := c.service.containerStore.List()
+	if len(containers) == 0 {
+		return
+	}
+
+	// Build request for all containers
+	req := &tasks.MetricsRequest{}
+	for _, cntr := range containers {
+		req.Filters = append(req.Filters, "id=="+cntr.ID)
+	}
+
+	resp, err := c.service.client.TaskService().Metrics(ctx, req)
+	if err != nil {
+		log.G(ctx).WithError(err).Debug("StatsCollector: failed to fetch container metrics")
+		return
+	}
+
+	timestamp := time.Now()
+	for _, metric := range resp.Metrics {
+		usageCoreNanoSeconds, ok := extractCPUUsage(metric.Data)
+		if !ok {
+			continue
+		}
+		c.addSample(metric.ID, timestamp, usageCoreNanoSeconds)
+	}
+}
+
+// collectSandboxStats fetches metrics for all sandboxes.
+// On Linux, sandbox/pod stats come from the parent cgroup (which includes all
+// containers in the pod), not from the pause container's task metrics.
+// This matches how sandbox_stats_linux.go retrieves pod-level CPU stats.
+func (c *StatsCollector) collectSandboxStats(ctx context.Context) {
+	sandboxes := c.service.sandboxStore.List()
+	if len(sandboxes) == 0 {
+		return
+	}
+
+	timestamp := time.Now()
+	for _, sb := range sandboxes {
+		// Get the parent cgroup path for the pod
+		cgroupPath := sb.Config.GetLinux().GetCgroupParent()
+		if cgroupPath == "" {
+			continue
+		}
+
+		usageCoreNanoSeconds, ok := c.getCgroupCPUUsage(ctx, cgroupPath)
+		if !ok {
+			continue
+		}
+		c.addSample(sb.ID, timestamp, usageCoreNanoSeconds)
+	}
+}
+
+// getCgroupCPUUsage reads CPU usage from a cgroup path.
+// Supports both cgroupv1 and cgroupv2.
+func (c *StatsCollector) getCgroupCPUUsage(ctx context.Context, cgroupPath string) (uint64, bool) {
+	switch cgroups.Mode() {
+	case cgroups.Unified:
+		cg, err := cgroupsv2.Load(cgroupPath)
+		if err != nil {
+			log.G(ctx).WithError(err).Debugf("StatsCollector: failed to load cgroupv2: %s", cgroupPath)
+			return 0, false
+		}
+		stats, err := cg.Stat()
+		if err != nil {
+			log.G(ctx).WithError(err).Debugf("StatsCollector: failed to get cgroupv2 stats: %s", cgroupPath)
+			return 0, false
+		}
+		if stats.CPU != nil {
+			// cgroupv2 reports in microseconds, convert to nanoseconds
+			return stats.CPU.UsageUsec * 1000, true
+		}
+	default:
+		control, err := cgroup1.Load(cgroup1.StaticPath(cgroupPath))
+		if err != nil {
+			log.G(ctx).WithError(err).Debugf("StatsCollector: failed to load cgroupv1: %s", cgroupPath)
+			return 0, false
+		}
+		stats, err := control.Stat(cgroup1.IgnoreNotExist)
+		if err != nil {
+			log.G(ctx).WithError(err).Debugf("StatsCollector: failed to get cgroupv1 stats: %s", cgroupPath)
+			return 0, false
+		}
+		if stats.CPU != nil && stats.CPU.Usage != nil {
+			return stats.CPU.Usage.Total, true
+		}
+	}
+	return 0, false
+}
+
+// addSample adds a CPU sample for the given container/sandbox ID.
+func (c *StatsCollector) addSample(id string, timestamp time.Time, usageCoreNanoSeconds uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	store, ok := c.stores[id]
+	if !ok {
+		store = stats.NewTimedStore(c.statsAge, c.maxSamples)
+		c.stores[id] = store
+	}
+	store.Add(timestamp, usageCoreNanoSeconds)
+}
+
+// GetUsageNanoCores returns the latest calculated UsageNanoCores for the given
+// container/sandbox ID. Returns 0 and false if no data is available or if
+// there aren't enough samples to calculate the rate.
+func (c *StatsCollector) GetUsageNanoCores(id string) (uint64, bool) {
+	c.mu.RLock()
+	store, ok := c.stores[id]
+	c.mu.RUnlock()
+
+	if !ok {
+		return 0, false
+	}
+
+	return store.GetLatestUsageNanoCores()
+}
+
+// GetLatestSample returns the latest CPU sample for the given container/sandbox ID.
+// Returns nil if no data is available.
+func (c *StatsCollector) GetLatestSample(id string) *stats.CPUSample {
+	c.mu.RLock()
+	store, ok := c.stores[id]
+	c.mu.RUnlock()
+
+	if !ok {
+		return nil
+	}
+
+	return store.GetLatest()
+}
+
+// RemoveContainer removes the stats store for a container/sandbox.
+// Should be called when a container is removed.
+func (c *StatsCollector) RemoveContainer(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.stores, id)
+}
+
+// extractCPUUsage extracts the CPU usage in nanoseconds from the metric data.
+// Supports both cgroupv1 and cgroupv2 metrics.
+func extractCPUUsage(data typeurl.Any) (uint64, bool) {
+	if data == nil {
+		return 0, false
+	}
+
+	taskMetrics, err := typeurl.UnmarshalAny(data)
+	if err != nil {
+		return 0, false
+	}
+
+	switch v := taskMetrics.(type) {
+	case *cg1.Metrics:
+		if v.CPU != nil && v.CPU.Usage != nil {
+			return v.CPU.Usage.Total, true
+		}
+	case *cg2.Metrics:
+		if v.CPU != nil {
+			// cgroupv2 reports in microseconds, convert to nanoseconds
+			return v.CPU.UsageUsec * 1000, true
+		}
+	}
+
+	return 0, false
+}

--- a/internal/cri/server/stats_collector_other.go
+++ b/internal/cri/server/stats_collector_other.go
@@ -1,0 +1,54 @@
+//go:build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/containerd/containerd/v2/internal/cri/store/stats"
+)
+
+// StatsCollector is a stub for non-Linux platforms.
+// On Linux, the real implementation periodically collects CPU stats for
+// containers and sandboxes, storing them in TimedStores.
+type StatsCollector struct{}
+
+// NewStatsCollector creates a new StatsCollector (stub on non-Linux).
+func NewStatsCollector(service *criService) *StatsCollector {
+	return &StatsCollector{}
+}
+
+// Start begins the background stats collection loop (no-op on non-Linux).
+func (c *StatsCollector) Start() {}
+
+// Stop stops the background stats collection loop (no-op on non-Linux).
+func (c *StatsCollector) Stop() {}
+
+// GetUsageNanoCores returns the latest calculated UsageNanoCores for the given
+// container/sandbox ID. Returns 0 and false on non-Linux platforms.
+func (c *StatsCollector) GetUsageNanoCores(id string) (uint64, bool) {
+	return 0, false
+}
+
+// GetLatestSample returns the latest CPU sample for the given container/sandbox ID.
+// Returns nil on non-Linux platforms.
+func (c *StatsCollector) GetLatestSample(id string) *stats.CPUSample {
+	return nil
+}
+
+// RemoveContainer removes the stats store for a container/sandbox (no-op on non-Linux).
+func (c *StatsCollector) RemoveContainer(id string) {}

--- a/internal/cri/store/stats/timed_store.go
+++ b/internal/cri/store/stats/timed_store.go
@@ -1,0 +1,182 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package stats
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// CPUSample holds a single CPU usage sample with timestamp.
+type CPUSample struct {
+	Timestamp            time.Time
+	UsageCoreNanoSeconds uint64
+	// UsageNanoCores is the instantaneous CPU usage rate calculated
+	// from this sample and the previous sample.
+	UsageNanoCores uint64
+}
+
+// timedStoreDataSlice is a time-ordered slice of CPU samples.
+type timedStoreDataSlice []CPUSample
+
+func (t timedStoreDataSlice) Less(i, j int) bool {
+	return t[i].Timestamp.Before(t[j].Timestamp)
+}
+
+func (t timedStoreDataSlice) Len() int {
+	return len(t)
+}
+
+func (t timedStoreDataSlice) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+// TimedStore is a time-based buffer for CPU stats samples.
+// It stores samples for a specific time period and/or a max number of items,
+// similar to cAdvisor's TimedStore but specialized for CPU stats.
+// All methods are thread-safe.
+type TimedStore struct {
+	mu       sync.RWMutex
+	buffer   timedStoreDataSlice
+	age      time.Duration
+	maxItems int
+}
+
+// NewTimedStore creates a new TimedStore.
+// age specifies how long samples are retained.
+// maxItems specifies the maximum number of samples to keep (-1 for no limit).
+func NewTimedStore(age time.Duration, maxItems int) *TimedStore {
+	capacity := maxItems
+	if capacity < 0 {
+		capacity = 0 // Will grow dynamically
+	}
+	return &TimedStore{
+		buffer:   make(timedStoreDataSlice, 0, capacity),
+		age:      age,
+		maxItems: maxItems,
+	}
+}
+
+// Add adds a new CPU sample to the store.
+// It calculates UsageNanoCores from the previous sample if available.
+// Samples are stored in timestamp order, and old samples are evicted
+// based on age and maxItems constraints.
+func (s *TimedStore) Add(timestamp time.Time, usageCoreNanoSeconds uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sample := CPUSample{
+		Timestamp:            timestamp,
+		UsageCoreNanoSeconds: usageCoreNanoSeconds,
+	}
+
+	// Calculate UsageNanoCores from the previous sample if we have one
+	if len(s.buffer) > 0 {
+		lastSample := s.buffer[len(s.buffer)-1]
+		sample.UsageNanoCores = calculateUsageNanoCores(lastSample, sample)
+	}
+
+	// Common case: data is added in order
+	if len(s.buffer) == 0 || !timestamp.Before(s.buffer[len(s.buffer)-1].Timestamp) {
+		s.buffer = append(s.buffer, sample)
+	} else {
+		// Data is out of order; insert it in the correct position
+		index := sort.Search(len(s.buffer), func(index int) bool {
+			return s.buffer[index].Timestamp.After(timestamp)
+		})
+		s.buffer = append(s.buffer, CPUSample{}) // Make room
+		copy(s.buffer[index+1:], s.buffer[index:])
+		s.buffer[index] = sample
+		// Recalculate UsageNanoCores for this and the next sample
+		if index > 0 {
+			s.buffer[index].UsageNanoCores = calculateUsageNanoCores(s.buffer[index-1], s.buffer[index])
+		}
+		if index+1 < len(s.buffer) {
+			s.buffer[index+1].UsageNanoCores = calculateUsageNanoCores(s.buffer[index], s.buffer[index+1])
+		}
+	}
+
+	// Remove any elements before eviction time
+	evictTime := timestamp.Add(-s.age)
+	index := sort.Search(len(s.buffer), func(index int) bool {
+		return s.buffer[index].Timestamp.After(evictTime)
+	})
+	if index < len(s.buffer) && index > 0 {
+		s.buffer = s.buffer[index:]
+	}
+
+	// Remove any elements if over max size
+	if s.maxItems >= 0 && len(s.buffer) > s.maxItems {
+		startIndex := len(s.buffer) - s.maxItems
+		s.buffer = s.buffer[startIndex:]
+	}
+}
+
+// GetLatest returns the most recent sample, or nil if no samples exist.
+func (s *TimedStore) GetLatest() *CPUSample {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if len(s.buffer) == 0 {
+		return nil
+	}
+	sample := s.buffer[len(s.buffer)-1]
+	return &sample
+}
+
+// GetLatestUsageNanoCores returns the most recent UsageNanoCores value.
+// Returns 0 and false if no samples with calculated UsageNanoCores exist.
+func (s *TimedStore) GetLatestUsageNanoCores() (uint64, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// We need at least 2 samples to have a calculated UsageNanoCores
+	if len(s.buffer) < 2 {
+		return 0, false
+	}
+
+	sample := s.buffer[len(s.buffer)-1]
+	return sample.UsageNanoCores, true
+}
+
+// Size returns the number of samples in the store.
+func (s *TimedStore) Size() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.buffer)
+}
+
+// calculateUsageNanoCores calculates the instantaneous CPU usage rate
+// (nanocores) from two consecutive samples.
+// Returns 0 if the calculation cannot be performed (e.g., invalid time delta).
+func calculateUsageNanoCores(prev, cur CPUSample) uint64 {
+	nanoSeconds := cur.Timestamp.UnixNano() - prev.Timestamp.UnixNano()
+
+	// Zero or negative interval
+	if nanoSeconds <= 0 {
+		return 0
+	}
+
+	// CPU usage can't go backwards (might happen if container was restarted)
+	if cur.UsageCoreNanoSeconds < prev.UsageCoreNanoSeconds {
+		return 0
+	}
+
+	usageDelta := cur.UsageCoreNanoSeconds - prev.UsageCoreNanoSeconds
+	return uint64(float64(usageDelta) / float64(nanoSeconds) * float64(time.Second/time.Nanosecond))
+}

--- a/internal/cri/store/stats/timed_store_test.go
+++ b/internal/cri/store/stats/timed_store_test.go
@@ -1,0 +1,307 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package stats
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimedStoreBasic(t *testing.T) {
+	store := NewTimedStore(time.Minute, 10)
+
+	// Initially empty
+	if store.Size() != 0 {
+		t.Errorf("expected size 0, got %d", store.Size())
+	}
+
+	// GetLatest should return nil when empty
+	if sample := store.GetLatest(); sample != nil {
+		t.Errorf("expected nil sample, got %v", sample)
+	}
+
+	// GetLatestUsageNanoCores should return false when empty
+	if _, ok := store.GetLatestUsageNanoCores(); ok {
+		t.Error("expected false for empty store")
+	}
+}
+
+func TestTimedStoreAddAndGet(t *testing.T) {
+	store := NewTimedStore(time.Minute, 10)
+
+	now := time.Now()
+
+	// Add first sample
+	store.Add(now, 1000000000) // 1 second of CPU time in nanoseconds
+
+	if store.Size() != 1 {
+		t.Errorf("expected size 1, got %d", store.Size())
+	}
+
+	sample := store.GetLatest()
+	if sample == nil {
+		t.Fatal("expected non-nil sample")
+	}
+	if sample.UsageCoreNanoSeconds != 1000000000 {
+		t.Errorf("expected UsageCoreNanoSeconds 1000000000, got %d", sample.UsageCoreNanoSeconds)
+	}
+	// First sample should have 0 UsageNanoCores (no previous sample to calculate from)
+	if sample.UsageNanoCores != 0 {
+		t.Errorf("expected UsageNanoCores 0 for first sample, got %d", sample.UsageNanoCores)
+	}
+
+	// GetLatestUsageNanoCores should still return false (need at least 2 samples)
+	if _, ok := store.GetLatestUsageNanoCores(); ok {
+		t.Error("expected false with only 1 sample")
+	}
+}
+
+func TestTimedStoreUsageNanoCoresCalculation(t *testing.T) {
+	store := NewTimedStore(time.Minute, 10)
+
+	now := time.Now()
+
+	// Add first sample: 1 second of CPU time
+	store.Add(now, 1000000000)
+
+	// Add second sample after 1 second: 2 seconds of CPU time
+	// This means the CPU was running at 100% (1 core) during that second
+	store.Add(now.Add(time.Second), 2000000000)
+
+	if store.Size() != 2 {
+		t.Errorf("expected size 2, got %d", store.Size())
+	}
+
+	// Now we should be able to get UsageNanoCores
+	usageNanoCores, ok := store.GetLatestUsageNanoCores()
+	if !ok {
+		t.Fatal("expected true with 2 samples")
+	}
+
+	// Expected: (2000000000 - 1000000000) / 1000000000 * 1000000000 = 1000000000 nanocores (1 core)
+	expected := uint64(1000000000)
+	if usageNanoCores != expected {
+		t.Errorf("expected UsageNanoCores %d, got %d", expected, usageNanoCores)
+	}
+}
+
+func TestTimedStoreHalfCoreUsage(t *testing.T) {
+	store := NewTimedStore(time.Minute, 10)
+
+	now := time.Now()
+
+	// Add first sample
+	store.Add(now, 0)
+
+	// Add second sample after 2 seconds: 1 second of CPU time
+	// This means the CPU was running at 50% (0.5 cores) during those 2 seconds
+	store.Add(now.Add(2*time.Second), 1000000000)
+
+	usageNanoCores, ok := store.GetLatestUsageNanoCores()
+	if !ok {
+		t.Fatal("expected true with 2 samples")
+	}
+
+	// Expected: 1000000000 / 2000000000 * 1000000000 = 500000000 nanocores (0.5 cores)
+	expected := uint64(500000000)
+	if usageNanoCores != expected {
+		t.Errorf("expected UsageNanoCores %d, got %d", expected, usageNanoCores)
+	}
+}
+
+func TestTimedStoreMaxItems(t *testing.T) {
+	store := NewTimedStore(time.Hour, 3) // Keep at most 3 samples
+
+	now := time.Now()
+
+	// Add 5 samples
+	for i := 0; i < 5; i++ {
+		store.Add(now.Add(time.Duration(i)*time.Second), uint64(i)*1000000000)
+	}
+
+	// Should only have 3 samples
+	if store.Size() != 3 {
+		t.Errorf("expected size 3, got %d", store.Size())
+	}
+
+	// Latest sample should be the 5th one (index 4)
+	sample := store.GetLatest()
+	if sample == nil {
+		t.Fatal("expected non-nil sample")
+	}
+	if sample.UsageCoreNanoSeconds != 4000000000 {
+		t.Errorf("expected UsageCoreNanoSeconds 4000000000, got %d", sample.UsageCoreNanoSeconds)
+	}
+}
+
+func TestTimedStoreAgeEviction(t *testing.T) {
+	store := NewTimedStore(3*time.Second, -1) // Keep samples for 3 seconds, no item limit
+
+	now := time.Now()
+
+	// Add sample at t=0
+	store.Add(now, 0)
+
+	// Add sample at t=1s
+	store.Add(now.Add(1*time.Second), 1000000000)
+
+	// Add sample at t=2s
+	store.Add(now.Add(2*time.Second), 2000000000)
+
+	if store.Size() != 3 {
+		t.Errorf("expected size 3, got %d", store.Size())
+	}
+
+	// Add sample at t=4s - this should evict t=0 sample only
+	// evictTime = t=4s - 3s = t=1s, so samples strictly after t=1s are kept (t=2s, t=4s)
+	store.Add(now.Add(4*time.Second), 4000000000)
+
+	// Should have t=2s and t=4s samples (samples strictly after evictTime t=1s)
+	if store.Size() != 2 {
+		t.Errorf("expected size 2 after eviction, got %d", store.Size())
+	}
+
+	// Verify latest sample is the one we just added
+	sample := store.GetLatest()
+	if sample == nil {
+		t.Fatal("expected non-nil sample")
+	}
+	if sample.UsageCoreNanoSeconds != 4000000000 {
+		t.Errorf("expected UsageCoreNanoSeconds 4000000000, got %d", sample.UsageCoreNanoSeconds)
+	}
+}
+
+func TestTimedStoreConcurrentAccess(t *testing.T) {
+	store := NewTimedStore(time.Minute, 100)
+
+	now := time.Now()
+	done := make(chan bool)
+
+	// Start multiple goroutines adding samples
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			for j := 0; j < 100; j++ {
+				store.Add(now.Add(time.Duration(id*100+j)*time.Millisecond), uint64(id*100+j)*1000000)
+			}
+			done <- true
+		}(i)
+	}
+
+	// Start multiple goroutines reading
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				store.GetLatest()
+				store.GetLatestUsageNanoCores()
+				store.Size()
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 20; i++ {
+		<-done
+	}
+
+	// Just verify no panic occurred and size is reasonable
+	if store.Size() > 100 {
+		t.Errorf("expected size <= 100, got %d", store.Size())
+	}
+}
+
+func TestCalculateUsageNanoCores(t *testing.T) {
+	// Use a fixed base time to ensure consistent time deltas in tests
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		prev     CPUSample
+		cur      CPUSample
+		expected uint64
+	}{
+		{
+			name: "normal case - 1 core",
+			prev: CPUSample{
+				Timestamp:            now,
+				UsageCoreNanoSeconds: 0,
+			},
+			cur: CPUSample{
+				Timestamp:            now.Add(time.Second),
+				UsageCoreNanoSeconds: 1000000000,
+			},
+			expected: 1000000000, // 1 core
+		},
+		{
+			name: "normal case - 2 cores",
+			prev: CPUSample{
+				Timestamp:            now,
+				UsageCoreNanoSeconds: 0,
+			},
+			cur: CPUSample{
+				Timestamp:            now.Add(time.Second),
+				UsageCoreNanoSeconds: 2000000000,
+			},
+			expected: 2000000000, // 2 cores
+		},
+		{
+			name: "zero time delta",
+			prev: CPUSample{
+				Timestamp:            now,
+				UsageCoreNanoSeconds: 0,
+			},
+			cur: CPUSample{
+				Timestamp:            now, // same timestamp
+				UsageCoreNanoSeconds: 1000000000,
+			},
+			expected: 0,
+		},
+		{
+			name: "negative time delta",
+			prev: CPUSample{
+				Timestamp:            now.Add(time.Second),
+				UsageCoreNanoSeconds: 0,
+			},
+			cur: CPUSample{
+				Timestamp:            now, // earlier than prev
+				UsageCoreNanoSeconds: 1000000000,
+			},
+			expected: 0,
+		},
+		{
+			name: "CPU usage decreased (container restart)",
+			prev: CPUSample{
+				Timestamp:            now,
+				UsageCoreNanoSeconds: 2000000000,
+			},
+			cur: CPUSample{
+				Timestamp:            now.Add(time.Second),
+				UsageCoreNanoSeconds: 1000000000, // less than prev
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateUsageNanoCores(tt.prev, tt.cur)
+			if result != tt.expected {
+				t.Errorf("calculateUsageNanoCores() = %d, want %d", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We added ListPodSandboxMetrics and ListMetricDescriptors  in https://github.com/containerd/containerd/pull/10691 So we can cleanup the TODO item.