### PR TITLE
Support custom env variables for logging binary

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/io_util.go
+++ b/cmd/containerd-shim-runc-v2/process/io_util.go
@@ -20,17 +20,31 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strings"
 )
 
+const envPrefix = "env."
+
 // NewBinaryCmd returns a Cmd to be used to start a logging binary.
-// The Cmd is generated from the provided uri, and the container ID and
-// namespace are appended to the Cmd environment.
+// The Cmd is generated from the provided uri. Query parameters with the
+// "env." prefix are interpreted as environment variables (prefix stripped)
+// and appended to the Cmd environment with the container ID and namespace.
+// Other query parameters are passed as args.
 func NewBinaryCmd(binaryURI *url.URL, id, ns string) *exec.Cmd {
 	var args []string
+	envs := make(map[string]string)
+
 	for k, vs := range binaryURI.Query() {
-		args = append(args, k)
-		if len(vs) > 0 {
-			args = append(args, vs[0])
+		if strings.HasPrefix(k, envPrefix) {
+			envKey := strings.TrimPrefix(k, envPrefix)
+			if len(vs) > 0 {
+				envs[envKey] = vs[0]
+			}
+		} else {
+			args = append(args, k)
+			if len(vs) > 0 {
+				args = append(args, vs[0])
+			}
 		}
 	}
 
@@ -40,6 +54,13 @@ func NewBinaryCmd(binaryURI *url.URL, id, ns string) *exec.Cmd {
 		"CONTAINER_ID="+id,
 		"CONTAINER_NAMESPACE="+ns,
 	)
+
+	for k, v := range envs {
+		if k == "CONTAINER_ID" || k == "CONTAINER_NAMESPACE" {
+			continue
+		}
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
 
 	return cmd
 }

--- a/cmd/containerd-shim-runc-v2/process/io_util_test.go
+++ b/cmd/containerd-shim-runc-v2/process/io_util_test.go
@@ -57,25 +57,25 @@ func TestNewBinaryCmd(t *testing.T) {
 		},
 		{
 			name:     "envs only",
-			uri:      "binary:///bin/logger?env.LOG_LEVEL=debug&env.API_KEY=secret",
+			uri:      "binary:///bin/logger#LOG_LEVEL=debug&API_KEY=secret",
 			wantArgs: []string{},
 			wantEnvs: []string{"LOG_LEVEL=debug", "API_KEY=secret"},
 		},
 		{
 			name:     "mixed args and envs",
-			uri:      "binary:///bin/logger?id=container1&env.LOG_LEVEL=debug",
+			uri:      "binary:///bin/logger?id=container1#LOG_LEVEL=debug",
 			wantArgs: []string{"id", "container1"},
 			wantEnvs: []string{"LOG_LEVEL=debug"},
 		},
 		{
 			name:        "cannot override CONTAINER_ID",
-			uri:         "binary:///bin/logger?env.CONTAINER_ID=custom-id",
+			uri:         "binary:///bin/logger#CONTAINER_ID=custom-id",
 			wantArgs:    []string{},
 			wantEnvsNot: []string{"CONTAINER_ID=custom-id"},
 		},
 		{
 			name:        "cannot override CONTAINER_NAMESPACE",
-			uri:         "binary:///bin/logger?env.CONTAINER_NAMESPACE=custom-ns",
+			uri:         "binary:///bin/logger#CONTAINER_NAMESPACE=custom-ns",
 			wantArgs:    []string{},
 			wantEnvsNot: []string{"CONTAINER_NAMESPACE=custom-ns"},
 		},
@@ -86,7 +86,7 @@ func TestNewBinaryCmd(t *testing.T) {
 		},
 		{
 			name:     "empty env value",
-			uri:      "binary:///bin/logger?env.EMPTY_VAR=",
+			uri:      "binary:///bin/logger#EMPTY_VAR=",
 			wantArgs: []string{},
 			wantEnvs: []string{"EMPTY_VAR="},
 		},

--- a/cmd/containerd-shim-runc-v2/process/io_util_test.go
+++ b/cmd/containerd-shim-runc-v2/process/io_util_test.go
@@ -1,0 +1,124 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertArgPair checks that a key-value pair exists in the command args.
+// Args are expected as consecutive elements: [cmd, key, value, key, value, ...].
+func assertArgPair(t *testing.T, args []string, key, value string) {
+	t.Helper()
+	for i := 1; i < len(args)-1; i++ {
+		if args[i] == key {
+			assert.Equal(t, value, args[i+1], "arg value mismatch for key %q", key)
+			return
+		}
+	}
+	t.Errorf("expected arg key %q not found in args %v", key, args)
+}
+
+func TestNewBinaryCmd(t *testing.T) {
+	const (
+		testID = "test-id"
+		testNS = "test-ns"
+	)
+
+	testCases := []struct {
+		name        string
+		uri         string
+		wantArgs    []string
+		wantEnvs    []string
+		wantEnvsNot []string
+	}{
+		{
+			name:     "args only",
+			uri:      "binary:///bin/logger?id=container1",
+			wantArgs: []string{"id", "container1"},
+		},
+		{
+			name:     "envs only",
+			uri:      "binary:///bin/logger?env.LOG_LEVEL=debug&env.API_KEY=secret",
+			wantArgs: []string{},
+			wantEnvs: []string{"LOG_LEVEL=debug", "API_KEY=secret"},
+		},
+		{
+			name:     "mixed args and envs",
+			uri:      "binary:///bin/logger?id=container1&env.LOG_LEVEL=debug",
+			wantArgs: []string{"id", "container1"},
+			wantEnvs: []string{"LOG_LEVEL=debug"},
+		},
+		{
+			name:        "cannot override CONTAINER_ID",
+			uri:         "binary:///bin/logger?env.CONTAINER_ID=custom-id",
+			wantArgs:    []string{},
+			wantEnvsNot: []string{"CONTAINER_ID=custom-id"},
+		},
+		{
+			name:        "cannot override CONTAINER_NAMESPACE",
+			uri:         "binary:///bin/logger?env.CONTAINER_NAMESPACE=custom-ns",
+			wantArgs:    []string{},
+			wantEnvsNot: []string{"CONTAINER_NAMESPACE=custom-ns"},
+		},
+		{
+			name:     "no query params",
+			uri:      "binary:///bin/logger",
+			wantArgs: []string{},
+		},
+		{
+			name:     "empty env value",
+			uri:      "binary:///bin/logger?env.EMPTY_VAR=",
+			wantArgs: []string{},
+			wantEnvs: []string{"EMPTY_VAR="},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := url.Parse(tc.uri)
+			require.NoError(t, err)
+
+			cmd := NewBinaryCmd(parsed, testID, testNS)
+
+			assert.Equal(t, "/bin/logger", cmd.Path)
+
+			// Check args (order may vary due to map iteration).
+			for i := 0; i < len(tc.wantArgs); i += 2 {
+				assertArgPair(t, cmd.Args, tc.wantArgs[i], tc.wantArgs[i+1])
+			}
+
+			// CONTAINER_ID and CONTAINER_NAMESPACE are always set from the provided id/ns.
+			assert.Contains(t, cmd.Env, "CONTAINER_ID="+testID)
+			assert.Contains(t, cmd.Env, "CONTAINER_NAMESPACE="+testNS)
+
+			// Check expected envs are present.
+			for _, env := range tc.wantEnvs {
+				assert.Contains(t, cmd.Env, env, "expected env %q not found", env)
+			}
+
+			// Check unwanted envs are not present.
+			for _, env := range tc.wantEnvsNot {
+				assert.NotContains(t, cmd.Env, env, "unexpected env %q found", env)
+			}
+		})
+	}
+}

--- a/cmd/containerd-shim-runc-v2/process/io_util_test.go
+++ b/cmd/containerd-shim-runc-v2/process/io_util_test.go
@@ -57,9 +57,9 @@ func TestNewBinaryCmd(t *testing.T) {
 		},
 		{
 			name:     "envs only",
-			uri:      "binary:///bin/logger#LOG_LEVEL=debug&API_KEY=secret",
+			uri:      "binary:///bin/logger#LOG_LEVEL=debug&LOG_FORMAT=json",
 			wantArgs: []string{},
-			wantEnvs: []string{"LOG_LEVEL=debug", "API_KEY=secret"},
+			wantEnvs: []string{"LOG_LEVEL=debug", "LOG_FORMAT=json"},
 		},
 		{
 			name:     "mixed args and envs",

--- a/pkg/cio/io.go
+++ b/pkg/cio/io.go
@@ -253,7 +253,16 @@ func LogURI(uri *url.URL) Creator {
 	}
 }
 
-// BinaryIO forwards container STDOUT|STDERR directly to a logging binary
+// BinaryIO forwards container STDOUT|STDERR directly to a logging binary.
+// Keys in the args map with the "env." prefix become environment variables
+// (with the prefix stripped), while other keys become command-line arguments.
+//
+// Example:
+//
+//	BinaryIO("/usr/bin/logger", map[string]string{
+//	    "format":        "json",   // arg: --format json
+//	    "env.LOG_LEVEL": "debug",  // env var: LOG_LEVEL=debug
+//	})
 func BinaryIO(binary string, args map[string]string) Creator {
 	return func(_ string) (IO, error) {
 		uri, err := LogURIGenerator("binary", binary, args)
@@ -291,6 +300,8 @@ func LogFile(path string) Creator {
 }
 
 // LogURIGenerator is the helper to generate log uri with specific scheme.
+// Args with the "env." prefix are passed through as-is and will be interpreted
+// as environment variables by the shim.
 func LogURIGenerator(scheme string, path string, args map[string]string) (*url.URL, error) {
 	path = filepath.Clean(path)
 	if !filepath.IsAbs(path) {

--- a/pkg/cio/io_test.go
+++ b/pkg/cio/io_test.go
@@ -88,14 +88,14 @@ func TestBinaryIOWithEnvs(t *testing.T) {
 			name:   "args and envs combined",
 			binary: prefix + "/usr/bin/logger",
 			args:   map[string]string{"id": "container1"},
-			opts:   []BinaryIOOpt{WithBinaryIOEnv(map[string]string{"API_KEY": "secret"})},
+			opts:   []BinaryIOOpt{WithBinaryIOEnv(map[string]string{"LOG_FORMAT": "json"})},
 			checkURI: func(t *testing.T, uri string) {
 				parsed, err := url.Parse(uri)
 				require.NoError(t, err)
 				assert.Equal(t, "container1", parsed.Query().Get("id"))
 				envs, err := url.ParseQuery(parsed.Fragment)
 				require.NoError(t, err)
-				assert.Equal(t, "secret", envs.Get("API_KEY"))
+				assert.Equal(t, "json", envs.Get("LOG_FORMAT"))
 			},
 		},
 		{

--- a/pkg/cio/io_unix.go
+++ b/pkg/cio/io_unix.go
@@ -176,11 +176,14 @@ func TerminalLogURI(uri *url.URL) Creator {
 
 // TerminalBinaryIO forwards container STDOUT|STDERR directly to a logging binary
 // and sets the terminal option to true.
-// Keys in the args map with the "env." prefix become environment variables
-// (with the prefix stripped), while other keys become command-line arguments.
-func TerminalBinaryIO(binary string, args map[string]string) Creator {
+func TerminalBinaryIO(binary string, args map[string]string, opts ...BinaryIOOpt) Creator {
+	cfg := &binaryIOConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	return func(_ string) (IO, error) {
-		uri, err := LogURIGenerator("binary", binary, args)
+		uri, err := logURIGeneratorWithEnv("binary", binary, args, cfg.env)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cio/io_unix.go
+++ b/pkg/cio/io_unix.go
@@ -175,7 +175,9 @@ func TerminalLogURI(uri *url.URL) Creator {
 }
 
 // TerminalBinaryIO forwards container STDOUT|STDERR directly to a logging binary
-// It also sets the terminal option to true
+// and sets the terminal option to true.
+// Keys in the args map with the "env." prefix become environment variables
+// (with the prefix stripped), while other keys become command-line arguments.
 func TerminalBinaryIO(binary string, args map[string]string) Creator {
 	return func(_ string) (IO, error) {
 		uri, err := LogURIGenerator("binary", binary, args)

--- a/pkg/cio/io_unix_test.go
+++ b/pkg/cio/io_unix_test.go
@@ -299,5 +299,28 @@ func TestLogURIGenerator(t *testing.T) {
 			// NOTE: Windows paths should not be parse-able outside of Windows:
 			err: "must be absolute",
 		},
+		{
+			scheme: "binary",
+			path:   "/full/path/bin",
+			args: map[string]string{
+				"env.LOG_LEVEL": "debug",
+			},
+			expected: "binary:///full/path/bin?env.LOG_LEVEL=debug",
+		},
+		{
+			scheme: "binary",
+			path:   "/full/path/bin",
+			args: map[string]string{
+				"id":         "testing",
+				"env.SECRET": "mysecret",
+			},
+			expected: "binary:///full/path/bin?env.SECRET=mysecret&id=testing",
+		},
+		{
+			scheme:   "binary",
+			path:     "/full/path/bin",
+			args:     map[string]string{},
+			expected: "binary:///full/path/bin",
+		},
 	})
 }

--- a/pkg/cio/io_unix_test.go
+++ b/pkg/cio/io_unix_test.go
@@ -300,27 +300,38 @@ func TestLogURIGenerator(t *testing.T) {
 			err: "must be absolute",
 		},
 		{
-			scheme: "binary",
-			path:   "/full/path/bin",
-			args: map[string]string{
-				"env.LOG_LEVEL": "debug",
-			},
-			expected: "binary:///full/path/bin?env.LOG_LEVEL=debug",
-		},
-		{
-			scheme: "binary",
-			path:   "/full/path/bin",
-			args: map[string]string{
-				"id":         "testing",
-				"env.SECRET": "mysecret",
-			},
-			expected: "binary:///full/path/bin?env.SECRET=mysecret&id=testing",
-		},
-		{
 			scheme:   "binary",
 			path:     "/full/path/bin",
 			args:     map[string]string{},
 			expected: "binary:///full/path/bin",
+		},
+		{
+			scheme: "binary",
+			path:   "/full/path/bin",
+			envs: map[string]string{
+				"LOG_LEVEL": "debug",
+			},
+			expected: "binary:///full/path/bin#LOG_LEVEL=debug",
+		},
+		{
+			scheme: "binary",
+			path:   "/full/path/bin",
+			args: map[string]string{
+				"id": "testing",
+			},
+			envs: map[string]string{
+				"SECRET": "mysecret",
+			},
+			expected: "binary:///full/path/bin?id=testing#SECRET=mysecret",
+		},
+		{
+			scheme: "binary",
+			path:   "/full/path/bin",
+			envs: map[string]string{
+				"KEY1": "value1",
+				"KEY2": "value2",
+			},
+			expected: "binary:///full/path/bin#KEY1=value1&KEY2=value2",
 		},
 	})
 }

--- a/pkg/cio/io_unix_test.go
+++ b/pkg/cio/io_unix_test.go
@@ -320,9 +320,9 @@ func TestLogURIGenerator(t *testing.T) {
 				"id": "testing",
 			},
 			envs: map[string]string{
-				"SECRET": "mysecret",
+				"LOG_FORMAT": "json",
 			},
-			expected: "binary:///full/path/bin?id=testing#SECRET=mysecret",
+			expected: "binary:///full/path/bin?id=testing#LOG_FORMAT=json",
 		},
 		{
 			scheme: "binary",

--- a/pkg/cio/io_windows.go
+++ b/pkg/cio/io_windows.go
@@ -176,11 +176,14 @@ func TerminalLogURI(uri *url.URL) Creator {
 
 // TerminalBinaryIO forwards container STDOUT|STDERR directly to a logging binary
 // and sets the terminal option to true.
-// Keys in the args map with the "env." prefix become environment variables
-// (with the prefix stripped), while other keys become command-line arguments.
-func TerminalBinaryIO(binary string, args map[string]string) Creator {
+func TerminalBinaryIO(binary string, args map[string]string, opts ...BinaryIOOpt) Creator {
+	cfg := &binaryIOConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	return func(_ string) (IO, error) {
-		uri, err := LogURIGenerator("binary", binary, args)
+		uri, err := logURIGeneratorWithEnv("binary", binary, args, cfg.env)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cio/io_windows.go
+++ b/pkg/cio/io_windows.go
@@ -175,7 +175,9 @@ func TerminalLogURI(uri *url.URL) Creator {
 }
 
 // TerminalBinaryIO forwards container STDOUT|STDERR directly to a logging binary
-// It also sets the terminal option to true
+// and sets the terminal option to true.
+// Keys in the args map with the "env." prefix become environment variables
+// (with the prefix stripped), while other keys become command-line arguments.
 func TerminalBinaryIO(binary string, args map[string]string) Creator {
 	return func(_ string) (IO, error) {
 		uri, err := LogURIGenerator("binary", binary, args)


### PR DESCRIPTION
This change adds support for setting environment variables for the logger binary.

### Problem https://github.com/containerd/containerd/issues/12760

When configuring container IO to forward to a logger binary, BinaryIO accepts a string map which will be passed to the binary as command line arguments in the format "--key value". This does not provide a way to set env variables.

### Solution
This change adds support for setting environment variables. Keys prefixed with "env." will be appended to the Cmd environment, while all others default to args (current behavior).

Example usage:
```
// This will append "LOG_LEVEL=debug" to the Cmd env when invoking /usr/bin/logger,
// with the arg "--format json".
BinaryIO("/usr/bin/logger", map[string]string{
    "format":        "json",
    "env.LOG_LEVEL": "debug",
})
```
