### PR TITLE
contrib/fuzz: don't inject github.com/AdamKorcz/go-118-fuzz-build

### DIFF
--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -59,7 +59,7 @@ export CXXFLAGS="$CXXFLAGS -lresolv"
 # Change path of socket since OSS-fuzz does not grant access to /run
 sed -i 's/\/run\/containerd/\/tmp\/containerd/g' $SRC/containerd/defaults/defaults_unix.go
 
-compile_fuzzers '^func Fuzz.*testing\.F' compile_native_go_fuzzer_v2 vendor
+compile_fuzzers '^func Fuzz.*testing\.F' compile_native_go_fuzzer vendor
 
 # The below fuzzers require more setup than the fuzzers above.
 # We need the binaries from "make".

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -88,7 +88,7 @@ sed -i 's/\/run\/containerd-test/\/tmp\/containerd-test/g' $SRC/containerd/integ
 
 cd integration/client
 
-compile_fuzzers '^func FuzzInteg.*testing\.F' compile_native_go_fuzzer_v2 vendor
+compile_fuzzers '^func FuzzInteg.*testing\.F' compile_native_go_fuzzer vendor
 
 cp $SRC/containerd/contrib/fuzz/*.options $OUT/
 cp $SRC/containerd/contrib/fuzz/*.dict $OUT/

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -45,10 +45,6 @@ mkdir temp-go
 rm -rf /root/.go/*
 tar -C temp-go/ -xzf go1.25.8.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
-cd $SRC/containerd
-
-printf "package client\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > client/registerfuzzdep.go
-go mod tidy
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 cd ../../
@@ -63,7 +59,6 @@ export CXXFLAGS="$CXXFLAGS -lresolv"
 sed -i 's/\/run\/containerd/\/tmp\/containerd/g' $SRC/containerd/defaults/defaults_unix.go
 
 compile_fuzzers '^func Fuzz.*testing\.F' compile_native_go_fuzzer vendor
-compile_fuzzers '^func Fuzz.*data' compile_go_fuzzer '(vendor|Integ)'
 
 # The below fuzzers require more setup than the fuzzers above.
 # We need the binaries from "make".
@@ -74,7 +69,7 @@ export CGO_ENABLED=1
 export GOARCH=amd64
 
 # Build runc
-cd $SRC/
+cd $SRC
 git clone https://github.com/opencontainers/runc --branch release-1.1
 cd runc
 make
@@ -84,8 +79,8 @@ make install
 cd $SRC/containerd
 make STATIC=1
 
-mkdir $OUT/containerd-binaries || true
-cd $SRC/containerd/bin && cp * $OUT/containerd-binaries/ && cd -
+mkdir -p $OUT/containerd-binaries
+cd $SRC/containerd/bin && cp * $OUT/containerd-binaries/
 
 # Change defaultState and defaultAddress fron /run/containerd-test to /tmp/containerd-test:
 sed -i 's/\/run\/containerd-test/\/tmp\/containerd-test/g' $SRC/containerd/integration/client/client_unix_test.go

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -50,6 +50,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 cd ../../
 
 rm -r vendor
+go mod tidy
 
 # Add temporary CXXFLAGS
 OLDCXXFLAGS=$CXXFLAGS

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -59,7 +59,7 @@ export CXXFLAGS="$CXXFLAGS -lresolv"
 # Change path of socket since OSS-fuzz does not grant access to /run
 sed -i 's/\/run\/containerd/\/tmp\/containerd/g' $SRC/containerd/defaults/defaults_unix.go
 
-compile_fuzzers '^func Fuzz.*testing\.F' compile_native_go_fuzzer vendor
+compile_fuzzers '^func Fuzz.*testing\.F' compile_native_go_fuzzer_v2 vendor
 
 # The below fuzzers require more setup than the fuzzers above.
 # We need the binaries from "make".
@@ -88,7 +88,7 @@ sed -i 's/\/run\/containerd-test/\/tmp\/containerd-test/g' $SRC/containerd/integ
 
 cd integration/client
 
-compile_fuzzers '^func FuzzInteg.*testing\.F' compile_native_go_fuzzer vendor
+compile_fuzzers '^func FuzzInteg.*testing\.F' compile_native_go_fuzzer_v2 vendor
 
 cp $SRC/containerd/contrib/fuzz/*.options $OUT/
 cp $SRC/containerd/contrib/fuzz/*.dict $OUT/

--- a/core/transfer/streaming/stream_test.go
+++ b/core/transfer/streaming/stream_test.go
@@ -33,8 +33,7 @@ func FuzzSendAndReceive(f *testing.F) {
 	f.Add([]byte("hello"))
 	f.Add(bytes.Repeat([]byte("hello"), windowSize+1))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := f.Context()
 	f.Fuzz(func(t *testing.T, expected []byte) {
 		runSendAndReceiveFuzz(ctx, t, expected)
 		runSendAndReceiveChainFuzz(ctx, t, expected)


### PR DESCRIPTION
relates to:

- https://github.com/containerd/containerd/pull/11189
- https://github.com/containerd/containerd/pull/11251


### contrib/fuzz: don't inject github.com/AdamKorcz/go-118-fuzz-build

All tests in the containerd module were rewritten to for native fuzzing,
but the script was still injecting the go-118-fuzz-build shim, preventing
use of (e.g.) `f.Context()`;

    + local func=FuzzSendAndReceive
    + compile_native_go_fuzzer github.com/containerd/containerd/v2/core/transfer/streaming FuzzSendAndReceive fuzz_FuzzSendAndReceive
    # github.com/containerd/containerd/v2/core/transfer/streaming
    core/transfer/streaming/stream_test.go_fuzz.go:20:11: f.Context undefined (type *"github.com/AdamKorcz/go-118-fuzz-build/testing".F has no field or method Context)
    2026/03/15 14:51:48 failed to build packages:exit status 1
    2026-03-15 14:51:51,623 - root - ERROR - Building fuzzers failed.
    2026-03-15 14:51:51,623 - root - ERROR - Error building fuzzers for (commit: fae237a2bf959270154afb79931babad7f6ce4b0, pr_ref: refs/pull/13022/merge).
    Traceback (most recent call last):
      File "/opt/oss-fuzz/infra/cifuzz/build_fuzzers_entrypoint.py", line 67, in <module>

Update the script to not patch the code.


### core/transfer/streaming: use f.Context()
