### PR TITLE
cri: propagate runtime-specific snapshotters to image service

### DIFF
--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/containerd/containerd/v2/internal/cri/server/images"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
 )
@@ -308,6 +309,9 @@ func (s *fakeImageService) Config() criconfig.ImageConfig {
 
 func (s *fakeImageService) PullImage(context.Context, string, func(string) (string, string, error), *runtime.PodSandboxConfig, string) (string, error) {
 	return "", errors.New("not implemented")
+}
+
+func (s *fakeImageService) UpdateRuntimeSnapshotter(runtimeName string, imagePlatform images.ImagePlatform) {
 }
 
 func patchExceptedWithState(expected *runtime.ContainerStatus, state runtime.ContainerState) {

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -42,6 +42,7 @@ import (
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/nri"
 	"github.com/containerd/containerd/v2/internal/cri/server/events"
+	"github.com/containerd/containerd/v2/internal/cri/server/images"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
 	"github.com/containerd/containerd/v2/internal/cri/store/label"
@@ -110,6 +111,8 @@ type ImageService interface {
 	ImageFSPaths() map[string]string
 
 	Config() criconfig.ImageConfig
+
+	UpdateRuntimeSnapshotter(runtimeName string, imagePlatform images.ImagePlatform)
 }
 
 // criService implements CRIService.


### PR DESCRIPTION
When users configure a snapshotter in the runtime config (e.g., `plugins."io.containerd.cri.v1.runtime".containerd.runtimes.kata.snapshotter`), the CRI image service was not aware of this configuration. This caused images to be pulled with the default snapshotter instead of the runtime-specific one, because the image service's runtimePlatforms map was not populated with these runtime-to-snapshotter mappings.

Let's make sure that during the CRI plugin init, we iterate over all the configured runtimes, and propagate any snapshotter configuration to the image service.

This issue was found while working on #12835.