### PR TITLE
fix: typo in comment

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/io_util.go
+++ b/cmd/containerd-shim-runc-v2/process/io_util.go
@@ -45,7 +45,7 @@ func NewBinaryCmd(binaryURI *url.URL, id, ns string) *exec.Cmd {
 }
 
 // CloseFiles closes any files passed in.
-// It it used for cleanup in the event of unexpected errors.
+// It is used for cleanup in the event of unexpected errors.
 func CloseFiles(files ...*os.File) {
 	for _, file := range files {
 		file.Close()


### PR DESCRIPTION
Fix typo: `It it used` → `It is used`