### PR TITLE
Fix transfer-service registry host config to support multi-root config_path

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -318,6 +318,14 @@ func HostDirFromRoots(roots []string) func(string) (string, error) {
 		}
 		hostDirFns = append(hostDirFns, HostDirFromRoot(r))
 	}
+	switch len(hostDirFns) {
+	case 0:
+		return func(string) (string, error) {
+			return "", errdefs.ErrNotFound
+		}
+	case 1:
+		return hostDirFns[0]
+	}
 
 	return func(host string) (dir string, err error) {
 		for _, fn := range hostDirFns {

--- a/core/remotes/docker/config/hosts_resolver_test.go
+++ b/core/remotes/docker/config/hosts_resolver_test.go
@@ -316,3 +316,25 @@ func (m testManifest) RegisterHandler(r *http.ServeMux, name string) {
 		r.Handle(fmt.Sprintf("/v2/%s/blobs/%s", name, c.Digest()), c)
 	}
 }
+
+func TestHostDirFromRoots(t *testing.T) {
+	t.Parallel()
+
+	// root1 intentionally does not exist
+	root1 := filepath.Join(t.TempDir(), "does-not-exist")
+	root2 := t.TempDir()
+
+	host := "registry.k8s.io"
+	want := filepath.Join(root2, host)
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", want, err)
+	}
+
+	dir, err := HostDirFromRoots([]string{root1, root2})(host)
+	if err != nil {
+		t.Fatalf("HostDirFromRoots(...)(%q) returned error: %v", host, err)
+	}
+	if dir != want {
+		t.Fatalf("unexpected host dir: got %q, want %q", dir, want)
+	}
+}

--- a/core/remotes/docker/config/hosts_resolver_test.go
+++ b/core/remotes/docker/config/hosts_resolver_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/containerd/errdefs"
 )
 
 func TestResolverWithHostsDir(t *testing.T) {
@@ -336,5 +337,33 @@ func TestHostDirFromRoots(t *testing.T) {
 	}
 	if dir != want {
 		t.Fatalf("unexpected host dir: got %q, want %q", dir, want)
+	}
+}
+
+func TestHostDirFromRoots_SingleRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	host := "registry.k8s.io"
+	want := filepath.Join(root, host)
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", want, err)
+	}
+
+	dir, err := HostDirFromRoots([]string{root})(host)
+	if err != nil {
+		t.Fatalf("HostDirFromRoots(...)(%q) returned error: %v", host, err)
+	}
+	if dir != want {
+		t.Fatalf("unexpected host dir: got %q, want %q", dir, want)
+	}
+}
+
+func TestHostDirFromRoots_EmptyRoots(t *testing.T) {
+	t.Parallel()
+
+	_, err := HostDirFromRoots([]string{"", ""})("registry.k8s.io")
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("expected not found error, got: %v", err)
 	}
 }

--- a/core/transfer/registry/registry.go
+++ b/core/transfer/registry/registry.go
@@ -47,8 +47,7 @@ func init() {
 type registryOpts struct {
 	headers       http.Header
 	creds         CredentialHelper
-	hostDir       string
-	hostDirRoots  []string
+	hostDirs      []string
 	defaultScheme string
 	httpDebug     bool
 	httpTrace     bool
@@ -74,23 +73,15 @@ func WithCredentials(creds CredentialHelper) Opt {
 	}
 }
 
-// WithHostDir specifies the host configuration directory.
+// WithHostDir appends a host configuration directory.
 //
-// To set multiple fallback config directories, use WithHostDirRoots instead.
+// This option may be set multiple times; directories are searched in call order.
 func WithHostDir(hostDir string) Opt {
 	return func(o *registryOpts) error {
-		o.hostDir = hostDir
-		return nil
-	}
-}
-
-// WithHostDirRoots specifies multiple host configuration directory roots to
-// search in order (e.g. CRI's registry.config_path split by filepath.SplitList()).
-//
-// The directory specified by WithHostDir is prepended as a search target.
-func WithHostDirRoots(roots []string) Opt {
-	return func(o *registryOpts) error {
-		o.hostDirRoots = append(o.hostDirRoots, roots...)
+		if hostDir == "" {
+			return nil
+		}
+		o.hostDirs = append(o.hostDirs, hostDir)
 		return nil
 	}
 }
@@ -139,11 +130,8 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
 
 	hostOptions := config.HostOptions{}
 
-	if ropts.hostDir != "" || len(ropts.hostDirRoots) > 0 {
-		roots := make([]string, 0)
-		roots = append(roots, ropts.hostDir)
-		roots = append(roots, ropts.hostDirRoots...)
-		hostOptions.HostDir = config.HostDirFromRoots(roots)
+	if len(ropts.hostDirs) > 0 {
+		hostOptions.HostDir = config.HostDirFromRoots(ropts.hostDirs)
 	}
 	if ropts.creds != nil {
 		// TODO: Support bearer
@@ -175,17 +163,23 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
 		Headers: ropts.headers,
 	})
 
-	return &OCIRegistry{
+	reg := &OCIRegistry{
 		reference:     ref,
 		headers:       ropts.headers,
 		creds:         ropts.creds,
 		resolver:      resolver,
-		hostDir:       ropts.hostDir,
 		defaultScheme: ropts.defaultScheme,
 		httpDebug:     ropts.httpDebug,
 		httpTrace:     ropts.httpTrace,
 		localStream:   ropts.localStream,
-	}, nil
+	}
+	// RegistryResolver carries a single host_dir field. Preserve the first
+	// configured host directory for transfer marshaling compatibility.
+	if len(ropts.hostDirs) > 0 {
+		reg.hostDir = ropts.hostDirs[0]
+	}
+
+	return reg, nil
 }
 
 // From stream

