### PR TITLE
ci: add retry logic for Fedora Vagrant box download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,7 +642,13 @@ jobs:
         run: |
           if  [ "$BOX" = "fedora/43-cloud-base" ]; then
             # fedora/41-cloud-base seems the last version available in https://portal.cloud.hashicorp.com/vagrant/discover/fedora
-            sudo vagrant box add fedora/43-cloud-base https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-43-1.6.x86_64.vagrant.libvirt.box
+            # Download the box file with curl (with retry) to handle flaky Fedora mirrors
+            curl -fL --retry 5 --retry-delay 5 --retry-all-errors \
+              --connect-timeout 30 --max-time 600 \
+              -o /tmp/fedora43.box \
+              https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-43-1.6.x86_64.vagrant.libvirt.box
+            sudo vagrant box add fedora/43-cloud-base /tmp/fedora43.box
+            rm -f /tmp/fedora43.box
           fi
           sudo BOX=$BOX RUNC_FLAVOR=$RUNC_FLAVOR vagrant up --no-tty
       - name: test-integration


### PR DESCRIPTION
The Fedora mirror can be flaky, causing 'Connection reset by peer' errors during the Vagrant box download. This change downloads the box file using curl with retry options before adding it to Vagrant:

- --retry 5: Retry up to 5 times on transient failures
- --retry-delay 5: Wait 5 seconds between retries
- --retry-all-errors: Retry on all errors including connection resets
- --connect-timeout 30: Fail if can't connect within 30 seconds
- --max-time 600: 10 minute max for the entire download

For example: https://github.com/containerd/containerd/actions/runs/21649195581/job/62409345138?pr=12502