### PR TITLE
[release/2.2 backport] Fix AppArmor bug disallowing unix domain sockets on newer kernels

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -40,6 +40,8 @@ import (
 const dir = "/etc/apparmor.d"
 
 const defaultTemplate = `
+abi <abi/3.0>,
+
 {{range $value := .Imports}}
 {{$value}}
 {{end}}


### PR DESCRIPTION
- backport https://github.com/containerd/containerd/pull/12864
- fixes https://github.com/containerd/containerd/issues/12726


This change sets the AppArmor policy used by containerd to indicate it is `abi/3.0`. This was chosen based on some code archeology which indicated that containerd 1.7 came out in March 2023, before the AppArmor 4.0 ABI. The AppArmor policies themselves date to much older; the last apparmor version-checks were removed in
4baa1876ba45ffdab9059753215aa1c5d6f79b1d and
c990e3f2ed88637ac084d32c08f658b211298b61, and both were looking for AppArmor 2.8.96 or older, pointing to abi/3.0 being the "correct" one to pick.

Nothing is preventing containerd from migrating to a newer AppArmor ABI; note, however, that anything newer than `abi/4.0` will need modifications to preserve UNIX domain sockets.

This was tested by building a custom k3s v1.35.0+k3s3, with the following modification:

```
diff --git a/go.mod b/go.mod
index 4e7bacd204..0fcaf76b8f 100644
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace (
        github.com/cilium/ebpf => github.com/cilium/ebpf v0.12.3
        github.com/cloudnativelabs/kube-router/v2 => github.com/k3s-io/kube-router/v2 v2.6.3-k3s1
        github.com/containerd/containerd/api => github.com/containerd/containerd/api v1.9.0
-       github.com/containerd/containerd/v2 => github.com/k3s-io/containerd/v2 v2.1.5-k3s1
+       github.com/containerd/containerd/v2 => github.com/achernya/containerd/v2 v2.0.0-20260206214308-5e0dce89c422
        github.com/containerd/imgcrypt => github.com/containerd/imgcrypt v1.1.11
        github.com/containerd/stargz-snapshotter => github.com/k3s-io/stargz-snapshotter v0.17.0-k3s1
        github.com/docker/distribution => github.com/docker/distribution v2.8.3+incompatible
```

to use a precursor to this commit.

Once built, the resulting k3s was tested on a brand-new Proxmox installation:

```
root@containerd-test:~# uname -a
Linux containerd-test 6.17.2-1-pve #1 SMP PREEMPT_DYNAMIC PMX 6.17.2-1 (2025-10-21T11:55Z) x86_64 GNU/Linux
root@containerd-test:~# pveversion
pve-manager/9.1.1/42db4a6cf33dac83 (running kernel: 6.17.2-1-pve)
```

Files were copied over:
```
achernya@achernya-dev:~/src/k3s$ scp -r dist/artifacts/ root@containerd-test:
```

and installed
```
root@containerd-test:~# mkdir -p /var/lib/rancher/k3s/agent/images/ /usr/local/bin
root@containerd-test:~# cp artifacts/k3s /usr/local/bin/
root@containerd-test:~# cp artifacts/k3s-airgap-images-amd64.tar.zst /var/lib/rancher/k3s/agent/images/
```

then finally started with `k3s server`. Argo CD was then installed:

```
root@containerd-test:~# k3s kubectl create namespace argocd
namespace/argocd created
root@containerd-test:~# k3s kubectl apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
[elided]
root@containerd-test:~# k3s kubectl get pods -A
NAMESPACE     NAME                                               READY   STATUS      RESTARTS   AGE
argocd        argocd-application-controller-0                    1/1     Running     0          31s
argocd        argocd-applicationset-controller-77475dfcf-6b4cb   1/1     Running     0          32s
argocd        argocd-dex-server-6485c5ddf5-ckp5s                 1/1     Running     0          32s
argocd        argocd-notifications-controller-758f795776-djx69   1/1     Running     0          32s
argocd        argocd-redis-6cc4bb5db5-lt9fh                      1/1     Running     0          32s
argocd        argocd-repo-server-c76cf57cd-mr4mc                 1/1     Running     0          32s
argocd        argocd-server-6f85b59c87-w6cns                     0/1     Running     0          32s
kube-system   coredns-6b4688786f-pnds2                           1/1     Running     0          4m1s
kube-system   helm-install-traefik-crd-cn28g                     0/1     Completed   0          4m1s
kube-system   helm-install-traefik-hc9gp                         0/1     Completed   2          4m1s
kube-system   local-path-provisioner-6bc6568469-7wglx            1/1     Running     0          4m1s
kube-system   metrics-server-77dbbf84b-nqzsc                     1/1     Running     0          4m1s
kube-system   svclb-traefik-fe6d3a0b-z7jsp                       2/2     Running     0          3m14s
kube-system   traefik-5fdc878c8d-cjhx5                           1/1     Running     0          3m15s
```

Fixes: #12726

(cherry picked from commit a6f03a7d56411648c2e97085ae8e120120c06b6b)