### PR TITLE
[DNM: just a quick write-up]: client: remoteContainers: add ListIter for streaming

### DIFF
--- a/core/containers/containers.go
+++ b/core/containers/containers.go
@@ -18,6 +18,7 @@ package containers
 
 import (
 	"context"
+	"iter"
 	"time"
 
 	"github.com/containerd/typeurl/v2"
@@ -114,4 +115,10 @@ type Store interface {
 	// nil will be returned on success. If the container is not known to the
 	// store, ErrNotFound will be returned.
 	Delete(ctx context.Context, id string) error
+}
+
+type IterStore interface {
+	// ListIter streams containers from the server.
+	// It yields (Container{}, errStreamNotAvailable) if the server does not implement streaming.
+	ListIter(context.Context, ...string) iter.Seq2[Container, error]
 }


### PR DESCRIPTION
- relates to / possible alternative to https://github.com/containerd/containerd/pull/12846

⚠️ just a quick write-up; not tested 😂 

edit: Did some very basic testing, just creating 300 containers, then trying, and it looks like `--stream` is faster, but don't see memory differences at a glance;

```bash
ctr images pull docker.io/library/nginx:alpine

for i in $(seq -w 1 300); do ctr run -d docker.io/library/nginx:alpine nginx-$i; done

ctr c ls | wc -l
301
```

```bash
/usr/bin/time -v ctr c ls > /dev/null
	Command being timed: "ctr c ls"
	User time (seconds): 0.01
	System time (seconds): 0.04
	Percent of CPU this job got: 82%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.06
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 27468
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 1534
	Voluntary context switches: 159
	Involuntary context switches: 1
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0

/usr/bin/time -v ctr c ls --stream > /dev/null
	Command being timed: "ctr c ls --stream"
	User time (seconds): 0.00
	System time (seconds): 0.01
	Percent of CPU this job got: 96%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.02
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 27496
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 1550
	Voluntary context switches: 119
	Involuntary context switches: 0
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

