### PR TITLE
nri: add dependency on internal tracing plugin

### DIFF
--- a/plugins/nri/plugin.go
+++ b/plugins/nri/plugin.go
@@ -25,8 +25,11 @@ import (
 
 func init() {
 	registry.Register(&plugin.Registration{
-		Type:   plugins.NRIApiPlugin,
-		ID:     "nri",
+		Type: plugins.NRIApiPlugin,
+		ID:   "nri",
+		Requires: []plugin.Type{
+			plugins.InternalPlugin,
+		},
 		Config: nri.DefaultConfig(),
 		InitFn: initFunc,
 	})


### PR DESCRIPTION
Ensure that the internal tracing plugin is initialized before the NRI plugin. This ensures that NRI has access to the global TracerProvider when it initializes its TTRPC interceptors.

Assisted-by: gemini-cli