### PR TITLE
fix:Resolve the issue of incorrect structure in the generated configuration file

### DIFF
--- a/script/setup/config-containerd
+++ b/script/setup/config-containerd
@@ -31,15 +31,14 @@ mkdir -p /etc/containerd
 cat << EOF | sudo tee /etc/containerd/config.toml
 version = 2
 
-[plugins."io.containerd.snapshotter.v1.overlayfs"]
-# slow_chown is needed to avoid an error with kernel < 5.19:
-# > "snapshotter \"overlayfs\" doesn't support idmap mounts on this host,
-# > configure \`slow_chown\` to allow a slower and expensive fallback"
-# https://github.com/containerd/containerd/pull/9920#issuecomment-1978901454
-# This is safely ignored for kernel >= 5.19.
-slow_chown = true
-
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
     enable_selinux = ${enable_selinux}
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    # slow_chown is needed to avoid an error with kernel < 5.19:
+    # > "snapshotter \"overlayfs\" doesn't support idmap mounts on this host,
+    # > configure \`slow_chown\` to allow a slower and expensive fallback"
+    # https://github.com/containerd/containerd/pull/9920#issuecomment-1978901454
+    # This is safely ignored for kernel >= 5.19.
+    slow_chown = true
 EOF


### PR DESCRIPTION
The TOML format requires defining the parent section [plugins] first, and then defining the child sections. The original script first defined [plugins. "io. mountainerd. napshotter. v1. overlays"], and then defined [plugins], which caused the parser to incorrectly associate enable_delinux with the overlays plug, resulting in a CI error

https://github.com/containerd/containerd/issues/12937