### PR TITLE
fix(oci): apply absolute symlink resolution to /etc/group

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -973,7 +973,7 @@ func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 			defer ensureAdditionalGids(s)
 
 			var ugroups []user.Group
-			f, groupErr := root.Open("etc/group")
+			f, groupErr := openUserFile(root, "etc/group")
 			if groupErr == nil {
 				defer f.Close()
 				ugroups, groupErr = user.ParseGroup(f)
@@ -1201,7 +1201,7 @@ func GIDFromFS(root fs.FS, filter func(user.Group) bool) (gid uint32, err error)
 }
 
 func getSupplementalGroupsFromFS(root fs.FS, filter func(user.Group) bool) ([]uint32, error) {
-	f, err := root.Open("etc/group")
+	f, err := openUserFile(root, "etc/group")
 	if err != nil {
 		return []uint32{}, err
 	}


### PR DESCRIPTION
This is a follow-up to PR #12732. 

As noted by @TheColorman, while the previous PR successfully resolved absolute symlinks pointing outside the mount root for `/etc/passwd` during user lookups, the same logic was missing for group lookups. This caused `openat etc/group: path escapes from parent` errors when `/etc/group` was also an absolute symlink (e.g., in NixOS environments).

This patch updates `GIDFromFS`, `getSupplementalGroupsFromFS`, and `WithAppendAdditionalGroups` to use the `openUserFile` helper, ensuring absolute symlinks are correctly re-anchored across all OCI user/group resolution paths.

Fixes #12683

Signed-off-by: Paulo Oliveira <paulo.hco47@gmail.com>