### PR TITLE
command: show help and exit on unknown positional arguments

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -119,6 +119,10 @@ can be used and modified as necessary as a custom configuration.`
 		ociHook,
 	}
 	app.Action = func(cliContext *cli.Context) error {
+		if args := cliContext.Args(); args.First() != "" {
+			return cli.ShowCommandHelp(cliContext, args.First())
+		}
+
 		var (
 			start       = time.Now()
 			signals     = make(chan os.Signal, 2048)


### PR DESCRIPTION
fix  use wrong command  "containerd 123" can start containerd
```
 containerd 123
WARN[0000] Ignoring unknown key in TOML                  column=1 error="strict mode: fields in the document are missing in the target struct" file=/etc/containerd/config.toml key=plugin_dir row=4                                                                                                
WARN[0000] Ignoring unknown key in TOML                  column=1 error="strict mode: fields in the document are missing in the target struct" file=/etc/containerd/config.toml key=split row=10                                                                                                    
WARN[0000] Ignoring unknown key in TOML                  column=3 error="strict mode: fields in the document are missing in the target struct" file=/etc/containerd/config.toml key="metrics container_metrics_only" row=35                                                                         
INFO[2026-01-06T11:18:52.802753580+08:00] starting containerd                           revision=1e154a8b2588dbe14d1bf942569d1256e2bd176c.m version=v2.2.0-152-g1e154a8b2.m                                                                                                                         
WARN[2026-01-06T11:18:52.824519398+08:00] Configuration migrated from version 2, use `containerd config migrate` to avoid migration  t="43.695µs"
INFO[2026-01-06T11:18:52.824584415+08:00] loading plugin               
```