### PR TITLE
Pass extended container status to NRI.

### DIFF
--- a/internal/cri/nri/nri_api_other.go
+++ b/internal/cri/nri/nri_api_other.go
@@ -21,6 +21,7 @@ package nri
 import (
 	"context"
 
+	eventtypes "github.com/containerd/containerd/api/events"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	cstore "github.com/containerd/containerd/v2/internal/cri/store/container"
@@ -110,7 +111,7 @@ func (*API) WithContainerAdjustment() containerd.NewContainerOpts {
 	}
 }
 
-func (*API) WithContainerExit(*cstore.Container) containerd.ProcessDeleteOpts {
+func (*API) WithContainerExit(*cstore.Container, *eventtypes.TaskExit) containerd.ProcessDeleteOpts {
 	return func(_ context.Context, _ containerd.Process) error {
 		return nil
 	}

--- a/internal/cri/server/events.go
+++ b/internal/cri/server/events.go
@@ -238,7 +238,7 @@ func (c *criService) handleContainerExit(ctx context.Context, e *eventtypes.Task
 		}
 
 		// TODO(random-liu): [P1] This may block the loop, we may want to spawn a worker
-		if _, err = task.Delete(ctx, c.nri.WithContainerExit(&cntr), containerd.WithProcessKill); err != nil {
+		if _, err = task.Delete(ctx, c.nri.WithContainerExit(&cntr, e), containerd.WithProcessKill); err != nil {
 			if !errdefs.IsNotFound(err) {
 				return fmt.Errorf("failed to stop container: %w", err)
 			}

--- a/internal/nri/container.go
+++ b/internal/nri/container.go
@@ -20,6 +20,17 @@ import (
 	nri "github.com/containerd/nri/pkg/adaptation"
 )
 
+type ContainerStatus struct {
+	State      nri.ContainerState
+	Reason     string
+	Message    string
+	Pid        uint32
+	CreatedAt  int64
+	StartedAt  int64
+	FinishedAt int64
+	ExitCode   int32
+}
+
 // Container interface for interacting with NRI.
 type Container interface {
 	GetDomain() string
@@ -27,7 +38,7 @@ type Container interface {
 	GetPodSandboxID() string
 	GetID() string
 	GetName() string
-	GetState() nri.ContainerState
+	GetStatus() *ContainerStatus
 	GetLabels() map[string]string
 	GetAnnotations() map[string]string
 	GetArgs() []string
@@ -35,8 +46,6 @@ type Container interface {
 	GetMounts() []*nri.Mount
 	GetHooks() *nri.Hooks
 	GetLinuxContainer() LinuxContainer
-
-	GetPid() uint32
 	GetCDIDevices() []*nri.CDIDevice
 }
 
@@ -55,19 +64,24 @@ type LinuxContainer interface {
 }
 
 func commonContainerToNRI(ctr Container) *nri.Container {
+	status := ctr.GetStatus()
 	return &nri.Container{
 		Id:           ctr.GetID(),
 		PodSandboxId: ctr.GetPodSandboxID(),
 		Name:         ctr.GetName(),
-		State:        ctr.GetState(),
+		State:        status.State,
 		Labels:       ctr.GetLabels(),
 		Annotations:  ctr.GetAnnotations(),
 		Args:         ctr.GetArgs(),
 		Env:          ctr.GetEnv(),
 		Mounts:       ctr.GetMounts(),
 		Hooks:        ctr.GetHooks(),
-		Pid:          ctr.GetPid(),
 		CDIDevices:   ctr.GetCDIDevices(),
+		Pid:          status.Pid,
+		CreatedAt:    status.CreatedAt,
+		StartedAt:    status.StartedAt,
+		FinishedAt:   status.FinishedAt,
+		ExitCode:     status.ExitCode,
 	}
 }
 


### PR DESCRIPTION
Pass more complete container status information to NRI, including exit code, and timestamps for container creation, start, and exit events.