### PR TITLE
client: add InfoWithRefresh interface

### DIFF
--- a/client/container.go
+++ b/client/container.go
@@ -53,6 +53,8 @@ type Container interface {
 	ID() string
 	// Info returns the underlying container record type
 	Info(context.Context, ...InfoOpts) (containers.Container, error)
+	// InfoWithRefresh returns the underlying container record type
+	InfoWithRefresh(context.Context, bool, ...InfoOpts) (containers.Container, error)
 	// Delete removes the container
 	Delete(context.Context, ...DeleteOpts) error
 	// NewTask creates a new task based on the container metadata
@@ -111,9 +113,12 @@ func (c *container) ID() string {
 }
 
 func (c *container) Info(ctx context.Context, opts ...InfoOpts) (containers.Container, error) {
+	return c.InfoWithRefresh(ctx, true, opts...)
+}
+
+func (c *container) InfoWithRefresh(ctx context.Context, Refresh bool, opts ...InfoOpts) (containers.Container, error) {
 	i := &InfoConfig{
-		// default to refreshing the container's local metadata
-		Refresh: true,
+		Refresh: Refresh,
 	}
 	for _, o := range opts {
 		o(i)

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -125,7 +125,7 @@ var listCommand = &cli.Command{
 		w := tabwriter.NewWriter(os.Stdout, 4, 8, 4, ' ', 0)
 		fmt.Fprintln(w, "CONTAINER\tIMAGE\tRUNTIME\t")
 		for _, c := range containers {
-			info, err := c.Info(ctx, containerd.WithoutRefreshedMetadata)
+			info, err := c.InfoWithRefresh(ctx, false, containerd.WithoutRefreshedMetadata)
 			if err != nil {
 				return err
 			}

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -324,6 +324,12 @@ type fakeSpecOnlyContainer struct {
 	errOnSpec error
 }
 
+// InfoWithRefresh implements client.Container.
+func (c *fakeSpecOnlyContainer) InfoWithRefresh(context.Context, bool, ...containerd.InfoOpts) (containers.Container, error) {
+	c.t.Error("fakeSpecOnlyContainer.InfoWithRefresh: not implemented")
+	return containers.Container{}, errors.New("not implemented")
+}
+
 // Spec implements client.Container.
 func (c *fakeSpecOnlyContainer) Spec(context.Context) (*specs.Spec, error) {
 	if c.errOnSpec != nil {

--- a/internal/cri/server/podsandbox/recover_test.go
+++ b/internal/cri/server/podsandbox/recover_test.go
@@ -155,6 +155,11 @@ func (f *fakeContainer) Info(ctx context.Context, opts ...containerd.InfoOpts) (
 	return f.c, nil
 }
 
+
+func (f *fakeContainer) InfoWithRefresh(context.Context, bool, ...containerd.InfoOpts) (containers.Container, error) {
+	return f.c, nil
+}
+
 func (f *fakeContainer) Delete(ctx context.Context, opts ...containerd.DeleteOpts) error {
 	return nil
 }


### PR DESCRIPTION
add InfoWithRefresh to support without fresh metadata.
the  function  Info  always call grpc c.get(ctx) sometimes user don't need to call it.
```
func (c *container) Info(ctx context.Context, opts ...InfoOpts) (containers.Container, error) {
	i := &InfoConfig{
		// default to refreshing the container's local metadata
		Refresh: true,
	}
	for _, o := range opts {
		o(i)
	}
	if i.Refresh {
		metadata, err := c.get(ctx)
		if err != nil {
			return c.metadata, err
		}
		c.metadata = metadata
	}
	return c.metadata, nil
}
```