### PR TITLE
Don't bail out if no image verifiers available

### DIFF
--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -17,6 +17,7 @@
 package transfer
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/containerd/errdefs"
@@ -71,7 +72,7 @@ func init() {
 			lc.Leases = l.(leases.Manager)
 
 			vps, err := ic.GetByType(plugins.ImageVerifierPlugin)
-			if err != nil {
+			if err != nil && !errors.Is(err, plugin.ErrPluginNotFound) {
 				return nil, err
 			}
 			if len(vps) > 0 {


### PR DESCRIPTION
When the local transfer plugin is instantiated, it loads verifiers through `ic.GetByType()` which returns ErrPluginNotFound if no plugins of the given type is available. This would happen if users explicitly disabled the bindir plugin.

Users may wish to disable that plugin to prevent containerd from executing arbitrary binaries on the host (e.g. when running rootless). Currently, the only way to achieve that is to set bindir's param `bin_dir` to the empty string but that seems more fragile than disabling the plugin altogether.

The local transfer plugin is already checking if there are no plugins available, and take action accordingly. Thus, not handling `ErrPluginNotFound` seems to be an oversight.