### PR TITLE
add check on version of drop in configs

### DIFF
--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -292,8 +292,9 @@ func LoadConfig(ctx context.Context, path string, out *Config) error {
 	}
 
 	var (
-		loaded  = map[string]bool{}
-		pending = []string{path}
+		loaded            = map[string]bool{}
+		pending           = []string{path}
+		rootConfigVersion = 0
 	)
 
 	for len(pending) > 0 {
@@ -307,6 +308,14 @@ func LoadConfig(ctx context.Context, path string, out *Config) error {
 		config, err := loadConfigFile(ctx, path)
 		if err != nil {
 			return err
+		}
+
+		// Check to make sure drop-in configs does not have a higher version than the root config version
+		if rootConfigVersion == 0 {
+			rootConfigVersion = config.Version
+		}
+		if config.Version > rootConfigVersion {
+			return fmt.Errorf("drop-in config version %d higher than root config version %d", config.Version, rootConfigVersion)
 		}
 
 		switch config.Version {

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -235,7 +235,7 @@ disabled_plugins = ["io.containerd.v1.xyz"]
 
 	var out Config
 	err = LoadConfig(context.Background(), filepath.Join(tempDir, "data1.toml"), &out)
-	assert.Error(t, err)
+	assert.Errorf(t, err, "drop-in config version 3 higher than root config version 2")
 }
 
 // https://github.com/containerd/containerd/issues/10905

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -214,6 +214,30 @@ imports = ["data1.toml", "data2.toml"]
 	}, out.Imports)
 }
 
+func TestLoadConfigWithImportsWithHigerVersion(t *testing.T) {
+	data1 := `
+version = 2
+root = "/var/lib/containerd"
+imports = ["data2.toml"]
+`
+
+	data2 := `
+version = 3
+disabled_plugins = ["io.containerd.v1.xyz"]
+`
+	tempDir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(data1), 0o600)
+	assert.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tempDir, "data2.toml"), []byte(data2), 0o600)
+	assert.NoError(t, err)
+
+	var out Config
+	err = LoadConfig(context.Background(), filepath.Join(tempDir, "data1.toml"), &out)
+	assert.Error(t, err)
+}
+
 // https://github.com/containerd/containerd/issues/10905
 func TestLoadConfigWithDefaultConfigVersion(t *testing.T) {
 	data1 := `


### PR DESCRIPTION
when a higher version of drop in config is used than the root containerd config, do not load the config. When config is merged, the higher version takes precedence preventing the root config from getting migrated to the newer version.

`/etc/containerd/config.toml`
```toml
version = 2
imports = ["/etc/containerd/conf.d/*.toml"]
[plugins]
  [plugins."io.containerd.grpc.v1.cri"]
    sandbox_image = "local.registry/pause:3.10"
```

`/etc/containerd/conf.d/toolkit.toml`
```toml
version = 3
[plugins]
  [plugins."io.containerd.cri.v1.runtime"]
    [plugins."io.containerd.cri.v1.runtime".containerd]
      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes]
        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.test]
          [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.test.options]
            BinaryName = "/usr/local/test/test-runc"
```

The above config prevents the `sandbox_image` from being migrated, and results in containerd using the default `registry.k8s.io/pause:3.10` image. 