### PR TITLE
fix: propagate `context deadline exceeded` error properly

### DIFF
--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -835,6 +835,9 @@ func (s *shimTask) State(ctx context.Context) (runtime.State, error) {
 		ID: s.ID(),
 	})
 	if err != nil {
+		if errdefs.IsDeadlineExceeded(err) {
+			return runtime.State{}, err
+		}
 		if !errors.Is(err, ttrpc.ErrClosed) {
 			return runtime.State{}, errgrpc.ToNative(err)
 		}

--- a/plugins/services/tasks/local.go
+++ b/plugins/services/tasks/local.go
@@ -349,7 +349,7 @@ func getProcessState(ctx context.Context, p runtime.Process) (*task.Process, err
 
 	state, err := p.State(ctx)
 	if err != nil {
-		if errdefs.IsNotFound(err) || errdefs.IsUnavailable(err) {
+		if errdefs.IsNotFound(err) || errdefs.IsUnavailable(err) || errdefs.IsDeadlineExceeded(err) {
 			return nil, err
 		}
 		log.G(ctx).WithError(err).Errorf("get state for %s", p.ID())


### PR DESCRIPTION
When a shim becomes unresponsive (e.g., stopped via SIGSTOP), ttrpc communication times out with `context deadline exceeded`.

Currently, this error is not properly propagated, causing redundant API calls and slow container listing by client sides.

Specifically, when executing the API to check the task state, it appears that the `context deadline exceeded` error via ttrpc is not being handled within `shimTask.State()` and `getProcessState()`.

As a result, when this error occurs, clients such as nerdctl cannot recognize this error, and it is thought that the issue described below is occurring:

- https://github.com/containerd/nerdctl/issues/4720

Therefore, this commit adds error handling to ensure timeouts are properly handled by client sides.