### PR TITLE
fsverity: add missing file descriptor close in Enable() preventing fsverity from being enabled

### DIFF
--- a/internal/fsverity/fsverity_linux.go
+++ b/internal/fsverity/fsverity_linux.go
@@ -99,6 +99,7 @@ func Enable(path string) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	var args = &fsverityEnableArg{}
 	args.version = 1


### PR DESCRIPTION
Adds missing file descriptor close in `fsverity.Enable()` that prevented fsverity from being properly enabled.

The `Enable()` function calls `FS_IOC_ENABLE_VERITY` but never closes the file descriptor. The filesystem requires the descriptor to be closed to finalize the state transition. Without this, the `FS_VERITY_FL` flag remains unset and subsequent `FS_IOC_MEASURE_VERITY` calls fail with `ENODATA`.

Adding `defer f.Close()` ensures proper cleanup and allows fsverity to activate successfully.