### PR TITLE
simplify selinux dependency in client

### DIFF
--- a/client/container.go
+++ b/client/container.go
@@ -34,7 +34,6 @@ import (
 	"github.com/containerd/typeurl/v2"
 	ver "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/selinux/go-selinux/label"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/images"
@@ -350,9 +349,8 @@ func (c *container) handleMounts(ctx context.Context, request *tasks.CreateTaskR
 		}
 		for _, m := range mounts {
 			if spec.Linux != nil && spec.Linux.MountLabel != "" {
-				if ml := label.FormatMountLabel("", spec.Linux.MountLabel); ml != "" {
-					m.Options = append(m.Options, ml)
-				}
+				ml := fmt.Sprintf("context=%q", spec.Linux.MountLabel)
+				m.Options = append(m.Options, ml)
 			}
 			request.Rootfs = append(request.Rootfs, &types.Mount{
 				Type:    m.Type,


### PR DESCRIPTION
Fixes: #12700

Instead of pulling in the selinux dependency for all users of the client library for no need, just inline the one Sprintf call we were using the library for here.