### PR TITLE
apparmor: add signal and ptrace rules for stacked profiles

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -65,6 +65,8 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   signal (receive) peer={{.DaemonProfile}},
   # Container processes may send signals amongst themselves.
   signal (send,receive) peer={{.Name}},
+  # In stacking mode, exec'd processes may have a stacked profile.
+  signal (send,receive) peer={{.Name}}//&*,
 {{if .RootlessKit}}
   # https://github.com/containerd/nerdctl/issues/2730
   signal (receive) peer={{.RootlessKit}},
@@ -92,6 +94,8 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   # allow processes within the container to trace each other,
   # provided all other LSM and yama setting allow it.
   ptrace (trace,tracedby,read,readby) peer={{.Name}},
+  # In stacking mode, exec'd processes may have a stacked profile.
+  ptrace (trace,tracedby,read,readby) peer={{.Name}}//&*,
 }
 `
 

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -65,6 +65,15 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   signal (receive) peer={{.DaemonProfile}},
   # Container processes may send signals amongst themselves.
   signal (send,receive) peer={{.Name}},
+  # In stacking mode, exec'd processes may have a stacked profile, whose
+  # label lists this profile alongside the others it is stacked with.
+  # The components are ordered lexically, not by stacking order, so this
+  # profile can appear at either end or in the middle; all three positions
+  # need a rule. ** rather than *, because * stops at "/", and both profile
+  # names and the remaining components can contain one.
+  signal (send,receive) peer={{.Name}}//&**,
+  signal (send,receive) peer=**//&{{.Name}},
+  signal (send,receive) peer=**//&{{.Name}}//&**,
 {{if .RootlessKit}}
   # https://github.com/containerd/nerdctl/issues/2730
   signal (receive) peer={{.RootlessKit}},
@@ -92,6 +101,10 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   # allow processes within the container to trace each other,
   # provided all other LSM and yama setting allow it.
   ptrace (trace,tracedby,read,readby) peer={{.Name}},
+  # Same three stacked-label positions as the signal rules above.
+  ptrace (trace,tracedby,read,readby) peer={{.Name}}//&**,
+  ptrace (trace,tracedby,read,readby) peer=**//&{{.Name}},
+  ptrace (trace,tracedby,read,readby) peer=**//&{{.Name}}//&**,
 }
 `
 

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -3,9 +3,11 @@
 package apparmor
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCleanProfileName(t *testing.T) {
@@ -15,4 +17,21 @@ func TestCleanProfileName(t *testing.T) {
 	assert.Equal(t, cleanProfileName("docker-default"), "docker-default")
 	assert.Equal(t, cleanProfileName("foo"), "foo")
 	assert.Equal(t, cleanProfileName("foo (enforce)"), "foo")
+}
+
+func TestGenerateStackedProfileRules(t *testing.T) {
+	p := &data{
+		Name:          "cri-containerd.apparmor.d",
+		DaemonProfile: "unconfined",
+	}
+	var buf bytes.Buffer
+	err := generate(p, &buf)
+	require.NoError(t, err)
+
+	profile := buf.String()
+	// Verify stacking rules for signal and ptrace are present.
+	// Where AppArmor stacking is enabled, exec'd processes get a stacked
+	// profile (e.g. "cri-containerd.apparmor.d//&unconfined").
+	assert.Contains(t, profile, "signal (send,receive) peer=cri-containerd.apparmor.d//&*,")
+	assert.Contains(t, profile, "ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d//&*,")
 }

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -3,9 +3,12 @@
 package apparmor
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCleanProfileName(t *testing.T) {
@@ -15,4 +18,34 @@ func TestCleanProfileName(t *testing.T) {
 	assert.Equal(t, cleanProfileName("docker-default"), "docker-default")
 	assert.Equal(t, cleanProfileName("foo"), "foo")
 	assert.Equal(t, cleanProfileName("foo (enforce)"), "foo")
+}
+
+func TestGenerateStackedProfileRules(t *testing.T) {
+	p := &data{
+		Name:          "cri-containerd.apparmor.d",
+		DaemonProfile: "unconfined",
+	}
+	var buf bytes.Buffer
+	err := generate(p, &buf)
+	require.NoError(t, err)
+
+	profile := buf.String()
+	// Where AppArmor stacking is enabled, exec'd processes get a stacked
+	// profile (e.g. "cri-containerd.apparmor.d//&unconfined"). Stacked label
+	// components are ordered lexically rather than by stacking order, so the
+	// profile can land at either end or in the middle of the label; each
+	// position needs its own rule. The glob must be ** and not *, since *
+	// stops at "/" and the remaining components can contain one.
+	for _, rule := range []string{
+		"signal (send,receive) peer=%s,",
+		"ptrace (trace,tracedby,read,readby) peer=%s,",
+	} {
+		for _, peer := range []string{
+			"cri-containerd.apparmor.d//&**",
+			"**//&cri-containerd.apparmor.d",
+			"**//&cri-containerd.apparmor.d//&**",
+		} {
+			assert.Contains(t, profile, fmt.Sprintf(rule, peer))
+		}
+	}
 }


### PR DESCRIPTION
On kernel 6.17 with AppArmor profile stacking enabled (`/sys/kernel/security/apparmor/features/domain/stack` = `yes`), processes created via CRI ExecSync (`kubectl exec`, exec-based probes) run under a stacked profile `cri-containerd.apparmor.d//&unconfined`:

```
$ kubectl exec <pod> -- cat /proc/1/attr/apparmor/current
cri-containerd.apparmor.d (enforce)

$ kubectl exec <pod> -- cat /proc/self/attr/apparmor/current
cri-containerd.apparmor.d//&unconfined (enforce)
```

The existing signal and ptrace rules use `peer={{.Name}}`, which expands to `cri-containerd.apparmor.d` and does not match the stacked peer name `cri-containerd.apparmor.d//&unconfined`. This causes AppArmor DENIED audit events when exec'd Go processes send SIGURG for goroutine preemption:

```
audit: type=1400 apparmor="DENIED" operation="signal" profile="cri-containerd.apparmor.d"
  comm="bao" requested_mask="send" denied_mask="send" signal=urg
  peer="cri-containerd.apparmor.d//&unconfined"
```

This change adds rules with `peer={{.Name}}//&*` to match stacked profile peers for both signal and ptrace operations. The `//&*` glob matches any stacked profile suffix (e.g., `//&unconfined`).

Tested on Ubuntu 25.10 (questing) aarch64 with kernel 6.17.0-1007-raspi, AppArmor parser 5.0.0~alpha1, containerd v2.1.5-k3s1. The modified profile was loaded via `apparmor_parser --replace`. After loading, zero new DENIED entries over 56+ seconds (11+ probe cycles at 5s interval), whereas before the fix there were continuous denials every cycle.

Note: the `abi <abi/3.0>` pin from #12864 is already on main and does not resolve this issue.

Fixes: #12886


### Why the rule is shaped this way

A flat `peer=<profile>` rule does not match a stacked peer label. The kernel matches the peer label as a single string: `label_compound_match()` walks the components and inserts the literal `//&` between them, so a rule whose text is `cri-containerd.apparmor.d` never matches `cri-containerd.apparmor.d//&unconfined`. The component fallback in `label_components_match()` does not rescue it either. It intersects permissions across components (`accum->allow &= addend->allow & ~addend->deny`), so `Name` contributes `send,receive`, `unconfined` contributes `receive`, and the intersection drops `send`. That is the SIGURG symptom in the report.

`**` rather than `*`, because `signal.cc` and `ptrace.cc` compile the peer label through `convert_aaregex_to_pcre(peer_label, 0, glob_default, ...)`, where `*` becomes `[^/\x00]*` and `**` becomes `[^\x00]*`. A single `*` stops at `/`. That leaves out path-named profiles and any stack deeper than two components, since the tail then contains a `/`.

Three positions, because the components of a stacked label are sorted lexically rather than by stacking order (`profile_cmp()` in `security/apparmor/label.c`). This profile can end up at the head, at the tail, or in the middle.

The rules do not widen privileges. A stacked label is an intersection of confinements: a task labelled `A//&B` is confined by both A and B, so its permissions are a subset of what A alone allows. A peer carrying this profile as a component is already inside the set that the existing `peer={{.Name}}` rule grants in full. The literal `//&` in the pattern also keeps hat profiles (`parent//child`, no `&`) out of the match.

Checked on a live kernel, Ubuntu 24.04, kernel 6.8, `domain/stack=yes`, AppArmor 4.0.1, entering the stacked label with `aa-exec` and running `kill -9` on an own child. `<profile>` below is the generated profile name, `cri-containerd.apparmor.d` by default:

| peer label | rules in the profile | result |
| --- | --- | --- |
| `<profile>//&unconfined` | flat `peer={{.Name}}` only | denied |
| `<profile>//&unconfined` | flat plus `//&*` | allowed |
| `<profile>//&other/sub//&unconfined` | flat plus `//&*` | denied |
| `<profile>//&other/sub//&unconfined` | flat plus `//&**` | allowed |
| `<profile>//&zzz-peer` | head-anchored `//&**` only | allowed |
| `aaa-peer//&<profile>` | head-anchored `//&**` only | denied |
| `<profile>//&zzz-peer` | all three positions | allowed |
| `aaa-peer//&<profile>` | all three positions | allowed |

The last two rows ran against the profile this template generates, not a hand-written stand-in.

The reported case looked like it needed only one rule because `c` sorts before `u`, so `cri-containerd.apparmor.d` happens to precede `unconfined` in the label. A profile named with a path always sorts first, `/` being `0x2f`, and would not have been covered.

There is a narrower one-line alternative, relaxing `signal (receive) peer=unconfined` to `(send,receive)` so the component fallback covers the stack. That works, but it grants against every peer named `unconfined`, host processes included. The stacked-label form stays inside this profile's own stack.

The generated profile compiles on `apparmor_parser` 2.12, 2.13.3, 2.13.6, 3.0.4 and 4.0.1 when given a current kernel feature set, with the new rules present in the compiled policy rather than dropped. I checked that by compiling with and without them and comparing the cache, using removal of an ordinary file rule as a control to confirm the comparison detects a change at all. `&` is not an AARE metacharacter, so older parsers treat `//&` as a literal and need no awareness of stacking. One caveat if you reproduce this: without a feature set, in a container with no AppArmor, 3.0.4 and 4.0.1 print `signal rules not enforced`, drop those rules, and still exit 0, so a bare parse check in that setup proves less than it appears to.
