### PR TITLE
add --sslkeylogfile flag to enable TLS session key logging for debugging

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -96,6 +96,10 @@ var (
 			Name:  "http-trace",
 			Usage: "Enable HTTP tracing for registry interactions",
 		},
+		&cli.StringFlag{
+			Name:  "sslkeylogfile",
+			Usage: "Path to write TLS session keys",
+		},
 	}
 
 	// RuntimeFlags are cli flags specifying runtime

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -106,7 +106,7 @@ command. As part of this process, we do the following:
 
 		if !cliContext.Bool("local") {
 			unsupportedFlags := []string{"max-concurrent-downloads", "print-chainid",
-				"skip-verify", "tlscacert", "tlscert", "tlskey", // RegistryFlags
+				"skip-verify", "tlscacert", "tlscert", "tlskey", "sslkeylogfile", // RegistryFlags
 			}
 			for _, s := range unsupportedFlags {
 				if cliContext.IsSet(s) {

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -98,7 +98,7 @@ var pushCommand = &cli.Command{
 		if !cliContext.Bool("local") {
 			unsupportedFlags := []string{
 				"manifest", "manifest-type", "max-concurrent-uploaded-layers", "allow-non-distributable-blobs",
-				"skip-verify", "tlscacert", "tlscert", "tlskey", "http-dump", "http-trace", // RegistryFlags
+				"skip-verify", "tlscacert", "tlscert", "tlskey", "http-dump", "http-trace", "sslkeylogfile", // RegistryFlags
 			}
 			for _, s := range unsupportedFlags {
 				if cliContext.IsSet(s) {

--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -130,6 +130,14 @@ func resolverDefaultTLS(cliContext *cli.Context) (*tls.Config, error) {
 		}
 	}
 
+	if sslKeyLogFile := cliContext.String("sslkeylogfile"); sslKeyLogFile != "" {
+		f, err := os.OpenFile(sslKeyLogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open SSL key log file %q: %w", sslKeyLogFile, err)
+		}
+		tlsConfig.KeyLogWriter = f
+	}
+
 	tlsCertPath := cliContext.String("tlscert")
 	tlsKeyPath := cliContext.String("tlskey")
 	if tlsCertPath != "" || tlsKeyPath != "" {
@@ -144,7 +152,7 @@ func resolverDefaultTLS(cliContext *cli.Context) (*tls.Config, error) {
 	}
 
 	// If nothing was set, return nil rather than empty config
-	if !tlsConfig.InsecureSkipVerify && tlsConfig.RootCAs == nil && tlsConfig.Certificates == nil {
+	if !tlsConfig.InsecureSkipVerify && tlsConfig.RootCAs == nil && tlsConfig.Certificates == nil && tlsConfig.KeyLogWriter == nil {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Add support for writing TLS session keys to a user-specified file using the --sslkeylogfile CLI flag.

This enables TLS traffic decryption in tools like Wireshark for debugging and development purposes.