### PR TITLE
client: stream containers serially to conserve memory

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"runtime"
 	"strconv"
 	"strings"
@@ -41,6 +42,7 @@ import (
 	versionservice "github.com/containerd/containerd/api/services/version/v1"
 	apitypes "github.com/containerd/containerd/api/types"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/platforms"
 	"github.com/containerd/typeurl/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -333,6 +335,27 @@ func (c *Client) Containers(ctx context.Context, filters ...string) ([]Container
 		out[i] = containerFromRecord(c, container)
 	}
 	return out, nil
+}
+
+// ContainersIter streams containers from the underlying container store.
+// This is only supported when the container service is backed by a remote store
+// that implements ListIter (streaming). If not supported, it returns an error.
+func (c *Client) ContainersIter(ctx context.Context, filters ...string) (iter.Seq2[Container, error], error) {
+	r, ok := c.ContainerService().(*remoteContainers)
+	if !ok {
+		return nil, errgrpc.ToNative(fmt.Errorf("c.ContainerService() is not a *remoteContainers"))
+	}
+	return func(yield func(Container, error) bool) {
+		for con, err := range r.listIter(ctx, filters...) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield(containerFromRecord(c, con), nil) {
+				return
+			}
+		}
+	}, nil
 }
 
 // NewContainer will create a new container with the provided id.

--- a/client/containerstore.go
+++ b/client/containerstore.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"iter"
 
 	containersapi "github.com/containerd/containerd/api/services/containers/v1"
 	"github.com/containerd/errdefs/pkg/errgrpc"
