### PR TITLE
sys, dialer: support AF_UNIX sockets on Windows

### DIFF
--- a/pkg/dialer/dialer_unix_test.go
+++ b/pkg/dialer/dialer_unix_test.go
@@ -18,30 +18,22 @@
 
 package dialer
 
-import (
-	"errors"
-	"fmt"
-	"net"
-	"strings"
-	"syscall"
-	"time"
-)
+import "testing"
 
-// DialAddress returns the address with unix:// prepended to the
-// provided address. An address that already carries the scheme is
-// returned unchanged.
-func DialAddress(address string) string {
-	if strings.HasPrefix(address, "unix://") {
-		return address
+func TestDialAddressScheme(t *testing.T) {
+	testcases := []struct {
+		name    string
+		address string
+		want    string
+	}{
+		{name: "bare path gets unix", address: "/run/containerd/containerd.sock", want: "unix:///run/containerd/containerd.sock"},
+		{name: "unix scheme idempotent", address: "unix:///run/containerd/containerd.sock", want: "unix:///run/containerd/containerd.sock"},
 	}
-	return fmt.Sprintf("unix://%s", address)
-}
-
-func isNoent(err error) bool {
-	return errors.Is(err, syscall.ENOENT)
-}
-
-func dialer(address string, timeout time.Duration) (net.Conn, error) {
-	address = strings.TrimPrefix(address, "unix://")
-	return net.DialTimeout("unix", address, timeout)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DialAddress(tc.address); got != tc.want {
+				t.Errorf("DialAddress(%q) = %q, want %q", tc.address, got, tc.want)
+			}
+		})
+	}
 }

--- a/pkg/dialer/dialer_windows.go
+++ b/pkg/dialer/dialer_windows.go
@@ -35,34 +35,47 @@ func isNamedPipePath(path string) bool {
 	return strings.HasPrefix(filepath.ToSlash(path), "//./pipe/")
 }
 
