### PR TITLE
[release/2.2] Prepare release notes for v2.2.1

### DIFF
--- a/releases/v2.2.1.toml
+++ b/releases/v2.2.1.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "v2.2.0"
+
+pre_release = false
+
+preface = """\
+The first patch release for containerd 2.2 contains various fixes and improvements.
+"""
+
+postface = """\
+### Which file should I download?
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.35 (Ubuntu 22.04).
+* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on Linux distributions that do not use glibc >= 2.35. Not position-independent.
+
+In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
+and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.
+
+See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.2.0+unknown"
+	Version = "2.2.1+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes

---

containerd 2.2.1

Welcome to the v2.2.1 release of containerd!

The first patch release for containerd 2.2 contains various fixes and improvements.

### Highlights

#### Container Runtime Interface (CRI)

* **Redact all query parameters in CRI error logs** ([#12546](https://github.com/containerd/containerd/pull/12546))

#### Image Distribution

* **Fix image defaults on Darwin to usable configuration** ([#12544](https://github.com/containerd/containerd/pull/12544))
* **Fix possible panic from WithMediaTypeKeyPrefix** ([#12516](https://github.com/containerd/containerd/pull/12516))

#### Runtime

* **Update runc binary to v1.3.4** ([#12593](https://github.com/containerd/containerd/pull/12593))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Krisztian Litkey
* Markus Lehtonen
* Derek McGowan
* Akihiro Suda
* Mike Brown
* Wei Fu
* Phil Estes
* Austin Vazquez
* Sascha Grunert
* Sebastiaan van Stijn
* Akhil Mohan
* Andrey Noskov
* Brian Goff
* CrazyMax
* Davanum Srinivas
* Neeraj Krishna Gopalakrishna
* Paweł Gronowski
* Tõnis Tiigi
* bo.jiang

### Changes
<details><summary>41 commits</summary>
<p>

  * [`d5a717542`](https://github.com/containerd/containerd/commit/d5a717542ad887a02e50160522f13c9aa8fab35d) Prepare release notes for v2.2.1
* go.{mod,sum}: bump CDI deps to v1.1.0. ([#12664](https://github.com/containerd/containerd/pull/12664))
  * [`c166a577d`](https://github.com/containerd/containerd/commit/c166a577d0638de704d6c9f999858ed47cf06a60) go.{mod,sum} bump CDI deps to v1.1.0.
* go.mod: containerd/zfs v2.0.0; remove exclude rules ([#12654](https://github.com/containerd/containerd/pull/12654))
  * [`73a08aa00`](https://github.com/containerd/containerd/commit/73a08aa00dc98a0662a40d45ed50dac534dce1e6) go.mod: remove exclude rules
  * [`cee08c8af`](https://github.com/containerd/containerd/commit/cee08c8af836002863b30e2ef8cd3c45b6ae56ad) build(deps): bump github.com/containerd/zfs/v2 from 2.0.0-rc.0 to 2.0.0
* go.mod: github.com/containernetworking/plugins v1.9.0 ([#12658](https://github.com/containerd/containerd/pull/12658))
  * [`8a5fc8641`](https://github.com/containerd/containerd/commit/8a5fc86416926d2a2189861391cd77b07d7f4443) go.mod: github.com/containernetworking/plugins v1.9.0
* go.mod: golang.org/x/crypto v0.45.0 ([#12638](https://github.com/containerd/containerd/pull/12638))
  * [`55c93d6fb`](https://github.com/containerd/containerd/commit/55c93d6fb85333d4988122b2ae97b947bcde02b7) go.mod: golang.org/x/crypto v0.45.0
* ci :bump Go 1.24.11, 1.25.5 ([#12625](https://github.com/containerd/containerd/pull/12625))
  * [`aedd29bb4`](https://github.com/containerd/containerd/commit/aedd29bb4ecabfae1d8806dc1011a347a3401fb2) ci: bump Go 1.24.11, 1.25.5
  * [`26628f139`](https://github.com/containerd/containerd/commit/26628f1397f991a9ee2fe7de32a6a2df70ab89bd) ci: bump Go 1.24.10, 1.25.4
  * [`8bb0e9be6`](https://github.com/containerd/containerd/commit/8bb0e9be6ceebc1ad1d76c88a661bacf84921b3d) ci(release): set GO_VERSION in Dockerfile
* core/runtime/v2: remove uses of otelgrpc.UnaryClientInterceptor ([#12622](https://github.com/containerd/containerd/pull/12622))
  * [`ed19c5420`](https://github.com/containerd/containerd/commit/ed19c542003cc00988760b0f72e487c20dc198a0) core/runtime/v2: remove uses of otelgrpc.UnaryClientInterceptor
* ci: update CIFuzz actions to support Ubuntu 24.04 ([#12632](https://github.com/containerd/containerd/pull/12632))
  * [`952237d9b`](https://github.com/containerd/containerd/commit/952237d9ba4390f4fa740f3832492e3870f0f9f9) ci: update CIFuzz actions to support Ubuntu 24.04
* Update runc binary to v1.3.4 ([#12593](https://github.com/containerd/containerd/pull/12593))
  * [`fb5b818a9`](https://github.com/containerd/containerd/commit/fb5b818a9a34ad4fe3b0901c73cd7432ae4bb8bc) runc: Update runc binary to v1.3.4
* : update containerd/cgroups from v3.1.0 to v3.1.2 ([#12598](https://github.com/containerd/containerd/pull/12598))
  * [`51582ed27`](https://github.com/containerd/containerd/commit/51582ed27b13941f6bbf1526d909a00deadfcc0f) bump containerd/cgroups to v3.1.2
  * [`50d0e4fd4`](https://github.com/containerd/containerd/commit/50d0e4fd4cb909829d9965d9da5be04ee812fe29) build(deps): bump github.com/containerd/cgroups/v3 from 3.1.0 to 3.1.1
* core/mount: should not call removeLoop when set autoclear ([#12587](https://github.com/containerd/containerd/pull/12587))
  * [`41a69eb0d`](https://github.com/containerd/containerd/commit/41a69eb0d19cafbf40e03c36ef6be259a52d6f5e) core/mount: should not call removeLoop when set autoclear
* build(deps): bump github.com/opencontainers/selinux ([#12589](https://github.com/containerd/containerd/pull/12589))
  * [`e3bf2b80b`](https://github.com/containerd/containerd/commit/e3bf2b80b9ca3280fd64a2bd0436fcdb894c4410) build(deps): bump github.com/opencontainers/selinux
* .github: skip 5 critest cases for window-2022 ([#12584](https://github.com/containerd/containerd/pull/12584))
  * [`da8e846f9`](https://github.com/containerd/containerd/commit/da8e846f97a081f580eccc4a7384f3f050dd5b5e) .github: skip 5 critest cases in window CI pipeline
* Fix image defaults on Darwin to usable configuration ([#12544](https://github.com/containerd/containerd/pull/12544))
  * [`d154e234b`](https://github.com/containerd/containerd/commit/d154e234b29c5bed4f14a72d605e92e4728415a2) Update the ctr pull defaults when using the transfer service
  * [`09364216d`](https://github.com/containerd/containerd/commit/09364216de92aab056118507da59fabf642d88ac) Fix transfer unpack defaults on darwin
  * [`2055d3c62`](https://github.com/containerd/containerd/commit/2055d3c62e85350642c4b031c35a63b22e2ec6f7) Update default differs on darwin
  * [`9da97686d`](https://github.com/containerd/containerd/commit/9da97686d151da046d5512bb9f7f1d67ea4c8393) Use default writable size in erofs snapshotter for non-Linux hosts
  * [`eeb0f889a`](https://github.com/containerd/containerd/commit/eeb0f889aed826b58a3033a5a5b14dff6ccd1979) Update default erofs block size on macOS during erofs diff
* Redact all query parameters in CRI error logs ([#12546](https://github.com/containerd/containerd/pull/12546))
  * [`c707f771a`](https://github.com/containerd/containerd/commit/c707f771a872f9dd22ad8f2f827317a800e4a74f) fix: redact all query parameters in CRI error logs
* Revert "Implement io.ReaderAt on docker fetch reader" ([#12542](https://github.com/containerd/containerd/pull/12542))
  * [`678f944dd`](https://github.com/containerd/containerd/commit/678f944dd16601d08ecbb19e350acc027728b656) Revert "Implement io.ReaderAt on docker fetch reader"
* Fix possible panic from WithMediaTypeKeyPrefix ([#12516](https://github.com/containerd/containerd/pull/12516))
  * [`8b73c2de3`](https://github.com/containerd/containerd/commit/8b73c2de310e95fe3a143473b511fcf99d03692f) remotes: fix possible panic from WithMediaTypeKeyPrefix
</p>
</details>

### Changes from containerd/nri
<details><summary>49 commits</summary>
<p>

* deps: bump runtime-spec to v1.3.0. ([containerd/nri#243](https://github.com/containerd/nri/pull/243))
  * [`29c5811`](https://github.com/containerd/nri/commit/29c581117267cb5d2289ff08902a93ff263caf0e) (v0.1.0) examples: lock NRI, runtime spec deps.
  * [`d812952`](https://github.com/containerd/nri/commit/d8129529588cca090c972aa5e5f7775162af59da) v010-adapter: lock NRI, runtime spec and tools deps.
  * [`7dd7c7f`](https://github.com/containerd/nri/commit/7dd7c7f8b21c08242de41634b12ab2ee71b91000) api,runtime-tools: adjust for runtime-spec v1.3.0.
  * [`5d5d4c4`](https://github.com/containerd/nri/commit/5d5d4c4c877fdef4fe0938e627b11b97234195b8) go.{mod,sum}: update runtime-tools, runtime-spec to v1.3.0.
* adaptation: ensure sync'ed plugins are fully registered in tests. ([containerd/nri#234](https://github.com/containerd/nri/pull/234))
  * [`c840397`](https://github.com/containerd/nri/commit/c84039771e9c2cee68952b4b7cc52cba1909784e) adaptation: ensure sync'ed plugins are fully registered in tests.
* Fix wasm example ([containerd/nri#237](https://github.com/containerd/nri/pull/237))
  * [`44b2861`](https://github.com/containerd/nri/commit/44b2861a26c8e392229cd8b27a20cf689925f176) Fix wasm example
* Makefile: build proto files unconditionally ([containerd/nri#229](https://github.com/containerd/nri/pull/229))
  * [`d99f960`](https://github.com/containerd/nri/commit/d99f96028e5226c004f94a3394be82190980c4bd) Fix dockerized proto build
  * [`9623748`](https://github.com/containerd/nri/commit/9623748f543343bfe6b2312df47a7ed9000d47fe) Makefile: build proto files unconditionally
  * [`25d9391`](https://github.com/containerd/nri/commit/25d9391690a7158d851364ef011e1f56fd607a70) build: ensure we use correct version of protoc and its deps.
* adaptation: test with populated initial resources. ([containerd/nri#231](https://github.com/containerd/nri/pull/231))
  * [`b6b98b5`](https://github.com/containerd/nri/commit/b6b98b56a60df29da312cc1e1e070697dec43583) adaptation: test with populated initial resources.
* Install protoc locally in the source tree ([containerd/nri#232](https://github.com/containerd/nri/pull/232))
  * [`2394daa`](https://github.com/containerd/nri/commit/2394daa45f1c7c0fcf28e9e39895c8b871a7445c) Install protoc locally in the source tree
* plugins/logger: fix default event subscription mask. ([containerd/nri#158](https://github.com/containerd/nri/pull/158))
  * [`33b1db1`](https://github.com/containerd/nri/commit/33b1db1add2e9a603f7c47e1efa95d386f4af560) logger: fix default event subscription mask.
* extract memory and CPU resource helpers ([containerd/nri#210](https://github.com/containerd/nri/pull/210))
  * [`7afb32a`](https://github.com/containerd/nri/commit/7afb32a3a444fd0a24e36988e0906ad35590c672) extract memory and CPU resource helpers
* api: expose container user/group ID to plugins. ([containerd/nri#230](https://github.com/containerd/nri/pull/230))
  * [`22aeb46`](https://github.com/containerd/nri/commit/22aeb467e553bffd7650930b3bc6c28b95a2dee5) docs: update README with container uid/gid info.
  * [`71b0335`](https://github.com/containerd/nri/commit/71b0335fdc262451ab2ff71591f1126c8a036265) api,adaptation: add container uid/gid info.
* contrib: add example for enabling per-container RDT monitoring ([containerd/nri#228](https://github.com/containerd/nri/pull/228))
  * [`91fbf06`](https://github.com/containerd/nri/commit/91fbf06ed654e46629cb7aefb11856953720c9cf) contrib: add example for enabling per-container RDT monitoring
* ci: enable image signing ([containerd/nri#224](https://github.com/containerd/nri/pull/224))
  * [`fb54916`](https://github.com/containerd/nri/commit/fb5491601ca84bf52b70e75d0e99ddc4dfe6a922) ci: enable image signing
* golangci: disable QF1008 from staticcheck linter ([containerd/nri#226](https://github.com/containerd/nri/pull/226))
  * [`0b3b577`](https://github.com/containerd/nri/commit/0b3b5770d1f6845d3a3e52ccb5218f2b3ce1f34e) golangci: disable QF1008 from staticcheck linter
* ci: bump golangci-lint to v2.4 ([containerd/nri#225](https://github.com/containerd/nri/pull/225))
  * [`9787127`](https://github.com/containerd/nri/commit/9787127c0f3e69726b968e12b29dae31e35e250b) Bump golangci-lint to v2.4
  * [`1a50ff5`](https://github.com/containerd/nri/commit/1a50ff585624f01763fd20aafaeaa92aa8b27c46) Add nolint directives
  * [`00fa1a1`](https://github.com/containerd/nri/commit/00fa1a124e605590d3ceea1e687600785ae6518d) Add and fix comments for exported types
  * [`ac21da7`](https://github.com/containerd/nri/commit/ac21da7be8f991a8699cef41acba8783dee5351e) pkg/api/seccomp: add comments for exported functions
  * [`3aff986`](https://github.com/containerd/nri/commit/3aff986af5f8abefda8552edae991608782df46c) pkg/runtime-tools/generate: remove embedded field "Generator"
  * [`c0c4bb6`](https://github.com/containerd/nri/commit/c0c4bb648ae46207f47d5b18bf447f7d5b32e26b) pkg/api/validate: add comments for exported methods
  * [`c0ba9da`](https://github.com/containerd/nri/commit/c0ba9da712934c860a64af54d96b5cfc74672ff5) adaptation/builtin: add comment for exported symbols
* .gitignore: revert hastily reviewed editor-specific addition. ([containerd/nri#221](https://github.com/containerd/nri/pull/221))
  * [`02376f3`](https://github.com/containerd/nri/commit/02376f371c707718144dd509172618c69ce6670c) .gitignore: add comment about global gitignore.
  * [`9336a79`](https://github.com/containerd/nri/commit/9336a7933c666dbe6da09fe3cb46e80b478fb268) Revert "nit: Add .idea folder to gitignore"
* nit: Add .idea folder to gitignore ([containerd/nri#218](https://github.com/containerd/nri/pull/218))
  * [`f578ea2`](https://github.com/containerd/nri/commit/f578ea2804642f2cd59594edc17b59d995289223) nit: Add .idea folder to gitignore
* chore: clean and unify nolint directives ([containerd/nri#217](https://github.com/containerd/nri/pull/217))
  * [`21741b9`](https://github.com/containerd/nri/commit/21741b9ee40d69eb9ee3d5688e45b0b022c32738) chore: clean and unify nolint directives
* Downgrade go to require 1.24.0 ([containerd/nri#214](https://github.com/containerd/nri/pull/214))
  * [`d26e910`](https://github.com/containerd/nri/commit/d26e910702c62126decc6befe835e7315cd738a9) Downgrade go to require 1.24.0
* Add dockerized target for building proto files ([containerd/nri#211](https://github.com/containerd/nri/pull/211))
  * [`13fcc07`](https://github.com/containerd/nri/commit/13fcc0773d23520ff44d54549122ec78c8f1e473) Add dockerized target for building proto files
</p>
</details>

### Dependency Changes

* **github.com/containerd/cgroups/v3**                  v3.1.0 -> v3.1.2
* **github.com/containerd/nri**                         v0.10.0 -> 3827d9da021a
* **github.com/containerd/zfs/v2**                      v2.0.0-rc.0 -> v2.0.0
* **github.com/containernetworking/plugins**            v1.8.0 -> v1.9.0
* **github.com/cyphar/filepath-securejoin**             v0.5.1 **_new_**
* **github.com/opencontainers/runtime-spec**            v1.2.1 -> v1.3.0
* **github.com/opencontainers/runtime-tools**           0ea5ed0382a2 -> edf4cb3d2116
* **github.com/opencontainers/selinux**                 v1.12.0 -> v1.13.1
* **golang.org/x/crypto**                               v0.41.0 -> v0.45.0
* **golang.org/x/net**                                  v0.43.0 -> v0.47.0
* **golang.org/x/sync**                                 v0.17.0 -> v0.18.0
* **golang.org/x/sys**                                  v0.37.0 -> v0.38.0
* **golang.org/x/term**                                 v0.34.0 -> v0.37.0
* **golang.org/x/text**                                 v0.28.0 -> v0.31.0
* **tags.cncf.io/container-device-interface**           v1.0.1 -> v1.1.0
* **tags.cncf.io/container-device-interface/specs-go**  v1.0.0 -> v1.1.0

Previous release can be found at [v2.2.0](https://github.com/containerd/containerd/releases/tag/v2.2.0)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.35 (Ubuntu 22.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on Linux distributions that do not use glibc >= 2.35. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
