### PR TITLE
cri: add tracing spans for image pull and sandbox setup paths

### DIFF
--- a/client/pull.go
+++ b/client/pull.go
@@ -167,6 +167,7 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 			unpackSpan.End()
 			return nil, err
 		}
+		unpackSpan.SetAttributes(tracing.Attribute("unpack.count", ur.Unpacks))
 		unpackSpan.End()
 	}
 
@@ -197,6 +198,12 @@ func (c *Client) fetch(ctx context.Context, rCtx *RemoteContext, ref string, lim
 	if err != nil {
 		return images.Image{}, fmt.Errorf("failed to resolve reference %q: %w", ref, err)
 	}
+	span.SetAttributes(
+		tracing.Attribute("container.image.ref", ref),
+		tracing.Attribute("image.name", name),
+		tracing.Attribute("target.mediaType", desc.MediaType),
+		tracing.Attribute("image.digest", desc.Digest.String()),
+	)
 
 	fetcher, err := rCtx.Resolver.Fetcher(ctx, name)
 	if err != nil {
@@ -268,12 +275,20 @@ func (c *Client) fetch(ctx context.Context, rCtx *RemoteContext, ref string, lim
 		handler = rCtx.HandlerWrapper(handler)
 	}
 
-	if err := images.Dispatch(ctx, handler, limiter, desc); err != nil {
+	dispatchCtx, dispatchSpan := tracing.StartSpan(ctx, tracing.Name(pullSpanPrefix, "dispatch"))
+	err = images.Dispatch(dispatchCtx, handler, limiter, desc)
+	dispatchSpan.SetStatus(err)
+	dispatchSpan.End()
+	if err != nil {
 		return images.Image{}, err
 	}
 
 	if isConvertible {
-		if desc, err = converterFunc(ctx, desc); err != nil {
+		convertCtx, convertSpan := tracing.StartSpan(ctx, tracing.Name(pullSpanPrefix, "convert_manifest"))
+		desc, err = converterFunc(convertCtx, desc)
+		convertSpan.SetStatus(err)
+		convertSpan.End()
+		if err != nil {
 			return images.Image{}, err
 		}
 	}


### PR DESCRIPTION
This PR adds opt-in tracing spans/attributes in CRI image pull and selected sandbox-related paths to improve debugging and correlation (e.g., sandbox.id/pod metadata). If maintainers prefer a smaller diff, I’m happy to split this into a pull-only PR plus follow-ups.

Signed-off-by: Cindy Li <xinhuil@netflix.com>