### PR TITLE
.github: re-enable windows image pull/list tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,15 +349,7 @@ jobs:
             $skipTests = @(
               # This test is exceedingly flaky only on ws2022 so skip for now to keep CI happy.
               # Info: https://github.com/containerd/containerd/issues/6652
-              "runtime should support exec with tty=true and stdin=true",
-
-              # Skip tests that are known to be flaky on Windows
-              # See https://github.com/containerd/containerd/issues/12580
-              "public image with tag should be pulled and removed",
-              "public image without tag should be pulled and removed",
-              "image status should support all kinds of references",
-              "listImage should get exactly 3 image in the result list",
-              "listImage should get exactly 3 repoTags in the result image"
+              "runtime should support exec with tty=true and stdin=true"
             )
             $skip = $skipTests -join "|"
           }


### PR DESCRIPTION
Fixes: #12580

---

```bash
docker manifest inspect gcr.io/k8s-staging-cri-tools/win-test-image-tags:1
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 670,
         "digest": "sha256:c3f2e09bfaa662c6a80ad5fd2657f24da718d4b158c015de2b68f6d77eedd51d",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.4405"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 566,
         "digest": "sha256:f22e2f8315ff8c7e41b5fd658dd3769ac44729d8668a0b4fee65e3471d7be263",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}
```