### PR TITLE
Pass container user (uid, gids) to plugins

### DIFF
--- a/internal/cri/nri/nri_api_linux.go
+++ b/internal/cri/nri/nri_api_linux.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
 
 	eventtypes "github.com/containerd/containerd/api/events"
 	containerd "github.com/containerd/containerd/v2/client"
@@ -1041,6 +1042,18 @@ func (c *criContainer) GetRlimits() []*api.POSIXRlimit {
 	}
 
 	return rlimits
+}
+
+func (c *criContainer) GetUser() *api.User {
+	if c.spec.Process == nil {
+		return nil
+	}
+
+	return &api.User{
+		Uid:            c.spec.Process.User.UID,
+		Gid:            c.spec.Process.User.GID,
+		AdditionalGids: slices.Clone(c.spec.Process.User.AdditionalGids),
+	}
 }
 
 //

--- a/internal/nri/container.go
+++ b/internal/nri/container.go
@@ -48,6 +48,7 @@ type Container interface {
 	GetLinuxContainer() LinuxContainer
 	GetCDIDevices() []*nri.CDIDevice
 	GetRlimits() []*nri.POSIXRlimit
+	GetUser() *nri.User
 }
 
 type LinuxContainer interface {
@@ -85,6 +86,7 @@ func commonContainerToNRI(ctr Container) *nri.Container {
 		FinishedAt:   status.FinishedAt,
 		ExitCode:     status.ExitCode,
 		Rlimits:      ctr.GetRlimits(),
+		User:         ctr.GetUser(),
 	}
 }
 


### PR DESCRIPTION
Implement missing support for passing any container user (uid, gids) as input to NRI plugins.