### PR TITLE
cri: implement RegistryToken support in image pull auth

### DIFF
--- a/core/remotes/docker/authorizer.go
+++ b/core/remotes/docker/authorizer.go
@@ -35,6 +35,11 @@ import (
 type dockerAuthorizer struct {
 	credentials func(string) (string, string, error)
 
+	// registryToken is a pre-obtained bearer token to be sent directly
+	// to the registry without token exchange. Corresponds to the
+	// RegistryToken field in the CRI AuthConfig.
+	registryToken string
+
 	client *http.Client
 	header http.Header
 	mu     sync.RWMutex
@@ -47,6 +52,7 @@ type dockerAuthorizer struct {
 
 type authorizerConfig struct {
 	credentials         func(string) (string, string, error)
+	registryToken       string
 	client              *http.Client
 	header              http.Header
 	onFetchRefreshToken OnFetchRefreshToken
@@ -88,6 +94,17 @@ func WithAuthHeader(hdr http.Header) AuthorizerOpt {
 // OnFetchRefreshToken is called on fetching request token.
 type OnFetchRefreshToken func(ctx context.Context, refreshToken string, req *http.Request)
 
+// WithRegistryToken sets a pre-obtained bearer token that will be sent
+// directly to the registry as "Authorization: Bearer <token>" without
+// going through the token exchange flow. This corresponds to the
+// RegistryToken field in the CRI AuthConfig and the "registrytoken"
+// field in Docker's config.json auth entries.
+func WithRegistryToken(token string) AuthorizerOpt {
+	return func(opt *authorizerConfig) {
+		opt.registryToken = token
+	}
+}
+
 // WithFetchRefreshToken enables fetching "refresh token" (aka "identity token", "offline token").
 func WithFetchRefreshToken(f OnFetchRefreshToken) AuthorizerOpt {
 	return func(opt *authorizerConfig) {
@@ -110,6 +127,7 @@ func NewDockerAuthorizer(opts ...AuthorizerOpt) Authorizer {
 
 	return &dockerAuthorizer{
 		credentials:         ao.credentials,
+		registryToken:       ao.registryToken,
 		client:              ao.client,
 		header:              ao.header,
 		handlers:            make(map[string]*authHandler),
@@ -119,6 +137,13 @@ func NewDockerAuthorizer(opts ...AuthorizerOpt) Authorizer {
 
 // Authorize handles auth request.
 func (a *dockerAuthorizer) Authorize(ctx context.Context, req *http.Request) error {
+	// If a pre-obtained registry token is set, use it directly without
+	// going through the challenge-response token exchange flow.
+	if a.registryToken != "" {
+		req.Header.Set("Authorization", "Bearer "+a.registryToken)
+		return nil
+	}
+
 	// skip if there is no auth handler
 	ah := a.getAuthHandler(req.URL.Host)
 	if ah == nil {
@@ -153,6 +178,12 @@ func (a *dockerAuthorizer) getAuthHandler(host string) *authHandler {
 func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.Response) error {
 	last := responses[len(responses)-1]
 	host := last.Request.URL.Host
+
+	// If a pre-obtained registry token was used and the server still
+	// returned 401, the token is invalid or insufficient.
+	if a.registryToken != "" {
+		return fmt.Errorf("pre-obtained registry token was rejected by %s: %w", host, ErrInvalidAuthorization)
+	}
 
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -148,6 +148,31 @@ func TestBasicAuthTokenResolver(t *testing.T) {
 	runBasicTest(t, "testname", withTokenServer(th, creds))
 }
 
+func TestRegistryTokenResolver(t *testing.T) {
+	registryTokenAuth := func(h http.Handler) (string, ResolverOptions, func()) {
+		wrapped := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "Bearer perfectlyvalidopaquetoken" {
+				rw.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			h.ServeHTTP(rw, r)
+		})
+
+		base, options, close := tlsServer(wrapped)
+		authorizer := NewDockerAuthorizer(
+			WithAuthClient(options.Client),
+			WithRegistryToken("perfectlyvalidopaquetoken"),
+		)
+		options.Hosts = ConfigureDefaultRegistries(
+			WithClient(options.Client),
+			WithAuthorizer(authorizer),
+		)
+		return base, options, close
+	}
+
+	runBasicTest(t, "testname", registryTokenAuth)
+}
+
 func TestRefreshTokenResolver(t *testing.T) {
 	th := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/core/transfer/registry/registry.go
+++ b/core/transfer/registry/registry.go
@@ -45,13 +45,14 @@ func init() {
 }
 
 type registryOpts struct {
-	headers       http.Header
-	creds         CredentialHelper
-	hostDir       string
-	defaultScheme string
-	httpDebug     bool
-	httpTrace     bool
-	localStream   io.WriteCloser
+	headers        http.Header
+	creds          CredentialHelper
+	hostDir        string
+	defaultScheme  string
+	httpDebug      bool
+	httpTrace      bool
+	localStream    io.WriteCloser
+	authorizerOpts []docker.AuthorizerOpt
 }
 
 // Opt sets registry-related configurations.
@@ -114,6 +115,15 @@ func WithClientStream(writer io.WriteCloser) Opt {
 	}
 }
 
+// WithAuthorizerOpts passes additional options to the docker authorizer
+// used by the registry resolver.
+func WithAuthorizerOpts(opts ...docker.AuthorizerOpt) Opt {
+	return func(o *registryOpts) error {
+		o.authorizerOpts = append(o.authorizerOpts, opts...)
+		return nil
+	}
+}
+
 // NewOCIRegistry initializes with hosts, authorizer callback, and headers
 func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry, error) {
 	var ropts registryOpts
@@ -128,7 +138,6 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
 		hostOptions.HostDir = config.HostDirFromRoot(ropts.hostDir)
 	}
 	if ropts.creds != nil {
-		// TODO: Support bearer
 		hostOptions.Credentials = func(host string) (string, string, error) {
 			c, err := ropts.creds.GetCredentials(context.Background(), ref, host)
 			if err != nil {
@@ -138,6 +147,7 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
 			return c.Username, c.Secret, nil
 		}
 	}
+	hostOptions.AuthorizerOpts = append(hostOptions.AuthorizerOpts, ropts.authorizerOpts...)
 	if ropts.defaultScheme != "" {
 		hostOptions.DefaultScheme = ropts.defaultScheme
 	}

--- a/integration/image_pull_timeout_test.go
+++ b/integration/image_pull_timeout_test.go
@@ -93,7 +93,7 @@ func testCRIImagePullTimeoutBySlowCommitWriter(t *testing.T, useLocal bool) {
 
 	ctx := namespaces.WithNamespace(logtest.WithT(context.Background(), t), k8sNamespace)
 
-	_, err = criService.PullImage(ctx, pullProgressTestImageName, nil, nil, "")
+	_, err = criService.PullImage(ctx, pullProgressTestImageName, nil, "", nil, "")
 	assert.NoError(t, err)
 }
 
@@ -220,7 +220,7 @@ func testCRIImagePullTimeoutByHoldingContentOpenWriter(t *testing.T, useLocal bo
 	go func() {
 		defer close(errCh)
 
-		_, err := criService.PullImage(ctx, pullProgressTestImageName, nil, nil, "")
+		_, err := criService.PullImage(ctx, pullProgressTestImageName, nil, "", nil, "")
 		errCh <- err
 	}()
 
@@ -316,7 +316,7 @@ func testCRIImagePullTimeoutByNoDataTransferred(t *testing.T, useLocal bool) {
 		dctx, _, err := cli.WithLease(ctx)
 		assert.NoError(t, err)
 
-		_, err = criService.PullImage(dctx, fmt.Sprintf("%s/%s", mirrorURL.Host, "containerd/volume-ownership:2.1"), nil, nil, "")
+		_, err = criService.PullImage(dctx, fmt.Sprintf("%s/%s", mirrorURL.Host, "containerd/volume-ownership:2.1"), nil, "", nil, "")
 
 		assert.Equal(t, context.Canceled, errors.Unwrap(err), "[%v] expected canceled error, but got (%v)", idx, err)
 		assert.True(t, mirrorSrv.limiter.clearHitCircuitBreaker(), "[%v] expected to hit circuit breaker", idx)

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -307,7 +307,7 @@ func (s *fakeImageService) Config() criconfig.ImageConfig {
 	return criconfig.ImageConfig{}
 }
 
-func (s *fakeImageService) PullImage(context.Context, string, func(string) (string, string, error), *runtime.PodSandboxConfig, string) (string, error) {
+func (s *fakeImageService) PullImage(context.Context, string, func(string) (string, string, error), string, *runtime.PodSandboxConfig, string) (string, error) {
 	return "", errors.New("not implemented")
 }
 

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -102,6 +102,14 @@ func (c *GRPCCRIImageService) PullImage(ctx context.Context, r *runtime.PullImag
 
 	imageRef := r.GetImage().GetImage()
 
+	// Extract RegistryToken before setting up credentials. RegistryToken is a
+	// pre-obtained bearer token that should be sent directly to the registry
+	// without going through the challenge-response token exchange flow.
+	var registryToken string
+	if authConfig := r.GetAuth(); authConfig != nil {
+		registryToken = authConfig.GetRegistryToken()
+	}
+
 	credentials := func(host string) (string, string, error) {
 		hostauth := r.GetAuth()
 		if hostauth == nil {
@@ -113,14 +121,14 @@ func (c *GRPCCRIImageService) PullImage(ctx context.Context, r *runtime.PullImag
 		return ParseAuth(hostauth, host)
 	}
 
-	ref, err := c.CRIImageService.PullImage(ctx, imageRef, credentials, r.SandboxConfig, r.GetImage().GetRuntimeHandler())
+	ref, err := c.CRIImageService.PullImage(ctx, imageRef, credentials, registryToken, r.SandboxConfig, r.GetImage().GetRuntimeHandler())
 	if err != nil {
 		return nil, err
 	}
 	return &runtime.PullImageResponse{ImageRef: ref}, nil
 }
 
-func (c *CRIImageService) PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (_ string, err error) {
+func (c *CRIImageService) PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), registryToken string, sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (_ string, err error) {
 	span := tracing.SpanFromContext(ctx)
 	defer func() {
 		// TODO: add domain label for imagePulls metrics, and we may need to provide a mechanism
@@ -182,9 +190,9 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 	// TODO: Add support for DisableSnapshotAnnotations, DiscardUnpackedLayers, ImagePullWithSyncFs and unpackDuplicationSuppressor
 	var image containerd.Image
 	if c.config.UseLocalImagePull {
-		image, err = c.pullImageWithLocalPull(ctx, ref, credentials, snapshotter, labels, imagePullProgressTimeout)
+		image, err = c.pullImageWithLocalPull(ctx, ref, credentials, registryToken, snapshotter, labels, imagePullProgressTimeout)
 	} else {
-		image, err = c.pullImageWithTransferService(ctx, ref, credentials, snapshotter, labels, imagePullProgressTimeout)
+		image, err = c.pullImageWithTransferService(ctx, ref, credentials, registryToken, snapshotter, labels, imagePullProgressTimeout)
 	}
 
 	if err != nil {
@@ -236,6 +244,7 @@ func (c *CRIImageService) pullImageWithLocalPull(
 	ctx context.Context,
 	ref string,
 	credentials func(string) (string, string, error),
+	registryToken string,
 	snapshotter string,
 	labels map[string]string,
 	imagePullProgressTimeout time.Duration,
@@ -245,7 +254,7 @@ func (c *CRIImageService) pullImageWithLocalPull(
 	pullReporter := newPullProgressReporter(ref, pcancel, imagePullProgressTimeout)
 	resolver := docker.NewResolver(docker.ResolverOptions{
 		Headers: c.config.Registry.Headers,
-		Hosts:   c.registryHosts(ctx, credentials, pullReporter.optionUpdateClient),
+		Hosts:   c.registryHosts(ctx, credentials, registryToken, pullReporter.optionUpdateClient),
 	})
 
 	log.G(ctx).Debugf("PullImage %q with snapshotter %s using client.Pull()", ref, snapshotter)
@@ -289,6 +298,7 @@ func (c *CRIImageService) pullImageWithTransferService(
 	ctx context.Context,
 	ref string,
 	credentials func(string) (string, string, error),
+	registryToken string,
 	snapshotter string,
 	labels map[string]string,
 	imagePullProgressTimeout time.Duration,
@@ -309,11 +319,14 @@ func (c *CRIImageService) pullImageWithTransferService(
 
 	log.G(ctx).Debugf("Getting new CRI credentials")
 
-	ch := newCRICredentials(ref, credentials)
+	ch := newCRICredentials(ref, credentials, registryToken)
 	opts := []registry.Opt{
 		registry.WithCredentials(ch),
 		registry.WithHeaders(c.config.Registry.Headers),
 		registry.WithHostDir(c.config.Registry.ConfigPath),
+	}
+	if registryToken != "" {
+		opts = append(opts, registry.WithAuthorizerOpts(docker.WithRegistryToken(registryToken)))
 	}
 
 	reg, err := registry.NewOCIRegistry(ctx, ref, opts...)
@@ -371,7 +384,10 @@ func ParseAuth(auth *runtime.AuthConfig, host string) (string, string, error) {
 		}
 		return user, strings.Trim(passwd, "\x00"), nil
 	}
-	// TODO(random-liu): Support RegistryToken.
+	// RegistryToken is handled separately at the PullImage level where it
+	// is passed directly to the authorizer via WithRegistryToken, bypassing
+	// the credentials-based token exchange flow. See GRPCCRIImageService.PullImage.
+
 	// An empty auth config is valid for anonymous registry
 	return "", "", nil
 }
@@ -493,7 +509,7 @@ func hostDirFromRoots(roots []string) func(string) (string, error) {
 }
 
 // registryHosts is the registry hosts to be used by the resolver.
-func (c *CRIImageService) registryHosts(ctx context.Context, credentials func(host string) (string, string, error), updateClientFn config.UpdateClientFunc) docker.RegistryHosts {
+func (c *CRIImageService) registryHosts(ctx context.Context, credentials func(host string) (string, string, error), registryToken string, updateClientFn config.UpdateClientFunc) docker.RegistryHosts {
 	paths := filepath.SplitList(c.config.Registry.ConfigPath)
 	if len(paths) > 0 {
 		hostOptions := config.HostOptions{
@@ -504,6 +520,10 @@ func (c *CRIImageService) registryHosts(ctx context.Context, credentials func(ho
 		// need to pass cri global headers to per-host authorizers
 		hostOptions.AuthorizerOpts = []docker.AuthorizerOpt{
 			docker.WithAuthHeader(c.config.Registry.Headers),
+		}
+		if registryToken != "" {
+			hostOptions.AuthorizerOpts = append(hostOptions.AuthorizerOpts,
+				docker.WithRegistryToken(registryToken))
 		}
 
 		return config.ConfigureHosts(ctx, hostOptions)
@@ -551,11 +571,15 @@ func (c *CRIImageService) registryHosts(ctx context.Context, credentials func(ho
 				}
 			}
 
-			authorizer := docker.NewDockerAuthorizer(
+			authOpts := []docker.AuthorizerOpt{
 				docker.WithAuthClient(client),
 				docker.WithAuthCreds(credentials),
 				docker.WithAuthHeader(c.config.Registry.Headers),
-			)
+			}
+			if registryToken != "" {
+				authOpts = append(authOpts, docker.WithRegistryToken(registryToken))
+			}
+			authorizer := docker.NewDockerAuthorizer(authOpts...)
 
 			if u.Path == "" {
 				u.Path = "/v2"
@@ -874,25 +898,36 @@ func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, i
 }
 
 type criCredentials struct {
-	ref         string
-	credentials func(string) (string, string, error)
+	ref           string
+	credentials   func(string) (string, string, error)
+	registryToken string
 }
 
-func newCRICredentials(ref string, credentials func(string) (string, string, error)) registry.CredentialHelper {
+func newCRICredentials(ref string, credentials func(string) (string, string, error), registryToken string) registry.CredentialHelper {
 	return &criCredentials{
-		ref:         ref,
-		credentials: credentials,
+		ref:           ref,
+		credentials:   credentials,
+		registryToken: registryToken,
 	}
 }
 
 // GetCredentials gets credential from criCredentials makes criCredentials a registry.CredentialHelper
 func (cc *criCredentials) GetCredentials(ctx context.Context, ref string, host string) (registry.Credentials, error) {
-	if cc.credentials == nil {
-		return registry.Credentials{}, fmt.Errorf("credential handler not initialized for ref %q", ref)
-	}
-
 	if ref != cc.ref {
 		return registry.Credentials{}, fmt.Errorf("invalid ref %q, expected %q", ref, cc.ref)
+	}
+
+	// If a pre-obtained registry token is available, return it via the
+	// Header field so the transfer service uses it as a direct bearer token.
+	if cc.registryToken != "" {
+		return registry.Credentials{
+			Host:   host,
+			Header: "Bearer " + cc.registryToken,
+		}, nil
+	}
+
+	if cc.credentials == nil {
+		return registry.Credentials{}, fmt.Errorf("credential handler not initialized for ref %q", ref)
 	}
 
 	username, secret, err := cc.credentials(host)

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/platforms"
 
 	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/containerd/v2/core/transfer/registry"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/labels"
@@ -131,6 +132,34 @@ func TestParseAuth(t *testing.T) {
 			assert.Equal(t, test.expectedSecret, s)
 		})
 	}
+}
+
+func TestCRICredentials(t *testing.T) {
+	t.Run("registry token is returned as header auth", func(t *testing.T) {
+		helper := newCRICredentials("example.com/ns/image:tag", nil, "some-bearer-token")
+
+		creds, err := helper.GetCredentials(context.Background(), "example.com/ns/image:tag", "example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, registry.Credentials{
+			Host:   "example.com",
+			Header: "Bearer some-bearer-token",
+		}, creds)
+	})
+
+	t.Run("username and secret are returned when registry token is absent", func(t *testing.T) {
+		helper := newCRICredentials("example.com/ns/image:tag", func(host string) (string, string, error) {
+			assert.Equal(t, "example.com", host)
+			return "user", "secret", nil
+		}, "")
+
+		creds, err := helper.GetCredentials(context.Background(), "example.com/ns/image:tag", "example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, registry.Credentials{
+			Host:     "example.com",
+			Username: "user",
+			Secret:   "secret",
+		}, creds)
+	})
 }
 
 func TestRegistryEndpoints(t *testing.T) {

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -115,6 +115,14 @@ func TestParseAuth(t *testing.T) {
 			expectedUser:   testUser,
 			expectedSecret: testPasswd,
 		},
+		{
+			desc: "should return empty auth for registry token (handled at PullImage level)",
+			auth: &runtime.AuthConfig{
+				RegistryToken: "some-bearer-token",
+			},
+			expectedUser:   "",
+			expectedSecret: "",
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			u, s, err := ParseAuth(test.auth, test.host)

--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -410,7 +410,7 @@ func (c *criService) ensurePauseImageExists(ctx context.Context, config *runtime
 		return fmt.Errorf("failed to get image %q: %w", ref, err)
 	}
 
-	_, err = c.ImageService.PullImage(ctx, ref, nil, config, runtimeHandler)
+	_, err = c.ImageService.PullImage(ctx, ref, nil, "", config, runtimeHandler)
 	if err != nil {
 		return fmt.Errorf("failed to pull image %q: %w", ref, err)
 	}

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -98,7 +98,7 @@ type RuntimeService interface {
 type ImageService interface {
 	RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string
 
-	PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
+	PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), registryToken string, sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
 	UpdateImage(ctx context.Context, r string) error
 
 	CheckImages(ctx context.Context) error


### PR DESCRIPTION
I have a use-case for passing a `registrytoken` credential into a Kubernetes `.dockerconfigjson` and found that it is unsupported by containerd with a 9-year old TODO. I'm not much accustomed to writing Go code, and even less so to the containerd codebase, so I've let Claude Code have a go at it.

Is the containerd project open to a contribution such as this?

---

## Summary

Implements the long-standing `TODO(random-liu): Support RegistryToken` in `ParseAuth`.

The CRI `AuthConfig` protobuf has had a `RegistryToken` field since its initial definition:
> "RegistryToken is a bearer token to be sent to a registry"

However, containerd's `ParseAuth` never handled this field — it fell through to anonymous auth. This meant Kubernetes pull secrets using the `registrytoken` field in `dockerconfigjson` (e.g., pre-obtained JWTs from GitLab Container Registry or other registries supporting direct bearer tokens) were silently ignored, resulting in "access forbidden" errors.

### Design rationale

`RegistryToken` is fundamentally different from `Username`/`Password`/`IdentityToken` — it's a pre-obtained bearer token that should be used directly, without any token exchange. This means it cannot be expressed through the existing `credentials func(string) (string, string, error)` pattern (which feeds into OAuth/basic auth flows).

The approach adds a `WithRegistryToken` option to the existing `dockerAuthorizer` and threads the token through at the CRI level, keeping the change contained and avoiding modifications to the public `Credentials` function type.

## Test plan

- [x] `go test ./core/remotes/docker/...` passes
- [x] `go test ./internal/cri/server/images/...` passes (new test case for RegistryToken)
- [x] `go build ./internal/cri/...` compiles
- [ ] Integration test: Kubernetes pull secret with `registrytoken` field successfully pulls image

🤖 Generated with [Claude Code](https://claude.com/claude-code)