### PR TITLE
fix(erofs): set TMPDIR for mkfs.erofs on Windows

### DIFF
--- a/internal/erofsutils/mount.go
+++ b/internal/erofsutils/mount.go
@@ -38,6 +38,16 @@ func IsErofsMediaType(mt string) bool {
 	return strings.HasPrefix(mt, "application/vnd.erofs.layer")
 }
 
+func mkfsEnv(layerPath string) []string {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	env := os.Environ()
+	tmpdir := filepath.Dir(layerPath)
+	env = append(env, "TMPDIR="+tmpdir)
+	return env
+}
+
 func ConvertTarErofs(ctx context.Context, r io.Reader, layerPath, uuid string, mkfsExtraOpts []string) error {
 	args := append([]string{"--tar=f", "--aufs", "--quiet", "-Enoinline_data"}, mkfsExtraOpts...)
 	if uuid != "" {
@@ -46,6 +56,7 @@ func ConvertTarErofs(ctx context.Context, r io.Reader, layerPath, uuid string, m
 	args = append(args, layerPath)
 	cmd := exec.CommandContext(ctx, "mkfs.erofs", args...)
 	cmd.Stdin = r
+	cmd.Env = mkfsEnv(layerPath)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("erofs apply failed: %s: %w", out, err)
@@ -80,6 +91,7 @@ func GenerateTarIndexAndAppendTar(ctx context.Context, r io.Reader, layerPath, u
 	args = append(args, layerPath)
 	cmd := exec.CommandContext(ctx, "mkfs.erofs", args...)
 	cmd.Stdin = teeReader
+	cmd.Env = mkfsEnv(layerPath)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("tar index generation failed with command 'mkfs.erofs %s': %s: %w",
@@ -131,6 +143,7 @@ func ConvertErofs(ctx context.Context, layerPath string, srcDir string, mkfsExtr
 	args := append([]string{"--quiet", "-Enoinline_data"}, mkfsExtraOpts...)
 	args = append(args, layerPath, srcDir)
 	cmd := exec.CommandContext(ctx, "mkfs.erofs", args...)
+	cmd.Env = mkfsEnv(layerPath)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("erofs apply failed: %s: %w", out, err)


### PR DESCRIPTION
## Summary

On Windows, `mkfs.erofs` (MinGW binary) reads `TMPDIR` for its diskbuf temp files. Windows does not set `TMPDIR`, so mkfs.erofs falls back to `/tmp` which resolves to `C:\tmp` for a native MinGW binary. `C:\tmp` doesn't exist on most Windows machines — `mkstemp` fails and `erofs_diskbuf_init` returns `ENOSPC` regardless of actual errno, producing a misleading "No space left on device" error even on disks with plenty of free space.

## Fix

Set `TMPDIR` to the snapshot directory (parent of the output `layer.erofs` file) for all `mkfs.erofs` invocations on Windows. On Unix, behavior is unchanged (`nil` env inherits parent process).

## Why not `os.TempDir()`?

On Windows `os.TempDir()` falls back to `C:\Windows\Temp` when `TMP`/`TEMP`/`USERPROFILE` are all unset (e.g. service contexts). The snapshot dir is always valid — containerd creates it before calling the differ.

## Verified

| TMPDIR | C:\tmp exists | Result |
|--------|---------------|--------|
| nonexistent dir | yes | ENOSPC (bug) |
| valid dir (backslashes) | yes | OK |
| valid dir (forward slashes) | yes | OK |
| dir with spaces | yes | OK |
| unset | no | ENOSPC (real-world bug) |