### PR TITLE
core/mount: use typed int for mount-flags

### DIFF
--- a/core/mount/mount_linux.go
+++ b/core/mount/mount_linux.go
@@ -32,7 +32,7 @@ import (
 )
 
 type mountOpt struct {
-	flags   int
+	flags   mntFlag
 	data    []string
 	losetup bool
 	uidmap  string
@@ -181,7 +181,7 @@ func (m *Mount) mount(target string) (err error) {
 		}
 	}
 
-	const broflags = unix.MS_BIND | unix.MS_RDONLY
+	const broflags mntFlag = unix.MS_BIND | unix.MS_RDONLY
 	if oflags&broflags == broflags {
 		// Preserve CL_UNPRIVILEGED "locked" flags of the
 		// bind mount target when we remount to make the bind readonly.
@@ -191,13 +191,14 @@ func (m *Mount) mount(target string) (err error) {
 		// CL_UNPRIVILEGED locked flags.
 		var unprivFlags int
 		if userns.RunningInUserNS() {
-			unprivFlags, err = getUnprivilegedMountFlags(target)
+			f, err := getUnprivilegedMountFlags(target)
 			if err != nil {
 				return err
 			}
+			unprivFlags = int(f)
 		}
 		// Remount the bind to apply read only.
-		return unix.Mount("", target, "", uintptr(oflags|unprivFlags|unix.MS_REMOUNT), "")
+		return unix.Mount("", target, "", uintptr(int(oflags)|unprivFlags|unix.MS_REMOUNT), "")
 	}
 
 	// remap non-overlay mount point
@@ -213,14 +214,14 @@ func (m *Mount) mount(target string) (err error) {
 // path and are locked by CL_UNPRIVILEGED.
 //
 // From https://github.com/moby/moby/blob/v23.0.1/daemon/oci_linux.go#L430-L460
-func getUnprivilegedMountFlags(path string) (int, error) {
+func getUnprivilegedMountFlags(path string) (mntFlag, error) {
 	var statfs unix.Statfs_t
 	if err := unix.Statfs(path, &statfs); err != nil {
 		return 0, err
 	}
 
 	// The set of keys come from https://github.com/torvalds/linux/blob/v4.13/fs/namespace.c#L1034-L1048.
-	unprivilegedFlags := []int{
+	unprivilegedFlags := []mntFlag{
 		unix.MS_RDONLY,
 		unix.MS_NODEV,
 		unix.MS_NOEXEC,
@@ -230,9 +231,9 @@ func getUnprivilegedMountFlags(path string) (int, error) {
 		unix.MS_NODIRATIME,
 	}
 
-	var flags int
+	var flags mntFlag
 	for _, flag := range unprivilegedFlags {
-		if int(statfs.Flags)&flag == flag {
+		if mntFlag(statfs.Flags)&flag == flag {
 			flags |= flag
 		}
 	}
@@ -329,7 +330,7 @@ func parseMountOptions(options []string) (opt mountOpt) {
 	loopOpt := "loop"
 	flagsMap := map[string]struct {
 		clear bool
-		flag  int
+		flag  mntFlag
 	}{
 		"async":         {true, unix.MS_SYNCHRONOUS},
 		"atime":         {true, unix.MS_NOATIME},

--- a/core/mount/mount_linux_test.go
+++ b/core/mount/mount_linux_test.go
@@ -421,7 +421,7 @@ func TestGetUnprivilegedMountFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
-		flag int
+		flag mntFlag
 		name string
 	}{
 		{unix.MS_NOEXEC, "MS_NOEXEC"},
@@ -435,7 +435,7 @@ func TestGetUnprivilegedMountFlags(t *testing.T) {
 
 	// MS_NOSUID and MS_NODEV should NOT be set since we didn't mount with them.
 	for _, tc := range []struct {
-		flag int
+		flag mntFlag
 		name string
 	}{
 		{unix.MS_NOSUID, "MS_NOSUID"},

--- a/core/mount/mount_unix.go
+++ b/core/mount/mount_unix.go
@@ -28,6 +28,13 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// mntFlag is a typed wrapper for mount/unmount flag values.
+//
+// It helps avoid accidental misuse of plain ints (e.g., passing a loop index
+// instead of a flag). While not fully preventing such errors, it forces
+// explicit conversions at boundaries, making mistakes easier to spot.
+type mntFlag int
+
 // UnmountRecursive unmounts the target and all mounts underneath, starting
 // with the deepest mount first.
 func UnmountRecursive(target string, flags int) error {
@@ -73,7 +80,7 @@ func UnmountRecursive(target string, flags int) error {
 	return nil
 }
 
-func unmount(target string, flags int) error {
+func unmount(target string, flags mntFlag) error {
 	if isFUSE(target) {
 		// TODO: Why error is ignored?
 		// Shouldn't this just be unconditional "return unmountFUSE(target)"?
@@ -82,7 +89,7 @@ func unmount(target string, flags int) error {
 		}
 	}
 	for range 50 {
-		if err := unix.Unmount(target, flags); err != nil {
+		if err := unix.Unmount(target, int(flags)); err != nil {
 			switch err {
 			case unix.EBUSY:
 				time.Sleep(50 * time.Millisecond)
@@ -98,10 +105,11 @@ func unmount(target string, flags int) error {
 
 // Unmount the provided mount path with the flags
 func Unmount(target string, flags int) error {
-	if err := unmount(target, flags); err != nil && err != unix.EINVAL {
-		return err
+	err := unmount(target, mntFlag(flags))
+	if err == nil || err == unix.EINVAL {
+		return nil
 	}
-	return nil
+	return err
 }
 
 // UnmountAll repeatedly unmounts the given mount point until there
@@ -120,15 +128,18 @@ func UnmountAll(mount string, flags int) error {
 	}
 
 	for {
-		if err := unmount(mount, flags); err != nil {
+		err := unmount(mount, mntFlag(flags))
+		switch err {
+		case nil:
+			continue
+		case unix.EINVAL:
 			// EINVAL is returned if the target is not a
 			// mount point, indicating that we are
 			// done. It can also indicate a few other
 			// things (such as invalid flags) which we
 			// unfortunately end up squelching here too.
-			if err == unix.EINVAL {
-				return nil
-			}
+			return nil
+		default:
 			return err
 		}
 	}


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/12941



Relates to 5d3b3447c7667d826eec59f9580c947ff24ecec6, which fixed a bug where accidentally the wrong "int" was used for flags.

This PR adds a (non-exported) typed `mntFlag` in an attempt to prevent accidental slip-ups.