### PR TITLE
fix: upgrade Go to 1.26.0 to resolve CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd/v2
 
-go 1.24.6
+go 1.26.0
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
## Summary
Upgrades Go version to 1.26.0 to fix a CRITICAL vulnerability in the Go standard library.

## CVE Fixed
CVE-2025-68121 (CRITICAL): crypto/tls session resumption vulnerability

This is a minimal version bump fix.