### PR TITLE
Update transfer service to support automatically garbage collecting extra references

### DIFF
--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -1034,6 +1034,7 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 	case ResourceImage:
 		ibkt := nsbkt.Bucket(bucketKeyObjectImages)
 		if ibkt != nil {
+			log.G(ctx).WithField("key", node.Key).Debug("remove image")
 			return &eventstypes.ImageDelete{
 				Name: node.Key,
 			}, ibkt.DeleteBucket([]byte(node.Key))

--- a/core/transfer/image/imagestore.go
+++ b/core/transfer/image/imagestore.go
@@ -276,7 +276,7 @@ func (is *Store) Store(ctx context.Context, desc ocispec.Descriptor, store image
 
 		// If extra references, store all complete references (skip prefixes)
 		for _, ref := range is.extraReferences {
-			if ref.IsPrefix {
+			if ref.IsPrefix && !ref.AddDigest {
 				continue
 			}
 			name := ref.Name

--- a/core/transfer/image/imagestore.go
+++ b/core/transfer/image/imagestore.go
@@ -19,6 +19,8 @@ package image
 import (
 	"context"
 	"fmt"
+	"maps"
+	"time"
 
 	"github.com/containerd/typeurl/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -215,6 +217,21 @@ func (is *Store) ImageFilter(h images.HandlerFunc, cs content.Store) images.Hand
 func (is *Store) Store(ctx context.Context, desc ocispec.Descriptor, store images.Store) ([]images.Image, error) {
 	var imgs []images.Image
 
+	// extraRefLabels returns image labels for extra references, adding
+	// GC back-reference and expire labels when a primary image name exists.
+	extraRefLabels := func() map[string]string {
+		if is.imageName == "" {
+			return is.imageLabels
+		}
+		labels := make(map[string]string, len(is.imageLabels)+2)
+		maps.Copy(labels, is.imageLabels)
+		// Delete this image when the parent is deleted
+		labels["containerd.io/gc.bref.image"] = is.imageName
+		// Immediately expire to allow collection
+		labels["containerd.io/gc.expire"] = time.Now().Format(time.RFC3339)
+		return labels
+	}
+
 	// If import ref type, store references from annotation or prefix
 	if refSource, ok := desc.Annotations["io.containerd.import.ref-source"]; ok {
 		switch refSource {
@@ -239,7 +256,7 @@ func (is *Store) Store(ctx context.Context, desc ocispec.Descriptor, store image
 						imgs = append(imgs, images.Image{
 							Name:   fmt.Sprintf("%s@%s", ref.Name, desc.Digest),
 							Target: desc,
-							Labels: is.imageLabels,
+							Labels: extraRefLabels(),
 						})
 					}
 					continue
@@ -248,7 +265,7 @@ func (is *Store) Store(ctx context.Context, desc ocispec.Descriptor, store image
 				imgs = append(imgs, images.Image{
 					Name:   name,
 					Target: desc,
-					Labels: is.imageLabels,
+					Labels: extraRefLabels(),
 				})
 
 				// If a named reference was found and SkipNamedDigest is true, do
@@ -257,7 +274,7 @@ func (is *Store) Store(ctx context.Context, desc ocispec.Descriptor, store image
 					imgs = append(imgs, images.Image{
 						Name:   fmt.Sprintf("%s@%s", ref.Name, desc.Digest),
 						Target: desc,
-						Labels: is.imageLabels,
+						Labels: extraRefLabels(),
 					})
 				}
 			}
@@ -274,7 +291,17 @@ func (is *Store) Store(ctx context.Context, desc ocispec.Descriptor, store image
 			})
 		}
 
-		// If extra references, store all complete references (skip prefixes)
+		// If extra references, store all complete references and prefix
+		// references which add a digest (prefixes without a digest are skipped
+		// since they have no concrete name to store).
+		//
+		// Note: SkipNamedDigest is intentionally not honored here. It applies
+		// to the annotation branch where a named reference is resolved from a
+		// descriptor's own annotations via the prefix — in that case a name
+		// ref is "found from the prefix" and the digest ref can be suppressed.
+		// In the NoAnnotation branch the only named reference is the top-level
+		// imageName (typically the index), which is not matched against the
+		// prefix, so the digest reference should still be recorded.
 		for _, ref := range is.extraReferences {
 			if ref.IsPrefix && !ref.AddDigest {
 				continue
@@ -283,10 +310,11 @@ func (is *Store) Store(ctx context.Context, desc ocispec.Descriptor, store image
 			if ref.AddDigest {
 				name = fmt.Sprintf("%s@%s", name, desc.Digest)
 			}
+
 			imgs = append(imgs, images.Image{
 				Name:   name,
 				Target: desc,
-				Labels: is.imageLabels,
+				Labels: extraRefLabels(),
 			})
 		}
 	}

--- a/core/transfer/image/imagestore_test.go
+++ b/core/transfer/image/imagestore_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/errdefs"
@@ -197,6 +198,58 @@ func TestStore(t *testing.T) {
 			Annotations: []string{"NoAnnotation"},
 			Images:      []string{"registry.test/index:latest"},
 		},
+		{
+			Name: "ImageNameWithPrefixAddDigest",
+			ImageStore: &Store{
+				imageName: "registry.test/index:latest",
+				extraReferences: []Reference{
+					{
+						Name:      "registry.test/base",
+						IsPrefix:  true,
+						AddDigest: true,
+					},
+				},
+			},
+			Annotations: []string{"NoAnnotation"},
+			Images:      []string{"registry.test/index:latest", "registry.test/base@"},
+		},
+		{
+			Name: "ImageNameWithExtraRef",
+			ImageStore: &Store{
+				imageName: "registry.test/index:latest",
+				extraReferences: []Reference{
+					{
+						Name: "registry.test/extra:v1",
+					},
+				},
+			},
+			Annotations: []string{"NoAnnotation"},
+			Images:      []string{"registry.test/index:latest", "registry.test/extra:v1"},
+		},
+		{
+			// SkipNamedDigest only suppresses digest refs in the annotation
+			// branch, where a named reference has been resolved from the
+			// descriptor's own annotations via the prefix. In the
+			// NoAnnotation branch the top-level imageName is not a
+			// prefix-matched name, so the digest ref must still be stored.
+			// This matches the integration test DigestRefsSkipNamed where
+			// the index digest reference is expected alongside the primary
+			// image name.
+			Name: "ImageNameWithPrefixAddDigestSkipNamed",
+			ImageStore: &Store{
+				imageName: "registry.test/index:latest",
+				extraReferences: []Reference{
+					{
+						Name:            "registry.test/base",
+						IsPrefix:        true,
+						AddDigest:       true,
+						SkipNamedDigest: true,
+					},
+				},
+			},
+			Annotations: []string{"NoAnnotation"},
+			Images:      []string{"registry.test/index:latest", "registry.test/base@"},
+		},
 	} {
 		for _, a := range testCase.Annotations {
 			name := testCase.Name + "_" + a
@@ -239,12 +292,41 @@ func TestStore(t *testing.T) {
 				if len(imgs) != len(expected) {
 					t.Fatalf("mismatched array length\nexpected:\n\t%v\nactual\n\t%v", expected, imgs)
 				}
+				primaryName := testCase.ImageStore.imageName
 				for i, name := range expected {
 					if imgs[i].Name != name {
 						t.Fatalf("wrong image name %q, expected %q", imgs[i].Name, name)
 					}
 					if imgs[i].Target.Digest != dgst {
 						t.Fatalf("wrong image digest %s, expected %s", imgs[i].Target.Digest, dgst)
+					}
+
+					// The primary image is never collectible via back-reference;
+					// extra references are tied to the primary via gc.bref.image
+					// with an immediate gc.expire so they are collected alongside
+					// it. When no primary image is set, extra references are
+					// standalone and receive no GC labels.
+					bref := imgs[i].Labels["containerd.io/gc.bref.image"]
+					expire := imgs[i].Labels["containerd.io/gc.expire"]
+					switch {
+					case imgs[i].Name == primaryName:
+						if bref != "" || expire != "" {
+							t.Fatalf("primary image %q unexpectedly has GC labels: bref=%q expire=%q", imgs[i].Name, bref, expire)
+						}
+					case primaryName == "":
+						if bref != "" || expire != "" {
+							t.Fatalf("extra ref %q unexpectedly has GC labels when no primary image: bref=%q expire=%q", imgs[i].Name, bref, expire)
+						}
+					default:
+						if bref != primaryName {
+							t.Fatalf("extra ref %q has gc.bref.image=%q, expected %q", imgs[i].Name, bref, primaryName)
+						}
+						if expire == "" {
+							t.Fatalf("extra ref %q missing gc.expire label", imgs[i].Name)
+						}
+						if _, err := time.Parse(time.RFC3339, expire); err != nil {
+							t.Fatalf("extra ref %q has invalid gc.expire %q: %v", imgs[i].Name, expire, err)
+						}
 					}
 				}
 			})

--- a/integration/client/import_test.go
+++ b/integration/client/import_test.go
@@ -614,7 +614,8 @@ func TestTransferImport(t *testing.T) {
 		// Images is the names of the images to create
 		// [0]: Index name or ""
 		// [1:]: Additional images and manifest to import
-		//  Images ending with @ will have digest appended and use the digest of the previously imported image
+		//  Images ending with @<manifest> will have the digest of the previously imported manifest appended
+		//  Images ending with @<index> will have the index digest appended
 		//  A space can be used to separate a repo name and tag, only the tag will be set in the imported image
 		Images []string
 		Opts   []image.StoreOpt
@@ -635,22 +636,22 @@ func TestTransferImport(t *testing.T) {
 		},
 		{
 			Name:   "DigestRefs",
-			Images: []string{"registry.test/all-refs:index", "registry.test/all-refs:1", "registry.test/all-refs@"},
+			Images: []string{"registry.test/all-refs:index", "registry.test/all-refs:1", "registry.test/all-refs@<manifest>", "registry.test/all-refs@<index>"},
 			Opts:   []image.StoreOpt{image.WithDigestRef("registry.test/all-refs", false, false)},
 		},
 		{
 			Name:   "DigestRefsSkipNamed",
-			Images: []string{"registry.test/all-refs:index", "registry.test/all-refs:1"},
+			Images: []string{"registry.test/all-refs:index", "registry.test/all-refs:1", "registry.test/all-refs@<index>"},
 			Opts:   []image.StoreOpt{image.WithDigestRef("registry.test/all-refs", false, true)},
 		},
 		{
 			Name:   "DigestOnly",
-			Images: []string{"", "", "imported-image@"},
+			Images: []string{"", "", "imported-image@<manifest>", "imported-image@<index>"},
 			Opts:   []image.StoreOpt{image.WithDigestRef("imported-image", false, true)},
 		},
 		{
 			Name:   "OverwriteDigestRefs",
-			Images: []string{"registry.test/all-refs:index", "registry.test/all-refs:1", "someimportname@"},
+			Images: []string{"registry.test/all-refs:index", "registry.test/all-refs:1", "someimportname@<manifest>", "someimportname@<index>"},
 			Opts:   []image.StoreOpt{image.WithDigestRef("someimportname", true, false)},
 		},
 		{
@@ -660,7 +661,7 @@ func TestTransferImport(t *testing.T) {
 		},
 		{
 			Name:   "TagOnlyOverwriteDigestRefs",
-			Images: []string{"registry.test/all-refs:index", "registry.test/basename latest", "registry.test/basename@"},
+			Images: []string{"registry.test/all-refs:index", "registry.test/basename latest", "registry.test/basename@<manifest>", "registry.test/basename@<index>"},
 			Opts:   []image.StoreOpt{image.WithDigestRef("registry.test/basename", true, false)},
 		},
 	} {
@@ -755,13 +756,20 @@ func createImages(tc tartest.TarContext, imageNames ...string) (descs map[string
 		},
 	}
 
+	// indexDigestRefs collects @<index> entries to be resolved with the
+	// index digest after the index is built.
+	var indexDigestRefs []string
+
 	if len(imageNames) > 1 {
 		var lastManifest ocispec.Descriptor
 
 		for _, image := range imageNames[1:] {
-			if image != "" && image[len(image)-1] == '@' {
-				image = image[:len(image)-1]
-				descs[fmt.Sprintf("%s@%s", image, lastManifest.Digest)] = lastManifest
+			if name, ok := strings.CutSuffix(image, "@<index>"); ok {
+				indexDigestRefs = append(indexDigestRefs, name)
+				continue
+			}
+			if name, ok := strings.CutSuffix(image, "@<manifest>"); ok {
+				descs[fmt.Sprintf("%s@%s", name, lastManifest.Digest)] = lastManifest
 				continue
 			}
 			seed := hash64(image)
@@ -816,6 +824,10 @@ func createImages(tc tartest.TarContext, imageNames ...string) (descs map[string
 	}
 	if idxName != "" {
 		descs[idxName] = id
+	}
+
+	for _, ref := range indexDigestRefs {
+		descs[fmt.Sprintf("%s@%s", ref, id.Digest)] = id
 	}
 
 	return


### PR DESCRIPTION
- Fix in transfer service to save digest reference
- Add GC labels to extra references to support automatic garbage collection with the primary is removed
- Add log in GC when the image is removed (no event since its an extra reference not explicitly deleted)