### PR TITLE
CNI DEL not issued on certain conditions

### DIFF
--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -292,8 +292,9 @@ func LoadConfig(ctx context.Context, path string, out *Config) error {
 	}
 
 	var (
-		loaded  = map[string]bool{}
-		pending = []string{path}
+		loaded            = map[string]bool{}
+		pending           = []string{path}
+		rootConfigVersion = 0
 	)
 
 	for len(pending) > 0 {
@@ -307,6 +308,14 @@ func LoadConfig(ctx context.Context, path string, out *Config) error {
 		config, err := loadConfigFile(ctx, path)
 		if err != nil {
 			return err
+		}
+
+		// Check to make sure drop-in configs does not have a higher version than the root config version
+		if rootConfigVersion == 0 {
+			rootConfigVersion = config.Version
+		}
+		if config.Version > rootConfigVersion {
+			return fmt.Errorf("drop-in config version %d higher than root config version %d", config.Version, rootConfigVersion)
 		}
 
 		switch config.Version {

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -214,6 +214,30 @@ imports = ["data1.toml", "data2.toml"]
 	}, out.Imports)
 }
 
+func TestLoadConfigWithImportsWithHigerVersion(t *testing.T) {
+	data1 := `
+version = 2
+root = "/var/lib/containerd"
+imports = ["data2.toml"]
+`
+
+	data2 := `
+version = 3
+disabled_plugins = ["io.containerd.v1.xyz"]
+`
+	tempDir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(data1), 0o600)
+	assert.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tempDir, "data2.toml"), []byte(data2), 0o600)
+	assert.NoError(t, err)
+
+	var out Config
+	err = LoadConfig(context.Background(), filepath.Join(tempDir, "data1.toml"), &out)
+	assert.Error(t, err)
+}
+
 // https://github.com/containerd/containerd/issues/10905
 func TestLoadConfigWithDefaultConfigVersion(t *testing.T) {
 	data1 := `


### PR DESCRIPTION
We have seen a condition, where the CNI ADD is executed, and containerd exits before the cniResult is saved to disk. When containerd recoverys the StopPodSandbox is called, but skips the CNI DEL because the CNI result is nil. The idea here is to ignore errors from the CNI DEL and try to do a best effort cleanup. The alternative is that a leaked resource could still exist which has been observed. 

We see the RunPodSandbox + StopPodSandbox RPC's executed, just no CNI DEL cmd is viewed. 