### PR TITLE
fix: correct typos found by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ A Kubernetes incubator project, [cri-tools](https://github.com/kubernetes-sigs/c
 
 #### CRI Guides
 * [Installing with Ansible and Kubeadm](contrib/ansible/README.md)
-* [For Non-Ansible Users, Preforming a Custom Installation Using the Release Tarball and Kubeadm](docs/getting-started.md)
+* [For Non-Ansible Users, Performing a Custom Installation Using the Release Tarball and Kubeadm](docs/getting-started.md)
 * [CRI Plugin Testing Guide](./docs/cri/testing.md)
 * [Debugging Pods, Containers, and Images with `crictl`](./docs/cri/crictl.md)
 * [Configuring `cri` Plugins](./docs/cri/config.md)

--- a/cmd/containerd/server/server_test.go
+++ b/cmd/containerd/server/server_test.go
@@ -111,7 +111,7 @@ func TestMigration(t *testing.T) {
 		},
 		ConfigMigration: func(ctx context.Context, v int, plugins map[string]interface{}) error {
 			if v != configVersion {
-				t.Errorf("unxpected version: %d", v)
+				t.Errorf("unexpected version: %d", v)
 			}
 			t1, ok := plugins["io.containerd.test.t1"]
 			if !ok {

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -273,7 +273,7 @@ func ProgressHandler(ctx context.Context, out io.Writer) (transfer.ProgressFunc,
 		// Use a buffered channel for progress to allow multiple completed
 		// progress updates to be processed before shutting down the progress
 		// handler. Currently the progress stream does not have an explicit
-		// end, however, done indicates the server has already commpleted
+		// end, however, done indicates the server has already completed
 		// sending all progress.
 		pc     = make(chan transfer.Progress, 5)
 		status string

--- a/core/diff/diff.go
+++ b/core/diff/diff.go
@@ -138,7 +138,7 @@ func WithSyncFs(sync bool) ApplyOpt {
 }
 
 // WithProgress is used to indicate process of the apply operation, should
-// atleast expect a progress of 0 and of the final size. It is up to the applier
+// at least expect a progress of 0 and of the final size. It is up to the applier
 // how much progress it reports in between.
 func WithProgress(f func(ocispec.Descriptor, int64)) ApplyOpt {
 	return func(_ context.Context, desc ocispec.Descriptor, c *ApplyConfig) error {

--- a/core/images/imagetest/content.go
+++ b/core/images/imagetest/content.go
@@ -165,7 +165,7 @@ func (tc ContentStore) Walk(c Content, fn func(context.Context, *Content, conten
 	return c
 }
 
-// AddPlatform alters the content desciptor by setting the platform
+// AddPlatform alters the content descriptor by setting the platform
 func AddPlatform(c Content, p ocispec.Platform) Content {
 	c.Descriptor.Platform = &p
 	return c

--- a/core/introspection/proxy/remote.go
+++ b/core/introspection/proxy/remote.go
@@ -83,7 +83,7 @@ func (i *introspectionRemote) PluginInfo(ctx context.Context, pluginType, id str
 	if options != nil {
 		optionsPB, err = typeurl.MarshalAnyToProto(options)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal runtime requst: %w", err)
+			return nil, fmt.Errorf("failed to marshal runtime request: %w", err)
 		}
 	}
 	resp, err = i.client.PluginInfo(ctx, &api.PluginInfoRequest{

--- a/core/transfer/image/imagestore_test.go
+++ b/core/transfer/image/imagestore_test.go
@@ -229,7 +229,7 @@ func TestStore(t *testing.T) {
 						t.Fatal(err)
 					}
 					if !errors.Is(err, testCase.Err) {
-						t.Fatalf("unexpected error %v: expeceted %v", err, testCase.Err)
+						t.Fatalf("unexpected error %v: expected %v", err, testCase.Err)
 					}
 					return
 				} else if testCase.Err != nil {

--- a/core/transfer/local/pull_test.go
+++ b/core/transfer/local/pull_test.go
@@ -143,7 +143,7 @@ func TestGetSupportedPlatform(t *testing.T) {
 			if sp.Platform != nil && !sp.Platform.Match(testCase.ExpectedPlatform.Platform) {
 				t.Fatalf("Expect Platform %v doesn't match", testCase.ExpectedPlatform.Platform)
 			}
-			// If the ExectedPlatform is not empty, the matched Platform shoule not be nil either
+			// If the ExectedPlatform is not empty, the matched Platform should not be nil either
 			if sp.Platform == nil && testCase.ExpectedPlatform.Platform.OS != "" {
 				t.Fatalf("Expect Platform %v doesn't match", testCase.ExpectedPlatform.Platform)
 			}


### PR DESCRIPTION
## Summary
Fix various typos across source code, tests, and documentation found by codespell:

| File | Typo | Fix |
|------|------|-----|
| `README.md` | Preforming | Performing |
| `cmd/ctr/commands/images/pull.go` | commpleted | completed |
| `cmd/containerd/server/server_test.go` | unxpected | unexpected |
| `core/diff/diff.go` | atleast | at least |
| `core/images/imagetest/content.go` | desciptor | descriptor |
| `core/introspection/proxy/remote.go` | requst | request |
| `core/transfer/image/imagestore_test.go` | expeceted | expected |
| `core/transfer/local/pull_test.go` | shoule | should |

## Test plan
- [ ] All existing tests pass (changes are only to string literals in comments, error messages, and test expectations)
- [ ] No functional changes