### PR TITLE
[release/2.1] Prepare release notes for v2.1.6

### DIFF
--- a/releases/v2.1.6.toml
+++ b/releases/v2.1.6.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "v2.1.5"
+
+pre_release = false
+
+preface = """\
+The sixth patch release for containerd 2.1 contains various fixes and updates.
+"""
+
+postface = """\
+### Which file should I download?
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.35 (Ubuntu 22.04).
+* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on Linux distributions that do not use glibc >= 2.35. Not position-independent.
+
+In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
+and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.
+
+See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.1.5+unknown"
+	Version = "2.1.6+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

---

containerd 2.1.6

Welcome to the v2.1.6 release of containerd!

The sixth patch release for containerd 2.1 contains various fixes and updates.

### Highlights

#### Runtime

* **Update runc binary to v1.3.4** ([#12618](https://github.com/containerd/containerd/pull/12618))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Derek McGowan
* Austin Vazquez
* Andrey Noskov
* CrazyMax
* Davanum Srinivas
* Maksym Pavlenko
* Mike Brown
* Paweł Gronowski
* Phil Estes
* Sebastiaan van Stijn
* Wei Fu

### Changes
<details><summary>21 commits</summary>
<p>

  * [`253f6af7b`](https://github.com/containerd/containerd/commit/253f6af7b65a3ff739e69baada14c79227a3e1d6) Prepare release notes for v2.1.6
* go.mod: golang.org/x/crypto v0.45.0 (drop support for Go 1.23) ([#12639](https://github.com/containerd/containerd/pull/12639))
  * [`e81678853`](https://github.com/containerd/containerd/commit/e816788537ca2b9484aa86da58391923e873f571) go.mod: golang.org/x/crypto v0.45.0
  * [`55a2d8c8d`](https://github.com/containerd/containerd/commit/55a2d8c8d0bf6c5a7481c8922eb5a351f82f9344) CI: drop Go 1.23
  * [`fd8e3c39b`](https://github.com/containerd/containerd/commit/fd8e3c39b952b2fb9278df64f9de4e46fa78dd36) Update Go requirements in BUILDING
* core/runtime/v2: remove uses of otelgrpc.UnaryClientInterceptor ([#12623](https://github.com/containerd/containerd/pull/12623))
  * [`a4454c49a`](https://github.com/containerd/containerd/commit/a4454c49a66b48309c0d9a1f5c386daf5d692614) core/runtime/v2: remove uses of otelgrpc.UnaryClientInterceptor
* Update runc binary to v1.3.4 ([#12618](https://github.com/containerd/containerd/pull/12618))
  * [`251f0a285`](https://github.com/containerd/containerd/commit/251f0a2854f7831ca040d7ba2dab181fd02f2240) runc: Update runc binary to v1.3.4
* ci: bump Go 1.24.11, 1.25.5 ([#12626](https://github.com/containerd/containerd/pull/12626))
  * [`c07c29bca`](https://github.com/containerd/containerd/commit/c07c29bca60eeff9454b005e9856acfb12cfd68c) ci: bump Go 1.24.11, 1.25.5
  * [`e52817652`](https://github.com/containerd/containerd/commit/e528176522bc3df790ea923cfac15c18336ae429) ci: bump Go 1.24.10, 1.25.4
  * [`04bbb66e4`](https://github.com/containerd/containerd/commit/04bbb66e408602872693282063c080bb2e9e6cf9) ci(release): set GO_VERSION in Dockerfile
* ci: update CIFuzz actions to support Ubuntu 24.04 ([#12633](https://github.com/containerd/containerd/pull/12633))
  * [`492987ccc`](https://github.com/containerd/containerd/commit/492987cccf044c4015ec35ce161606cc514de75e) ci: update CIFuzz actions to support Ubuntu 24.04
* build(deps): bump github.com/opencontainers/selinux ([#12590](https://github.com/containerd/containerd/pull/12590))
  * [`55a25ec6e`](https://github.com/containerd/containerd/commit/55a25ec6efa335cdb9e6b56207643f33277be4d4) build(deps): bump github.com/opencontainers/selinux
* Redact all query parameters in CRI error logs ([#12547](https://github.com/containerd/containerd/pull/12547))
  * [`b72d0dfe0`](https://github.com/containerd/containerd/commit/b72d0dfe0458e1b5f1e67ba70476fc4887ee5f08) fix: redact all query parameters in CRI error logs
* Update 2.1 branch to no longer build as latest ([#12487](https://github.com/containerd/containerd/pull/12487))
  * [`ecd58bd65`](https://github.com/containerd/containerd/commit/ecd58bd6507cb6c566c68b440ceea5d7d99b3260) Update 2.1 branch to no longer build as latest
</p>
</details>

### Dependency Changes

* **github.com/cyphar/filepath-securejoin**  v0.5.1 **_new_**
* **github.com/opencontainers/selinux**      v1.12.0 -> v1.13.1
* **golang.org/x/crypto**                    v0.36.0 -> v0.45.0
* **golang.org/x/mod**                       v0.24.0 -> v0.29.0
* **golang.org/x/net**                       v0.38.0 -> v0.47.0
* **golang.org/x/sync**                      v0.14.0 -> v0.18.0
* **golang.org/x/sys**                       v0.33.0 -> v0.38.0
* **golang.org/x/term**                      v0.30.0 -> v0.37.0
* **golang.org/x/text**                      v0.23.0 -> v0.31.0

Previous release can be found at [v2.1.5](https://github.com/containerd/containerd/releases/tag/v2.1.5)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.35 (Ubuntu 22.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on Linux distributions that do not use glibc >= 2.35. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
