### PR TITLE
content: drain stream on proxy writer close to fix ingest race

### DIFF
--- a/core/content/proxy/content_writer.go
+++ b/core/content/proxy/content_writer.go
@@ -151,5 +151,15 @@ func (rw *remoteWriter) Truncate(size int64) error {
 }
 
 func (rw *remoteWriter) Close() error {
-	return rw.client.CloseSend()
+	err := rw.client.CloseSend()
+	// Drain remaining messages to ensure the server-side stream handler
+	// completes (including deferred writer cleanup) before returning.
+	// Without this, a subsequent Abort could race with the server's
+	// deferred Close writing to the ingest directory.
+	for {
+		if _, recvErr := rw.client.Recv(); recvErr != nil {
+			break
+		}
+	}
+	return err
 }


### PR DESCRIPTION
(Attempt at fixing one of the flaky tests, will mark as draft and see if its hit, for example)
```
=== Failed
=== FAIL: integration/client TestContentClient/CommitErrorState (0.20s)
    testsuite.go:122: Cleanup failed: failed to abort c1-commiterror-state: unlinkat /var/lib/containerd-test/io.containerd.content.v1.content/ingest/9101c5f249b4cb38a50dddda86a787c09f31099573c87c525fc50774ac21d05d: directory not empty
    --- FAIL: TestContentClient/CommitErrorState (0.20s)

=== FAIL: integration/client TestContentClient (5.94s)
```

Fix a race between the proxy writer's Close and a subsequent Abort on the same ingest ref. CloseSend() returns immediately without waiting for the server-side stream handler to complete its deferred cleanup. The server's deferred writer Close writes an updatedat file to the ingest directory, which can race with Abort's os.RemoveAll on the same directory, causing:

  unlinkat .../<ingest-dir>: directory not empty

Drain the stream after CloseSend to ensure the server handler fully completes before the client proceeds.