### PR TITLE
chore: Add explicit digest requirement to docker pusher

### DIFF
--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -60,6 +60,12 @@ func (p dockerPusher) Writer(ctx context.Context, opts ...content.WriterOpt) (co
 	if wOpts.Ref == "" {
 		return nil, fmt.Errorf("ref must not be empty: %w", errdefs.ErrInvalidArgument)
 	}
+	if wOpts.Desc.Digest == "" {
+		return nil, fmt.Errorf("descriptor digest must not be empty: %w", errdefs.ErrInvalidArgument)
+	}
+	if wOpts.Desc.MediaType == "" {
+		return nil, fmt.Errorf("descriptor media type must not be empty: %w", errdefs.ErrInvalidArgument)
+	}
 	return p.push(ctx, wOpts.Desc, wOpts.Ref, true)
 }
 


### PR DESCRIPTION
The `push` function below assumes that digest and mediatypes are populated and set. If they aren't, then the requests made are malformed, attempting to invoke `HEAD /blobs/` (instead of `HEAD /blobs/<digest>`). Additionally, if we *were* to move past this point, we'd then populate an empty digest in the query parameter, and even provide invalid HTTP mediatypes.

However, the `WithDescriptor` `WriterOpt` specifically notes that "Write does not require any field of desc to be set". It's very easy for the caller to read this as an optional field, to skip it, and then get confusing HTTP errors from inside the `push` function.

We can avoid this by explicitly validating that the descriptor is valid and provide early feedback.

I think there's no valid case where this should have worked? This seems to have been introduced when this API was first implemented by the docker pusher in https://github.com/containerd/containerd/pull/5379.