+// dialer connects to address using the transport determined by the scheme
+// prefix, or by path content for bare (unschemed) addresses:
+//
+//   - "unix://" → AF_UNIX socket (always, regardless of path content)
+//   - "npipe://" → Windows named pipe
+//   - bare "//./pipe/..." or "\\.\pipe\..." path → named pipe (backward compat)
+//   - any other bare path → AF_UNIX socket
+//
+// The scheme prefix, when present, is authoritative. A "unix://" address is
+// always dialed as an AF_UNIX socket even if the path looks like a named pipe.
 func dialer(address string, timeout time.Duration) (net.Conn, error) {
-	// accept npipe://<pipe>
-	if strings.HasPrefix(address, "npipe://") {
-		address = strings.TrimPrefix(filepath.ToSlash(address), "npipe://")
-		return winio.DialPipe(address, &timeout)
+	// unix:// is authoritative: always AF_UNIX regardless of path content.
+	if rest, ok := strings.CutPrefix(address, "unix://"); ok {
+		return net.DialTimeout("unix", rest, timeout)
 	}
-
-	address = strings.TrimPrefix(address, "unix://")
-	// accept //./pipe/ and \\.\pipe\
+	// npipe:// is authoritative: always a named pipe.
+	if rest, ok := strings.CutPrefix(filepath.ToSlash(address), "npipe://"); ok {
+		return winio.DialPipe(rest, &timeout)
+	}
+	// Bare //./pipe/ or \\.\pipe\ paths: named pipe (backward compatibility).
 	if isNamedPipePath(address) {
 		return winio.DialPipe(address, &timeout)
 	}
-	// other paths are AF_UNIX, like Unix
+	// Bare filesystem paths: AF_UNIX socket.
 	return net.DialTimeout("unix", address, timeout)
 }
 
 // DialAddress returns the address with the appropriate scheme prepended.
-// Named pipe paths get npipe://, everything else gets unix://.
+//
+// If the address already carries a "npipe://" or "unix://" scheme it is
+// returned unchanged (idempotent). For bare paths, named pipe paths
+// (//./pipe/... or \\.\pipe\...) receive the "npipe://" scheme; all other
+// paths receive "unix://".
 func DialAddress(address string) string {
-	address = filepath.ToSlash(address)
-	if isNamedPipePath(address) {
-		if !strings.HasPrefix(address, "npipe://") {
-			address = fmt.Sprintf("npipe://%s", address)
-		}
+	// Already scheme-prefixed: return as-is (idempotent).
+	if strings.HasPrefix(address, "npipe://") || strings.HasPrefix(address, "unix://") {
 		return address
 	}
-	if !strings.HasPrefix(address, "unix://") {
-		address = fmt.Sprintf("unix://%s", address)
+	address = filepath.ToSlash(address)
+	if isNamedPipePath(address) {
+		return fmt.Sprintf("npipe://%s", address)
 	}
-	return address
+	return fmt.Sprintf("unix://%s", address)
 }

--- a/pkg/dialer/dialer_windows_test.go
+++ b/pkg/dialer/dialer_windows_test.go
@@ -1,0 +1,66 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package dialer
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDialAddressScheme(t *testing.T) {
+	testcases := []struct {
+		name    string
+		address string
+		want    string
+	}{
+		{name: "pipe gets npipe", address: "//./pipe/docker", want: "npipe:////./pipe/docker"},
+		{name: "unix path gets unix", address: "/tmp/docker.sock", want: "unix:///tmp/docker.sock"},
+		{name: "windows path gets unix", address: "C:/Users/test/docker.sock", want: "unix://C:/Users/test/docker.sock"},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DialAddress(tc.address); got != tc.want {
+				t.Errorf("DialAddress(%q) = %q, want %q", tc.address, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDialerUnixSocket(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer l.Close()
+
+	go func() {
+		conn, err := l.Accept()
+		if err == nil {
+			conn.Close()
+		}
+	}()
+
+	conn, err := dialer(sockPath, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dialer(%q) failed: %v", sockPath, err)
+	}
+	conn.Close()
+}

--- a/pkg/dialer/dialer_windows_test.go
+++ b/pkg/dialer/dialer_windows_test.go
@@ -29,9 +29,16 @@ func TestDialAddressScheme(t *testing.T) {
 		address string
 		want    string
 	}{
+		// Bare paths: scheme is inferred from path content.
 		{name: "pipe gets npipe", address: "//./pipe/docker", want: "npipe:////./pipe/docker"},
+		{name: "backslash pipe gets npipe", address: `\\.\pipe\docker`, want: "npipe:////./pipe/docker"},
 		{name: "unix path gets unix", address: "/tmp/docker.sock", want: "unix:///tmp/docker.sock"},
 		{name: "windows path gets unix", address: "C:/Users/test/docker.sock", want: "unix://C:/Users/test/docker.sock"},
+
+		// Already-schemed inputs: must be returned unchanged (idempotent).
+		{name: "npipe scheme idempotent", address: "npipe:////./pipe/docker", want: "npipe:////./pipe/docker"},
+		{name: "npipe scheme with backslash idempotent", address: `npipe://\\.\pipe\docker`, want: `npipe://\\.\pipe\docker`},
+		{name: "unix scheme idempotent", address: "unix:///tmp/docker.sock", want: "unix:///tmp/docker.sock"},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -61,6 +68,32 @@ func TestDialerUnixSocket(t *testing.T) {
 	conn, err := dialer(sockPath, 5*time.Second)
 	if err != nil {
 		t.Fatalf("dialer(%q) failed: %v", sockPath, err)
+	}
+	conn.Close()
+}
+
+// TestDialerUnixSocketWithScheme verifies that a "unix://" prefix is stripped
+// before dialing and that the scheme is authoritative (a unix:// address is
+// always dialed as AF_UNIX, even if the path looks like a named pipe).
+func TestDialerUnixSocketWithScheme(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer l.Close()
+
+	go func() {
+		conn, err := l.Accept()
+		if err == nil {
+			conn.Close()
+		}
+	}()
+
+	conn, err := dialer("unix://"+sockPath, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dialer(%q) failed: %v", "unix://"+sockPath, err)
 	}
 	conn.Close()
 }

--- a/pkg/sys/socket_unix.go
+++ b/pkg/sys/socket_unix.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/sys/unix"
 )
@@ -42,8 +43,12 @@ func CreateUnixSocket(path string) (net.Listener, error) {
 	return net.Listen("unix", path)
 }
 
-// GetLocalListener returns a listener out of a unix socket.
+// GetLocalListener returns a listener out of a unix socket. The path may
+// optionally carry a "unix://" prefix, matching the addresses produced by
+// dialer.DialAddress.
 func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
+	path = strings.TrimPrefix(path, "unix://")
+
 	// Ensure parent directory is created
 	if err := mkdirAs(filepath.Dir(path), uid, gid); err != nil {
 		return nil, err

--- a/pkg/sys/socket_unix_test.go
+++ b/pkg/sys/socket_unix_test.go
@@ -1,0 +1,67 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGetLocalListenerScheme verifies that a "unix://" prefix is stripped
+// before the path is used, on Unix as well as on Windows, so that a schemed
+// address in the daemon configuration listens where it says it does rather
+// than under a directory literally named "unix:".
+func TestGetLocalListenerScheme(t *testing.T) {
+	for _, prefix := range []string{"", "unix://"} {
+		t.Run("prefix="+prefix, func(t *testing.T) {
+			sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+			l, err := GetLocalListener(prefix+sockPath, os.Getuid(), os.Getgid())
+			if err != nil {
+				t.Fatalf("GetLocalListener(%q) failed: %v", prefix+sockPath, err)
+			}
+			defer l.Close()
+
+			if _, err := os.Stat(sockPath); err != nil {
+				t.Fatalf("no socket at %q: %v", sockPath, err)
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				conn, err := l.Accept()
+				if err == nil {
+					conn.Close()
+				}
+				done <- err
+			}()
+
+			conn, err := net.Dial("unix", sockPath)
+			if err != nil {
+				t.Fatalf("Dial(%q) failed: %v", sockPath, err)
+			}
+			conn.Close()
+
+			if err := <-done; err != nil {
+				t.Fatalf("Accept failed: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/sys/socket_windows.go
+++ b/pkg/sys/socket_windows.go
@@ -24,34 +24,73 @@ import (
 	"strings"
 
 	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
 )
+
+// sddlSocketAdministratorsLocalSystem grants full access to Builtin
+// Administrators and Local System, and to nobody else. Unlike
+// SddlAdministratorsLocalSystem it carries no OI/CI inheritance flags: those
+// only apply to containers, and a socket has no children.
+const sddlSocketAdministratorsLocalSystem = "D:P(A;;GA;;;BA)(A;;GA;;;SY)"
 
 func isNamedPipePath(path string) bool {
 	return strings.HasPrefix(filepath.ToSlash(path), "//./pipe/")
 }
 
-// GetLocalListener returns a listener for the given path. If the path is a
-// Windows named pipe (\\.\pipe\...), it creates a named pipe listener.
-// Otherwise, it creates an AF_UNIX socket listener, which is supported on
-// Windows 10 1803+ and Windows Server 2019+.
+// GetLocalListener returns a listener for the given path. The path may be:
+//   - A Windows named pipe path (\\.\pipe\... or //./pipe/...): named pipe listener
+//   - Prefixed with "npipe://": named pipe listener
+//   - Prefixed with "unix://": AF_UNIX socket listener
+//   - Any other bare path: AF_UNIX socket listener
+//
+// AF_UNIX sockets are supported on Windows 10 1803+ and Windows Server 2019+.
+//
+// The scheme prefix, when present, is authoritative for the transport type.
+// A "unix://" prefix always results in an AF_UNIX socket, even if the path
+// looks like a named pipe path.
+//
+// Note: the uid and gid parameters are not used on Windows. For AF_UNIX
+// sockets, access control is enforced via Windows ACLs: newly-created parent
+// directories and the socket file itself are restricted to Builtin
+// Administrators and Local System. Named pipe security follows go-winio
+// defaults.
 func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
+	// unix:// is authoritative: always AF_UNIX regardless of path content.
+	if rest, ok := strings.CutPrefix(path, "unix://"); ok {
+		return createUnixSocket(rest)
+	}
+	// npipe:// is authoritative: always a named pipe.
+	if rest, ok := strings.CutPrefix(filepath.ToSlash(path), "npipe://"); ok {
+		return winio.ListenPipe(rest, nil)
+	}
+	// Bare //./pipe/ or \\.\pipe\ paths are named pipes (backward compatibility).
 	if isNamedPipePath(path) {
 		return winio.ListenPipe(path, nil)
 	}
-
+	// All other bare paths are AF_UNIX sockets.
 	return createUnixSocket(path)
 }
 
+// createUnixSocket creates an AF_UNIX socket at path and returns a listener.
+//
+// The parent directory is created (with MkdirAllWithACL) and the socket file
+// itself is protected with a DACL granting access to Builtin Administrators
+// and Local System only. os.Chmod and os.Chown have no effect on Windows, so
+// unlike the Unix implementation this is the only access control available,
+// and the uid/gid arguments of GetLocalListener have no analogue.
+//
+// Windows embraced the 108 byte sun_path limit, same as Linux, see
+// https://lwn.net/Articles/987098/
 func createUnixSocket(path string) (net.Listener, error) {
-	// Windows embraced the 108 limit, same as Linux
-	// see https://lwn.net/Articles/987098/
 	if len(path) > 108 {
 		return nil, fmt.Errorf("%q: unix socket path too long (> 108)", path)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0660); err != nil {
+	// Use MkdirAllWithACL so newly-created parent directories are restricted
+	// to Builtin Administrators and Local System (SddlAdministratorsLocalSystem).
+	if err := MkdirAllWithACL(filepath.Dir(path), 0750); err != nil {
 		return nil, err
 	}
-	// Remove existing socket file if present.
+	// Remove an existing socket file so we can rebind cleanly.
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
@@ -59,5 +98,34 @@ func createUnixSocket(path string) (net.Listener, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on unix socket %s: %w", path, err)
 	}
+	// The socket file is created by net.Listen with the ACEs it inherits from
+	// its parent, so it is briefly reachable by whoever the parent grants
+	// access to before the DACL below replaces them. MkdirAllWithACL closes
+	// that window for directories containerd creates itself; a pre-existing
+	// parent is the deployer's to restrict.
+	if err := setFileSecurityDescriptor(path, sddlSocketAdministratorsLocalSystem); err != nil {
+		l.Close()
+		return nil, fmt.Errorf("failed to set security descriptor on unix socket %s: %w", path, err)
+	}
 	return l, nil
+}
+
+// setFileSecurityDescriptor applies the DACL from the given SDDL string to
+// the named file object. PROTECTED_DACL_SECURITY_INFORMATION prevents the
+// inherited parent-directory ACEs from overriding the explicit DACL.
+func setFileSecurityDescriptor(path, sddl string) error {
+	sd, err := windows.SecurityDescriptorFromString(sddl)
+	if err != nil {
+		return err
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, dacl, nil,
+	)
 }

--- a/pkg/sys/socket_windows_test.go
+++ b/pkg/sys/socket_windows_test.go
@@ -1,0 +1,73 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsNamedPipePath(t *testing.T) {
+	testcases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "forward slash pipe", path: "//./pipe/containerd", want: true},
+		{name: "backslash pipe", path: `\\.\pipe\containerd`, want: true},
+		{name: "unix socket path", path: "/tmp/test.sock", want: false},
+		{name: "windows fs path", path: `C:\Users\test\docker.sock`, want: false},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNamedPipePath(tc.path); got != tc.want {
+				t.Errorf("isNamedPipePath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetLocalListenerUnixSocket(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	l, err := GetLocalListener(sockPath, 0, 0)
+	if err != nil {
+		t.Fatalf("GetLocalListener(%q) failed: %v", sockPath, err)
+	}
+	defer l.Close()
+
+	// Verify we can connect to it
+	done := make(chan error, 1)
+	go func() {
+		conn, err := l.Accept()
+		if err == nil {
+			conn.Close()
+		}
+		done <- err
+	}()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	conn.Close()
+
+	if err := <-done; err != nil {
+		t.Fatalf("Accept failed: %v", err)
+	}
+}

--- a/pkg/sys/socket_windows_test.go
+++ b/pkg/sys/socket_windows_test.go
@@ -19,7 +19,10 @@ package sys
 import (
 	"net"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"golang.org/x/sys/windows"
 )
 
 func TestIsNamedPipePath(t *testing.T) {
@@ -69,5 +72,96 @@ func TestGetLocalListenerUnixSocket(t *testing.T) {
 
 	if err := <-done; err != nil {
 		t.Fatalf("Accept failed: %v", err)
+	}
+}
+
+// TestGetLocalListenerUnixSocketWithScheme verifies that a "unix://" prefix is
+// stripped before use, so that callers may pass a schemed address directly.
+func TestGetLocalListenerUnixSocketWithScheme(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	schemed := "unix://" + sockPath
+
+	l, err := GetLocalListener(schemed, 0, 0)
+	if err != nil {
+		t.Fatalf("GetLocalListener(%q) failed: %v", schemed, err)
+	}
+	defer l.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, err := l.Accept()
+		if err == nil {
+			conn.Close()
+		}
+		done <- err
+	}()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Dial(%q) failed: %v", sockPath, err)
+	}
+	conn.Close()
+
+	if err := <-done; err != nil {
+		t.Fatalf("Accept failed: %v", err)
+	}
+}
+
+// TestCreateUnixSocketPathTooLong verifies that paths exceeding the 108-byte
+// sun_path limit are rejected with an error rather than passed to the OS.
+func TestCreateUnixSocketPathTooLong(t *testing.T) {
+	// Construct a path that is definitely more than 108 bytes long.
+	longPath := strings.Repeat("a", 109)
+	_, err := createUnixSocket(longPath)
+	if err == nil {
+		t.Fatal("expected error for path > 108 bytes, got nil")
+	}
+}
+
+// TestCreateUnixSocketDACL verifies that the socket is reachable only by
+// Builtin Administrators and Local System. The API socket is root-equivalent,
+// so a socket left with its inherited (potentially world-readable) ACL would
+// be a privilege escalation. This also confirms that SetNamedSecurityInfo
+// accepts an AF_UNIX socket path at all, which the implementation relies on.
+func TestCreateUnixSocketDACL(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	l, err := createUnixSocket(sockPath)
+	if err != nil {
+		t.Fatalf("createUnixSocket(%q) failed: %v", sockPath, err)
+	}
+	defer l.Close()
+
+	sd, err := windows.GetNamedSecurityInfo(sockPath, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatalf("GetNamedSecurityInfo(%q) failed: %v", sockPath, err)
+	}
+
+	// The DACL must be protected, otherwise inherited ACEs from the parent
+	// directory are merged in and can widen access.
+	control, _, err := sd.Control()
+	if err != nil {
+		t.Fatalf("Control failed: %v", err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Errorf("DACL is not protected: control = %#x, sd = %q", control, sd)
+	}
+
+	// Exactly two ACEs, for the two principals named in the SDDL. Any third
+	// grants access to somebody we did not intend.
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		t.Fatalf("DACL failed: %v", err)
+	}
+	if dacl == nil {
+		t.Fatal("socket has a NULL DACL, which grants everyone full access")
+	}
+	if dacl.AceCount != 2 {
+		t.Errorf("DACL has %d ACEs, want 2: %q", dacl.AceCount, sd)
+	}
+	for _, sid := range []string{";;;BA)", ";;;SY)"} {
+		if !strings.Contains(sd.String(), sid) {
+			t.Errorf("DACL %q is missing an ACE for %q", sd, sid)
+		}
 	}
 }


### PR DESCRIPTION
GetLocalListener and the containerd dialer on Windows were hardcoded to use named pipes via go-winio. AF_UNIX sockets are supported on Windows 10 1803+ and Windows Server 2019+, and Go supports them natively via net.Listen("unix", path) / net.DialTimeout("unix", ...).

Accept
- \\.\pipe\... for backward compat
- npipe://
- unix://

Note Windows also has the 108 byte Limit (same as Linux), but there is hope, see: https://lwn.net/Articles/987098/

This will help get containerd + nerdbox working on Windows.

Include some extremely basic unit tests, as documentation for the different paths accepted.