@@ -80,31 +81,47 @@ func (r *remoteContainers) list(ctx context.Context, filters ...string) ([]conta
 var errStreamNotAvailable = errors.New("streaming api not available")
 
 func (r *remoteContainers) stream(ctx context.Context, filters ...string) ([]containers.Container, error) {
-	session, err := r.client.ListStream(ctx, &containersapi.ListContainersRequest{
-		Filters: filters,
-	})
-	if err != nil {
-		return nil, errgrpc.ToNative(err)
-	}
 	var containers []containers.Container
-	for {
-		c, err := session.Recv()
+	for con, err := range r.listIter(ctx, filters...) {
 		if err != nil {
-			if err == io.EOF {
-				return containers, nil
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return containers, err
 			}
-			if s, ok := status.FromError(err); ok {
-				if s.Code() == codes.Unimplemented {
-					return nil, errStreamNotAvailable
-				}
-			}
-			return nil, errgrpc.ToNative(err)
+			return nil, err
 		}
-		select {
-		case <-ctx.Done():
-			return containers, ctx.Err()
-		default:
-			containers = append(containers, containerFromProto(c.Container))
+		containers = append(containers, con)
+	}
+	return containers, nil
+}
+
+// listIter streams containers from the server.
+func (r *remoteContainers) listIter(ctx context.Context, filters ...string) iter.Seq2[containers.Container, error] {
+	return func(yield func(containers.Container, error) bool) {
+		session, err := r.client.ListStream(ctx, &containersapi.ListContainersRequest{
+			Filters: filters,
+		})
+		if err != nil {
+			yield(containers.Container{}, errgrpc.ToNative(err))
+			return
+		}
+		for {
+			con, err := session.Recv()
+			if err != nil {
+				if err == io.EOF {
+					return
+				}
+				if s, ok := status.FromError(err); ok {
+					if s.Code() == codes.Unimplemented {
+						yield(containers.Container{}, errStreamNotAvailable)
+						return
+					}
+				}
+				yield(containers.Container{}, errgrpc.ToNative(err))
+				return
+			}
+			if !yield(containerFromProto(con.Container), nil) {
+				return
+			}
 		}
 	}
 }

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -19,6 +19,7 @@ package containers
 import (
 	"context"
 	"fmt"
+	"iter"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -101,30 +102,56 @@ var listCommand = &cli.Command{
 			Aliases: []string{"q"},
 			Usage:   "Print only the container id",
 		},
+		&cli.BoolFlag{
+			Name:    "stream",
+			Aliases: []string{"s"},
+			Usage:   "Enable streaming output mode",
+		},
 	},
 	Action: func(cliContext *cli.Context) error {
 		var (
 			filters = cliContext.Args().Slice()
 			quiet   = cliContext.Bool("quiet")
+			stream  = cliContext.Bool("stream")
 		)
 		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		containers, err := client.Containers(ctx, filters...)
-		if err != nil {
-			return err
+
+		var (
+			containers iter.Seq2[containerd.Container, error]
+			ctrs       []containerd.Container
+		)
+		if stream {
+			containers, err = client.ContainersIter(ctx, filters...)
+			if err != nil {
+				return err
+			}
+		} else {
+			ctrs, err = client.Containers(ctx, filters...)
+			if err != nil {
+				return err
+			}
+			containers = sliceIter(ctrs)
 		}
 		if quiet {
-			for _, c := range containers {
+			for c, err := range containers {
+				if err != nil {
+					return err
+				}
 				fmt.Printf("%s\n", c.ID())
 			}
 			return nil
 		}
 		w := tabwriter.NewWriter(os.Stdout, 4, 8, 4, ' ', 0)
 		fmt.Fprintln(w, "CONTAINER\tIMAGE\tRUNTIME\t")
-		for _, c := range containers {
+
+		for c, err := range containers {
+			if err != nil {
+				return err
+			}
 			info, err := c.Info(ctx, containerd.WithoutRefreshedMetadata)
 			if err != nil {
 				return err
@@ -143,6 +170,16 @@ var listCommand = &cli.Command{
 		}
 		return w.Flush()
 	},
+}
+
+func sliceIter(ctrs []containerd.Container) iter.Seq2[containerd.Container, error] {
+	return func(yield func(containerd.Container, error) bool) {
+		for _, c := range ctrs {
+			if !yield(c, nil) {
+				return
+			}
+		}
+	}
 }
 
 var deleteCommand = &cli.Command{

--- a/integration/client/benchmark_test.go
+++ b/integration/client/benchmark_test.go
@@ -17,7 +17,10 @@
 package client
 
 import (
+	"context"
 	"fmt"
+	"iter"
+	"strings"
 	"testing"
 
 	. "github.com/containerd/containerd/v2/client"
@@ -66,6 +69,122 @@ func BenchmarkContainerCreate(b *testing.B) {
 		containers = append(containers, container)
 	}
 	b.StopTimer()
+}
+
+func BenchmarkContainerGet(b *testing.B) {
+	client, err := newClient(b, address)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer client.Close()
+
+	ctx, cancel := testContext(b)
+	defer cancel()
+	image, err := client.GetImage(ctx, testImage)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	var containers []Container
+	defer func() {
+		for _, c := range containers {
+			if err := c.Delete(ctx, WithSnapshotCleanup); err != nil {
+				b.Error(err)
+			}
+		}
+	}()
+
+	var envs []string
+	// Simulate injecting a large number of Kubernetes service environment variables.
+	// see  https://github.com/kubernetes/kubernetes/issues/121787
+	// so that it will take up more memory when fetching the container list.
+	envs = append(envs, generateK8sServiceEnvVarsList()...)
+	for i := 0; i < 500; i++ {
+		id := fmt.Sprintf("%s-%d", b.Name(), i)
+		container, err := client.NewContainer(ctx, id, WithNewSnapshot(id, image), WithNewSpec(oci.WithImageConfig(image), oci.WithEnv(envs), withExitStatus(7)))
+		if err != nil {
+			b.Error(err)
+			return
+		}
+		containers = append(containers, container)
+	}
+	b.Run("use client.ContainersIter", benchmarkGetContainers(ctx, true, client))
+	b.Run("use client.Containers", benchmarkGetContainers(ctx, false, client))
+}
+
+func benchmarkGetContainers(ctx context.Context, useIter bool, client *Client) func(b *testing.B) {
+	return func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var filter []string
+			var containers iter.Seq2[Container, error]
+			var err error
+			if useIter {
+				containers, err = client.ContainersIter(ctx, filter...)
+				if err != nil {
+					b.Fatal(err)
+				}
+			} else {
+				ctrs, err := client.Containers(ctx, filter...)
+				if err != nil {
+					b.Fatal(err)
+				}
+				containers = sliceIter(ctrs)
+			}
+			for con, err := range containers {
+				if err != nil {
+					b.Fatal(err)
+				}
+				_, err := con.Info(ctx, WithoutRefreshedMetadata)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	}
+}
+
+func sliceIter(ctrs []Container) iter.Seq2[Container, error] {
+	return func(yield func(Container, error) bool) {
+		for _, c := range ctrs {
+			if !yield(c, nil) {
+				return
+			}
+		}
+	}
+}
+
+const (
+	fixedIP       = "172.20.200.100"
+	fixedPort     = 8080
+	servicePrefix = "long-k8s-service-for-test-env-var-"
+	portTemplate  = "tcp://%s:%d"
+)
+
+func generateK8sServiceEnvVarsList() []string {
+	var envVarsList []string
+	for i := 1; i <= 4000; i++ {
+		serviceName := fmt.Sprintf("%s%03d-extra-long-suffix-to-increase-length-abcdefghijklmnop",
+			servicePrefix, i)
+		if len(serviceName) > 50 {
+			serviceName = serviceName[:50]
+		}
+		serviceName = strings.TrimSuffix(serviceName, "-")
+		envPrefix := strings.ToUpper(strings.ReplaceAll(serviceName, "-", "_"))
+		portStr := fmt.Sprintf("%d", fixedPort)
+		fullPort := fmt.Sprintf(portTemplate, fixedIP, fixedPort)
+		envVarsList = append(envVarsList,
+			fmt.Sprintf("%s_SERVICE_HOST=%s", envPrefix, fixedIP),
+			fmt.Sprintf("%s_SERVICE_PORT=%s", envPrefix, portStr),
+			fmt.Sprintf("%s_PORT=%s", envPrefix, fullPort),
+			fmt.Sprintf("%s_PORT_%d_TCP=%s", envPrefix, fixedPort, fullPort),
+			fmt.Sprintf("%s_PORT_%d_TCP_PROTO=tcp", envPrefix, fixedPort),
+			fmt.Sprintf("%s_PORT_%d_TCP_PORT=%s", envPrefix, fixedPort, portStr),
+			fmt.Sprintf("%s_PORT_%d_TCP_ADDR=%s", envPrefix, fixedPort, fixedIP),
+		)
+	}
+	return envVarsList
 }
 
 func BenchmarkContainerStart(b *testing.B) {


### PR DESCRIPTION
stream containers serially to conserve memory
ctr/nerdctl  use 
https://github.com/containerd/containerd/blob/v2.2.1/client/containerstore.go#L107  to get all containers list
if  every container spec size is big we have to use much memory to store the container list.
what I did:
‌Process one item from the container at a time, without adding it to any list.

fix https://github.com/containerd/containerd/issues/12858

use  /usr/bin/time -v ctr  -n k8s.io c ls

        Command being timed: "./ctr_old -n k8s.io c ls"
        User time (seconds): 0.33
        System time (seconds): 0.24
        Percent of CPU this job got: 79%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.73
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 338328
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 5174
        Voluntary context switches: 7363
        Involuntary context switches: 1172
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0


after this pr

        Command being timed: "./ctr_new -n k8s.io c ls"
        User time (seconds): 0.47
        System time (seconds): 0.20
        Percent of CPU this job got: 79%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.85
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 45556
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 1
        Minor (reclaiming a frame) page faults: 24264
        Voluntary context switches: 8915
        Involuntary context switches: 1998
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0


 Maximum resident set size from  338328 reduce to  45556

@fuweid  @mikebrow  @mxpv @AkihiroSuda 
