### PR TITLE
metadata/content: add media type label on ingest

### DIFF
--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -657,6 +657,18 @@ func (nw *namespacedWriter) commit(ctx context.Context, tx *bolt.Tx, size int64,
 			return "", 0, err
 		}
 	}
+
+	// Automatically set the media type label from the ingest descriptor
+	// if the caller has not explicitly provided one.
+	if nw.desc.MediaType != "" {
+		if base.Labels == nil {
+			base.Labels = map[string]string{}
+		}
+		if _, exists := base.Labels[labels.LabelMediaType]; !exists {
+			base.Labels[labels.LabelMediaType] = nw.desc.MediaType
+		}
+	}
+
 	if err := validateInfo(&base); err != nil {
 		if nw.w != nil {
 			nw.w.Close()

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -27,3 +27,9 @@ const LabelSharedNamespace = "containerd.io/namespace.shareable"
 // LabelDistributionSource is added to content to indicate its origin.
 // e.g., "containerd.io/distribution.source.docker.io=library/redis"
 const LabelDistributionSource = "containerd.io/distribution.source"
+
+// LabelMediaType is automatically set on content at ingest time to record
+// the OCI descriptor media type. The value is the full IANA media type
+// (e.g., "application/vnd.oci.image.manifest.v1+json"). This label is
+// informational and does not affect GC or other containerd subsystems.
+const LabelMediaType = "containerd.io/content.mediatype"


### PR DESCRIPTION
## Summary

Automatically sets `containerd.io/content.mediatype` label when content is ingested with an OCI descriptor that includes a media type.

The label is applied in `namespacedWriter.commit()`, covering all ingest paths (Fetch, WriteBlob, direct Writer).

- Callers may explicitly override the label via `WithLabels`
- If no media type is present in the descriptor, no label is added
- The label is informational only and does not alter behavior

## Motivation

Closes #12884

The content store currently does not persist media type information.
Given only a digest, consumers must either inspect blob contents or traverse the image graph to determine the media type. Both approaches are inefficient and not guaranteed to be stable.

Persisting the media type at ingest time makes this metadata directly queryable via the content API without requiring blob parsing or graph traversal.

Using a label avoids any API surface change and keeps the implementation fully backward compatible.

## Design considerations

- Injection point: `namespacedWriter.commit()` ensures coverage for all content written through the metadata layer
- Backward compatible: existing content simply will not have the label
- No GC impact: the label does not use the `containerd.io/gc.*` prefix and is ignored by GC
- No API changes: internal metadata-only enhancement
- Minimal storage overhead: a single short string label per content entry

## Test plan

- Auto-set from descriptor media type
- Explicit caller override preserved
- No label when descriptor has empty media type
- Existing content tests pass
