### PR TITLE
cri: close stdin stream after exec process exited

### DIFF
--- a/internal/cri/io/exec_io.go
+++ b/internal/cri/io/exec_io.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containerd/log"
 
+	"github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	cioutil "github.com/containerd/containerd/v2/pkg/ioutil"
 )
@@ -89,31 +90,34 @@ func (e *ExecIO) Config() cio.Config {
 }
 
 // Attach attaches exec stdio. The logic is similar with container io attach.
-func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
+func (e *ExecIO) Attach(opts AttachOptions, exitCh <-chan client.ExitStatus) <-chan struct{} {
 	var wg sync.WaitGroup
 	var stdinStreamRC io.ReadCloser
+	var enableStdin bool
 	if e.stdin != nil && opts.Stdin != nil {
 		stdinStreamRC = cioutil.NewWrapReadCloser(opts.Stdin)
+		enableStdin = opts.StdinOnce && !opts.Tty
 		wg.Go(func() {
 			if _, err := io.Copy(e.stdin, stdinStreamRC); err != nil {
 				log.L.WithError(err).Errorf("Failed to redirect stdin for container exec %q", e.id)
 			}
 			log.L.Infof("Container exec %q stdin closed", e.id)
-			if opts.StdinOnce && !opts.Tty {
+			if enableStdin {
 				e.stdin.Close()
 				if err := opts.CloseStdin(); err != nil {
 					log.L.WithError(err).Errorf("Failed to close stdin for container exec %q", e.id)
 				}
-			} else {
-				if e.stdout != nil {
-					e.stdout.Close()
-				}
-				if e.stderr != nil {
-					e.stderr.Close()
-				}
 			}
 		})
 	}
+
+	go func() {
+		// close stdinStreamRC after exec process exited.
+		<-exitCh
+		if stdinStreamRC != nil {
+			stdinStreamRC.Close()
+		}
+	}()
 
 	attachOutput := func(t StreamType, stream io.WriteCloser, out io.ReadCloser) {
 		if _, err := io.Copy(stream, out); err != nil {
@@ -121,9 +125,6 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 		}
 		out.Close()
 		stream.Close()
-		if stdinStreamRC != nil {
-			stdinStreamRC.Close()
-		}
 		e.closer.wg.Done()
 		wg.Done()
 		log.L.Debugf("Finish piping %q of container exec %q", t, e.id)
@@ -146,6 +147,14 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		wg.Wait()
+		if !enableStdin {
+			if e.stdout != nil {
+				e.stdout.Close()
+			}
+			if e.stderr != nil {
+				e.stderr.Close()
+			}
+		}
 		close(done)
 	}()
 	return done

--- a/internal/cri/io/exec_io.go
+++ b/internal/cri/io/exec_io.go
@@ -89,31 +89,34 @@ func (e *ExecIO) Config() cio.Config {
 }
 
 // Attach attaches exec stdio. The logic is similar with container io attach.
-func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
+func (e *ExecIO) Attach(opts AttachOptions, exited <-chan struct{}) <-chan struct{} {
 	var wg sync.WaitGroup
 	var stdinStreamRC io.ReadCloser
+	var enableStdin bool
 	if e.stdin != nil && opts.Stdin != nil {
 		stdinStreamRC = cioutil.NewWrapReadCloser(opts.Stdin)
+		enableStdin = opts.StdinOnce && !opts.Tty
 		wg.Go(func() {
 			if _, err := io.Copy(e.stdin, stdinStreamRC); err != nil {
 				log.L.WithError(err).Errorf("Failed to redirect stdin for container exec %q", e.id)
 			}
 			log.L.Infof("Container exec %q stdin closed", e.id)
-			if opts.StdinOnce && !opts.Tty {
+			if enableStdin {
 				e.stdin.Close()
 				if err := opts.CloseStdin(); err != nil {
 					log.L.WithError(err).Errorf("Failed to close stdin for container exec %q", e.id)
 				}
-			} else {
-				if e.stdout != nil {
-					e.stdout.Close()
-				}
-				if e.stderr != nil {
-					e.stderr.Close()
-				}
 			}
 		})
 	}
+
+	go func() {
+		// close stdinStreamRC after exec process exited.
+		<-exited
+		if stdinStreamRC != nil {
+			stdinStreamRC.Close()
+		}
+	}()
 
 	attachOutput := func(t StreamType, stream io.WriteCloser, out io.ReadCloser) {
 		if _, err := io.Copy(stream, out); err != nil {
@@ -121,9 +124,6 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 		}
 		out.Close()
 		stream.Close()
-		if stdinStreamRC != nil {
-			stdinStreamRC.Close()
-		}
 		e.closer.wg.Done()
 		wg.Done()
 		log.L.Debugf("Finish piping %q of container exec %q", t, e.id)
@@ -146,6 +146,14 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		wg.Wait()
+		if !enableStdin {
+			if e.stdout != nil {
+				e.stdout.Close()
+			}
+			if e.stderr != nil {
+				e.stderr.Close()
+			}
+		}
 		close(done)
 	}()
 	return done

--- a/internal/cri/server/container_execsync.go
+++ b/internal/cri/server/container_execsync.go
@@ -217,7 +217,7 @@ func (c *criService) execInternal(ctx context.Context, container containerd.Cont
 		CloseStdin: func() error {
 			return process.CloseIO(ctx, containerd.WithStdinCloser)
 		},
-	})
+	}, exitCh)
 
 	execCtx := ctx
 	if opts.timeout > 0 {

--- a/internal/cri/server/container_execsync.go
+++ b/internal/cri/server/container_execsync.go
@@ -207,7 +207,7 @@ func (c *criService) execInternal(ctx context.Context, container containerd.Cont
 			log.G(ctx).WithError(err).Errorf("Failed to resize process %q console for container %q", execID, id)
 		}
 	})
-
+	exited := make(chan struct{})
 	attachDone := execIO.Attach(cio.AttachOptions{
 		Stdin:     opts.stdin,
 		Stdout:    opts.stdout,
@@ -217,7 +217,7 @@ func (c *criService) execInternal(ctx context.Context, container containerd.Cont
 		CloseStdin: func() error {
 			return process.CloseIO(ctx, containerd.WithStdinCloser)
 		},
-	})
+	}, exited)
 
 	execCtx := ctx
 	if opts.timeout > 0 {
@@ -234,6 +234,7 @@ func (c *criService) execInternal(ctx context.Context, container containerd.Cont
 		}
 		// Wait for the process to be killed.
 		exitRes := <-exitCh
+		close(exited)
 		log.G(ctx).Debugf("Timeout received while waiting for exec process kill %q code %d and error %v",
 			execID, exitRes.ExitCode(), exitRes.Error())
 
@@ -243,6 +244,7 @@ func (c *criService) execInternal(ctx context.Context, container containerd.Cont
 
 		return nil, fmt.Errorf("timeout %v exceeded: %w", opts.timeout, execCtx.Err())
 	case exitRes := <-exitCh:
+		close(exited)
 		code, _, err := exitRes.Result()
 		log.G(ctx).Debugf("Exec process %q exits with exit code %d and error %v", execID, code, err)
 		if err != nil {


### PR DESCRIPTION
fix https://github.com/containerd/containerd/issues/12734   ping  @fuweid  @dmcgowan  @AkihiroSuda @mikebrow 
we find when exec in a container, if  the exec process close stdout stream  containerd will close stdin stream(even exec process is still running and stdin is still need in the container)