### PR TITLE
re-use HostDirFromRoots for both local pulls and transfer service pulls

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -288,6 +288,32 @@ func updateTLSConfigFromHost(tlsConfig *tls.Config, host *hostConfig) error {
 	return nil
 }
 
+// HostDirFromRoots returns a function which finds a host directory by
+// searching for the host under each of the given roots in order, returning
+// the first match. Empty roots are ignored. If no roots remain, the returned
+// function reports errdefs.ErrNotFound.
+func HostDirFromRoots(roots []string) func(string) (string, error) {
+	rootfn := make([]func(string) (string, error), 0, len(roots))
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		rootfn = append(rootfn, HostDirFromRoot(root))
+	}
+	return func(host string) (dir string, err error) {
+		if len(rootfn) == 0 {
+			return "", errdefs.ErrNotFound
+		}
+		for _, fn := range rootfn {
+			dir, err = fn(host)
+			if (err != nil && !errdefs.IsNotFound(err)) || (dir != "") {
+				break
+			}
+		}
+		return
+	}
+}
+
 // HostDirFromRoot returns a function which finds a host directory
 // based at the given root.
 func HostDirFromRoot(root string) func(string) (string, error) {

--- a/core/remotes/docker/config/hosts_test.go
+++ b/core/remotes/docker/config/hosts_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log/logtest"
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
@@ -321,6 +322,86 @@ func TestLoadCertFiles(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHostDirFromRoots(t *testing.T) {
+	const host = "testing.io"
+
+	// mkRoot creates a temp root and, if create is true, the host subdir
+	// under it so HostDirFromRoot resolves a match there.
+	mkRoot := func(t *testing.T, create bool) string {
+		root := t.TempDir()
+		if create {
+			if err := os.MkdirAll(filepath.Join(root, hostDirectory(host)), 0700); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return root
+	}
+
+	t.Run("first root matches", func(t *testing.T) {
+		first := mkRoot(t, true)
+		second := mkRoot(t, false)
+		dir, err := HostDirFromRoots([]string{first, second})(host)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := filepath.Join(first, hostDirectory(host)); dir != want {
+			t.Fatalf("expected %q, got %q", want, dir)
+		}
+	})
+
+	t.Run("ordered search falls through to second root", func(t *testing.T) {
+		first := mkRoot(t, false)
+		second := mkRoot(t, true)
+		dir, err := HostDirFromRoots([]string{first, second})(host)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := filepath.Join(second, hostDirectory(host)); dir != want {
+			t.Fatalf("expected %q, got %q", want, dir)
+		}
+	})
+
+	t.Run("first root takes precedence when both match", func(t *testing.T) {
+		first := mkRoot(t, true)
+		second := mkRoot(t, true)
+		dir, err := HostDirFromRoots([]string{first, second})(host)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := filepath.Join(first, hostDirectory(host)); dir != want {
+			t.Fatalf("expected %q, got %q", want, dir)
+		}
+	})
+
+	t.Run("no match returns not found", func(t *testing.T) {
+		first := mkRoot(t, false)
+		second := mkRoot(t, false)
+		_, err := HostDirFromRoots([]string{first, second})(host)
+		if !errdefs.IsNotFound(err) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("empty roots are ignored and do not probe relative paths", func(t *testing.T) {
+		root := mkRoot(t, true)
+		dir, err := HostDirFromRoots([]string{"", root, ""})(host)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := filepath.Join(root, hostDirectory(host)); dir != want {
+			t.Fatalf("expected %q, got %q", want, dir)
+		}
+	})
+
+	t.Run("all-empty and nil roots return not found", func(t *testing.T) {
+		for _, roots := range [][]string{nil, {}, {"", ""}} {
+			if _, err := HostDirFromRoots(roots)(host); !errdefs.IsNotFound(err) {
+				t.Fatalf("roots %v: expected ErrNotFound, got %v", roots, err)
+			}
+		}
+	})
 }
 
 func TestHTTPFallback(t *testing.T) {

--- a/core/transfer/registry/registry.go
+++ b/core/transfer/registry/registry.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -73,7 +74,10 @@ func WithCredentials(creds CredentialHelper) Opt {
 	}
 }
 
-// WithHostDir specifies the host configuration directory.
+// WithHostDir specifies the host configuration directory. The value may be a
+// single directory or a list of directories separated by os.PathListSeparator
+// (e.g. "/etc/containerd/certs.d:/etc/docker/certs.d" on Unix), which are
+// searched in order for a matching host configuration.
 func WithHostDir(hostDir string) Opt {
 	return func(o *registryOpts) error {
 		o.hostDir = hostDir
@@ -125,7 +129,7 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
 
 	hostOptions := config.HostOptions{}
 	if ropts.hostDir != "" {
-		hostOptions.HostDir = config.HostDirFromRoot(ropts.hostDir)
+		hostOptions.HostDir = config.HostDirFromRoots(filepath.SplitList(ropts.hostDir))
 	}
 	if ropts.creds != nil {
 		// TODO: Support bearer

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -489,22 +489,6 @@ func (c *CRIImageService) UpdateImage(ctx context.Context, r string) error {
 	return nil
 }
 
-func hostDirFromRoots(roots []string) func(string) (string, error) {
-	rootfn := make([]func(string) (string, error), len(roots))
-	for i := range roots {
-		rootfn[i] = config.HostDirFromRoot(roots[i])
-	}
-	return func(host string) (dir string, err error) {
-		for _, fn := range rootfn {
-			dir, err = fn(host)
-			if (err != nil && !errdefs.IsNotFound(err)) || (dir != "") {
-				break
-			}
-		}
-		return
-	}
-}
-
 // registryHosts is the registry hosts to be used by the resolver.
 func (c *CRIImageService) registryHosts(ctx context.Context, credentials func(host string) (string, string, error), updateClientFn config.UpdateClientFunc) docker.RegistryHosts {
 	paths := filepath.SplitList(c.config.Registry.ConfigPath)
@@ -513,7 +497,7 @@ func (c *CRIImageService) registryHosts(ctx context.Context, credentials func(ho
 			UpdateClient: updateClientFn,
 		}
 		hostOptions.Credentials = credentials
-		hostOptions.HostDir = hostDirFromRoots(paths)
+		hostOptions.HostDir = config.HostDirFromRoots(paths)
 		// need to pass cri global headers to per-host authorizers
 		hostOptions.AuthorizerOpts = []docker.AuthorizerOpt{
 			docker.WithAuthHeader(c.config.Registry.Headers),

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -493,22 +493,6 @@ func (c *CRIImageService) UpdateImage(ctx context.Context, r string) error {
 	return nil
 }
 
-func hostDirFromRoots(roots []string) func(string) (string, error) {
-	rootfn := make([]func(string) (string, error), len(roots))
-	for i := range roots {
-		rootfn[i] = config.HostDirFromRoot(roots[i])
-	}
-	return func(host string) (dir string, err error) {
-		for _, fn := range rootfn {
-			dir, err = fn(host)
-			if (err != nil && !errdefs.IsNotFound(err)) || (dir != "") {
-				break
-			}
-		}
-		return
-	}
-}
-
 // registryHosts is the registry hosts to be used by the resolver.
 func (c *CRIImageService) registryHosts(ctx context.Context, credentials func(host string) (string, string, error), updateClientFn config.UpdateClientFunc) docker.RegistryHosts {
 	paths := filepath.SplitList(c.config.Registry.ConfigPath)
@@ -517,7 +501,7 @@ func (c *CRIImageService) registryHosts(ctx context.Context, credentials func(ho
 			UpdateClient: updateClientFn,
 		}
 		hostOptions.Credentials = credentials
-		hostOptions.HostDir = hostDirFromRoots(paths)
+		hostOptions.HostDir = config.HostDirFromRoots(paths)
 		// need to pass cri global headers to per-host authorizers
 		hostOptions.AuthorizerOpts = []docker.AuthorizerOpt{
 			docker.WithAuthHeader(c.config.Registry.Headers),


### PR DESCRIPTION
- move (and export) `HostDirFromRoots` to core/remotes/docker/config (together with `HostDirFromRoot`)
- in transfer/registry, use `filepath.SplitList()` and use shared `HostDirFromRoots`
- this fixes `config_path = '/etc/containerd/certs.d:/etc/docker/certs.d'` (the default) when used with the transfer service (also default)
- ignore empty roots so leading/trailing/repeated path-list separators don't probe relative CWD paths; return `ErrNotFound` when no valid roots remain
- document `WithHostDir` path-list support (os.PathListSeparator)
- add `TestHostDirFromRoots` covering ordering, precedence, not-found, and empty/nil roots
