### PR TITLE
Prepare release notes for api/v1.11.0-beta.0

### DIFF
--- a/api/releases/v1.11.0-beta.toml
+++ b/api/releases/v1.11.0-beta.toml
@@ -1,0 +1,16 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+sub_path = "api"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "api/v1.10.0"
+
+pre_release = true
+
+preface = """\
+The 12th release for the containerd 1.x API aligns with the containerd 2.3 release.
+"""


### PR DESCRIPTION
First step in v2.3 beta process

----
containerd api/v1.11.0-beta.0

Welcome to the api/v1.11.0-beta.0 release of containerd!  
*This is a pre-release of containerd*

The 12th release for the containerd 1.x API aligns with the containerd 2.3 release.

### Highlights

* Update sandbox API to include spec field ([#12840](https://github.com/containerd/containerd/pull/12840))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Maksym Pavlenko
* Derek McGowan
* Sebastiaan van Stijn
* Wei Fu

### Changes
<details><summary>17 commits</summary>
<p>

  * [`aac6b5348`](https://github.com/containerd/containerd/commit/aac6b53488f05253f88fb061fed6674630feb41f) Prepare release notes for api/v1.11.0-beta.0
* api: regenerate and re-vendor protos ([#12913](https://github.com/containerd/containerd/pull/12913))
  * [`4b4eb6715`](https://github.com/containerd/containerd/commit/4b4eb67150b724e0c0450cc92f295b8d6582ca9a) api: regenerate and re-vendor protos
* Remove Container field from sandbox metadata ([#12840](https://github.com/containerd/containerd/pull/12840))
  * [`8ccf18724`](https://github.com/containerd/containerd/commit/8ccf18724f691f7f5503faf0b004334eb9f92cf3) Update sandbox API to include spec field
* Use buf to format proto files ([#12841](https://github.com/containerd/containerd/pull/12841))
  * [`ca1c5b2d3`](https://github.com/containerd/containerd/commit/ca1c5b2d3db8c620c26ab9674b7ccb9a4b023a63) Reformat and revendor proto files
  * [`2a87c9d7d`](https://github.com/containerd/containerd/commit/2a87c9d7d29a5d947fa671a0d7b52f449835fd11) Add .editorconfig for proto files
* Generate api/next.txtpb and name module ([#12815](https://github.com/containerd/containerd/pull/12815))
  * [`472e0a8e7`](https://github.com/containerd/containerd/commit/472e0a8e7ada278b7aa376173eca20ad0a0348be) Generate next.txtpb to replace next.pb.txt
  * [`f58dbbda0`](https://github.com/containerd/containerd/commit/f58dbbda0b34bea75f714e82463eb0706c06d30d) Add buf.build repository name for publishing API
* Migrate from protobuild to buf ([#12762](https://github.com/containerd/containerd/pull/12762))
  * [`dac9721fa`](https://github.com/containerd/containerd/commit/dac9721faf891205ed46105cd38340bc3bceabcb) Drop outdated pb.txt files
  * [`6a6283193`](https://github.com/containerd/containerd/commit/6a6283193b6f865c35529717068259bf54ccc307) Update pb files
  * [`57782b717`](https://github.com/containerd/containerd/commit/57782b7175f743489010c348a8f59da720140722) Move buf configuration under api/
  * [`39991b661`](https://github.com/containerd/containerd/commit/39991b6617041c8c5b471f11f08461f36cc6719f) Use relative import intead of GOPATH style imports
  * [`eb586b5ef`](https://github.com/containerd/containerd/commit/eb586b5ef2e20c5f845f28d5e9cd5f5e8e10885d) Regenerate proto files
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [api/v1.10.0](https://github.com/containerd/containerd/releases/tag/api/v1.10.0)

