### PR TITLE
Use new filtered cgroups stats API

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -114,7 +114,7 @@ func TestTaskUpdate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		stat, err := cgroup2.Stat()
+		stat, err := cgroup2.StatFiltered(cgroupsv2.StatMemory)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -144,7 +144,7 @@ func TestTaskUpdate(t *testing.T) {
 	}
 	// check that the task has a limit of 64mb
 	if cgroups.Mode() == cgroups.Unified {
-		stat, err := cgroup2.Stat()
+		stat, err := cgroup2.StatFiltered(cgroupsv2.StatMemory)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -78,7 +78,7 @@ func getCgroupSwapLimitForTask(t *testing.T, task containerd.Task) uint64 {
 		if err != nil {
 			t.Fatal(err)
 		}
-		stat, err := cgroup2.Stat()
+		stat, err := cgroup2.StatFiltered(cgroupsv2.StatMemory)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -105,7 +105,7 @@ func getCgroupMemoryLimitForTask(t *testing.T, task containerd.Task) uint64 {
 		if err != nil {
 			t.Fatal(err)
 		}
-		stat, err := cgroup2.Stat()
+		stat, err := cgroup2.StatFiltered(cgroupsv2.StatMemory)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cri/server/sandbox_stats_linux.go
+++ b/internal/cri/server/sandbox_stats_linux.go
@@ -201,7 +201,7 @@ func cgroupMetricsForSandbox(sandbox sandboxstore.Sandbox) (*cgroupMetrics, erro
 		if err != nil {
 			return nil, fmt.Errorf("failed to load sandbox cgroup: %v: %w", cgroupPath, err)
 		}
-		stats, err := cg.Stat()
+		stats, err := cg.StatFiltered(cgroupsv2.StatCPU | cgroupsv2.StatMemory)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get stats for cgroup: %v: %w", cgroupPath, err)
 		}

--- a/internal/cri/server/stats_collector.go
+++ b/internal/cri/server/stats_collector.go
@@ -231,7 +231,7 @@ func (c *StatsCollector) getCgroupCPUUsage(ctx context.Context, cgroupPath strin
 			log.G(ctx).WithError(err).Debugf("StatsCollector: failed to load cgroupv2: %s", cgroupPath)
 			return 0, false
 		}
-		stats, err := cg.Stat()
+		stats, err := cg.StatFiltered(cgroupsv2.StatCPU)
 		if err != nil {
 			log.G(ctx).WithError(err).Debugf("StatsCollector: failed to get cgroupv2 stats: %s", cgroupPath)
 			return 0, false


### PR DESCRIPTION
In some spots we can get away with only reading a subset of the cgroup stats we are today. It would be reaaally nice for container stats in the cri plugin, but they're requested via the task API and we have no way to signify we only want a subset through this surface yet. We can still get some benefit in the stats collector and the existing sandbox stats where we only need mem and cpu.
 