### PR TITLE
Introduce Windows Arm64 build in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
             goarch: amd64
           - goos: freebsd
             goarch: arm64
+          - goos: windows
+            goarch: arm64
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -154,7 +156,7 @@ jobs:
             echo "CGO_ENABLED=1" >> $GITHUB_ENV
             echo "CC=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
             ;;
-          windows/arm/v7)
+          windows/arm64)
             echo "CGO_ENABLED=0" >> $GITHUB_ENV
             ;;
           esac


### PR DESCRIPTION
https://github.com/containerd/containerd/pull/12844 removed Windows 32 bit ARM build from CI workflow.
This PR adds windows arm64 build in CI workflow.