### PR TITLE
cri,nri: pass any POSIX rlimits to plugins.

### DIFF
--- a/internal/cri/nri/nri_api_linux.go
+++ b/internal/cri/nri/nri_api_linux.go
@@ -1017,6 +1017,24 @@ func (c *criContainer) GetPid() uint32 {
 	return c.pid
 }
 
+func (c *criContainer) GetRlimits() []*api.POSIXRlimit {
+	if c.spec == nil {
+		return nil
+	}
+
+	var rlimits []*api.POSIXRlimit
+
+	for _, l := range c.spec.Process.Rlimits {
+		rlimits = append(rlimits, &api.POSIXRlimit{
+			Type: l.Type,
+			Hard: l.Hard,
+			Soft: l.Soft,
+		})
+	}
+
+	return rlimits
+}
+
 //
 // conversion to/from CRI types
 //

--- a/internal/nri/container.go
+++ b/internal/nri/container.go
@@ -47,6 +47,7 @@ type Container interface {
 	GetHooks() *nri.Hooks
 	GetLinuxContainer() LinuxContainer
 	GetCDIDevices() []*nri.CDIDevice
+	GetRlimits() []*nri.POSIXRlimit
 }
 
 type LinuxContainer interface {
@@ -82,6 +83,7 @@ func commonContainerToNRI(ctr Container) *nri.Container {
 		StartedAt:    status.StartedAt,
 		FinishedAt:   status.FinishedAt,
 		ExitCode:     status.ExitCode,
+		Rlimits:      ctr.GetRlimits(),
 	}
 }
 


### PR DESCRIPTION
Implement missing support for passing any container POSIX rlimits as input to NRI plugins. 

```release-note
Pass any POSIX rlimits to plugins
```