### PR TITLE
test(fuzz): add timeout to prevent context deadline exceeded

### DIFF
--- a/contrib/fuzz/content_fuzz_test.go
+++ b/contrib/fuzz/content_fuzz_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	digest "github.com/opencontainers/go-digest"
@@ -96,7 +97,8 @@ func populateBlobStore(ctx context.Context, cs content.Store, f *fuzz.ConsumeFuz
 // FuzzCSWalk implements a fuzzer that targets contentStore.Walk()
 func FuzzCSWalk(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+		defer cancel()
 		expected := map[digest.Digest]struct{}{}
 		found := map[digest.Digest]struct{}{}
 		tmpDir := t.TempDir()
@@ -138,7 +140,8 @@ func FuzzArchiveExport(f *testing.F) {
 		if err != nil {
 			return
 		}
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+		defer cancel()
 		tmpDir := t.TempDir()
 		cs, err := local.NewStore(tmpDir)
 		if err != nil {


### PR DESCRIPTION
/kind bug
/kind flake

FuzzArchiveExport and FuzzCSWalk were using context.Background() without timeout, causing occasional test failures when certain fuzz inputs triggered slow operations that exceeded the 30s fuzztime limit.

Add 25s timeout to both tests, leaving 5s buffer for cleanup.

Fixes intermittent 'context deadline exceeded' failures in CI.
https://github.com/containerd/containerd/issues/12991