### PR TITLE
ci: set fetch-depth for containerd to 0 for version parsing

### DIFF
--- a/.github/workflows/node-e2e.yml
+++ b/.github/workflows/node-e2e.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: src/github.com/containerd/containerd
+          fetch-depth: 0
 
       - name: Checkout Kubernetes
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
image volume e2e tests in k/k uses containerd version to trigger tests for some features. ref: https://github.com/kubernetes/kubernetes/blob/bfafa32d90958a8fe7a2ce09ed553fdfef4edd98/test/e2e_node/image_volume.go#L64

The current CI builds have only the SHA as the version in the node e2e tests since the tags are not present. setting fetch-depth makes sure the tags are present and will be used while testing.

The issue occured now because as part of https://github.com/kubernetes/kubernetes/pull/136530, the ImageVolume feature now started testing in the github actions e2e node tests. 