### PR TITLE
contrib/apparmor: fix /proc/sys rule

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -72,7 +72,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
-  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny @{PROC}/{[^1-9/],[^1-9/][^0-9/],[^1-9s/][^0-9y/][^0-9s/],[^1-9/][^0-9/][^0-9/][^0-9/]*}/** w,
   deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
   deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
   deny @{PROC}/sysrq-trigger rwklx,


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/39791
- relates to https://github.com/moby/moby/pull/39792


The current AppArmor profile intends to block write access to everything in `/proc`, except for `/proc/<pid>` and `/proc/sys/kernel/shm*`.

Currently the rules block access to everything in `/proc/sys`, and do not successfully allow access to `/proc/sys/kernel/shm*`. Specifically, a path like /proc/sys/kernel/shmmax matches this part of the pattern:

    deny @{PROC}/{[^1-9][^0-9][^0-9][^0-9]*     }/** w,
         /proc  / s     y     s     /     kernel /shmmax

This downstreams the patch from [moby@66f14e4] to the containerd profile, and updates the rule so that it works as intended.

[moby@66f14e4]: https://github.com/moby/moby/commit/66f14e4ae9173f6fb7d1e4a7e13632297bdb8d29