### PR TITLE
fix(shim): implement io.Closer on ShimManager for graceful shutdown

### DIFF
--- a/core/runtime/v2/shim_manager.go
+++ b/core/runtime/v2/shim_manager.go
@@ -480,3 +480,24 @@ func (m *ShimManager) loadShimInfo(ctx context.Context, shim string) (*shimInfo,
 	m.shimInfos.Store(shim, sinfo)
 	return sinfo, nil
 }
+
+// Close implements io.Closer so that Server.Stop() will close all tracked
+// shim client connections during shutdown.
+func (m *ShimManager) Close() error {
+	if m.shims.IsEmpty() {
+		return nil
+	}
+
+	ctx := context.Background()
+	shims, err := m.shims.GetAll(ctx, true)
+	if err != nil {
+		return fmt.Errorf("listing shims for shutdown: %w", err)
+	}
+
+	for _, s := range shims {
+		if err := s.Close(); err != nil {
+			log.G(ctx).WithFields(log.Fields{"id": s.ID(), "error": err}).Warn("failed to close shim")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add Close() method to ShimManager so containerd's [Server.Stop()](https://github.com/containerd/containerd/blob/910171e90ec3a402c6669333483fbec9d0b414d7/cmd/containerd/server/server.go#L475) closes all tracked shim client connections during shutdown. Without this, Stop() returns before shims have disconnected, causing race conditions where shims write to paths that have already been cleaned up by the caller.