### PR TITLE
Selinux test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,6 +650,8 @@ jobs:
             rm -f /tmp/fedora43.box
           fi
           sudo BOX=$BOX RUNC_FLAVOR=$RUNC_FLAVOR vagrant up --no-tty
+      - name: unit-test
+        run: sudo BOX=$BOX RUNC_FLAVOR=$RUNC_FLAVOR vagrant up --provision-with=selinux,install-runc,install-gotestsum,unit-test
       - name: test-integration
         run: sudo BOX=$BOX RUNC_FLAVOR=$RUNC_FLAVOR vagrant up --provision-with=selinux,install-runc,install-gotestsum,test-integration
       - name: test-cri-integration

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -247,6 +247,26 @@ EOF
   # SELinux is Enforcing by default (via provisioning) in this VM. To re-run with SELinux disabled:
   #   SELINUX=Disabled vagrant up --provision-with=selinux,test-integration
   #
+
+    config.vm.provision "unit-test", type: "shell", run: "never" do |sh|
+    sh.upload_path = "/tmp/unit-test"
+    sh.env = {
+        'RUNC_FLAVOR': ENV['RUNC_FLAVOR'] || "runc",
+        'GOTEST': ENV['GOTEST'] || "go test",
+        'GOTESTSUM_JUNITFILE': ENV['GOTESTSUM_JUNITFILE'],
+        'GOTESTSUM_JSONFILE': ENV['GOTESTSUM_JSONFILE'],
+    }
+    sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        source /etc/environment
+        source /etc/profile.d/sh.local
+        set -eux -o pipefail
+        cd ${GOPATH}/src/github.com/containerd/containerd
+        make test
+        make root-test
+    SHELL
+  end
+
   config.vm.provision "test-integration", type: "shell", run: "never" do |sh|
     sh.upload_path = "/tmp/test-integration"
     sh.env = {

--- a/internal/cri/server/podsandbox/helpers_selinux_linux_test.go
+++ b/internal/cri/server/podsandbox/helpers_selinux_linux_test.go
@@ -50,7 +50,7 @@ func TestInitSelinuxOpts(t *testing.T) {
 				Type:  "",
 				Level: "s0:c1,c2",
 			},
-			processLabel: "system_u:user_r:(container_file_t|svirt_lxc_net_t):s0:c1,c2",
+			processLabel: "system_u:user_r:container_t:s0:c1,c2",
 			mountLabel:   "system_u:object_r:(container_file_t|svirt_sandbox_file_t):s0:c1,c2",
 		},
 		{


### PR DESCRIPTION
fix  on fedora/almalinux
```
    default: --- FAIL: TestInitSelinuxOpts (0.00s)
    default:     --- FAIL: TestInitSelinuxOpts/Should_overlay_fields_on_processLabel_when_selinuxOpt_has_been_initialized_partially (0.00s)
    default:         helpers_selinux_linux_test.go:94:
    default:             	Error Trace:	/root/go/src/github.com/containerd/containerd/internal/cri/server/podsandbox/helpers_selinux_linux_test.go:94
    default:             	Error:      	Expect "system_u:user_r:container_t:s0:c1,c2" to match "system_u:user_r:(container_file_t|svirt_lxc_net_t):s0:c1,c2"
    default:             	Test:       	TestInitSelinuxOpts/Should_overlay_fields_on_processLabel_when_selinuxOpt_has_been_initialized_partially
```