### PR TITLE
feat(config): add max_label_size parameter for label key-value byte length validation

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/containerd/containerd/v2/core/metrics" // import containerd build info
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/errdefs"
@@ -142,6 +143,11 @@ can be used and modified as necessary as a custom configuration.`
 		// Apply flags to the config
 		if err := applyFlags(cliContext, config); err != nil {
 			return err
+		}
+
+		// Values less than 4096 are considered invalid.
+		if config.MaxLabelSize > 4096 {
+			labels.MaxLabelSize = config.MaxLabelSize
 		}
 
 		if config.GRPC.Address == "" {

--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -91,6 +91,8 @@ type Config struct {
 	Imports []string `toml:"imports"`
 	// StreamProcessors configuration
 	StreamProcessors map[string]StreamProcessor `toml:"stream_processors"`
+	// MaxLabelSize specifies the maximum size of all labels in bytes
+	MaxLabelSize int `toml:"max_label_size"`
 }
 
 // StreamProcessor provides configuration for diff content processors

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -38,6 +38,10 @@ config as version 1 has been deprecated.
 **plugin_dir**
 : The directory for dynamic plugins to be stored
 
+**max_label_size**
+:The threshold for validating the total byte length of label key-value pairs is 4096 bytes by default.
+It can be configured to a larger positive integer.
+
 **[grpc]**
 : Section for gRPC socket listener settings. Contains the following properties:
 

--- a/pkg/labels/validate.go
+++ b/pkg/labels/validate.go
@@ -22,20 +22,20 @@ import (
 	"github.com/containerd/errdefs"
 )
 
-const (
-	maxSize = 4096
-	// maximum length of key portion of error message if len of key + len of value > maxSize
-	keyMaxLen = 64
-)
+// MaxLabelSize specifies the maximum size of a label in bytes, configurable via containerd config
+var MaxLabelSize = 4096
 
-// Validate a label's key and value are under 4096 bytes
+// maximum length of key portion of error message if len of key + len of value > MaxLabelSize
+const keyMaxLen = 64
+
+// Validate a label's key and value are under MaxLabelSize
 func Validate(k, v string) error {
 	total := len(k) + len(v)
-	if total > maxSize {
+	if total > MaxLabelSize {
 		if len(k) > keyMaxLen {
 			k = k[:keyMaxLen]
 		}
-		return fmt.Errorf("label key and value length (%d bytes) greater than maximum size (%d bytes), key: %s: %w", total, maxSize, k, errdefs.ErrInvalidArgument)
+		return fmt.Errorf("label key and value length (%d bytes) greater than maximum size (%d bytes), key: %s: %w", total, MaxLabelSize, k, errdefs.ErrInvalidArgument)
 	}
 	return nil
 }

--- a/pkg/labels/validate_test.go
+++ b/pkg/labels/validate_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestValidLabels(t *testing.T) {
 	shortStr := "s"
-	longStr := strings.Repeat("s", maxSize-1)
+	longStr := strings.Repeat("s", MaxLabelSize-1)
 
 	for key, value := range map[string]string{
 		"some":   "value",
@@ -40,7 +40,7 @@ func TestValidLabels(t *testing.T) {
 
 func TestInvalidLabels(t *testing.T) {
 	addOneStr := "s"
-	maxSizeStr := strings.Repeat("s", maxSize)
+	maxSizeStr := strings.Repeat("s", MaxLabelSize)
 
 	for key, value := range map[string]string{
 		maxSizeStr: addOneStr,
@@ -55,25 +55,25 @@ func TestInvalidLabels(t *testing.T) {
 
 func TestLongKey(t *testing.T) {
 	key := strings.Repeat("s", keyMaxLen+1)
-	value := strings.Repeat("v", maxSize-len(key))
+	value := strings.Repeat("v", MaxLabelSize-len(key))
 
 	err := Validate(key, value)
 	assert.Equal(t, err, nil)
 
 	key = strings.Repeat("s", keyMaxLen+12)
-	value = strings.Repeat("v", maxSize-len(key)+1)
+	value = strings.Repeat("v", MaxLabelSize-len(key)+1)
 
 	err = Validate(key, value)
 	assert.ErrorIs(t, err, errdefs.ErrInvalidArgument)
 
 	key = strings.Repeat("s", keyMaxLen-1)
-	value = strings.Repeat("v", maxSize-len(key))
+	value = strings.Repeat("v", MaxLabelSize-len(key))
 
 	err = Validate(key, value)
 	assert.Equal(t, err, nil)
 
 	key = strings.Repeat("s", keyMaxLen-1)
-	value = strings.Repeat("v", maxSize-len(key)-1)
+	value = strings.Repeat("v", MaxLabelSize-len(key)-1)
 
 	err = Validate(key, value)
 	assert.Equal(t, err, nil)


### PR DESCRIPTION
In many special scenarios—such as when there are a sufficient number of -v mounted paths—the label validation will exceed 4096 bytes. 
Consequently, such containers will fail to start due to the 4096-byte limit imposed by the Validate function.
Therefore, I aim to modify the parameter to be configurable, allowing customers to optionally set values larger than 4096 to accommodate these special scenarios.

- Add new configurable parameter `max_label_size` to validate total byte length of label key-value pairs
- Default threshold: 4096 bytes
- Support custom configuration with larger positive integers