### PR TITLE
cmd/protoc-gen-go-fieldpath: add support for optional fields

### DIFF
--- a/cmd/protoc-gen-go-fieldpath/generator.go
+++ b/cmd/protoc-gen-go-fieldpath/generator.go
@@ -107,14 +107,27 @@ func (gen *generator) genFieldMethod(m *protogen.Message) {
 				p.P("}")
 				p.P("return m.", f.GoName, ".Field(fieldpath[1:])")
 			case f.Desc.Kind() == protoreflect.StringKind:
-				p.P("return string(m.", f.GoName, "), len(m.", f.GoName, ") > 0")
+				if f.Desc.HasPresence() {
+					p.P("if m.", f.GoName, " == nil {")
+					p.P(`return "", false`)
+					p.P("}")
+					p.P("return *m.", f.GoName, ", true")
+				} else {
+					p.P("return string(m.", f.GoName, "), len(m.", f.GoName, ") > 0")
+				}
 			case f.Desc.Kind() == protoreflect.BoolKind:
 				fmtSprint := gen.out.QualifiedGoIdent(protogen.GoIdent{
 					GoImportPath: "fmt",
 					GoName:       "Sprint",
 				})
-
-				p.P("return ", fmtSprint, "(m.", f.GoName, "), true")
+				if f.Desc.HasPresence() {
+					p.P("if m.", f.GoName, " == nil {")
+					p.P(`return "", false`)
+					p.P("}")
+					p.P("return ", fmtSprint, "(*m.", f.GoName, "), true")
+				} else {
+					p.P("return ", fmtSprint, "(m.", f.GoName, "), true")
+				}
 			}
 		}
 

--- a/cmd/protoc-gen-go-fieldpath/main.go
+++ b/cmd/protoc-gen-go-fieldpath/main.go
@@ -18,10 +18,12 @@ package main
 
 import (
 	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 func main() {
 	protogen.Options{}.Run(func(gen *protogen.Plugin) error {
+		gen.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
 		for _, f := range gen.Files {
 			if !f.Generate {
 				continue


### PR DESCRIPTION
generating protos produced a warning:

    WARN plugin "protoc-gen-go-fieldpath" does not support required features. Feature "proto3 optional" is required by 1 file(s): services/images/v1/images.proto

Implement handling for optional fields (nillable / pointer)
