### PR TITLE
ci: fix TestOOMEventMonitor failed

### DIFF
--- a/integration/oom_linux_test.go
+++ b/integration/oom_linux_test.go
@@ -128,6 +128,9 @@ version = 3
 					}
 
 					if reason := status.GetReason(); reason != "OOMKilled" {
+						if reason == "Error" {
+							return false, nil
+						}
 						return false, fmt.Errorf("expected OOMKilled but got %s", reason)
 					}
 					return true, nil


### PR DESCRIPTION
ping @fuweid 


Because container 46fe4f885669a771 oomExitReason   can't get in time the default reason is errorExitReason ="Error", when testcase call  ctrd.criRuntimeService(t).RemoveContainer(cntrID) to delete container, container can't get oom reason anymore because cgroup is deleted.
```
2026-03-05T18:17:16.0053536Z     default: time="2026-03-05T18:17:16Z" level=info msg="[RuntimeService] ContainerStatus (containerID=46fe4f885669a771c81e298247832ea451f143a2c0049d48a938549906a42503, timeout=1m0s)"
2026-03-05T18:17:16.0061112Z     default: time="2026-03-05T18:17:16Z" level=info msg="Connecting to runtime service /tmp/TestOOMEventMonitor1526825400/001/containerd.sock"
2026-03-05T18:17:16.0063064Z     default: time="2026-03-05T18:17:16Z" level=info msg="[RuntimeService] ContainerStatus (containerID=4ef0fe6db327ac9303c8fc4947656f38ba72f5fa2e21584447ea01487aae3143, timeout=1m0s)"
2026-03-05T18:17:16.0071244Z     default:     oom_linux_test.go:115:
2026-03-05T18:17:16.0072184Z     default:         	Error Trace:	/root/go/src/github.com/containerd/containerd/integration/oom_linux_test.go:115
2026-03-05T18:17:16.0073127Z     default:         	            				/usr/local/go/src/runtime/asm_amd64.s:1693
2026-03-05T18:17:16.0074083Z     default:         	Error:      	Received unexpected error:
2026-03-05T18:17:16.0074716Z     default:         	            	expected OOMKilled but got Error
2026-03-05T18:17:16.0075315Z     default:         	Test:       	TestOOMEventMonitor
2026-03-05T18:17:16.0076353Z     default:         	Messages:   	wait for container 46fe4f885669a771c81e298247832ea451f143a2c0049d48a938549906a42503 to exit
2026-03-05T18:17:16.0083513Z     default: time="2026-03-05T18:17:16Z" level=info msg="[RuntimeService] ContainerStatus Response (containerID=46fe4f885669a771c81e298247832ea451f143a2c0049d48a938549906a42503, status=id:\"46fe4f885669a771c81e298247832ea451f143a2c0049d48a938549906a42503\"  metadata:{name:\"round-0-running\"}  state:CONTAINER_EXITED  created_at:1772734634037745915  started_at:1772734634972926353  finished_at:1772734634906442983  exit_code:137  image:{image:\"ghcr.io/containerd/busybox:1.36\"}  image_ref:\"ghcr.io/containerd/busybox@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c\"  reason:\"Error\"  resources:{linux:{memory_limit_in_bytes:15728640  memory_swap_limit_in_bytes:15728640}}  image_id:\"sha256:66ba00ad3de8677a3fa4bc4ea0fc46ebca0f14db46ca365e7f60833068dd0148\"  user:{linux:{supplemental_groups:0  supplemental_groups:10}})"
2026-03-05T18:17:16.0092086Z     default: time="2026-03-05T18:17:16Z" level=info msg="Connecting to runtime service /tmp/TestOOMEventMonitor1526825400/001/containerd.sock"
2026-03-05T18:17:16.0093674Z     default: time="2026-03-05T18:17:16Z" level=info msg="[RuntimeService] RemoveContainer (containerID=46fe4f885669a771c81e298247832ea451f143a2c0049d48a938549906a42503, timeout=1m0s)"
2026-03-05T18:17:16.0097510Z     default: time="2026-03-05T18:17:16Z" level=info msg="[RuntimeService] ContainerStatus Response (containerID=4ef0fe6db327ac9303c8fc4947656f38ba72f5fa2e21584447ea01487aae3143, status=id:\"4ef0fe6db327ac9303c8fc4947656f38ba72f5fa2e21584447ea01487aae3143\"  metadata:{name:\"round-0-running\"}  state:CONTAINER_RUNNING  created_at:1772734634094309068  started_at:1772734634985365779  image:{image:\"ghcr.io/containerd/busybox:1.36\"}  image_ref:\"ghcr.io/containerd/busybox@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c\"  reason:\"OOMKilled\"  resources:{linux:{memory_limit_in_bytes:15728640  memory_swap_limit_in_bytes:15728640}}  image_id:\"sha256:66ba00ad3de8677a3fa4bc4ea0fc46ebca0f14db46ca365e7f60833068dd0148\"  user:{linux:{supplemental_groups:0  supplemental_groups:10}})"
2026-03-05T18:17:16.0198800Z     default: time="2026-03-05T18:17:16Z" level=info msg="[RuntimeService] RemoveContainer Response (containerID=46fe4f885669a771c81e298247832ea451f143a2c0049d48a938549906a42503)"
2026-03-05T18:17:16.0923349Z     default: time="2026-03-05T18:17:16Z" level=info msg="Connecting to runtime service /tmp/TestOOMEventMonitor1526825400/001/containerd.sock"
```
