### PR TITLE
Simplify/Cleanup unit tests

### DIFF
--- a/core/metadata/containers_test.go
+++ b/core/metadata/containers_test.go
@@ -707,7 +707,7 @@ func checkContainersEqual(t *testing.T, a, b *containers.Container, format strin
 }
 
 func testEnv(t *testing.T) (context.Context, *bolt.DB) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := t.Context()
 	ctx = namespaces.WithNamespace(ctx, "testing")
 	ctx = logtest.WithT(ctx, t)
 	dirname := t.TempDir()
@@ -717,7 +717,6 @@ func testEnv(t *testing.T) (context.Context, *bolt.DB) {
 
 	t.Cleanup(func() {
 		assert.NoError(t, db.Close())
-		cancel()
 	})
 
 	return ctx, db

--- a/core/metadata/db_test.go
+++ b/core/metadata/db_test.go
@@ -66,7 +66,7 @@ func withSnapshotter(name string, fn func(string) (snapshots.Snapshotter, error)
 }
 
 func testDB(t *testing.T, opt ...testOpt) (context.Context, *DB) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := t.Context()
 	ctx = namespaces.WithNamespace(ctx, "testing")
 	ctx = logtest.WithT(ctx, t)
 
@@ -104,7 +104,6 @@ func testDB(t *testing.T, opt ...testOpt) (context.Context, *DB) {
 
 	t.Cleanup(func() {
 		assert.NoError(t, bdb.Close())
-		cancel()
 	})
 
 	return ctx, db

--- a/core/runtime/v2/shim_windows_test.go
+++ b/core/runtime/v2/shim_windows_test.go
@@ -17,15 +17,13 @@
 package v2
 
 import (
-	"context"
 	"errors"
 	"os"
 	"testing"
 )
 
 func TestCheckCopyShimLogError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	testError := errors.New("test error")
 
 	if err := checkCopyShimLogError(ctx, nil); err != nil {

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -1848,10 +1848,7 @@ func TestShimSockLength(t *testing.T) {
 	// Max length of namespace should be 76
 	namespace := strings.Repeat("n", 76)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ctx = namespaces.WithNamespace(ctx, namespace)
+	ctx := namespaces.WithNamespace(t.Context(), namespace)
 
 	client, err := newClient(t, address)
 	if err != nil {
@@ -2072,10 +2069,7 @@ func TestRegressionIssue4769(t *testing.T) {
 	id := t.Name()
 	ns := fmt.Sprintf("%s-%s", testNamespace, id)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ctx = namespaces.WithNamespace(ctx, ns)
+	ctx := namespaces.WithNamespace(t.Context(), ns)
 	ctx = logtest.WithT(ctx, t)
 
 	image, err := client.Pull(ctx, testImage, WithPullUnpack)
@@ -2180,10 +2174,7 @@ func TestRegressionIssue6429(t *testing.T) {
 	id := t.Name()
 	ns := fmt.Sprintf("%s-%s", testNamespace, id)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ctx = namespaces.WithNamespace(ctx, ns)
+	ctx := namespaces.WithNamespace(t.Context(), ns)
 	ctx = logtest.WithT(ctx, t)
 
 	image, err := client.Pull(ctx, testImage, WithPullUnpack)

--- a/integration/client/mount_manager_linux_test.go
+++ b/integration/client/mount_manager_linux_test.go
@@ -223,10 +223,7 @@ func createImgFile(t *testing.T, name string) string {
 }
 
 func setupMount(t *testing.T, f string) {
-	root, err := os.MkdirTemp(t.TempDir(), "")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
-
+	root := t.TempDir()
 	m := []mount.Mount{
 		{
 			Type:    "xfs",

--- a/integration/sandbox_clean_remove_windows_test.go
+++ b/integration/sandbox_clean_remove_windows_test.go
@@ -243,7 +243,7 @@ func TestCreateContainer(t *testing.T) {
 	client, err := RawRuntimeClient()
 	require.NoError(t, err, "failed to get raw grpc runtime service client")
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	t.Log("Create a pod sandbox")
 	sbConfig := &runtime.PodSandboxConfig{

--- a/internal/cri/server/container_create_linux_test.go
+++ b/internal/cri/server/container_create_linux_test.go
@@ -1315,16 +1315,12 @@ func TestBaseOCISpec(t *testing.T) {
 	assert.Equal(t, *spec.Linux.Resources.Memory.Limit, containerConfig.Linux.Resources.MemoryLimitInBytes)
 }
 
-func writeFilesToTempDir(tmpDirPattern string, content []string) (string, error) {
+func writeFilesToTempDir(t *testing.T, content []string) (string, error) {
 	if len(content) == 0 {
 		return "", nil
 	}
 
-	dir, err := os.MkdirTemp("", tmpDirPattern)
-	if err != nil {
-		return "", err
-	}
-
+	dir := t.TempDir()
 	for idx, data := range content {
 		file := filepath.Join(dir, fmt.Sprintf("spec-%d.yaml", idx))
 		err := os.WriteFile(file, []byte(data), 0644)
@@ -1638,10 +1634,7 @@ containerEdits:
 
 			specCheck(t, testID, testSandboxID, testPid, spec)
 
-			cdiDir, err := writeFilesToTempDir("containerd-test-CDI-injections-", test.cdiSpecFiles)
-			if cdiDir != "" {
-				defer os.RemoveAll(cdiDir)
-			}
+			cdiDir, err := writeFilesToTempDir(t, test.cdiSpecFiles)
 			require.NoError(t, err)
 
 			err = cdi.Configure(cdi.WithSpecDirs(cdiDir))

--- a/pkg/cio/io_unix_test.go
+++ b/pkg/cio/io_unix_test.go
@@ -65,9 +65,7 @@ func TestOpenFifos(t *testing.T) {
 // TestOpenFifosWithTerminal tests openFifos should not open stderr if terminal
 // is set.
 func TestOpenFifosWithTerminal(t *testing.T) {
-	var ctx, cancel = context.WithCancel(context.Background())
-	defer cancel()
-
+	ctx := t.Context()
 	ioFifoDir := t.TempDir()
 
 	cfg := Config{

--- a/plugins/gc/scheduler_test.go
+++ b/plugins/gc/scheduler_test.go
@@ -37,9 +37,7 @@ func TestPauseThreshold(t *testing.T) {
 	}
 
 	scheduler := newScheduler(tc, cfg)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go scheduler.run(ctx)
 
@@ -74,9 +72,7 @@ func TestDeletionThreshold(t *testing.T) {
 	}
 
 	scheduler := newScheduler(tc, cfg)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go scheduler.run(ctx)
 
@@ -110,17 +106,14 @@ func TestDeletionThreshold(t *testing.T) {
 
 func TestTrigger(t *testing.T) {
 	var (
-		cfg = &config{}
-		tc  = &testCollector{
-			d: time.Millisecond * 10,
-		}
-		ctx, cancel = context.WithCancel(context.Background())
-		scheduler   = newScheduler(tc, cfg)
-		stats       gc.Stats
-		err         error
+		cfg       = &config{}
+		tc        = &testCollector{d: time.Millisecond * 10}
+		ctx       = t.Context()
+		scheduler = newScheduler(tc, cfg)
+		stats     gc.Stats
+		err       error
 	)
 
-	defer cancel()
 	go scheduler.run(ctx)
 
 	// Block until next GC finishes
@@ -155,13 +148,10 @@ func TestStartupDelay(t *testing.T) {
 			PauseThreshold: 0.001,
 			StartupDelay:   tomlext.Duration(startupDelay),
 		}
-		tc = &testCollector{
-			d: time.Second,
-		}
-		ctx, cancel = context.WithCancel(context.Background())
-		scheduler   = newScheduler(tc, cfg)
+		tc        = &testCollector{d: time.Second}
+		ctx       = t.Context()
+		scheduler = newScheduler(tc, cfg)
 	)
-	defer cancel()
 
 	t1 := time.Now()
 	go scheduler.run(ctx)

--- a/plugins/snapshots/erofs/erofs_linux_test.go
+++ b/plugins/snapshots/erofs/erofs_linux_test.go
@@ -66,12 +66,7 @@ func newSnapshotter(t *testing.T, opts ...Opt) func(ctx context.Context, root st
 }
 
 func testMount(t *testing.T, scratchFile string) error {
-	root, err := os.MkdirTemp(t.TempDir(), "")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(root)
-
+	root := t.TempDir()
 	m := []mount.Mount{
 		{
 			Type:    "ext4",


### PR DESCRIPTION
Cleans up unit tests code a bit with features available in Go 1.24

```go
ctx, cancel := context.WithCancel(context.Background())
defer cancel()
```

can be replaced with just [`t.Context()`](https://pkg.go.dev/testing#T.Context), which automatically cancels the context once out of scope.

And replaces redundant

```go
root, err := os.MkdirTemp(t.TempDir(), "")
if err != nil {
	return err
}
defer os.RemoveAll(root)
```

with just [`t.TempDir()`](https://pkg.go.dev/testing#T.TempDir) because it already takes care of create/cleanup.