### PR TITLE
cri: Use the runtimeHandler parameter in PullImage

### DIFF
--- a/internal/cri/annotations/annotations.go
+++ b/internal/cri/annotations/annotations.go
@@ -88,7 +88,10 @@ const (
 	// See https://github.com/containerd/containerd/issues/6657 and https://github.com/containerd/containerd/pull/6899 for details.
 	// The value of this annotation should be the runtime for sandboxes.
 	// e.g. for [plugins.cri.containerd.runtimes.runc] runtime config, this value should be runc
-	// TODO: we should deprecate this annotation as soon as kubelet supports passing RuntimeHandler from PullImageRequest
+	//
+	// Deprecated: Since cri-api v0.29.0 (Kubernetes 1.29+), kubelet passes the RuntimeHandler
+	// in PullImageRequest. This annotation is only used as a fallback for older CRI clients
+	// and will be removed in containerd 2.5.
 	RuntimeHandler = "io.containerd.cri.runtime-handler"
 
 	// WindowsHostProcess is used by hcsshim to identify windows pods that are running HostProcesses

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -165,7 +165,7 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 		return "", fmt.Errorf("failed to parse image_pull_progress_timeout %q: %w", c.config.ImagePullProgressTimeout, err)
 	}
 
-	snapshotter, err := c.snapshotterFromPodSandboxConfig(ctx, ref, sandboxConfig)
+	snapshotter, err := c.snapshotterFromPodSandboxConfig(ctx, ref, sandboxConfig, runtimeHandler)
 	if err != nil {
 		return "", err
 	}
@@ -823,25 +823,41 @@ func (rt *pullRequestReporterRoundTripper) RoundTrip(req *http.Request) (*http.R
 	return resp, err
 }
 
-// Given that runtime information is not passed from PullImageRequest, we depend on an experimental annotation
-// passed from pod sandbox config to get the runtimeHandler. The annotation key is specified in configuration.
-// Once we know the runtime, try to override default snapshotter if it is set for this runtime.
+// snapshotterFromPodSandboxConfig returns the snapshotter to use for the given
+// runtime handler. If a runtime-specific snapshotter is configured, it will be
+// returned; otherwise the default snapshotter is used.
+//
+// The runtimeHandler parameter (from CRI PullImageRequest, available since cri-api v0.29.0)
+// takes precedence. If empty, we fall back to the experimental annotation for backward
+// compatibility with clients that don't pass the runtime handler.
+//
+// Deprecated: The annotation-based fallback (io.containerd.cri.runtime-handler) is
+// deprecated and will be removed in containerd 2.5.
+//
 // See https://github.com/containerd/containerd/issues/6657
 func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, imageRef string,
-	s *runtime.PodSandboxConfig) (string, error) {
+	s *runtime.PodSandboxConfig, runtimeHandler string) (string, error) {
 	snapshotter := c.config.Snapshotter
-	if s == nil || s.Annotations == nil {
+	if s == nil {
 		return snapshotter, nil
 	}
 
-	// TODO(kiashok): honor the new CRI runtime handler field added to v0.29.0
-	// for image pull per runtime class support.
-	runtimeHandler, ok := s.Annotations[annotations.RuntimeHandler]
-	if !ok {
-		return snapshotter, nil
+	// If runtimeHandler parameter is empty, fall back to annotation for backward compatibility
+	if runtimeHandler == "" {
+		if s.Annotations == nil {
+			return snapshotter, nil
+		}
+		var ok bool
+		runtimeHandler, ok = s.Annotations[annotations.RuntimeHandler]
+		if !ok {
+			return snapshotter, nil
+		}
+		log.G(ctx).Warnf("Using deprecated annotation %q for runtime handler. "+
+			"This will be removed in a future release (2.5). "+
+			"Please update your CRI client to pass runtime handler in PullImageRequest.",
+			annotations.RuntimeHandler)
 	}
 
-	// TODO: Ensure error is returned if runtime not found?
 	if c.runtimePlatforms != nil {
 		if p, ok := c.runtimePlatforms[runtimeHandler]; ok && p.Snapshotter != snapshotter {
 			snapshotter = p.Snapshotter


### PR DESCRIPTION
The runtimeHandler parameter was added to PullImage() but never used.
Instead, the code relied on an experimental annotation
(io.containerd.cri.runtime-handler) passed in the pod sandbox config.

This annotation was a workaround because CRI's PullImageRequest didn't
include the runtime handler. However, since cri-api v0.29.0, the runtime
handler is available in the API and passed as a parameter to PullImage().

For backward compatibility with CRI clients that don't yet pass the
runtime handler parameter, we fall back to the annotation if the
parameter is empty. The annotation-based fallback is deprecated and
will be removed in containerd 2.5.

cc @kiashok @mxpv @mikebrow @fuweid @zvonkok @danmihai1 @skaegi