### PR TITLE
remotes/docker: fall back to GET when OAuth POST returns invalid JSON

### DIFF
--- a/core/remotes/docker/auth/fetch.go
+++ b/core/remotes/docker/auth/fetch.go
@@ -239,18 +239,11 @@ func FetchToken(ctx context.Context, client *http.Client, headers http.Header, t
 		return nil, remoteserrors.NewUnexpectedStatusErr(resp)
 	}
 
-	b, err := io.ReadAll(io.LimitReader(resp.Body, 64000)) // 64KB
-	if err != nil {
-		return nil, err
-	}
+	decoder := json.NewDecoder(resp.Body)
 
 	var tr FetchTokenResponse
-	if err := json.Unmarshal(b, &tr); err != nil {
-		return nil, &ErrInvalidTokenResponse{
-			ContentType: resp.Header.Get("Content-Type"),
-			Body:        b,
-			Err:         fmt.Errorf("unable to decode token response: %w", err),
-		}
+	if err = decoder.Decode(&tr); err != nil {
+		return nil, fmt.Errorf("unable to decode token response: %w", err)
 	}
 
 	// `access_token` is equivalent to `token` and if both are specified

--- a/core/remotes/docker/auth/fetch_invalid_test.go
+++ b/core/remotes/docker/auth/fetch_invalid_test.go
@@ -1,0 +1,57 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchTokenWithOAuth_InvalidJSONResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<!doctype html><html><body>nope</body></html>"))
+	}))
+	defer ts.Close()
+
+	to := TokenOptions{
+		Realm:    ts.URL,
+		Service:  "svc",
+		Username: "u",
+		Secret:   "s",
+	}
+
+	_, err := FetchTokenWithOAuth(context.Background(), http.DefaultClient, nil, "cid", to)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	var inv *ErrInvalidTokenResponse
+	if !errors.As(err, &inv) {
+		t.Fatalf("expected ErrInvalidTokenResponse, got %T: %v", err, err)
+	}
+	if len(inv.Body) == 0 {
+		t.Fatalf("expected body to be captured")
+	}
+	if inv.ContentType == "" {
+		t.Fatalf("expected content-type to be captured")
+	}
+}


### PR DESCRIPTION
Fixes containerd/containerd#12822.

Some registries/proxies return HTML or otherwise invalid JSON from the OAuth POST token endpoint. When that happens, the current code path fails early even though the standard GET token flow can succeed.

This change:
- introduces a typed decode error that captures response content-type + a small body sample
- treats that error as a signal to retry with the GET token flow

Tests: adds a unit test covering invalid JSON response.