### PR TITLE
fix: sanitize error before gRPC return to prevent credential leak in pod events

### DIFF
--- a/internal/cri/instrument/instrumented_service.go
+++ b/internal/cri/instrument/instrumented_service.go
@@ -354,8 +354,6 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
 	log.G(ctx).Infof("PullImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
-			// Sanitize error to remove sensitive information
-			err = ctrdutil.SanitizeError(err)
 			log.G(ctx).WithError(err).Errorf("PullImage %q failed", r.GetImage().GetImage())
 		} else {
 			log.G(ctx).Infof("PullImage %q returns image reference %q",
@@ -364,6 +362,10 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
 		span.RecordError(err)
 	}()
 	res, err = in.c.PullImage(ctrdutil.WithNamespace(ctx), r)
+	// Sanitize error to remove sensitive information from both logs and returned gRPC error
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
 	return res, errgrpc.ToGRPC(err)
 }
 
@@ -374,8 +376,6 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
 	log.G(ctx).Tracef("ListImages with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
-			// Sanitize error to remove sensitive information
-			err = ctrdutil.SanitizeError(err)
 			log.G(ctx).WithError(err).Errorf("ListImages with filter %+v failed", r.GetFilter())
 		} else {
 			log.G(ctx).Tracef("ListImages with filter %+v returns image list %+v",
@@ -383,6 +383,10 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
 		}
 	}()
 	res, err = in.c.ListImages(ctrdutil.WithNamespace(ctx), r)
+	// Sanitize error to remove sensitive information from both logs and returned gRPC error
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
 	return res, errgrpc.ToGRPC(err)
 }
 
@@ -393,8 +397,6 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
 	log.G(ctx).Tracef("ImageStatus for %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
-			// Sanitize error to remove sensitive information
-			err = ctrdutil.SanitizeError(err)
 			log.G(ctx).WithError(err).Errorf("ImageStatus for %q failed", r.GetImage().GetImage())
 		} else {
 			log.G(ctx).Tracef("ImageStatus for %q returns image status %+v",
@@ -402,6 +404,10 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
 		}
 	}()
 	res, err = in.c.ImageStatus(ctrdutil.WithNamespace(ctx), r)
+	// Sanitize error to remove sensitive information from both logs and returned gRPC error
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
 	return res, errgrpc.ToGRPC(err)
 }
 
@@ -413,8 +419,6 @@ func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.Remov
 	log.G(ctx).Infof("RemoveImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
-			// Sanitize error to remove sensitive information
-			err = ctrdutil.SanitizeError(err)
 			log.G(ctx).WithError(err).Errorf("RemoveImage %q failed", r.GetImage().GetImage())
 		} else {
 			log.G(ctx).Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
@@ -422,6 +426,10 @@ func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.Remov
 		span.RecordError(err)
 	}()
 	res, err := in.c.RemoveImage(ctrdutil.WithNamespace(ctx), r)
+	// Sanitize error to remove sensitive information from both logs and returned gRPC error
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
 	return res, errgrpc.ToGRPC(err)
 }
 


### PR DESCRIPTION
PR #12491 fixed credential leaks in containerd logs but the gRPC error returned to kubelet still contains sensitive information (e.g., SAS tokens). This is visible in Kubernetes pod events via `kubectl describe pod`.

**Issue:**
The `SanitizeError` call was placed inside the defer block:
```
defer func() {
    if err != nil {
        err = ctrdutil.SanitizeError(err)  // Runs AFTER return is evaluated
        log.G(ctx).WithError(err).Errorf(...)
    }
}()
res, err = in.c.PullImage(...)
return res, errgrpc.ToGRPC(err)  // Uses ORIGINAL unsanitized error
```

Go evaluates `errgrpc.ToGRPC(err)` before the defer runs, so the gRPC message contains the original unsanitized error with credentials.

**Fix:**
Move `SantiizeError` before the return statement:

```
res, err = in.c.PullImage(...)
if err != nil {
    err = ctrdutil.SanitizeError(err)
}
return res, errgrpc.ToGRPC(err)  // Now uses sanitized error
```

This ensures both the logged error and the gRPC error use the sanitized error.

**Testing**:
- Tested on an AKS cluster
- Blocked blob storage IPs via iptables to force image pull failure
- Deployed pod with ACR image requiring SAS token authentication

When describing pod:
<img width="2375" height="327" alt="image" src="https://github.com/user-attachments/assets/4b6f3c47-9a02-4fc6-bdf9-8c36fc7010f3" />

containerd log:
```
Jan 20 22:35:45 aks-nodepool1-35109453-vmss000000 containerd[38541]: time="2026-01-20T22:35:45.730403025Z" level=error msg="PullImage \"akscon
tainerhost.azurecr.io/newimage:v1\" failed" error="rpc error: code = Unknown desc = failed to pull and unpack image \"akscontainerhost.azurecr
.io/newimage:v1\": failed to copy: httpReadSeeker: failed open: failed to do request: Get \"https://eusmanaged213.blob.core.windows.net/d46180
728b794a35a39c3b22ed20f8a3-6k5n90bm44//docker/registry/v2/blobs/sha256/bc/bc717f9cc8f343d7e59d10bc7fc0c811530afa98d437c9f6bcd8fb3dfc2308da/dat
a?anon=%5BREDACTED%5D&regid=%5BREDACTED%5D&se=%5BREDACTED%5D&sig=%5BREDACTED%5D&ske=%5BREDACTED%5D&skoid=%5BREDACTED%5D&sks=%5BREDACTED%5D&skt
=%5BREDACTED%5D&sktid=%5BREDACTED%5D&skv=%5BREDACTED%5D&sp=%5BREDACTED%5D&spr=%5BREDACTED%5D&sr=%5BREDACTED%5D&sv=%5BREDACTED%5D\": dial tcp 2
0.60.63.193:443: connect: connection refused"
Jan 20 22:35:45 aks-nodepool1-35109453-vmss000000 containerd[38541]: time="2026-01-20T22:35:45.730424836Z" level=info msg="stop pulling image
akscontainerhost.azurecr.io/newimage:v1: active requests=0, bytes read=0"
root@aks-nodepool1-35109453-vmss000000 [ / ]#
```