### PR TITLE
Remove protoc dependency from BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -26,7 +26,6 @@ A codespace will open in a web-based version of Visual Studio Code. The [dev con
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
 * Go compiler (download from https://go.dev/dl/). The two most recent major Go versions are supported. For example, if Go 1.25 is the latest, then 1.25 and 1.24 are supported.
-* Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/protocolbuffers/protobuf/releases))
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 
 > *Note*: On macOS, you need a third party runtime to run containers on containerd


### PR DESCRIPTION
This line was missed in the PR to switch to `buf`

Followup to #12762 // cc @mxpv 