### PR TITLE
Make linter for release branches happy

### DIFF
--- a/internal/cri/server/sandbox_stop.go
+++ b/internal/cri/server/sandbox_stop.go
@@ -117,9 +117,8 @@ func (c *criService) stopPodSandbox(ctx context.Context, sandbox sandboxstore.Sa
 		if err := c.teardownPodNetwork(ctx, sandbox); err != nil {
 			if sandbox.CNIResult != nil {
 				return fmt.Errorf("failed to destroy network for sandbox %q: %w", id, err)
-			} else {
-				log.G(ctx).WithError(err).Warnf("failed to destroy network for sandbox %q; and ignoring because the sandbox network setup result is nil indicating the network setup never completed", id)
 			}
+			log.G(ctx).WithError(err).Warnf("failed to destroy network for sandbox %q; and ignoring because the sandbox network setup result is nil indicating the network setup never completed", id)
 		}
 		if err := sandbox.NetNS.Remove(); err != nil {
 			return fmt.Errorf("failed to remove network namespace for sandbox %q: %w", id, err)


### PR DESCRIPTION
The linter appears different for 2.1 and 2.2 release branches. 

Fixes:
https://github.com/containerd/containerd/pull/12927
