### PR TITLE
Detect breaking API changes in proto files

### DIFF
--- a/.github/workflows/buf-breaking.yml
+++ b/.github/workflows/buf-breaking.yml
@@ -1,0 +1,35 @@
+# Detects breaking changes in protobuf files using buf.
+# This check can be bypassed by adding the 'breaking-api-change' label to the PR.
+# For more info: https://buf.build/docs/bsr/ci-cd/github-actions/
+
+name: Protobuf
+
+on:
+  pull_request:
+    branches: ['main', 'release/**']
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'api/**/*.proto'
+      - 'api/buf.yaml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  breaking:
+    name: Detect breaking API changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: bufbuild/buf-action@v1
+        with:
+          version: 1.63.0
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          input: 'api'
+          breaking: ${{ !contains(github.event.pull_request.labels.*.name, 'breaking-api-change') }}
+          lint: false
+          format: false
+          pr_comment: false


### PR DESCRIPTION
Follow up to https://github.com/containerd/containerd/pull/12762

This adds a CI job to detect breaking changes in proto files (using buf's [breaking](https://buf.build/docs/breaking/) subcommand).

There is also an option to skip this check if there is `breaking-api-change` label attached to the PR.

ccing @containerd/committers to be aware of this label ^^

Also looks like Github won't run new jobs from PRs until it gets merged first.