### PR TITLE
issues/12607 - adhere to runc 1.4 oci standard where pid.limit 0 is considered same as 1 (not unlimited unlike earlier)

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1607,6 +1607,15 @@ func WithPidsLimit(limit int64) SpecOpts {
 		if s.Linux.Resources.Pids == nil {
 			s.Linux.Resources.Pids = &specs.LinuxPids{}
 		}
+		// If limit is less than 0, set to nil (unlimited/default)
+		if limit < 0 {
+			s.Linux.Resources.Pids.Limit = nil
+			return nil
+		}
+		// Check if limit is 0, then assign limit to 1
+		if limit == 0 {
+			limit = 1
+		}
 		s.Linux.Resources.Pids.Limit = &limit
 		return nil
 	}


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/issues/12607