### PR TITLE
remotes/docker: Propagate registry warnings to the resolver

### DIFF
--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -231,6 +231,13 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 		return nil, err
 	}
 
+	if r.warningHandler != nil {
+		ctx = context.WithValue(ctx, warningSourceKey{}, WarningSource{
+			Desc:   &desc,
+			Digest: &desc.Digest,
+		})
+	}
+
 	return newHTTPReadSeeker(desc.Size, func(offset int64) (io.ReadCloser, error) {
 		// firstly try fetch via external urls
 		for _, us := range desc.URLs {
@@ -243,6 +250,7 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 				log.G(ctx).Debug("non-http(s) alternative url is unsupported")
 				continue
 			}
+
 			ctx = log.WithLogger(ctx, log.G(ctx).WithField("url", u))
 			log.G(ctx).Info("request")
 
@@ -377,6 +385,12 @@ func (r dockerFetcher) FetchByDigest(ctx context.Context, dgst digest.Digest, op
 	ctx, err := ContextWithRepositoryScope(ctx, r.refspec, false)
 	if err != nil {
 		return nil, desc, err
+	}
+
+	if r.warningHandler != nil {
+		ctx = context.WithValue(ctx, warningSourceKey{}, WarningSource{
+			Digest: &dgst,
+		})
 	}
 
 	var (

--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -82,6 +82,12 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 	if err != nil {
 		return nil, err
 	}
+	if p.dockerBase.warningHandler != nil {
+		ctx = context.WithValue(ctx, warningSourceKey{}, WarningSource{
+			Desc:   &desc,
+			Digest: &desc.Digest,
+		})
+	}
 	status, err := p.tracker.GetStatus(ref)
 	if err == nil {
 		if status.Committed && status.Offset == status.Total {

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -102,6 +102,13 @@ type ResolverOptions struct {
 	// mechanism for getting blob upload status is expensive.
 	Tracker StatusTracker
 
+	// WarningHandler is called for each warning received from the registry.
+	// Warnings are reported via HTTP Warning headers with warn-code 299.
+	// It may be called concurrently from multiple goroutines, so
+	// implementations must be safe for concurrent use.
+	// If nil, warnings are ignored.
+	WarningHandler WarningHandler
+
 	// Authorizer is used to authorize registry requests
 	//
 	// Deprecated: use Hosts.
@@ -139,11 +146,12 @@ func DefaultHost(ns string) (string, error) {
 }
 
 type dockerResolver struct {
-	hosts         RegistryHosts
-	header        http.Header
-	resolveHeader http.Header
-	tracker       StatusTracker
-	config        transfer.ImageResolverOptions
+	hosts          RegistryHosts
+	header         http.Header
+	resolveHeader  http.Header
+	tracker        StatusTracker
+	config         transfer.ImageResolverOptions
+	warningHandler WarningHandler
 }
 
 // NewResolver returns a new resolver to a Docker registry
@@ -198,10 +206,11 @@ func NewResolver(options ResolverOptions) remotes.Resolver {
 		options.Hosts = ConfigureDefaultRegistries(opts...)
 	}
 	return &dockerResolver{
-		hosts:         options.Hosts,
-		header:        options.Headers,
-		resolveHeader: resolveHeader,
-		tracker:       options.Tracker,
+		hosts:          options.Hosts,
+		header:         options.Headers,
+		resolveHeader:  resolveHeader,
+		tracker:        options.Tracker,
+		warningHandler: options.WarningHandler,
 	}
 }
 
@@ -316,6 +325,10 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				"method": req.method,
 				"url":    req.sanitizedURL(),
 			}))
+
+			// Don't report warnings during resolution; will report after descriptor construction
+			req.warningHandler = nil
+
 			log.G(ctx).Debug("resolving")
 			resp, err := req.doWithRetries(ctx, i == len(hosts)-1)
 			if err != nil {
@@ -328,6 +341,10 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				}
 				log.G(ctx).WithError(err).Info(nextHostOrFail(i))
 				continue // try another host
+			}
+			var respHeaders http.Header
+			if r.warningHandler != nil {
+				respHeaders = resp.Header.Clone()
 			}
 			resp.Body.Close() // don't care about body contents.
 
@@ -398,6 +415,9 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 					req.header[key] = append(req.header[key], value...)
 				}
 
+				// Don't report warnings during resolution
+				req.warningHandler = nil
+
 				resp, err := req.doWithRetries(ctx, true)
 				if err != nil {
 					return "", ocispec.Descriptor{}, err
@@ -407,6 +427,11 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				if resp.StatusCode >= http.StatusBadRequest {
 					defer resp.Body.Close()
 					return "", ocispec.Descriptor{}, unexpectedResponseErr(resp)
+				}
+
+				// Save response headers for warning reporting later
+				if r.warningHandler != nil {
+					respHeaders = resp.Header.Clone()
 				}
 
 				bodyReader := countingReader{reader: resp.Body}
@@ -446,6 +471,13 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				MediaType: contentType,
 				Size:      size,
 			}
+
+			// Report any warnings with the warning source
+			reportWarningsWithSource(ctx, respHeaders, r.warningHandler, WarningSource{
+				Ref:    refspec,
+				Desc:   &desc,
+				Digest: &dgst,
+			})
 
 			log.G(ctx).WithField("desc.digest", desc.Digest).Debug("resolved")
 			return ref, desc, nil
@@ -501,12 +533,13 @@ func (r *dockerResolver) resolveDockerBase(ref string) (*dockerBase, error) {
 }
 
 type dockerBase struct {
-	refspec      reference.Spec
-	repository   string
-	hosts        []RegistryHost
-	header       http.Header
-	performances transfer.ImageResolverPerformanceSettings
-	limiter      *semaphore.Weighted
+	refspec        reference.Spec
+	repository     string
+	hosts          []RegistryHost
+	header         http.Header
+	performances   transfer.ImageResolverPerformanceSettings
+	limiter        *semaphore.Weighted
+	warningHandler WarningHandler
 }
 
 func (r *dockerBase) Acquire(ctx context.Context, weight int64) error {
@@ -529,12 +562,13 @@ func (r *dockerResolver) base(refspec reference.Spec) (*dockerBase, error) {
 		return nil, err
 	}
 	return &dockerBase{
-		refspec:      refspec,
-		repository:   strings.TrimPrefix(refspec.Locator, host+"/"),
-		hosts:        hosts,
-		header:       r.header,
-		performances: r.config.Performances,
-		limiter:      r.config.DownloadLimiter,
+		refspec:        refspec,
+		repository:     strings.TrimPrefix(refspec.Locator, host+"/"),
+		hosts:          hosts,
+		header:         r.header,
+		performances:   r.config.Performances,
+		limiter:        r.config.DownloadLimiter,
+		warningHandler: r.warningHandler,
 	}, nil
 }
 
@@ -568,10 +602,12 @@ func (r *dockerBase) request(host RegistryHost, method string, ps ...string) *re
 		p = p + "/"
 	}
 	return &request{
-		method: method,
-		path:   p,
-		header: header,
-		host:   host,
+		method:         method,
+		path:           p,
+		header:         header,
+		host:           host,
+		refspec:        r.refspec,
+		warningHandler: r.warningHandler,
 	}
 }
 
