### PR TITLE
cri: fix create container panic if originalAnnotations is nil

### DIFF
--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -253,6 +253,9 @@ func (c *criService) CRImportCheckpoint(
 	}
 
 	originalAnnotations := containerStatus.GetAnnotations()
+	if originalAnnotations == nil {
+		originalAnnotations = make(map[string]string)
+	}
 	originalLabels := containerStatus.GetLabels()
 
 	sandboxUID := sandboxConfig.GetMetadata().GetUid()


### PR DESCRIPTION
fix 
```
time="2026-01-09T11:35:09.999566318+08:00" level=info msg="CreateContainer within sandbox \"5a19671260ab5bdc9f7c360790e54b5686f6a18d997f85cf02d0408ad0017b30\" for name:\"busybox\" returns container id \"\""
panic: assignment to entry in nil map

goroutine 140 [running]:
github.com/containerd/containerd/v2/internal/cri/server.(*criService).CRImportCheckpoint(0xc00013af08, {0x2b41a48, 0xc000aa6360}, 0xc000aa8280, 0xc0001692c0, 0xc000a9e000)
	/home/nmx/containerd/internal/cri/server/container_checkpoint_linux.go:373 +0x46d6
github.com/containerd/containerd/v2/internal/cri/server.(*criService).CreateContainer(0xc00013af08, {0x2b41a48, 0xc000aa6360}, 0xc000a8c550)
	/home/nmx/containerd/internal/cri/server/container_create.go:154 +0x17be
github.com/containerd/containerd/v2/internal/cri/instrument.(*instrumentedService).CreateContainer(0xc0002af1d0, {0x2b41a48, 0xc000857d70}, 0xc000a8c550)
	/home/nmx/containerd/internal/cri/instrument/instrumented_service.go:188 +0x42a
k8s.io/cri-api/pkg/apis/runtime/v1._RuntimeService_CreateContainer_Handler.func1({0x2b41a48, 0xc000857d70}, {0x27b5880, 0xc000a8c550})
	/home/nmx/containerd/vendor/k8s.io/cri-api/pkg/apis/runtime/v1/api_grpc.pb.go:864 +0xf1
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryServerInterceptor.func1({0x2b41a48, 0xc000857d70}, {0x27b5880, 0xc000a8c550}, 0xc000a8ad80, 0xc00011c858)
	/home/nmx/containerd/vendor/github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/server.go:22 +0x368
google.golang.org/grpc.getChainUnaryHandler.func1({0x2b41a48, 0xc000857d70}, {0x27b5880, 0xc000a8c550})
	/home/nmx/containerd/vendor/google.golang.org/grpc/server.go:1241 +0x11a
```