### PR TITLE
Fix ST1005 lint violations: lowercase error strings

### DIFF
--- a/core/metadata/images.go
+++ b/core/metadata/images.go
@@ -362,15 +362,15 @@ func validateTarget(target *ocispec.Descriptor) error {
 	// NOTE(stevvooe): Only validate fields we actually store.
 
 	if err := target.Digest.Validate(); err != nil {
-		return fmt.Errorf("Target.Digest %q invalid: %v: %w", target.Digest, err, errdefs.ErrInvalidArgument)
+		return fmt.Errorf("target.Digest %q invalid: %v: %w", target.Digest, err, errdefs.ErrInvalidArgument)
 	}
 
 	if target.Size <= 0 {
-		return fmt.Errorf("Target.Size must be greater than zero: %w", errdefs.ErrInvalidArgument)
+		return fmt.Errorf("target.Size must be greater than zero: %w", errdefs.ErrInvalidArgument)
 	}
 
 	if target.MediaType == "" {
-		return fmt.Errorf("Target.MediaType must be set: %w", errdefs.ErrInvalidArgument)
+		return fmt.Errorf("target.MediaType must be set: %w", errdefs.ErrInvalidArgument)
 	}
 
 	return nil

--- a/core/remotes/docker/httpreadseeker.go
+++ b/core/remotes/docker/httpreadseeker.go
@@ -105,7 +105,7 @@ func (hrs *httpReadSeeker) Close() error {
 
 func (hrs *httpReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	if hrs.closed {
-		return 0, fmt.Errorf("Fetcher.Seek: closed: %w", errdefs.ErrUnavailable)
+		return 0, fmt.Errorf("httpReadSeeker.Seek: closed: %w", errdefs.ErrUnavailable)
 	}
 
 	abs := hrs.offset
@@ -116,21 +116,21 @@ func (hrs *httpReadSeeker) Seek(offset int64, whence int) (int64, error) {
 		abs += offset
 	case io.SeekEnd:
 		if hrs.size == -1 {
-			return 0, fmt.Errorf("Fetcher.Seek: unknown size, cannot seek from end: %w", errdefs.ErrUnavailable)
+			return 0, fmt.Errorf("httpReadSeeker.Seek: unknown size, cannot seek from end: %w", errdefs.ErrUnavailable)
 		}
 		abs = hrs.size + offset
 	default:
-		return 0, fmt.Errorf("Fetcher.Seek: invalid whence: %w", errdefs.ErrInvalidArgument)
+		return 0, fmt.Errorf("httpReadSeeker.Seek: invalid whence: %w", errdefs.ErrInvalidArgument)
 	}
 
 	if abs < 0 {
-		return 0, fmt.Errorf("Fetcher.Seek: negative offset: %w", errdefs.ErrInvalidArgument)
+		return 0, fmt.Errorf("httpReadSeeker.Seek: negative offset: %w", errdefs.ErrInvalidArgument)
 	}
 
 	if abs != hrs.offset {
 		if hrs.rc != nil {
 			if err := hrs.rc.Close(); err != nil {
-				log.L.WithError(err).Error("Fetcher.Seek: failed to close ReadCloser")
+				log.L.WithError(err).Error("httpReadSeeker.Seek: failed to close ReadCloser")
 			}
 
 			hrs.rc = nil

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -878,7 +878,7 @@ func testFetch(ctx context.Context, f remotes.Fetcher, desc ocispec.Descriptor) 
 	}
 	r2, desc2, err := fByDigest.FetchByDigest(ctx, desc.Digest)
 	if err != nil {
-		return fmt.Errorf("FetcherByDigest: faild to fetch %v: %w", desc.Digest, err)
+		return fmt.Errorf("FetcherByDigest: failed to fetch %v: %w", desc.Digest, err)
 	}
 	if desc2.Size != desc.Size {
 		r2b, err := io.ReadAll(r2)
@@ -889,7 +889,7 @@ func testFetch(ctx context.Context, f remotes.Fetcher, desc ocispec.Descriptor) 
 	}
 	dgstr2 := desc.Digest.Algorithm().Digester()
 	if _, err = io.Copy(dgstr2.Hash(), r2); err != nil {
-		return fmt.Errorf("FetcherByDigest: faild to copy: %w", err)
+		return fmt.Errorf("FetcherByDigest: failed to copy: %w", err)
 	}
 	if dgstr2.Digest() != desc.Digest {
 		return fmt.Errorf("FetcherByDigest: content mismatch: %s != %s", dgstr2.Digest(), desc.Digest)

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -486,7 +486,7 @@ func getLogDirPath(runtimeVersion, id string) string {
 	case "v2":
 		return filepath.Join(defaultState, "io.containerd.runtime.v2.task", testNamespace, id)
 	default:
-		panic(fmt.Errorf("Unsupported runtime version %s", runtimeVersion))
+		panic(fmt.Errorf("unsupported runtime version %s", runtimeVersion))
 	}
 }
 

--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -153,7 +153,7 @@ func TestContainerdImage(t *testing.T) {
 			return false, err
 		}
 		if s.Resources == nil || (s.Resources.Linux == nil && s.Resources.Windows == nil) {
-			return false, fmt.Errorf("No Resource field in container status: %+v", s)
+			return false, fmt.Errorf("no Resource field in container status: %+v", s)
 		}
 		return s.GetState() == runtime.ContainerState_CONTAINER_RUNNING, nil
 	}

--- a/integration/remote/util/util_unsupported.go
+++ b/integration/remote/util/util_unsupported.go
@@ -62,7 +62,7 @@ func UnlockPath(fileHandles []uintptr) {
 
 // LocalEndpoint empty implementation
 func LocalEndpoint(path, file string) (string, error) {
-	return "", fmt.Errorf("LocalEndpoints are unsupported in this build")
+	return "", fmt.Errorf("LocalEndpoint is unsupported in this build")
 }
 
 // GetBootTime empty implementation

--- a/integration/sandbox_clean_remove_windows_test.go
+++ b/integration/sandbox_clean_remove_windows_test.go
@@ -77,7 +77,7 @@ func getTestImage() (string, error) {
 		if buildNum > osversion.V21H2Server {
 			return "ghcr.io/containerd/windows/nanoserver:ltsc2022", nil
 		}
-		return "", fmt.Errorf("No test image defined for Windows build version: %s", b)
+		return "", fmt.Errorf("no test image defined for Windows build version: %s", b)
 	}
 }
 


### PR DESCRIPTION
Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, per Go style guide and staticcheck ST1005.

This change lowercases the first letter of error messages in fmt.Errorf calls throughout the codebase, while preserving uppercase for acronyms at the start of error strings (e.g., NRI, RDT, CDI, UID, GID, VHD, FUSE).

Also fixes typo 'faild' -> 'failed' in resolver_test.go.

Changes:
- core/metadata: target.Digest, target.Size, target.MediaType
- core/remotes/docker: fetcher.Seek
- integration: various test error messages
- internal/cri/server: containerConfig

Fixes #12011