### PR TITLE
erofs: add a config param for rwlayer mount options

### DIFF
--- a/plugins/snapshots/erofs/erofs.go
+++ b/plugins/snapshots/erofs/erofs.go
@@ -39,6 +39,8 @@ import (
 type SnapshotterConfig struct {
 	// ovlOptions are the base options added to the overlayfs mount (defaults to [""])
 	ovlOptions []string
+	// rwlOptions are the extra mount options for rwlayer (defaults to [""])
+	rwlOptions []string
 	// enableFsverity enables fsverity for EROFS layers
 	enableFsverity bool
 	// setImmutable enables IMMUTABLE_FL file attribute for EROFS layers
@@ -57,6 +59,13 @@ type Opt func(config *SnapshotterConfig)
 func WithOvlOptions(options []string) Opt {
 	return func(config *SnapshotterConfig) {
 		config.ovlOptions = options
+	}
+}
+
+// WithRwlOptions defines the extra mount options for rwlayer
+func WithRwlOptions(options []string) Opt {
+	return func(config *SnapshotterConfig) {
+		config.rwlOptions = options
 	}
 }
 
@@ -105,6 +114,7 @@ type snapshotter struct {
 	root            string
 	ms              *storage.MetaStore
 	ovlOptions      []string
+	rwlOptions      []string
 	enableFsverity  bool
 	setImmutable    bool
 	defaultWritable int64
@@ -181,6 +191,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		root:            root,
 		ms:              ms,
 		ovlOptions:      config.ovlOptions,
+		rwlOptions:      config.rwlOptions,
 		enableFsverity:  config.enableFsverity,
 		setImmutable:    config.setImmutable,
 		defaultWritable: config.defaultSize,
@@ -396,14 +407,14 @@ func (s *snapshotter) mounts(snap storage.Snapshot, info snapshots.Info) ([]moun
 			mounts = append(mounts, mount.Mount{
 				Source: s.writablePath(snap.ID),
 				Type:   "mkfs/ext4",
-				Options: []string{
+				Options: append([]string{
 					"X-containerd.mkfs.fs=ext4",
 					// TODO: Get size from snapshot labels
 					fmt.Sprintf("X-containerd.mkfs.size=%d", s.defaultWritable),
 					// TODO: Add UUID
 					"rw",
 					"loop",
-				},
+				}, s.rwlOptions...),
 			})
 			options = append(options,
 				"X-containerd.mkdir.path={{ mount 0 }}/upper:0755",

--- a/plugins/snapshots/erofs/plugin/plugin.go
+++ b/plugins/snapshots/erofs/plugin/plugin.go
@@ -42,6 +42,9 @@ type Config struct {
 	// MountOptions are options used for the EROFS overlayfs mount
 	OvlOptions []string `toml:"ovl_mount_options"`
 
+	// RwlOptions are options used for the rwlayer mount
+	RwlOptions []string `toml:"rwl_mount_options"`
+
 	// EnableFsverity enables fsverity for EROFS layers
 	// Linux only
 	EnableFsverity bool `toml:"enable_fsverity"`
@@ -78,6 +81,10 @@ func init() {
 
 			if len(config.OvlOptions) > 0 {
 				opts = append(opts, erofs.WithOvlOptions(config.OvlOptions))
+			}
+
+			if len(config.RwlOptions) > 0 {
+				opts = append(opts, erofs.WithRwlOptions(config.RwlOptions))
 			}
 
 			if config.EnableFsverity {


### PR DESCRIPTION
There's currently no way to specify custom mount options for the rwlayer created by the erofs snapshotter. Add rwl_mount_options to the plugin config struct.