### PR TITLE
cri: treat NotFound from LocalResolve as non-checkpoint image

### DIFF
--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -201,6 +201,9 @@ func (c *criService) checkIfCheckpointOCIImage(ctx context.Context, input string
 
 	image, err := c.LocalResolve(input)
 	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return "", nil
+		}
 		return "", fmt.Errorf("failed to resolve image %q: %w", input, err)
 	}
 	containerdImage, err := c.toContainerdImage(ctx, image)

--- a/internal/cri/server/container_checkpoint_linux_test.go
+++ b/internal/cri/server/container_checkpoint_linux_test.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 	"testing"
 
+	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -368,4 +370,72 @@ func TestCRImportCheckpointDisabled(t *testing.T) {
 	if !strings.Contains(err.Error(), "criu support is disabled by configuration") {
 		t.Errorf("expected error containing 'criu support is disabled by configuration', got: %v", err)
 	}
+}
+
+func TestCheckIfCheckpointOCIImage(t *testing.T) {
+	for _, test := range []struct {
+		desc         string
+		input        string
+		localResolve func(string) (imagestore.Image, error)
+		expectID     string
+		expectErr    bool
+	}{
+		{
+			desc:      "empty input returns empty without error",
+			input:     "",
+			expectID:  "",
+			expectErr: false,
+		},
+		{
+			desc:      "file path returns empty without error",
+			input:     createTempFile(t),
+			expectID:  "",
+			expectErr: false,
+		},
+		{
+			desc:  "LocalResolve NotFound returns empty without error",
+			input: "nix:0/nix/store/abc123-image.tar:latest",
+			localResolve: func(string) (imagestore.Image, error) {
+				return imagestore.Image{}, errdefs.ErrNotFound
+			},
+			expectID:  "",
+			expectErr: false,
+		},
+		{
+			desc:  "LocalResolve other error propagates",
+			input: "some-image:latest",
+			localResolve: func(string) (imagestore.Image, error) {
+				return imagestore.Image{}, errdefs.ErrUnknown
+			},
+			expectID:  "",
+			expectErr: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			fake := &fakeImageService{}
+			if test.localResolve != nil {
+				fake.localResolveFunc = test.localResolve
+			}
+			c := newTestCRIService(withImageService(fake))
+			id, err := c.checkIfCheckpointOCIImage(context.Background(), test.input)
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.expectID, id)
+		})
+	}
+}
+
+func createTempFile(t *testing.T) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "checkpoint-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return f.Name()
 }

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -361,7 +361,8 @@ func TestToCRISignal(t *testing.T) {
 }
 
 type fakeImageService struct {
-	imageStore *imagestore.Store
+	imageStore       *imagestore.Store
+	localResolveFunc func(string) (imagestore.Image, error)
 }
 
 func (s *fakeImageService) RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
@@ -379,6 +380,9 @@ func (s *fakeImageService) GetSnapshot(key, snapshotter string) (snapshotstore.S
 }
 
 func (s *fakeImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
+	if s.localResolveFunc != nil {
+		return s.localResolveFunc(refOrID)
+	}
 	return imagestore.Image{}, errors.New("not implemented")
 }
 

--- a/internal/cri/server/service_test.go
+++ b/internal/cri/server/service_test.go
@@ -141,6 +141,12 @@ func withRuntimeService(rs RuntimeService) testOpt {
 	}
 }
 
+func withImageService(is ImageService) testOpt {
+	return func(service *criService) {
+		service.ImageService = is
+	}
+}
+
 // newTestCRIService creates a fake criService for test.
 func newTestCRIService(opts ...testOpt) *criService {
 	labels := label.NewStore()


### PR DESCRIPTION
## What

`checkIfCheckpointOCIImage` (introduced in v2.1 via #10365 for KEP-2008) is
called on every `CreateContainer`. When `LocalResolve` returns `ErrNotFound`,
it currently propagates as a hard error and fails container creation — even
though the image is not a checkpoint image.

This patch treats `ErrNotFound` from `LocalResolve` as "not a checkpoint
image" (`return "", nil`), matching the behavior for images that exist but
lack checkpoint annotations.

## Why

containerd has two image stores:

1. **Metadata store** — content-addressed, written by `client.Import()` / Transfer API
2. **CRI in-memory store** — populated asynchronously via `ImageCreate` event handlers

When an image is imported via a path that bypasses `PullImage` (e.g. a
containerd client importing directly), there's a window where the image exists
in the metadata store but hasn't synced to the CRI store yet. During this
window, `checkIfCheckpointOCIImage` gets `ErrNotFound` and fails
`CreateContainer`:

```
failed to check if this is a checkpoint image: failed to resolve image
"sha256:...": not found
```

This affects custom image services and snapshotters (e.g.
[nix-snapshotter](https://github.com/pdtpartners/nix-snapshotter)) that
import images through the containerd client API.

## Safety

An image absent from the CRI store cannot be a checkpoint image. The existing
logic already returns `("", nil)` for non-checkpoint images — this extends
that to the "image not found" case. Other errors (permissions, store
corruption) still propagate.

## Testing

- Added unit tests for `checkIfCheckpointOCIImage` covering: empty input, file
  path input, `ErrNotFound` (returns nil), and other errors (propagates)
- Verified in production (k3s + nix-snapshotter) — resolves the issue

Fixes #12980