### PR TITLE
Add environment variable support to BinaryIO logging

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/io_util_test.go
+++ b/cmd/containerd-shim-runc-v2/process/io_util_test.go
@@ -1,0 +1,135 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertArgPair checks that a key-value pair exists in the command args.
+// Args are expected as consecutive elements: [cmd, key, value, key, value, ...].
+func assertArgPair(t *testing.T, args []string, key, value string) {
+	t.Helper()
+	for i := 1; i < len(args)-1; i++ {
+		if args[i] == key {
+			assert.Equal(t, value, args[i+1], "arg value mismatch for key %q", key)
+			return
+		}
+	}
+	t.Errorf("expected arg key %q not found in args %v", key, args)
+}
+
+func TestNewBinaryCmd(t *testing.T) {
+	testCases := []struct {
+		name        string
+		uri         string
+		id          string
+		ns          string
+		wantArgs    []string
+		wantEnvs    []string
+		wantEnvsNot []string
+	}{
+		{
+			name:     "args only",
+			uri:      "binary:///bin/logger?id=container1",
+			id:       "test-id",
+			ns:       "test-ns",
+			wantArgs: []string{"id", "container1"},
+		},
+		{
+			name:     "envs only",
+			uri:      "binary:///bin/logger?env.LOG_LEVEL=debug&env.API_KEY=secret",
+			id:       "test-id",
+			ns:       "test-ns",
+			wantArgs: []string{},
+			wantEnvs: []string{"LOG_LEVEL=debug", "API_KEY=secret"},
+		},
+		{
+			name:     "mixed args and envs",
+			uri:      "binary:///bin/logger?id=container1&env.LOG_LEVEL=debug",
+			id:       "test-id",
+			ns:       "test-ns",
+			wantArgs: []string{"id", "container1"},
+			wantEnvs: []string{"LOG_LEVEL=debug"},
+		},
+		{
+			name:        "cannot override CONTAINER_ID",
+			uri:         "binary:///bin/logger?env.CONTAINER_ID=custom-id",
+			id:          "test-id",
+			ns:          "test-ns",
+			wantArgs:    []string{},
+			wantEnvsNot: []string{"CONTAINER_ID=custom-id"},
+		},
+		{
+			name:        "cannot override CONTAINER_NAMESPACE",
+			uri:         "binary:///bin/logger?env.CONTAINER_NAMESPACE=custom-ns",
+			id:          "test-id",
+			ns:          "test-ns",
+			wantArgs:    []string{},
+			wantEnvsNot: []string{"CONTAINER_NAMESPACE=custom-ns"},
+		},
+		{
+			name:     "no query params",
+			uri:      "binary:///bin/logger",
+			id:       "test-id",
+			ns:       "test-ns",
+			wantArgs: []string{},
+		},
+		{
+			name:     "empty env value",
+			uri:      "binary:///bin/logger?env.EMPTY_VAR=",
+			id:       "test-id",
+			ns:       "test-ns",
+			wantArgs: []string{},
+			wantEnvs: []string{"EMPTY_VAR="},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := url.Parse(tc.uri)
+			require.NoError(t, err)
+
+			cmd := NewBinaryCmd(parsed, tc.id, tc.ns)
+
+			assert.Equal(t, "/bin/logger", cmd.Path)
+
+			// Check args (order may vary due to map iteration).
+			for i := 0; i < len(tc.wantArgs); i += 2 {
+				assertArgPair(t, cmd.Args, tc.wantArgs[i], tc.wantArgs[i+1])
+			}
+
+			// CONTAINER_ID and CONTAINER_NAMESPACE are always set from the provided id/ns.
+			assert.Contains(t, cmd.Env, "CONTAINER_ID="+tc.id)
+			assert.Contains(t, cmd.Env, "CONTAINER_NAMESPACE="+tc.ns)
+
+			// Check expected envs are present.
+			for _, env := range tc.wantEnvs {
+				assert.Contains(t, cmd.Env, env, "expected env %q not found", env)
+			}
+
+			// Check unwanted envs are not present.
+			for _, env := range tc.wantEnvsNot {
+				assert.NotContains(t, cmd.Env, env, "unexpected env %q found", env)
+			}
+		})
+	}
+}

--- a/pkg/cio/io.go
+++ b/pkg/cio/io.go
@@ -253,7 +253,17 @@ func LogURI(uri *url.URL) Creator {
 	}
 }
 
