### PR TITLE
[release/2.2] cri: UpdatePodSandbox should return Unimplemented

### DIFF
--- a/internal/cri/instrument/instrumented_service.go
+++ b/internal/cri/instrument/instrumented_service.go
@@ -18,7 +18,6 @@ package instrument
 
 import (
 	"context"
-	"errors"
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/errdefs/pkg/errgrpc"
@@ -664,5 +663,5 @@ func (in *instrumentedService) RuntimeConfig(ctx context.Context, r *runtime.Run
 }
 
 func (in *instrumentedService) UpdatePodSandboxResources(ctx context.Context, r *runtime.UpdatePodSandboxResourcesRequest) (res *runtime.UpdatePodSandboxResourcesResponse, err error) {
-	return nil, errors.New("not implemented yet")
+	return nil, errgrpc.ToGRPC(errdefs.ErrNotImplemented)
 }


### PR DESCRIPTION
errgrpc will correctly translate ErrNotImplemented to GRPC's Unimplemented, but a plain error will be returned directly.

```release-note
Ensure UpdatePodSandbox returns Unimplemented instead of a generic error
```