### PR TITLE
doc: add k8s 1.35 to support matrix

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -149,10 +149,10 @@ of containerd for every supported version of Kubernetes.
 
 | Kubernetes Version | containerd Version               | CRI Version     |
 |--------------------|----------------------------------|-----------------|
-| 1.31               | 2.1.0+, 2.0.0+, 1.7.20+, 1.6.34+ | v1              |
 | 1.32               | 2.1.0+, 2.0.1+, 1.7.24+, 1.6.36+ | v1              |
 | 1.33               | 2.1.0+, 2.0.4+, 1.7.24+, 1.6.36+ | v1              |
 | 1.34               | 2.1.3+, 2.0.6+, 1.7.28+, 1.6.39+ | v1              |
+| 1.35               | 2.2.0+, 2.1.5+, 1.7.28+  | v1              |
 
 Deprecated containerd and kubernetes versions
 


### PR DESCRIPTION
- add k8s 1.35 into support matrix
- remove k8s 1.31 as its EOL in Nov 2025
- 2.0 is removed from the supported list as it was EOL when 1.35
released