-// BinaryIO forwards container STDOUT|STDERR directly to a logging binary
+// BinaryIO forwards container STDOUT|STDERR directly to a logging binary.
+// The args map is converted to URI query parameters. Keys with the "env."
+// prefix are set as environment variables for the logging binary (with the
+// prefix stripped), while other keys become command-line arguments.
+//
+// Example:
+//
+//	BinaryIO("/usr/bin/logger", map[string]string{
+//	    "id":            "container1",  // CLI arg
+//	    "env.LOG_LEVEL": "debug",       // env var LOG_LEVEL=debug
+//	})
 func BinaryIO(binary string, args map[string]string) Creator {
 	return func(_ string) (IO, error) {
 		uri, err := LogURIGenerator("binary", binary, args)
@@ -291,6 +301,8 @@ func LogFile(path string) Creator {
 }
 
 // LogURIGenerator is the helper to generate log uri with specific scheme.
+// Args with the "env." prefix are passed through as-is and will be interpreted
+// as environment variables by the shim.
 func LogURIGenerator(scheme string, path string, args map[string]string) (*url.URL, error) {
 	path = filepath.Clean(path)
 	if !filepath.IsAbs(path) {

--- a/pkg/cio/io_unix.go
+++ b/pkg/cio/io_unix.go
@@ -174,8 +174,11 @@ func TerminalLogURI(uri *url.URL) Creator {
 	}
 }
 
-// TerminalBinaryIO forwards container STDOUT|STDERR directly to a logging binary
-// It also sets the terminal option to true
+// TerminalBinaryIO forwards container STDOUT|STDERR directly to a logging binary.
+// It also sets the terminal option to true.
+// The args map is converted to URI query parameters. Keys with the "env."
+// prefix are set as environment variables for the logging binary (with the
+// prefix stripped), while other keys become command-line arguments.
 func TerminalBinaryIO(binary string, args map[string]string) Creator {
 	return func(_ string) (IO, error) {
 		uri, err := LogURIGenerator("binary", binary, args)

--- a/pkg/cio/io_unix_test.go
+++ b/pkg/cio/io_unix_test.go
@@ -299,5 +299,28 @@ func TestLogURIGenerator(t *testing.T) {
 			// NOTE: Windows paths should not be parse-able outside of Windows:
 			err: "must be absolute",
 		},
+		{
+			scheme: "binary",
+			path:   "/full/path/bin",
+			args: map[string]string{
+				"env.LOG_LEVEL": "debug",
+			},
+			expected: "binary:///full/path/bin?env.LOG_LEVEL=debug",
+		},
+		{
+			scheme: "binary",
+			path:   "/full/path/bin",
+			args: map[string]string{
+				"id":         "testing",
+				"env.SECRET": "mysecret",
+			},
+			expected: "binary:///full/path/bin?env.SECRET=mysecret&id=testing",
+		},
+		{
+			scheme:   "binary",
+			path:     "/full/path/bin",
+			args:     map[string]string{},
+			expected: "binary:///full/path/bin",
+		},
 	})
 }

--- a/pkg/cio/io_windows.go
+++ b/pkg/cio/io_windows.go
@@ -174,8 +174,11 @@ func TerminalLogURI(uri *url.URL) Creator {
 	}
 }
 
-// TerminalBinaryIO forwards container STDOUT|STDERR directly to a logging binary
-// It also sets the terminal option to true
+// TerminalBinaryIO forwards container STDOUT|STDERR directly to a logging binary.
+// It also sets the terminal option to true.
+// The args map is converted to URI query parameters. Keys with the "env."
+// prefix are set as environment variables for the logging binary (with the
+// prefix stripped), while other keys become command-line arguments.
 func TerminalBinaryIO(binary string, args map[string]string) Creator {
 	return func(_ string) (IO, error) {
 		uri, err := LogURIGenerator("binary", binary, args)


### PR DESCRIPTION
This change adds support for passing environment variables to logging binaries when using BinaryIO and TerminalBinaryIO.

### Problem

Currently, BinaryIO only supports passing configuration to logging binaries via command-line arguments. Some logging integrations (e.g., https://github.com/aws/shim-loggers-for-containerd/pull/389) support passing sensitive values like tokens via environment variables.



### Solution

Query parameters with the env. prefix are now set as environment variables for the logging binary (with the prefix stripped), while other parameters continue to be passed as command-line arguments.

Example usage:
```
BinaryIO("/usr/bin/logger", map[string]string{
    "id":            "container1",  // CLI arg: --id container1
    "env.LOG_LEVEL": "debug",       // env var: LOG_LEVEL=debug
    "env.API_TOKEN": "secret",      // env var: API_TOKEN=secret
})
```