### PR TITLE
cri: checkpoint and restore /dev/shm

### DIFF
--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -199,6 +199,7 @@ func (c *criService) CRImportCheckpoint(
 				crmetadata.NetworkStatusFile,
 				crmetadata.DeletedFilesFile,
 				crmetadata.CheckpointDirectory,
+				crmetadata.DevShmCheckpointTar,
 			}
 			for _, pattern := range excludePatterns {
 				if strings.HasPrefix(hdr.Name, pattern) {
@@ -591,6 +592,25 @@ func (c *criService) CheckpointContainer(ctx context.Context, r *runtime.Checkpo
 			filepath.Join(cpPath, "container.log"),
 			0o600,
 		); err != nil {
+			return nil, err
+		}
+	}
+
+	// Keep the content of /dev/shm directory
+	sandboxDevShm := c.getSandboxDevShm(container.SandboxID)
+	if _, err := c.os.Stat(sandboxDevShm); err == nil {
+		shmDirTarFileFullPath := filepath.Join(cpPath, crmetadata.DevShmCheckpointTar)
+		shmDirTarFile, err := os.Create(shmDirTarFileFullPath)
+		if err != nil {
+			return nil, err
+		}
+		defer shmDirTarFile.Close()
+
+		shmTar := archive.Diff(ctx, "", sandboxDevShm)
+		if _, err = io.Copy(shmDirTarFile, shmTar); err != nil {
+			return nil, err
+		}
+		if err := shmTar.Close(); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/cri/server/container_start.go
+++ b/internal/cri/server/container_start.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containerd/containerd/v2/pkg/archive"
 	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
@@ -106,6 +107,23 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 	}
 
 	if cntr.Status.Get().Restore {
+		// Restore /dev/shm content
+		sandboxDevShm := c.getSandboxDevShm(meta.SandboxID)
+		shmDirTarFilePath := filepath.Join(c.getContainerRootDir(r.GetContainerId()), crmetadata.DevShmCheckpointTar)
+		if _, err := os.Stat(shmDirTarFilePath); err != nil {
+			log.G(ctx).Debugf("container checkpoint doesn't contain /dev/shm: %v", err)
+		} else {
+			shmDirTarFile, err := os.Open(shmDirTarFilePath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open /dev/shm checkpoint archive: %w", err)
+			}
+			defer shmDirTarFile.Close()
+
+			if _, err := archive.Apply(ctx, sandboxDevShm, shmDirTarFile); err != nil {
+				return nil, fmt.Errorf("failed to restore /dev/shm from checkpoint: %w", err)
+			}
+		}
+
 		// If during start the container is detected as a checkpoint the container
 		// will be marked with Restore() == true. In this case not the normal
 		// start code is needed but this code which does a restore.
@@ -164,6 +182,7 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 			crmetadata.NetworkStatusFile,
 			crmetadata.RootFsDiffTar,
 			crmetadata.DeletedFilesFile,
+			crmetadata.DevShmCheckpointTar,
 			crmetadata.CheckpointDirectory,
 			crmetadata.StatusDumpFile,
 			crmetadata.ConfigDumpFile,


### PR DESCRIPTION
similar to https://github.com/containers/podman/pull/12665

this pull request creates a tar file with the content of /dev/shm that is included in the container checkpoint and used to restore the container

tested on k3s with docker.io/budsinan/snapshot:1772800329