### PR TITLE
go.mod: remove exclude rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -159,18 +159,3 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.0.0 // indirect
 )
-
-exclude (
-	// These dependencies were updated to "master" in some modules we depend on,
-	// but have no code-changes since their last release. Unfortunately, this also
-	// causes a ripple effect, forcing all users of the containerd module to also
-	// update these dependencies to an unrelease / un-tagged version.
-	//
-	// Both these dependencies will unlikely do a new release in the near future,
-	// so exclude these versions so that we can downgrade to the current release.
-	//
-	// For additional details, see this PR and links mentioned in that PR:
-	// https://github.com/kubernetes-sigs/kustomize/pull/5830#issuecomment-2569960859
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
-)


### PR DESCRIPTION
relates to:

- https://github.com/containerd/containerd/pull/11220
- https://github.com/containerd/containerd/pull/12641
- https://github.com/containerd/zfs/pull/89


Commit 00a11e91d38b5a1e3540382eaedfda878b1314b1 added these exclude rules as a temporary workaround until these transitive dependency versions would be gone;

> downgrade go-difflib and go-spew to tagged releases
>
> These dependencies were updated to "master" in some modules we depend on,
> but have no code-changes since their last release. Unfortunately, this also
> causes a ripple effect, forcing all users of the containerd module to also
> update these dependencies to an unrelease / un-tagged version.
>
> Both these dependencies will unlikely do a new release in the near future,
> so exclude these versions so that we can downgrade to the current release.

Commit fb8c01ded46d2cdbb99720ed33a9f7eb6dc13dda updated the containerd/zfs module to v2.0.0, which was the remaining dependency using these untagged versions, so we can remove these exclude rules again.

This reverts commit 00a11e91d38b5a1e3540382eaedfda878b1314b1.