### PR TITLE
[release/2.1] cri: Fix image volumes with user namespaces

### DIFF
--- a/internal/cri/server/container_image_mount.go
+++ b/internal/cri/server/container_image_mount.go
@@ -127,8 +127,14 @@ func (c *criService) mutateImageMount(
 	}
 	chainID := identity.ChainID(diffIDs).String()
 
+	// Get snapshot options with user namespace idmap labels if needed
+	snapshotOpts, err := c.getImageVolumeSnapshotOpts(ctx, extraMount)
+	if err != nil {
+		return fmt.Errorf("failed to get snapshot options for image volume: %w", err)
+	}
+
 	s := c.client.SnapshotService(snapshotter)
-	mounts, err := s.Prepare(ctx, target, chainID)
+	mounts, err := s.Prepare(ctx, target, chainID, snapshotOpts...)
 	if err != nil {
 		if errdefs.IsAlreadyExists(err) {
 			mounts, err = s.Mounts(ctx, target)
@@ -154,6 +160,15 @@ func (c *criService) mutateImageMount(
 	}
 
 	extraMount.HostPath = target
+
+	// Clear UID/GID mappings from the mount to prevent the OCI runtime from
+	// attempting idmap on the bind mount. The idmap is already applied to the
+	// overlay lower layers via the snapshotter when the image volume is prepared.
+	// This must be done regardless of whether the image volume was already mounted
+	// (e.g., by another container in the same pod).
+	extraMount.UidMappings = nil
+	extraMount.GidMappings = nil
+
 	return nil
 }
 

--- a/internal/cri/server/container_image_mount_linux_test.go
+++ b/internal/cri/server/container_image_mount_linux_test.go
@@ -1,0 +1,148 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestGetImageVolumeSnapshotOpts(t *testing.T) {
+	ctx := context.Background()
+
+	mappings := []*runtime.IDMapping{
+		{
+			ContainerId: 0,
+			HostId:      65536,
+			Length:      65536,
+		},
+	}
+
+	expectedOpts := optsToInfo(t, containerd.WithRemapperLabels(0, 65536, 0, 65536, 65536))
+
+	for _, test := range []struct {
+		name        string
+		mount       *runtime.Mount
+		expectInfo  *snapshots.Info
+		expectError bool
+	}{
+		{
+			name: "with user namespace mappings",
+			mount: &runtime.Mount{
+				ContainerPath: "/test",
+				UidMappings:   mappings,
+				GidMappings:   mappings,
+			},
+			expectInfo: expectedOpts,
+		},
+		{
+			name: "without mappings",
+			mount: &runtime.Mount{
+				ContainerPath: "/test",
+			},
+		},
+		{
+			name: "with empty mappings",
+			mount: &runtime.Mount{
+				ContainerPath: "/test",
+				UidMappings:   []*runtime.IDMapping{},
+				GidMappings:   []*runtime.IDMapping{},
+			},
+		},
+		{
+			name: "with only UID mappings",
+			mount: &runtime.Mount{
+				ContainerPath: "/test",
+				UidMappings:   mappings,
+			},
+		},
+		{
+			name: "with only GID mappings",
+			mount: &runtime.Mount{
+				ContainerPath: "/test",
+				GidMappings:   mappings,
+			},
+		},
+		{
+			name: "with multiple UID mapping lines",
+			mount: &runtime.Mount{
+				ContainerPath: "/test",
+				UidMappings: []*runtime.IDMapping{
+					{
+						ContainerId: 0,
+						HostId:      65536,
+						Length:      65536,
+					},
+					{
+						ContainerId: 65536,
+						HostId:      131072,
+						Length:      65536,
+					},
+				},
+				GidMappings: mappings,
+			},
+			expectError: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := &criService{}
+
+			opts, err := c.getImageVolumeSnapshotOpts(ctx, test.mount)
+
+			if test.expectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			gotInfo := optsToInfo(t, opts...)
+			if test.expectInfo == nil {
+				assert.Nil(t, gotInfo)
+			} else {
+				require.NotNil(t, gotInfo)
+				assert.Equal(t, test.expectInfo.Labels, gotInfo.Labels)
+			}
+
+			if test.mount.UidMappings != nil {
+				assert.NotNil(t, test.mount.UidMappings, "UidMappings should NOT be cleared by getImageVolumeSnapshotOpts")
+			}
+			if test.mount.GidMappings != nil {
+				assert.NotNil(t, test.mount.GidMappings, "GidMappings should NOT be cleared by getImageVolumeSnapshotOpts")
+			}
+		})
+	}
+}
+
+func optsToInfo(t *testing.T, opts ...snapshots.Opt) *snapshots.Info {
+	t.Helper()
+	if len(opts) == 0 {
+		return nil
+	}
+	var info snapshots.Info
+	for _, opt := range opts {
+		require.NoError(t, opt(&info))
+	}
+	return &info
+}

--- a/internal/cri/server/container_image_mount_other.go
+++ b/internal/cri/server/container_image_mount_other.go
@@ -19,10 +19,13 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // addVolatileOptionOnImageVolumeMount is no-op on non-linux platforms.
@@ -41,4 +44,8 @@ func ensureImageVolumeMounted(target string) (bool, error) {
 		return false, fmt.Errorf("failed to stat %s: %w", target, err)
 	}
 	return true, nil
+}
+
+func (c *criService) getImageVolumeSnapshotOpts(ctx context.Context, mount *runtime.Mount) ([]snapshots.Opt, error) {
+	return nil, nil
 }


### PR DESCRIPTION
This is a backport of #12816 for release 2.1.

Release 2.1 also has this bug, when using a pod with an image volume source and userns:

```
  Warning  Failed     36s (x4 over 82s)  kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: failed to fulfil mount request: failed to set MOUNT_ATTR_IDMAP on /run/containerd-rata/io.containerd.grpc.v1.cri/image-volumes/df5958c01c5df9cb67c8e9d1143f0282cbdbc01675f6b010d228b39c528ba24b/2c91e484d93f0830a7e05a2b9d92a7b102be7cab562198b984a84fdbc7806d91: invalid argument (maybe the filesystem used doesn't support idmap mounts on this kernel?)

```

With the backport, it works fine.

cc @estesp @AutuSnow 

---

This backport had conflicts in
`internal/cri/server/container_image_mount.go`. The code that calls `c.getImageVolumeSnapshotOpts() and `s.Prepare()` was moved inside an if in release 2.2 and main, so the conflict resolution was quite simple (just move it out of the if).

Also, in 2.1 WithIDMapImageVolumeMount() in main_test.go doesn't take an argument for sub_path (this was added in 2.2). But this test was not using a subpath (just ""), so I just removed that param.


(cherry picked from commit db9546b6df3671efe1a5727f43ba925531362354)

```release-note
Fix image volumes when using user namespaces in CRI
```