### PR TITLE
cri,nri: pass linux sysctl to plugins.

### DIFF
--- a/internal/cri/nri/nri_api_linux.go
+++ b/internal/cri/nri/nri_api_linux.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
@@ -914,6 +915,13 @@ func (c *criContainer) GetSeccompProfile() *api.SecurityProfile {
 		ProfileType:  api.SecurityProfile_ProfileType(profile.GetProfileType()),
 		LocalhostRef: profile.GetLocalhostRef(),
 	}
+}
+
+func (c *criContainer) GetSysctl() map[string]string {
+	if c.spec.Linux == nil || len(c.spec.Linux.Sysctl) == 0 {
+		return nil
+	}
+	return maps.Clone(c.spec.Linux.Sysctl)
 }
 
 func (c *criContainer) GetPid() uint32 {

--- a/internal/nri/container.go
+++ b/internal/nri/container.go
@@ -50,6 +50,7 @@ type LinuxContainer interface {
 	GetNetDevices() map[string]*nri.LinuxNetDevice
 	GetRdt() *nri.LinuxRdt
 	GetSeccompProfile() *nri.SecurityProfile
+	GetSysctl() map[string]string
 }
 
 func commonContainerToNRI(ctr Container) *nri.Container {

--- a/internal/nri/container_linux.go
+++ b/internal/nri/container_linux.go
@@ -36,6 +36,7 @@ func containerToNRI(ctr Container) *nri.Container {
 		NetDevices:     lnxCtr.GetNetDevices(),
 		Rdt:            lnxCtr.GetRdt(),
 		SeccompProfile: lnxCtr.GetSeccompProfile(),
+		Sysctl:         lnxCtr.GetSysctl(),
 	}
 	return nriCtr
 }


### PR DESCRIPTION
Implement missing support for passing any container linux sysctl parameters as input to NRI plugins.

```release-note
Pass linux sysctl to plugins
```