### PR TITLE
cri: move noisy CDI logs to debug level

### DIFF
--- a/internal/cri/opts/spec_linux.go
+++ b/internal/cri/opts/spec_linux.go
@@ -151,7 +151,7 @@ func WithCDI(annotations map[string]string, CDIDevices []*runtime.CDIDevice) oci
 			devices = append(devices, deviceName)
 			seen[deviceName] = true
 		}
-		log.G(ctx).Infof("Container %v: CDI devices from CRI Config.CDIDevices: %v", c.ID, devices)
+		log.G(ctx).Debugf("Container %v: CDI devices from CRI Config.CDIDevices: %v", c.ID, devices)
 
 		// Add devices from CDI annotations
 		_, devsFromAnnotations, err := cdi.ParseAnnotations(annotations)
@@ -160,7 +160,7 @@ func WithCDI(annotations map[string]string, CDIDevices []*runtime.CDIDevice) oci
 		}
 
 		if devsFromAnnotations != nil {
-			log.G(ctx).Infof("Container %v: CDI devices from annotations: %v", c.ID, devsFromAnnotations)
+			log.G(ctx).Debugf("Container %v: CDI devices from annotations: %v", c.ID, devsFromAnnotations)
 			for _, deviceName := range devsFromAnnotations {
 				if seen[deviceName] {
 					// TODO: change to Warning when passing CDI devices as annotations is deprecated


### PR DESCRIPTION
`WithCDI` currently emits logs at `Info` level for every container even when `len(Config.CDIDevices) == 0`.  Move these to `Debug` level.