### PR TITLE
 cri/podsandbox: reduce dependencies to internal CRI APIs

### DIFF
--- a/internal/cri/server/images/service.go
+++ b/internal/cri/server/images/service.go
@@ -199,10 +199,9 @@ func (c *CRIImageService) ImageFSPaths() map[string]string {
 	return c.imageFSPaths
 }
 
-// PinnedImage is used to lookup a pinned image by name.
-// Most often used to get the "sandbox" image.
-func (c *CRIImageService) PinnedImage(name string) string {
-	return c.config.PinnedImages[name]
+// Config returns the image configuration.
+func (c *CRIImageService) Config() criconfig.ImageConfig {
+	return c.config
 }
 
 // GRPCService returns a new CRI Image Service grpc server.

--- a/internal/cri/server/podsandbox/sandbox_run_linux.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux.go
@@ -196,7 +196,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 
 	specOpts = append(specOpts, annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...)
 
-	return c.runtimeSpec(id, "", specOpts...)
+	return c.runtimeSpec(id, specOpts...)
 }
 
 // sandboxContainerSpecOpts generates OCI spec options for

--- a/internal/cri/server/podsandbox/sandbox_run_other.go
+++ b/internal/cri/server/podsandbox/sandbox_run_other.go
@@ -27,9 +27,8 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
-	return c.runtimeSpec(id, "", annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...)
+func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig, _ *imagespec.ImageConfig, _ string, _ []string) (_ *runtimespec.Spec, _ error) {
+	return c.runtimeSpec(id, annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...)
 }
 
 // sandboxContainerSpecOpts generates OCI spec options for

--- a/internal/cri/server/podsandbox/sandbox_run_windows.go
+++ b/internal/cri/server/podsandbox/sandbox_run_windows.go
@@ -87,7 +87,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...,
 	)
 
-	return c.runtimeSpec(id, "", specOpts...)
+	return c.runtimeSpec(id, specOpts...)
 }
 
 // No sandbox container spec options for windows yet.


### PR DESCRIPTION
Reduces `podsandbox/` dependencies from internal CRI APIs.

This PR:
- Removes `RuntimeService` service dependency. `LoadOCISpec` was never used for sadnbox containers.
- Reduces `ImageService` dependencies. Fetches required info from the config instead of calling APIs.

This relies on CRI configuration injected during init time. This would be straightforward to handle in the runtime code.