### PR TITLE
Fix TOCTOU race bug in tar extraction

### DIFF
--- a/pkg/archive/tar_unix.go
+++ b/pkg/archive/tar_unix.go
@@ -80,7 +80,7 @@ func openFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 		return nil, err
 	}
 	// Call chmod to avoid permission mask
-	if err := os.Chmod(name, perm); err != nil {
+	if err := f.Chmod(perm); err != nil {
 		f.Close()
 		return nil, err
 	}


### PR DESCRIPTION
See https://github.com/containerd/containerd/security/advisories/GHSA-ww5g-h6rh-8wm3 for a conversation around this particular bug.