### PR TITLE
contrib/apparmor: remove non-matching rules for /proc/mem, /proc/kmem

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -76,8 +76,6 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
   deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
   deny @{PROC}/sysrq-trigger rwklx,
-  deny @{PROC}/mem rwklx,
-  deny @{PROC}/kmem rwklx,
   deny @{PROC}/kcore rwklx,
 
   deny mount,


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/35113

This downstreams the patch from [moby@b4a6ccb]:

> drop useless apparmor denies
> These files don't exist under proc so this rule does nothing.
>
> They are protected against by docker's default cgroup devices since they're
> both character devices and not explicitly allowed.

[moby@b4a6ccb]: https://github.com/moby/moby/commit/b4a6ccbc5fe695062111cad5a20bb3d0ac5a94db