@@ -616,12 +652,14 @@ func (r *request) addNamespace(ns string) error {
 }
 
 type request struct {
-	method string
-	path   string
-	header http.Header
-	host   RegistryHost
-	body   func() (io.ReadCloser, error)
-	size   int64
+	method         string
+	path           string
+	header         http.Header
+	host           RegistryHost
+	body           func() (io.ReadCloser, error)
+	size           int64
+	refspec        reference.Spec
+	warningHandler WarningHandler
 }
 
 func (r *request) clone() *request {
@@ -681,6 +719,7 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 		return nil, fmt.Errorf("failed to do request: %w", err)
 	}
 	log.G(ctx).WithFields(responseFields(resp)).Debug("fetch response received")
+	reportWarnings(ctx, resp.Header, r.warningHandler)
 	return resp, nil
 }
 
@@ -734,6 +773,9 @@ const maxAttempts = 5
 
 func (r *request) doWithRetries(ctx context.Context, lastHost bool, checks ...doChecks) (resp *http.Response, err error) {
 	attempts := maxAttempts
+	if r.warningHandler != nil {
+		ctx = updateWarningSource(ctx, r.refspec)
+	}
 	resp, err = r.doWithRetriesInner(ctx, nil, &attempts, lastHost)
 	if err != nil {
 		return nil, err

--- a/core/remotes/docker/warnings.go
+++ b/core/remotes/docker/warnings.go
@@ -1,0 +1,223 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package docker
+
+import (
+	"context"
+	"encoding/hex"
+	"net/http"
+	"strings"
+
+	"github.com/containerd/log"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/pkg/reference"
+)
+
+// WarningSource contains the information about the request that caused the warning.
+type WarningSource struct {
+	// Ref is the reference specification of the content that the warning is for.
+	Ref reference.Spec
+
+	// Desc is the descriptor of the content that the warning is for.
+	// Can be nil if the warning is not for a specific content.
+	Desc *ocispec.Descriptor
+
+	// Digest is the digest of the content that the warning is for.
+	// Can be nil if the warning is not for a specific content.
+	Digest *digest.Digest
+}
+
+// WarningHandler is a function that receives warnings from the registry.
+// Warnings are extracted from HTTP Warning headers as defined in RFC 7234.
+// The src parameter contains information about the request that the warning is
+// for. If the warning is for specific content, its descriptor is available via
+// src.Desc. src.Desc is nil if the warning is not for a specific content.
+type WarningHandler interface {
+	Warn(ctx context.Context, src WarningSource, warning string)
+}
+
+type warningHandlerFunc func(ctx context.Context, src WarningSource, warning string)
+
+func (f warningHandlerFunc) Warn(ctx context.Context, src WarningSource, warning string) {
+	f(ctx, src, warning)
+}
+
+type warningSourceKey struct{}
+
+// reportWarnings extracts and reports warnings from HTTP Warning headers.
+// Per RFC 7234 and OCI distribution spec, warnings use warn-code 299,
+// warn-agent "-", and the format: Warning: 299 - "message"
+func reportWarnings(ctx context.Context, header http.Header, handler WarningHandler) {
+	if handler == nil {
+		return
+	}
+
+	var warnSrc WarningSource
+	if v, ok := ctx.Value(warningSourceKey{}).(WarningSource); ok {
+		warnSrc = v
+	}
+
+	reportWarningsWithSource(ctx, header, handler, warnSrc)
+}
+
+func reportWarningsWithSource(ctx context.Context, header http.Header, handler WarningHandler, warnSrc WarningSource) {
+	if handler == nil {
+		return
+	}
+
+	for _, warning := range header.Values("Warning") {
+		// Parse RFC 7234 warning format: warn-code warn-agent "warn-text"
+		// Expected format for OCI: 299 - "message"
+		if text := parseWarningText(warning); text != "" {
+			handler.Warn(ctx, warnSrc, text)
+		}
+	}
+}
+
+// parseWarningText extracts the warn-text from an RFC 7234 Warning header value.
+// Only the OCI distribution spec recommended format is supported:
+// 299 - "message"
+// Other warn-agent values (tokens other than "-") and optional warn-date
+// suffixes defined in RFC 7234 are not supported and will cause the
+// warning to be silently ignored.
+// Characters are validated per RFC 7230 section 3.2.6 quoted-string rules:
+//   - qdtext: HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
+//   - quoted-pair: "\" ( HTAB / SP / VCHAR / obs-text )
+//   - percent-encoding: %xx where xx is a hex value; decoded byte must be valid qdtext
+func parseWarningText(warning string) string {
+	text, ok := strings.CutPrefix(warning, "299 - ")
+	if !ok {
+		return ""
+	}
+
+	text = strings.TrimSpace(text)
+
+	ln := len(text)
+	if ln == 0 || text[0] != '"' || text[ln-1] != '"' {
+		return ""
+	}
+
+	out := strings.Builder{}
+	idx := 1 // skip opening quote
+	end := ln - 1
+
+	for idx < end {
+		c := text[idx]
+
+		if c == '\\' {
+			if idx+1 >= end {
+				return ""
+			}
+			nextC := text[idx+1]
+			if !isQuotedPairChar(nextC) {
+				return ""
+			}
+			out.WriteByte(nextC)
+			idx += 2
+			continue
+		}
+
+		// Handle percent-encoding (%xx)
+		if c == '%' && idx+2 < end {
+			decoded, err := hex.DecodeString(text[idx+1 : idx+3])
+			if err == nil && len(decoded) == 1 {
+				if !isQdtext(decoded[0]) {
+					return ""
+				}
+				out.WriteByte(decoded[0])
+				idx += 3
+				continue
+			}
+			// Invalid percent-encoding, treat as literal
+		}
+
+		if !isQdtext(c) {
+			return ""
+		}
+		out.WriteByte(c)
+		idx++
+	}
+
+	return out.String()
+}
+
+func updateWarningSource(ctx context.Context, ref reference.Spec) context.Context {
+	var warnSrc WarningSource
+	if v, ok := ctx.Value(warningSourceKey{}).(WarningSource); ok {
+		warnSrc = v
+	}
+	warnSrc.Ref = ref
+	ctx = context.WithValue(ctx, warningSourceKey{}, warnSrc)
+	return ctx
+}
+
+// isQdtext returns whether c is valid unescaped inside a quoted-string per RFC 7230 §3.2.6.
+//
+//	qdtext = HTAB / SP / %x21 / %x23-5B / %x5D-7E / %x80-FF
+func isQdtext(c byte) bool {
+	if c == 0x09 || c == 0x20 { // HTAB, SP
+		return true
+	}
+	if c == 0x21 { // '!'
+		return true
+	}
+	if c >= 0x23 && c <= 0x5B { // '#' to '['
+		return true
+	}
+	if c >= 0x5D && c <= 0x7E { // ']' to '~'
+		return true
+	}
+	if c >= 0x80 { // obs-text
+		return true
+	}
+	return false
+}
+
+// isQuotedPairChar returns whether c is valid after a backslash per RFC 7230 §3.2.6.
+//
+//	quoted-pair = "\" ( HTAB / SP / VCHAR / %x80-FF )
+//	VCHAR = %x21-7E
+func isQuotedPairChar(c byte) bool {
+	if c == 0x09 || c == 0x20 { // HTAB, SP
+		return true
+	}
+	if c >= 0x21 && c <= 0x7E { // VCHAR
+		return true
+	}
+	if c >= 0x80 { // obs-text
+		return true
+	}
+	return false
+}
+
+// LogWarningHandler is a WarningHandler that logs warnings using the
+// containerd log package.
+type LogWarningHandler struct{}
+
+// Warn logs the warning message with source information.
+func (LogWarningHandler) Warn(ctx context.Context, src WarningSource, warning string) {
+	fields := log.Fields{}
+	if ref := src.Ref.String(); ref != "" {
+		fields["ref"] = ref
+	}
+	if src.Digest != nil {
+		fields["digest"] = src.Digest.String()
+	}
+	log.G(ctx).WithFields(fields).Warn("registry warning: " + warning)
+}

--- a/core/remotes/docker/warnings_test.go
+++ b/core/remotes/docker/warnings_test.go
@@ -1,0 +1,392 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/pkg/reference"
+)
+
+func TestWarningHandler(t *testing.T) {
+	name := "testname"
+	tag := "latest"
+
+	m := newManifest(
+		newContent(ocispec.MediaTypeImageConfig, []byte("{}")),
+		newContent(ocispec.MediaTypeImageLayerGzip, []byte("layer content")),
+	)
+	mc := newContent(ocispec.MediaTypeImageManifest, m.OCIManifest())
+
+	mux := http.NewServeMux()
+	addWarning := func(h http.Handler, msg string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Warning", fmt.Sprintf(`299 - "%s"`, msg))
+			h.ServeHTTP(w, r)
+		})
+	}
+
+	for _, c := range []testContent{m.config, m.references[0]} {
+		mux.Handle(fmt.Sprintf("/v2/%s/blobs/%s", name, c.Digest()), addWarning(c, "Blob access warning"))
+	}
+	mux.Handle(fmt.Sprintf("/v2/%s/manifests/%s", name, tag), addWarning(mc, "Manifest access warning"))
+	mux.Handle(fmt.Sprintf("/v2/%s/manifests/%s", name, mc.Digest()), addWarning(mc, "Manifest access warning"))
+
+	s := httptest.NewServer(mux)
+	defer s.Close()
+
+	image := fmt.Sprintf("%s/%s:%s", strings.TrimPrefix(s.URL, "http://"), name, tag)
+
+	// Create expected descriptors and digests
+	mcDesc := mc.Descriptor()
+	mcDigest := mc.Digest()
+	configDesc := m.config.Descriptor()
+	configDigest := m.config.Digest()
+	layer0Desc := m.references[0].Descriptor()
+	layer0Digest := m.references[0].Digest()
+
+	type expectedWarning struct {
+		warning string
+		src     WarningSource
+	}
+
+	tests := []struct {
+		name             string
+		resolve          bool
+		descriptors      []ocispec.Descriptor
+		expectedWarnings []expectedWarning
+	}{
+		{
+			name:    "Resolve",
+			resolve: true,
+			expectedWarnings: []expectedWarning{
+				{
+					warning: "Manifest access warning",
+					src: WarningSource{
+						Ref:    mustParseRef(t, image),
+						Desc:   &mcDesc,
+						Digest: &mcDigest,
+					},
+				},
+			},
+		},
+		{
+			name:        "Fetch manifest",
+			descriptors: []ocispec.Descriptor{mc.Descriptor()},
+			expectedWarnings: []expectedWarning{
+				{
+					warning: "Manifest access warning",
+					src: WarningSource{
+						Ref:    mustParseRef(t, image),
+						Desc:   &mcDesc,
+						Digest: &mcDigest,
+					},
+				},
+			},
+		},
+		{
+			name:        "Fetch blob",
+			descriptors: []ocispec.Descriptor{m.config.Descriptor(), m.references[0].Descriptor()},
+			expectedWarnings: []expectedWarning{
+				{
+					warning: "Blob access warning",
+					src: WarningSource{
+						Ref:    mustParseRef(t, image),
+						Desc:   &configDesc,
+						Digest: &configDigest,
+					},
+				},
+				{
+					warning: "Blob access warning",
+					src: WarningSource{
+						Ref:    mustParseRef(t, image),
+						Desc:   &layer0Desc,
+						Digest: &layer0Digest,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			type capturedWarning struct {
+				src     WarningSource
+				warning string
+			}
+			// No synchronization needed: Resolve and Fetch calls are
+			// sequential, so the handler is never called concurrently here.
+			var warnings []capturedWarning
+			resolver := NewResolver(ResolverOptions{
+				WarningHandler: warningHandlerFunc(func(ctx context.Context, src WarningSource, warning string) {
+					warnings = append(warnings, capturedWarning{src: src, warning: warning})
+				}),
+			})
+
+			ctx := t.Context()
+
+			if tc.resolve {
+				if _, _, err := resolver.Resolve(ctx, image); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if len(tc.descriptors) > 0 {
+				fetcher, err := resolver.Fetcher(ctx, image)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, desc := range tc.descriptors {
+					rc, err := fetcher.Fetch(ctx, desc)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if _, err := io.Copy(io.Discard, rc); err != nil {
+						t.Fatal(err)
+					}
+					if err := rc.Close(); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+
+			if len(warnings) != len(tc.expectedWarnings) {
+				t.Fatalf("Expected %d warnings, got %d: %v", len(tc.expectedWarnings), len(warnings), warnings)
+			}
+
+			for i, w := range warnings {
+				expected := tc.expectedWarnings[i]
+				if w.warning != expected.warning {
+					t.Fatalf("Expected warning %q, got: %s", expected.warning, w.warning)
+				}
+				if w.src.Ref.String() != expected.src.Ref.String() {
+					t.Fatalf("Expected warning source ref %q, got: %s", expected.src.Ref.String(), w.src.Ref.String())
+				}
+				// Check descriptor if present in expected
+				if expected.src.Desc != nil {
+					if w.src.Desc == nil {
+						t.Fatalf("Expected warning source descriptor %+v, got nil", expected.src.Desc)
+					}
+					if !reflect.DeepEqual(*w.src.Desc, *expected.src.Desc) {
+						t.Fatalf("Expected warning source descriptor %+v, got: %+v", expected.src.Desc, w.src.Desc)
+					}
+				}
+				// Check digest if present in expected
+				if expected.src.Digest != nil {
+					if w.src.Digest == nil {
+						t.Fatalf("Expected warning source digest %v, got nil", expected.src.Digest)
+					}
+					if *w.src.Digest != *expected.src.Digest {
+						t.Fatalf("Expected warning source digest %v, got: %v", expected.src.Digest, w.src.Digest)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestParseWarningText(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{
+			name:   "simple warning",
+			header: `299 - "message"`,
+			want:   "message",
+		},
+		{
+			name:   "prefixed header text invalid",
+			header: `foobar 299 - "prefixed message"`,
+			want:   "",
+		},
+		{
+			name:   "escaped quotes preserved",
+			header: `299 - "quoted \"text\" inside"`,
+			want:   `quoted "text" inside`,
+		},
+		{
+			name:   "escaped backslash",
+			header: `299 - "path\\to\\file"`,
+			want:   `path\to\file`,
+		},
+		{
+			name:   "escaped tab",
+			header: "299 - \"escaped\\\ttab\"",
+			want:   "escaped\ttab",
+		},
+		{
+			name:   "escaped space",
+			header: `299 - "escaped\ space"`,
+			want:   "escaped space",
+		},
+		{
+			name:   "backslash followed by NUL rejected",
+			header: "299 - \"bad\\\x00text\"",
+			want:   "",
+		},
+		{
+			name:   "backslash followed by newline rejected",
+			header: "299 - \"bad\\\ntext\"",
+			want:   "",
+		},
+		{
+			name:   "backslash followed by DEL rejected",
+			header: "299 - \"bad\\\x7ftext\"",
+			want:   "",
+		},
+		{
+			name:   "bare control char NUL in qdtext rejected",
+			header: "299 - \"bad\x00text\"",
+			want:   "",
+		},
+		{
+			name:   "bare control char BEL in qdtext rejected",
+			header: "299 - \"bad\x07text\"",
+			want:   "",
+		},
+		{
+			name:   "bare DEL in qdtext rejected",
+			header: "299 - \"bad\x7ftext\"",
+			want:   "",
+		},
+		{
+			name:   "obs-text byte in qdtext accepted",
+			header: "299 - \"caf\xe9\"",
+			want:   "caf\xe9",
+		},
+		{
+			name:   "multi-byte UTF-8 accepted as obs-text bytes",
+			header: "299 - \"\xc3\xa9l\xc3\xa8ve\"",
+			want:   "\xc3\xa9l\xc3\xa8ve",
+		},
+		{
+			name:   "backslash followed by obs-text accepted",
+			header: "299 - \"test\\\x80value\"",
+			want:   "test\x80value",
+		},
+		{
+			name:   "percent-encoded space",
+			header: `299 - "hello%20world"`,
+			want:   "hello world",
+		},
+		{
+			name:   "percent-encoded special chars",
+			header: `299 - "100%25 complete"`,
+			want:   "100% complete",
+		},
+		{
+			name:   "percent-encoded quote rejected",
+			header: `299 - "say %22hello%22"`,
+			want:   "",
+		},
+		{
+			name:   "invalid percent-encoding treated as literal",
+			header: `299 - "100%ZZ invalid"`,
+			want:   "100%ZZ invalid",
+		},
+		{
+			name:   "incomplete percent-encoding at end",
+			header: `299 - "trailing%2"`,
+			want:   "trailing%2",
+		},
+		{
+			name:   "percent-encoded newline rejected",
+			header: `299 - "inject%0aline"`,
+			want:   "",
+		},
+		{
+			name:   "percent-encoded CR rejected",
+			header: `299 - "inject%0dline"`,
+			want:   "",
+		},
+		{
+			name:   "percent-encoded NUL rejected",
+			header: `299 - "inject%00byte"`,
+			want:   "",
+		},
+		{
+			name:   "trailing characters invalid",
+			header: `299 - "warn text" extra data`,
+			want:   "",
+		},
+		{
+			name:   "second quoted string invalid",
+			header: `299 - "warn text" "extra data"`,
+			want:   "",
+		},
+		{
+			name:   "non oci warning code",
+			header: `199 - "ignored"`,
+			want:   "",
+		},
+		{
+			name:   "missing closing quote",
+			header: `299 - "incomplete`,
+			want:   "",
+		},
+		{
+			name:   "missing opening quote",
+			header: `299 - warn text"`,
+			want:   "",
+		},
+		{
+			name:   "empty input",
+			header: "",
+			want:   "",
+		},
+		{
+			name:   "trailing backslash before closing quote",
+			header: `299 - "trailing\"`,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseWarningText(tt.header)
+			if got != tt.want {
+				t.Fatalf("parseWarningText(%q) = %q, want %q", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReportWarningsWithNilHandler(t *testing.T) {
+	header := http.Header{}
+	header.Add("Warning", `299 - "warning message"`)
+
+	reportWarningsWithSource(t.Context(), header, nil, WarningSource{})
+}
+
+func mustParseRef(t *testing.T, ref string) reference.Spec {
+	spec, err := reference.Parse(ref)
+	if err != nil {
+		t.Fatalf("failed to parse reference %q: %v", ref, err)
+	}
+	return spec
+}


### PR DESCRIPTION
According to the OCI distribution spec registries may include informational warnings in HTTP Warning headers:

- https://github.com/opencontainers/distribution-spec/blob/e612a6e1e1bc717f9fa7e1feb4f05c8b6568754a/spec.md#warnings
- https://www.rfc-editor.org/rfc/rfc7234#section-5.5

This change implements support for handling these warnings and propagating them to the resolver.

This patch adds a new WarningHandler to ResolverOptions that allows callers to receive and process warnings sent by registries via HTTP Warning headers with warn-code 299.

```release-note
Support propagating HTTP 299 warning headers from registries to the resolver
```
