### PR TITLE
Pass seccomp policy to plugins

### DIFF
--- a/internal/cri/nri/nri_api_linux.go
+++ b/internal/cri/nri/nri_api_linux.go
@@ -1013,6 +1013,14 @@ func (c *criContainer) GetSysctl() map[string]string {
 	return maps.Clone(c.spec.Linux.Sysctl)
 }
 
+func (c *criContainer) GetSeccompPolicy() *api.LinuxSeccomp {
+	if c.spec.Linux == nil || c.spec.Linux.Seccomp == nil {
+		return nil
+	}
+
+	return api.FromOCILinuxSeccomp(c.spec.Linux.Seccomp)
+}
+
 func (c *criContainer) GetPid() uint32 {
 	return c.pid
 }

--- a/internal/nri/container.go
+++ b/internal/nri/container.go
@@ -62,6 +62,7 @@ type LinuxContainer interface {
 	GetRdt() *nri.LinuxRdt
 	GetSeccompProfile() *nri.SecurityProfile
 	GetSysctl() map[string]string
+	GetSeccompPolicy() *nri.LinuxSeccomp
 }
 
 func commonContainerToNRI(ctr Container) *nri.Container {

--- a/internal/nri/container_linux.go
+++ b/internal/nri/container_linux.go
@@ -37,6 +37,7 @@ func containerToNRI(ctr Container) *nri.Container {
 		Rdt:            lnxCtr.GetRdt(),
 		SeccompProfile: lnxCtr.GetSeccompProfile(),
 		Sysctl:         lnxCtr.GetSysctl(),
+		SeccompPolicy:  lnxCtr.GetSeccompPolicy(),
 	}
 	return nriCtr
 }


### PR DESCRIPTION
Implement missing support for passing any container seccomp policy as input to NRI plugins.