### PR TITLE
Fix missing kernel modules for CNI

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,6 +73,7 @@ Vagrant.configure("2") do |config|
     sh.inline = <<~SHELL
         #!/usr/bin/env bash
         set -eux -o pipefail
+        dnf -y install kernel-modules-$(uname -r) kernel-modules-extra-$(uname -r) || true
         dnf -y install \
             container-selinux \
             curl \
@@ -162,6 +163,8 @@ EOF
         source /etc/environment
         source /etc/profile.d/sh.local
         set -eux -o pipefail
+        modprobe br_netfilter || true
+        modprobe xt_comment || true
         cd ${GOPATH}/src/github.com/containerd/containerd
         script/setup/install-cni
         PATH=/opt/cni/bin:$PATH type ${CNI_BINARIES} || true


### PR DESCRIPTION
Integration tests using Vagrant VMs (AlmaLinux 10 and Fedora 43) have been failing during CNI network setup. The `bridge` CNI plugin uses `iptables` with the `comment` extension, which fails with:

`Warning: Extension comment revision 0 not supported, missing kernel module?`

This happens because newer, minimal cloud images often do not ship with or load all netfilter kernel modules by default.

This commit fixes the issue by:
1. Attempting to install `kernel-modules` and `kernel-modules-extra` for the currently running kernel during the package installation phase. This is done as a best-effort (`|| true`) to avoid breaking the build on OS versions that don't package these separately.
2. Explicitly loading the `br_netfilter` and `xt_comment` modules via `modprobe` before setting up the CNI binaries.

Assisted-by: gemini-cli