### PR TITLE
[release/2.2] cri: treat disabled CDI an error for injection requests.

### DIFF
--- a/internal/cri/server/container_create_linux.go
+++ b/internal/cri/server/container_create_linux.go
@@ -102,7 +102,17 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 	}
 	if c.config.EnableCDI {
 		specOpts = append(specOpts, customopts.WithCDI(config.Annotations, config.CDIDevices))
+	} else {
+		if len(config.CDIDevices) > 0 {
+			names, sep := "", ""
+			for _, dev := range config.CDIDevices {
+				names += sep + dev.Name
+				sep = ", "
+			}
+			return nil, fmt.Errorf("CDI devices (%s) requested but CDI support is explicitly disabled", names)
+		}
 	}
+
 	return specOpts, nil
 }
 

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -255,6 +255,14 @@ func NewCRIService(options *CRIServiceOptions) (CRIService, runtime.RuntimeServi
 		SupplementalGroupsPolicy: true,
 	}
 
+	if !c.config.EnableCDI {
+		log.L.Warn("CDI support is explicitly disabled by configuration. This will cause")
+		log.L.Warn("container creation requests with CDI devices to be rejected with an")
+		log.L.Warn("error. The possibility to disable CDI will be removed in a future")
+		log.L.Warn("release, at which point CDI support will always be enabled.")
+		log.L.Warn("In preparation for that consider enabling CDI now.")
+	}
+
 	return c, c, nil
 }
 


### PR DESCRIPTION
If a container has CDI devices requested by the dedicated CRI protocol field, treat this as an error if CDI support is explicitly disabled by configuration, instead of silently ignoring the requested devices.

Additionally, if CDI support is disabled log a warning about the future deprecation of the EnableCDI configuration option.