### PR TITLE
mount/manager: set sparse file attribute on Windows before mkfs

### DIFF
--- a/core/mount/manager/mkfs_other.go
+++ b/core/mount/manager/mkfs_other.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import "os"
+
+// setSparseFile is a no-op on non-Windows platforms where Truncate
+// already creates sparse files.
+func setSparseFile(_ *os.File) error {
+	return nil
+}

--- a/core/mount/manager/mkfs_windows.go
+++ b/core/mount/manager/mkfs_windows.go
@@ -1,0 +1,39 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"os"
+	"syscall"
+)
+
+const fsctlSetSparse = 0x000900c4
+
+// setSparseFile marks a file as sparse on NTFS/ReFS. This must be called
+// before Truncate so that extending the file does not zero-fill the
+// intervening space on disk, which is extremely slow for large files.
+func setSparseFile(f *os.File) error {
+	var bytesReturned uint32
+	return syscall.DeviceIoControl(
+		syscall.Handle(f.Fd()),
+		fsctlSetSparse,
+		nil, 0,
+		nil, 0,
+		&bytesReturned,
+		nil,
+	)
+}


### PR DESCRIPTION
(slightly experimental, still being tested)

On Windows (NTFS/ReFS), extending a file with Truncate does not create a sparse file by default. When mkfs.ext4 subsequently writes metadata at scattered offsets across the file, NTFS must zero-fill all intervening blocks up to the valid data length before each write. For large filesystem images this is extremely slow.

Fix this by marking the file as sparse via FSCTL_SET_SPARSE before calling Truncate. This allows NTFS to leave unwritten regions unallocated, matching the behavior of macOS/Linux where Truncate already produces sparse files.

Benchmark results (8 GB file, Windows 11, NTFS):

```
  Without FSCTL_SET_SPARSE (before):
    Create + Truncate:    535µs   (on-disk: 8192 MB)
    Scattered writes:     4.74s   (on-disk: 8192 MB)
    Total:                4.74s

  With FSCTL_SET_SPARSE (after):
    Create + Truncate:    526µs   (on-disk: 0 MB)
    Scattered writes:     15.6ms  (on-disk: 1 MB)
    Total:                16.1ms
```

~300x speedup for the file creation + write pattern, and on-disk usage drops from 8 GB to only the blocks actually written by mkfs.