### PR TITLE
Makefile: extract "-X" options to a separate var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,13 +102,18 @@ SHIM_GO_BUILDTAGS := $(GO_BUILDTAGS) no_grpc
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(strip $(GO_BUILDTAGS))",)
 SHIM_GO_TAGS=$(if $(SHIM_GO_BUILDTAGS),-tags "$(strip $(SHIM_GO_BUILDTAGS))",)
 
-GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)
+GO_LD_X = \
+	-X $(PKG)/version.Version=$(VERSION) \
+	-X $(PKG)/version.Revision=$(REVISION) \
+	-X $(PKG)/version.Package=$(PACKAGE)
+
+GO_LDFLAGS=-ldflags '$(GO_LD_X) $(EXTRA_LDFLAGS)
 ifneq ($(STATIC),)
 	GO_LDFLAGS += -extldflags "-static"
 endif
 GO_LDFLAGS+='
 
-SHIM_GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) -extldflags "-static" $(EXTRA_LDFLAGS)'
+SHIM_GO_LDFLAGS=-ldflags '$(GO_LD_X) -extldflags "-static" $(EXTRA_LDFLAGS)'
 
 # Project packages.
 PACKAGES := $(shell $(GO) list ${GO_TAGS} ./... | grep -v /integration)


### PR DESCRIPTION
- relates to / extracted from https://github.com/containerd/containerd/pull/10622#discussion_r2777411056

With this PR:


```bash
make VERSION=v7.8.9 REVISION=deadbeef PACKAGE=hello-world binaries install
# go build  -gcflags=-trimpath=/go/src -buildmode=pie  -o bin/ctr -ldflags '-X github.com/containerd/containerd/v2/version.Version=v7.8.9 -X github.com/containerd/containerd/v2/version.Revision=deadbeef -X github.com/containerd/containerd/v2/version.Package=hello-world -s -w ' -tags "urfave_cli_no_docs"  ./cmd/ctr

ctr --version
ctr hello-world v7.8.9

containerd --version
containerd hello-world v7.8.9 deadbeef

containerd-shim-runc-v2 -v
containerd-shim-runc-v2:
  Version:  v7.8.9
  Revision: deadbeef
  Go version: go1.24.12
```