### PR TITLE
install-dev-tools: update protoc-gen-go-ttrpc to v1.2.7

### DIFF
--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -22,5 +22,5 @@ set -eu -o pipefail
 go install github.com/containerd/protobuild/cmd/go-fix-acronym@v0.3.0
 go install github.com/cpuguy83/go-md2man/v2@v2.0.7
 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.5
-go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@v1.2.5
+go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@v1.2.7
 go install github.com/bufbuild/buf/cmd/buf@v1.63.0


### PR DESCRIPTION
Align with the version of ttrpc used.

full diff: https://github.com/containerd/ttrpc/compare/v1.2.5...v1.2.7