### PR TITLE
fix: avoid content storage pollution by limiting the fallback on ref resolution

### DIFF
--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -292,6 +292,14 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 	}
 
 	for _, u := range paths {
+		// falling back to /blobs endpoint should happen in extreme cases - those to
+		// support legacy registries. we want to limit the fallback to when /manifests endpoint
+		// returned 404. Falling back on transient errors could do more harm, like polluting
+		// the local content store with incorrectly typed descriptors as /blobs endpoint tends
+		// always return with application/octet-stream.
+		if firstErrPriority > 2 {
+			break
+		}
 		for i, host := range hosts {
 			ctx := log.WithLogger(ctx, log.G(ctx).WithField("host", host.Host))
 

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -1007,6 +1007,138 @@ func (m testManifest) RegisterHandler(r *http.ServeMux, name string) {
 	}
 }
 
+// TestResolveTransientManifestError verifies that a transient server error (5xx)
+// from the /manifests/ endpoint does NOT cause containerd to fall back to the
+// /blobs/ endpoint. Before this fix, a 500 from /manifests/ would cause Resolve()
+// to silently retry via /blobs/, which returns "application/octet-stream" instead
+// of a proper manifest media type — poisoning the descriptor and corrupting the
+// local content store.
+//
+// The correct behavior is: 5xx from /manifests/ → return the server error, do NOT
+// try /blobs/.
+func TestResolveTransientManifestError(t *testing.T) {
+	var (
+		manifestCalled int
+		blobsCalled    bool
+		repo           = "test-repo"
+		dgst           = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" // empty sha
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/manifests/"+dgst) {
+			manifestCalled++
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/blobs/"+dgst) {
+			blobsCalled = true
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Docker-Content-Digest", dgst)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	resolver := NewResolver(ResolverOptions{
+		Hosts: func(string) ([]RegistryHost, error) {
+			return []RegistryHost{
+				{
+					Host:         ts.URL[len("http://"):],
+					Scheme:       "http",
+					Capabilities: HostCapabilityPull | HostCapabilityResolve,
+				},
+			}, nil
+		},
+	})
+
+	ref := fmt.Sprintf("%s/%s@%s", ts.URL[len("http://"):], repo, dgst)
+	_, _, err := resolver.Resolve(context.Background(), ref)
+
+	if manifestCalled == 0 {
+		t.Fatal("manifests endpoint was not called")
+	}
+	if blobsCalled {
+		t.Error("blobs endpoint was called, but should not have been after a 500 on /manifests/")
+	}
+	if err == nil {
+		t.Fatal("expected error from Resolve, but got nil")
+	}
+
+	// The error should surface the unexpected 500 status, not a generic "not found".
+	var unexpectedStatus remoteerrors.ErrUnexpectedStatus
+	if !errors.As(err, &unexpectedStatus) {
+		t.Errorf("expected ErrUnexpectedStatus (from 500), got %T: %v", err, err)
+	} else if unexpectedStatus.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", unexpectedStatus.StatusCode)
+	}
+}
+
+// TestResolve404ManifestFallback verifies that a 404 from /manifests/ DOES
+// allow fallback to /blobs/. This preserves backward compatibility with
+// non-standard registries that may only serve certain digests via /blobs/.
+func TestResolve404ManifestFallback(t *testing.T) {
+	var (
+		manifestCalled bool
+		blobsCalled    bool
+		repo           = "test-repo"
+		dgst           = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/manifests/"+dgst) {
+			manifestCalled = true
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/blobs/"+dgst) {
+			blobsCalled = true
+			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+			w.Header().Set("Docker-Content-Digest", dgst)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	}))
+	defer ts.Close()
+
+	resolver := NewResolver(ResolverOptions{
+		Hosts: func(string) ([]RegistryHost, error) {
+			return []RegistryHost{
+				{
+					Host:         ts.URL[len("http://"):],
+					Scheme:       "http",
+					Capabilities: HostCapabilityPull | HostCapabilityResolve,
+				},
+			}, nil
+		},
+	})
+
+	ref := fmt.Sprintf("%s/%s@%s", ts.URL[len("http://"):], repo, dgst)
+	_, desc, err := resolver.Resolve(context.Background(), ref)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !manifestCalled {
+		t.Error("manifests endpoint was not called")
+	}
+	if !blobsCalled {
+		t.Error("blobs endpoint was not called on 404")
+	}
+	if desc.MediaType != "application/vnd.docker.distribution.manifest.v2+json" {
+		t.Errorf("unexpected media type: %s", desc.MediaType)
+	}
+}
+
 func newRefreshTokenServer(t testing.TB, name string, disablePOST bool, onFetchRefreshToken OnFetchRefreshToken) *refreshTokenServer {
 	return &refreshTokenServer{
 		T:                   t,


### PR DESCRIPTION
/kind bug

### What

Fixes: https://github.com/containerd/containerd/issues/13007 by limiting the fallback to `/blobs` endpoint on `resolve.Resolve`. It could permanently corrupt an image in local content store due to incorrect `content-type` returned.

### Alternatives considered


#### Remove the `/blobs/` fallback entirely

The `/blobs/` fallback was introduced to support non-standard or legacy registries that serve manifest content only through the blob endpoint. Removing it entirely would be the cleanest fix, but could silently break users relying on this behavior without any clear migration path. Since there is no registry conformance test enforcing the `/manifests/` endpoint, some private/custom registries may depend on it. Rejected to avoid a potentially breaking change.

#### Validate the `Content-Type` returned by `/blobs/` against known manifest media types

After falling back to `/blobs/`, check whether the returned `Content-Type` is a recognized manifest or index media type (using `images.IsManifestType` / `images.IsIndexType`). If not, skip the result and continue.

This approach catches the symptom (wrong media type) rather than the cause (wrong error triggering the fallback). It also makes a hidden assumption that `Resolve()` is only ever used to resolve manifests — but `Resolve()` is a general-purpose descriptor resolver and `/blobs/` is a legitimate path for non-manifest content in some workflows. Rejected as too narrow and fragile.
