### PR TITLE
[release/1.7] cri: fix can't see images when use Transfer api to import images

### DIFF
--- a/services/images/local.go
+++ b/services/images/local.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/containerd/log"
 
-	eventstypes "github.com/containerd/containerd/api/events"
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
@@ -130,13 +129,6 @@ func (l *local) Create(ctx context.Context, req *imagesapi.CreateImageRequest, _
 
 	resp.Image = imageToProto(&created)
 
-	if err := l.publisher.Publish(ctx, "/images/create", &eventstypes.ImageCreate{
-		Name:   resp.Image.Name,
-		Labels: resp.Image.Labels,
-	}); err != nil {
-		return nil, err
-	}
-
 	l.emitSchema1DeprecationWarning(ctx, &image)
 	return &resp, nil
 
@@ -169,13 +161,6 @@ func (l *local) Update(ctx context.Context, req *imagesapi.UpdateImageRequest, _
 
 	resp.Image = imageToProto(&updated)
 
-	if err := l.publisher.Publish(ctx, "/images/update", &eventstypes.ImageUpdate{
-		Name:   resp.Image.Name,
-		Labels: resp.Image.Labels,
-	}); err != nil {
-		return nil, err
-	}
-
 	l.emitSchema1DeprecationWarning(ctx, &image)
 	return &resp, nil
 }
@@ -185,12 +170,6 @@ func (l *local) Delete(ctx context.Context, req *imagesapi.DeleteImageRequest, _
 
 	if err := l.store.Delete(ctx, req.Name); err != nil {
 		return nil, errdefs.ToGRPC(err)
-	}
-
-	if err := l.publisher.Publish(ctx, "/images/delete", &eventstypes.ImageDelete{
-		Name: req.Name,
-	}); err != nil {
-		return nil, err
 	}
 
 	if req.Sync {


### PR DESCRIPTION
only happen on containerd 1.7
```
ctr  -n k8s.io i import --local=false  /home/nmx/pods/busybox.tar
docker.io/library/busybox:1.28                  saved
docker.io/library/busybox:latest                saved
Importing       elapsed: 0.4 s  total:   0.0 B  (0.0 B/s)


 crictl  images
IMAGE               TAG                 IMAGE ID            SIZE

```

@dmcgowan  @fuweid    @AkihiroSuda  nerdctl also have this bug 