### PR TITLE
 [DNM] add check for skipVerify in explicitTLSFromHost

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -167,7 +167,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 		rhosts := make([]docker.RegistryHost, len(hosts))
 		for i, host := range hosts {
 			// Allow setting for each host as well
-			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil
+			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || (host.skipVerify != nil && !*host.skipVerify)
 			explicitTLS := tlsConfigured || explicitTLSFromHost
 
 			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 {


### PR DESCRIPTION
currently when default TLS is not setup and skipVerify=true for a given host, if the registry is not running at port 80, containerd will still try with https and then fall back to http using docker.NewHTTPFallback.

This patch adds additional check if skipVerify is set to false, before setting the explicitTLSFromHost / setting the transport for the given host.