### PR TITLE
fetcher: Reset buffer before returning to pool

### DIFF
--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -60,6 +60,7 @@ func (p *bufferPool) Get() *bytes.Buffer {
 }
 
 func (p *bufferPool) Put(buffer *bytes.Buffer) {
+	buffer.Reset()
 	p.pool.Put(buffer)
 }
 


### PR DESCRIPTION
Safe and small fix I have extracted from PR #12205, to make it smaller.
This avoids potential `Data corruption` during pulls.