--- a/core/transfer/registry/registry_test.go
+++ b/core/transfer/registry/registry_test.go
@@ -1,0 +1,58 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestWithHostDir_AppendsInCallOrder(t *testing.T) {
+	var ropts registryOpts
+
+	if err := WithHostDir("")(&ropts); err != nil {
+		t.Fatalf("WithHostDir(empty): %v", err)
+	}
+	if err := WithHostDir("/etc/containerd/certs.d")(&ropts); err != nil {
+		t.Fatalf("WithHostDir(first): %v", err)
+	}
+	if err := WithHostDir("/etc/docker/certs.d")(&ropts); err != nil {
+		t.Fatalf("WithHostDir(second): %v", err)
+	}
+
+	want := []string{"/etc/containerd/certs.d", "/etc/docker/certs.d"}
+	if !reflect.DeepEqual(ropts.hostDirs, want) {
+		t.Fatalf("unexpected hostDirs: got %v, want %v", ropts.hostDirs, want)
+	}
+}
+
+func TestNewOCIRegistry_PreservesFirstHostDirForTransferMarshaling(t *testing.T) {
+	reg, err := NewOCIRegistry(
+		context.Background(),
+		"registry.k8s.io/pause:3.10",
+		WithHostDir("/etc/containerd/certs.d"),
+		WithHostDir("/etc/docker/certs.d"),
+	)
+	if err != nil {
+		t.Fatalf("NewOCIRegistry() error = %v", err)
+	}
+
+	if reg.hostDir != "/etc/containerd/certs.d" {
+		t.Fatalf("unexpected marshaling hostDir: got %q, want %q", reg.hostDir, "/etc/containerd/certs.d")
+	}
+}

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -313,7 +313,7 @@ func (c *CRIImageService) pullImageWithTransferService(
 	opts := []registry.Opt{
 		registry.WithCredentials(ch),
 		registry.WithHeaders(c.config.Registry.Headers),
-		registry.WithHostDir(c.config.Registry.ConfigPath),
+		registry.WithHostDirRoots(filepath.SplitList(c.config.Registry.ConfigPath)),
 	}
 
 	reg, err := registry.NewOCIRegistry(ctx, ref, opts...)
@@ -476,22 +476,6 @@ func (c *CRIImageService) UpdateImage(ctx context.Context, r string) error {
 	return nil
 }
 
-func hostDirFromRoots(roots []string) func(string) (string, error) {
-	rootfn := make([]func(string) (string, error), len(roots))
-	for i := range roots {
-		rootfn[i] = config.HostDirFromRoot(roots[i])
-	}
-	return func(host string) (dir string, err error) {
-		for _, fn := range rootfn {
-			dir, err = fn(host)
-			if (err != nil && !errdefs.IsNotFound(err)) || (dir != "") {
-				break
-			}
-		}
-		return
-	}
-}
-
 // registryHosts is the registry hosts to be used by the resolver.
 func (c *CRIImageService) registryHosts(ctx context.Context, credentials func(host string) (string, string, error), updateClientFn config.UpdateClientFunc) docker.RegistryHosts {
 	paths := filepath.SplitList(c.config.Registry.ConfigPath)
@@ -500,7 +484,7 @@ func (c *CRIImageService) registryHosts(ctx context.Context, credentials func(ho
 			UpdateClient: updateClientFn,
 		}
 		hostOptions.Credentials = credentials
-		hostOptions.HostDir = hostDirFromRoots(paths)
+		hostOptions.HostDir = config.HostDirFromRoots(paths)
 		// need to pass cri global headers to per-host authorizers
 		hostOptions.AuthorizerOpts = []docker.AuthorizerOpt{
 			docker.WithAuthHeader(c.config.Registry.Headers),

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -313,7 +313,9 @@ func (c *CRIImageService) pullImageWithTransferService(
 	opts := []registry.Opt{
 		registry.WithCredentials(ch),
 		registry.WithHeaders(c.config.Registry.Headers),
-		registry.WithHostDirRoots(filepath.SplitList(c.config.Registry.ConfigPath)),
+	}
+	for _, hostDir := range filepath.SplitList(c.config.Registry.ConfigPath) {
+		opts = append(opts, registry.WithHostDir(hostDir))
 	}
 
 	reg, err := registry.NewOCIRegistry(ctx, ref, opts...)


### PR DESCRIPTION
### What this PR does

Fixes inconsistent behavior in containerd's CRI image pull using the transfer service.  
Previously, when `registry.config_path` contained a colon-separated list (e.g. `/etc/containerd/certs.d:/etc/docker/certs.d`), the CRI layer handled it correctly, but the transfer-service layer did not.

This PR:

- Parses the `config_path` using `filepath.SplitList()`
- Tries host config lookup across multiple roots
- Adds a regression test to to verify support for multi-root host dirs.

### Why it matters

Without this fix, host configs (e.g. `hosts.toml`) are silently ignored if not located in the first root path — and no errors are logged. This causes image pulls to fall back to public registries, unexpectedly.

### Related issue
Fixes: #12808