### PR TITLE
cri: fix unpack failure when mixing remote and local snapshotters

### DIFF
--- a/client/image.go
+++ b/client/image.go
@@ -261,10 +261,20 @@ type UnpackConfig struct {
 	DuplicationSuppressor kmutex.KeyedLocker
 	// Limiter is used to limit concurrent unpacks
 	Limiter *semaphore.Weighted
+	// FetchMissingContent enables verification of content blob existence even if snapshot exists.
+	FetchMissingContent bool
 }
 
 // UnpackOpt provides configuration for unpack
 type UnpackOpt func(context.Context, *UnpackConfig) error
+
+// WithUnpackFetchMissingContent configures whether to check content integrity.
+func WithUnpackFetchMissingContent(check bool) UnpackOpt {
+	return func(ctx context.Context, uc *UnpackConfig) error {
+		uc.FetchMissingContent = check
+		return nil
+	}
+}
 
 // WithSnapshotterPlatformCheck sets `CheckPlatformSupported` on the UnpackConfig
 func WithSnapshotterPlatformCheck() UnpackOpt {

--- a/client/pull.go
+++ b/client/pull.go
@@ -123,6 +123,7 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 			Applier:                 c.DiffService(),
 			ApplyOpts:               uconfig.ApplyOpts,
 			SnapshotterCapabilities: snCapabilities,
+			FetchMissingContent:     uconfig.FetchMissingContent,
 		}
 		uopts := []unpack.UnpackerOpt{unpack.WithUnpackPlatform(platform)}
 		if uconfig.DuplicationSuppressor != nil {

--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -243,7 +243,7 @@ func TestContainerdSandboxImagePulledOutsideCRI(t *testing.T) {
 	imageService.RemoveImage(&runtime.ImageSpec{Image: pauseImage})
 
 	t.Log("pull pause image")
-	_, err := containerdClient.Pull(ctx, pauseImage)
+	_, err := containerdClient.Pull(ctx, pauseImage, containerd.WithPullUnpack)
 	assert.NoError(t, err)
 
 	t.Log("pause image should be seen by cri plugin")

--- a/internal/cri/server/container_checkpoint.go
+++ b/internal/cri/server/container_checkpoint.go
@@ -30,7 +30,7 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func (c *criService) checkIfCheckpointOCIImage(ctx context.Context, input string) (string, error) {
+func (c *criService) checkIfCheckpointOCIImage(ctx context.Context, input string, snapshotter string) (string, error) {
 	return "", nil
 }
 

--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -61,7 +61,7 @@ import (
 
 // checkIfCheckpointOCIImage returns checks if the input refers to a checkpoint image.
 // It returns the StorageImageID of the image the input resolves to, nil otherwise.
-func (c *criService) checkIfCheckpointOCIImage(ctx context.Context, input string) (string, error) {
+func (c *criService) checkIfCheckpointOCIImage(ctx context.Context, input string, snapshotter string) (string, error) {
 	if input == "" {
 		return "", nil
 	}
@@ -69,7 +69,7 @@ func (c *criService) checkIfCheckpointOCIImage(ctx context.Context, input string
 		return "", nil
 	}
 
-	image, err := c.LocalResolve(input)
+	image, err := c.LocalResolve(input, snapshotter)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve image %q: %w", input, err)
 	}
@@ -124,7 +124,7 @@ func (c *criService) CRImportCheckpoint(
 	createAnnotations := meta.Config.Annotations
 	createLabels := meta.Config.Labels
 
-	restoreStorageImageID, err := c.checkIfCheckpointOCIImage(ctx, inputImage)
+	restoreStorageImageID, err := c.checkIfCheckpointOCIImage(ctx, inputImage, "")
 	if err != nil {
 		return "", err
 	}
@@ -325,7 +325,7 @@ func (c *criService) CRImportCheckpoint(
 		// checkpoint archive as NAME@DIGEST. The checkpoint archive also contains
 		// the tag with which it was initially pulled.
 		// First step is to pull NAME@DIGEST
-		containerdImage, err = c.client.Pull(ctx, config.RootfsImageRef)
+		containerdImage, err = c.client.Pull(ctx, config.RootfsImageRef, client.WithPullUnpack)
 		if err != nil {
 			return "", fmt.Errorf("failed to pull checkpoint base image %s: %w", config.RootfsImageRef, err)
 		}

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -296,7 +296,7 @@ func (s *fakeImageService) GetSnapshot(key, snapshotter string) (snapshotstore.S
 	return snapshotstore.Snapshot{}, errors.New("not implemented")
 }
 
-func (s *fakeImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
+func (s *fakeImageService) LocalResolve(refOrID string, snapshotter ...string) (imagestore.Image, error) {
 	return imagestore.Image{}, errors.New("not implemented")
 }
 

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -260,6 +260,7 @@ func (c *CRIImageService) pullImageWithLocalPull(
 		containerd.WithUnpackOpts([]containerd.UnpackOpt{
 			containerd.WithUnpackDuplicationSuppressor(c.unpackDuplicationSuppressor),
 			containerd.WithUnpackApplyOpts(diff.WithSyncFs(c.config.ImagePullWithSyncFs)),
+			containerd.WithUnpackFetchMissingContent(!c.snapshotStore.IsRemoteSnapshotter(snapshotter)),
 		}),
 	}
 

--- a/internal/cri/server/images/service_test.go
+++ b/internal/cri/server/images/service_test.go
@@ -43,7 +43,7 @@ func newTestCRIService() (*CRIImageService, *GRPCCRIImageService) {
 		runtimePlatforms: map[string]ImagePlatform{},
 		imageFSPaths:     map[string]string{"overlayfs": testImageFSPath},
 		imageStore:       imagestore.NewStore(nil, nil, platforms.Default()),
-		snapshotStore:    snapshotstore.NewStore(),
+		snapshotStore:    snapshotstore.NewStore(nil, nil),
 	}
 
 	return service, &GRPCCRIImageService{service}

--- a/internal/cri/server/images/snapshots.go
+++ b/internal/cri/server/images/snapshots.go
@@ -33,18 +33,15 @@ import (
 // TODO(random-liu): Benchmark with high workload. We may need a statsSyncer instead if
 // benchmark result shows that container cpu/memory stats also need to be cached.
 type snapshotsSyncer struct {
-	store        *snapshotstore.Store
-	snapshotters map[string]snapshot.Snapshotter
-	syncPeriod   time.Duration
+	store      *snapshotstore.Store
+	syncPeriod time.Duration
 }
 
 // newSnapshotsSyncer creates a snapshot syncer.
-func newSnapshotsSyncer(store *snapshotstore.Store, snapshotters map[string]snapshot.Snapshotter,
-	period time.Duration) *snapshotsSyncer {
+func newSnapshotsSyncer(store *snapshotstore.Store, period time.Duration) *snapshotsSyncer {
 	return &snapshotsSyncer{
-		store:        store,
-		snapshotters: snapshotters,
-		syncPeriod:   period,
+		store:      store,
+		syncPeriod: period,
 	}
 }
 
@@ -71,7 +68,7 @@ func (s *snapshotsSyncer) sync() error {
 	ctx := ctrdutil.NamespacedContext()
 	start := time.Now().UnixNano()
 
-	for key, snapshotter := range s.snapshotters {
+	for key, snapshotter := range s.store.Snapshotters() {
 		var snapshots []snapshot.Info
 		// Do not call `Usage` directly in collect function, because
 		// `Usage` takes time, we don't want `Walk` to hold read lock

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -111,7 +111,7 @@ func init() {
 
 // ImageService specifies dependencies to CRI image service.
 type ImageService interface {
-	LocalResolve(refOrID string) (imagestore.Image, error)
+	LocalResolve(refOrID string, snapshotter ...string) (imagestore.Image, error)
 	GetImage(id string) (imagestore.Image, error)
 	PullImage(ctx context.Context, name string, creds func(string) (string, string, error), sc *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
 }

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -105,7 +105,7 @@ type ImageService interface {
 	GetImage(id string) (imagestore.Image, error)
 	GetSnapshot(key, snapshotter string) (snapshotstore.Snapshot, error)
 
-	LocalResolve(refOrID string) (imagestore.Image, error)
+	LocalResolve(refOrID string, snapshotter ...string) (imagestore.Image, error)
 
 	ImageFSPaths() map[string]string
 }

--- a/internal/cri/store/snapshot/snapshot_test.go
+++ b/internal/cri/store/snapshot/snapshot_test.go
@@ -64,7 +64,7 @@ func TestSnapshotStore(t *testing.T) {
 	}
 	assert := assertlib.New(t)
 
-	s := NewStore()
+	s := NewStore(nil, nil)
 
 	t.Logf("should be able to add snapshot")
 	for _, sn := range snapshots {


### PR DESCRIPTION
This fix ensures CRI triggers a re-pull to fetch the required content blobs from the registry.

Fixes: #12752

Based on https://github.com/containerd/containerd/pull/12637
