### PR TITLE
shim/task: harden exit handling for recycled PIDs

### DIFF
--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -52,7 +52,9 @@ import (
 	"github.com/containerd/containerd/v2/pkg/shim"
 	"github.com/containerd/containerd/v2/pkg/shutdown"
 	"github.com/containerd/containerd/v2/pkg/stdio"
+	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/containerd/v2/pkg/sys/reaper"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -94,6 +96,11 @@ func NewTaskService(ctx context.Context, publisher shim.Publisher, sd shutdown.S
 		return nil, fmt.Errorf("failed to initialized platform behavior: %w", err)
 	}
 	go s.forward(ctx, publisher)
+	sd.RegisterCallback(func(context.Context) error {
+		reaper.Default.Unsubscribe(s.ec)
+		s.closeTrackedPidFDs()
+		return nil
+	})
 	sd.RegisterCallback(func(context.Context) error {
 		close(s.events)
 		return nil
@@ -145,9 +152,16 @@ type service struct {
 	shutdown shutdown.Service
 }
 
+const invalidPidFD = -1
+
 type containerProcess struct {
 	Container *runc.Container
 	Process   process.Process
+	// pidfd is a stable handle to the tracked process, when supported by the
+	// kernel. Unlike a numeric PID, it remains bound to the original process and
+	// can be used to detect stale exits after PID recycling. When pidfds are not
+	// supported or cannot be opened, pidfd is set to invalidPidFD.
+	pidfd int
 }
 
 // preStart prepares for starting a container process and handling its exit.
@@ -177,6 +191,8 @@ func (s *service) preStart(c *runc.Container) (handleStarted func(*runc.Containe
 		for _, cp := range s.running[pid] {
 			if cp.Container != c {
 				newRunning = append(newRunning, cp)
+			} else {
+				closePidFD(cp.pidfd)
 			}
 		}
 		if len(newRunning) > 0 {
@@ -199,14 +215,30 @@ func (s *service) preStart(c *runc.Container) (handleStarted func(*runc.Containe
 		exits = nil
 		if pid == 0 || exited {
 			s.lifecycleMu.Unlock()
-			for _, ee := range ees {
-				s.handleProcessExit(ee, c, p)
+			// Only process the first exit event for this PID. A PID can
+			// only be recycled after Wait4 reaps its zombie, so the first
+			// event is always from the original process. Subsequent events
+			// are from processes that recycled the PID and must be ignored
+			// to avoid publishing spurious TaskExit events with wrong exit
+			// codes or double-decrementing the running exec counter.
+			if len(ees) > 1 {
+				log.G(s.context).WithField("pid", pid).
+					Warnf("PID was recycled (%d exit events), processing only the first", len(ees))
+			}
+			if len(ees) > 0 {
+				s.handleProcessExit(ees[0], c, p)
 			}
 		} else {
 			// Process start was successful, add to `s.running`.
+			pidfd, err := openPidFD(pid)
+			if err != nil {
+				log.G(s.context).WithError(err).WithField("pid", pid).
+					Debug("failed to open pidfd for tracked process")
+			}
 			s.running[pid] = append(s.running[pid], containerProcess{
 				Container: c,
 				Process:   p,
+				pidfd:     pidfd,
 			})
 			s.lifecycleMu.Unlock()
 		}
@@ -665,10 +697,12 @@ func (s *service) processExits() {
 	for e := range s.ec {
 		// While unlikely, it is not impossible for a container process to exit
 		// and have its PID be recycled for a new container process before we
-		// have a chance to process the first exit. As we have no way to tell
-		// for sure which of the processes the exit event corresponds to (until
-		// pidfd support is implemented) there is no way for us to handle the
-		// exit correctly in that case.
+		// process the first exit. If a pidfd for the tracked process still proves
+		// it is alive, the exit must belong to an earlier process that used the
+		// same PID and is ignored.
+		//
+		// A full fix would still be to plumb stable pidfd-backed identity
+		// through the runtime/reaper exit path rather than matching by PID.
 
 		s.lifecycleMu.Lock()
 		// Inform any concurrent s.Start() calls so they can handle the exit
@@ -679,15 +713,28 @@ func (s *service) processExits() {
 		// Handle the exit for a created/started process. If there's more than
 		// one, assume they've all exited. One of them will be the correct
 		// process.
-		var cps []containerProcess
+		var (
+			cps  []containerProcess
+			keep []containerProcess
+		)
 		for _, cp := range s.running[e.Pid] {
+			if isLive, ok := pidFDIsRunning(cp.pidfd); ok && isLive {
+				s.warnIgnoredStaleExit(e, cp, "pidfd-still-alive")
+				keep = append(keep, cp)
+				continue
+			}
+			closePidFD(cp.pidfd)
 			_, init := cp.Process.(*process.Init)
 			if init {
 				s.containerInitExit[cp.Container] = e
 			}
 			cps = append(cps, cp)
 		}
-		delete(s.running, e.Pid)
+		if len(keep) > 0 {
+			s.running[e.Pid] = keep
+		} else {
+			delete(s.running, e.Pid)
+		}
 		s.lifecycleMu.Unlock()
 
 		for _, cp := range cps {
@@ -698,6 +745,63 @@ func (s *service) processExits() {
 			}
 		}
 	}
+}
+
+func openPidFD(pid int) (int, error) {
+	if pid <= 0 || !sys.SupportsPidFD() {
+		return invalidPidFD, nil
+	}
+
+	pidfd, err := unix.PidfdOpen(pid, 0)
+	if err != nil {
+		return invalidPidFD, err
+	}
+	return pidfd, nil
+}
+
+func closePidFD(pidfd int) {
+	if pidfd >= 0 {
+		_ = unix.Close(pidfd)
+	}
+}
+
+func (s *service) closeTrackedPidFDs() {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+
+	for pid, cps := range s.running {
+		for i := range cps {
+			closePidFD(cps[i].pidfd)
+			cps[i].pidfd = invalidPidFD
+		}
+		s.running[pid] = cps
+	}
+}
+
+func pidFDIsRunning(pidfd int) (bool, bool) {
+	if pidfd == invalidPidFD {
+		return false, false
+	}
+
+	if err := unix.PidfdSendSignal(pidfd, 0, nil, 0); err == nil {
+		return true, true
+	} else if err == unix.ESRCH {
+		return false, true
+	}
+
+	return false, false
+}
+
+func (s *service) warnIgnoredStaleExit(e runcC.Exit, cp containerProcess, reason string) {
+	logger := log.G(s.context).WithField("pid", e.Pid).
+		WithField("container_id", cp.Container.ID).
+		WithField("process_id", cp.Process.ID()).
+		WithField("exit_status", e.Status).
+		WithField("reason", reason)
+	if !e.Timestamp.IsZero() {
+		logger = logger.WithField("exit_timestamp", e.Timestamp)
+	}
+	logger.Warn("ignoring stale exit event for recycled PID")
 }
 
 func (s *service) oomEvent(id string) {

--- a/cmd/containerd-shim-runc-v2/task/service_test.go
+++ b/cmd/containerd-shim-runc-v2/task/service_test.go
@@ -1,0 +1,469 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/containerd/console"
+	eventstypes "github.com/containerd/containerd/api/events"
+	taskAPI "github.com/containerd/containerd/api/runtime/task/v3"
+	runcC "github.com/containerd/go-runc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/process"
+	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/runc"
+	oomv2 "github.com/containerd/containerd/v2/internal/oom"
+	"github.com/containerd/containerd/v2/pkg/stdio"
+	"github.com/containerd/containerd/v2/pkg/sys"
+)
+
+func TestHandleStartedIgnoresDuplicateEarlyExitsForInit(t *testing.T) {
+	s := newTestService()
+	initProc := newTestInit(t, "init", 1234)
+	container := newTestContainer(t, "init-ctr", initProc)
+
+	s.running[initProc.Pid()] = []containerProcess{{
+		Container: container,
+		Process:   initProc,
+		pidfd:     invalidPidFD,
+	}}
+
+	s.lifecycleMu.Lock()
+	handleStarted, cleanup := s.preStart(container)
+	s.lifecycleMu.Unlock()
+	t.Cleanup(cleanup)
+
+	_, stillRunning := s.running[initProc.Pid()]
+	require.False(t, stillRunning, "preStart should remove the init from running while Start is in flight")
+
+	injectEarlyExits(s, initProc.Pid(),
+		runcC.Exit{Pid: initProc.Pid(), Status: 1, Timestamp: time.Unix(1, 0)},
+		runcC.Exit{Pid: initProc.Pid(), Status: 2, Timestamp: time.Unix(2, 0)},
+	)
+
+	handleStarted(container, initProc)
+
+	exit := readTaskExit(t, s)
+	require.Equal(t, container.ID, exit.ContainerID)
+	require.Equal(t, "init", exit.ID)
+	require.Equal(t, uint32(initProc.Pid()), exit.Pid)
+	require.Equal(t, uint32(1), exit.ExitStatus)
+	require.Equal(t, 1, initProc.ExitStatus(), "stored exit status should remain the first exit")
+	require.Equal(t, []string{container.ID}, s.cg2oom.(*fakeOOM).stopped)
+	assertNoMoreEvents(t, s)
+}
+
+func TestHandleStartedIgnoresDuplicateEarlyExitsForExec(t *testing.T) {
+	s := newTestService()
+	container := newTestContainer(t, "exec-ctr", newTestInit(t, "init", 2222))
+	execProc := &fakeProcess{id: "exec1", pid: 3333}
+	container.ProcessAdd(execProc)
+	s.containers[container.ID] = container
+
+	s.runningExecs[container] = 1
+
+	s.lifecycleMu.Lock()
+	handleStarted, cleanup := s.preStart(nil)
+	s.lifecycleMu.Unlock()
+	t.Cleanup(cleanup)
+
+	injectEarlyExits(s, execProc.Pid(),
+		runcC.Exit{Pid: execProc.Pid(), Status: 1, Timestamp: time.Unix(3, 0)},
+		runcC.Exit{Pid: execProc.Pid(), Status: 2, Timestamp: time.Unix(4, 0)},
+	)
+
+	handleStarted(container, execProc)
+
+	exit := readTaskExit(t, s)
+	require.Equal(t, container.ID, exit.ContainerID)
+	require.Equal(t, execProc.id, exit.ID)
+	require.Equal(t, uint32(execProc.Pid()), exit.Pid)
+	require.Equal(t, uint32(1), exit.ExitStatus)
+	require.Equal(t, 1, execProc.status, "stored exit status should remain the first exit")
+	require.Equal(t, 1, execProc.setExitedCalls, "duplicate exits must not call SetExited twice")
+	require.Equal(t, 0, s.runningExecs[container], "duplicate exits must not double-decrement running execs")
+
+	state, err := s.State(context.Background(), &taskAPI.StateRequest{
+		ID:     container.ID,
+		ExecID: execProc.id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), state.ExitStatus, "State should expose the first early exit")
+
+	resp, err := s.Delete(context.Background(), &taskAPI.DeleteRequest{
+		ID:     container.ID,
+		ExecID: execProc.id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), resp.ExitStatus, "Delete should expose the first early exit")
+	assertNoMoreEvents(t, s)
+}
+
+func TestProcessExitsSkipsLivePidFDForRecycledInit(t *testing.T) {
+	if !sys.SupportsPidFD() {
+		t.Skip("pidfd not supported")
+	}
+
+	s := newTestService()
+	initProc := newTestInit(t, "init", os.Getpid())
+	container := newTestContainer(t, "live-pidfd-init-ctr", initProc)
+	pidfd, err := openPidFD(os.Getpid())
+	if err != nil || pidfd == invalidPidFD {
+		t.Skip("pidfd_open failed")
+	}
+	t.Cleanup(func() {
+		closePidFD(pidfd)
+	})
+
+	s.containers[container.ID] = container
+	s.running[initProc.Pid()] = []containerProcess{{
+		Container: container,
+		Process:   initProc,
+		pidfd:     pidfd,
+	}}
+
+	runProcessExitsOnce(t, s, runcC.Exit{
+		Pid:       initProc.Pid(),
+		Status:    2,
+		Timestamp: time.Unix(31, 0),
+	})
+
+	require.Equal(t, 0, initProc.ExitStatus(), "live pidfd must prevent attribution to a newer init process with the same PID")
+	_, initExited := s.containerInitExit[container]
+	require.False(t, initExited, "live pidfd must prevent recording an init exit")
+	require.Contains(t, s.running, initProc.Pid(), "live pidfd must keep the newer init tracked")
+	assertNoMoreEvents(t, s)
+}
+
+func TestProcessExitsSkipsLivePidFDForRecycledExec(t *testing.T) {
+	if !sys.SupportsPidFD() {
+		t.Skip("pidfd not supported")
+	}
+
+	s := newTestService()
+	container := newTestContainer(t, "live-pidfd-exec-ctr", newTestInit(t, "init", 5555))
+	pidfd, err := openPidFD(os.Getpid())
+	if err != nil || pidfd == invalidPidFD {
+		t.Skip("pidfd_open failed")
+	}
+	t.Cleanup(func() {
+		closePidFD(pidfd)
+	})
+
+	execProc := &fakeProcess{id: "exec1", pid: os.Getpid()}
+	container.ProcessAdd(execProc)
+
+	s.containers[container.ID] = container
+	s.running[execProc.Pid()] = []containerProcess{{
+		Container: container,
+		Process:   execProc,
+		pidfd:     pidfd,
+	}}
+	s.runningExecs[container] = 1
+
+	runProcessExitsOnce(t, s, runcC.Exit{
+		Pid:       execProc.Pid(),
+		Status:    2,
+		Timestamp: time.Unix(41, 0),
+	})
+
+	require.Equal(t, 0, execProc.status, "live pidfd must prevent attribution to a newer process with the same PID")
+	require.Equal(t, 0, execProc.setExitedCalls, "live pidfd must prevent SetExited")
+	require.Equal(t, 1, s.runningExecs[container], "live pidfd must prevent runningExecs decrement")
+	require.Contains(t, s.running, execProc.Pid(), "live pidfd must keep the newer process tracked")
+	assertNoMoreEvents(t, s)
+}
+
+// This is a characterization test for the remaining PID-only lookup in
+// processExits. It shows that once a process is in s.running, an exit is
+// attributed purely by PID and becomes visible through State().
+func TestProcessExitsMatchesRunningInitByPIDOnly(t *testing.T) {
+	s := newTestService()
+	initProc := newTestInit(t, "init", 4444)
+	container := newTestContainer(t, "running-init-ctr", initProc)
+	container.Bundle = newPrivatePIDBundle(t)
+
+	s.containers[container.ID] = container
+	s.running[initProc.Pid()] = []containerProcess{{
+		Container: container,
+		Process:   initProc,
+		pidfd:     invalidPidFD,
+	}}
+
+	runProcessExitsOnce(t, s, runcC.Exit{
+		Pid:       initProc.Pid(),
+		Status:    2,
+		Timestamp: time.Unix(6, 0),
+	})
+
+	exit := readTaskExit(t, s)
+	require.Equal(t, container.ID, exit.ContainerID)
+	require.Equal(t, uint32(2), exit.ExitStatus)
+	require.Equal(t, 2, initProc.ExitStatus(), "the tracked init process inherits the exit solely by PID")
+	require.Equal(t, 2, s.containerInitExit[container].Status)
+	require.Equal(t, []string{container.ID}, s.cg2oom.(*fakeOOM).stopped)
+
+	state, err := s.State(context.Background(), &taskAPI.StateRequest{ID: container.ID})
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), state.ExitStatus)
+	assertNoMoreEvents(t, s)
+}
+
+func TestCloseTrackedPidFDs(t *testing.T) {
+	if !sys.SupportsPidFD() {
+		t.Skip("pidfd not supported")
+	}
+
+	s := newTestService()
+	execProc := &fakeProcess{id: "exec1", pid: os.Getpid()}
+	pidfd, err := openPidFD(execProc.Pid())
+	if err != nil || pidfd == invalidPidFD {
+		t.Skip("pidfd_open failed")
+	}
+
+	s.running[execProc.Pid()] = []containerProcess{{
+		Container: newTestContainer(t, "cleanup-ctr", newTestInit(t, "init", 33333)),
+		Process:   execProc,
+		pidfd:     pidfd,
+	}}
+
+	isLive, ok := pidFDIsRunning(pidfd)
+	require.True(t, ok)
+	require.True(t, isLive)
+
+	s.closeTrackedPidFDs()
+
+	require.Equal(t, invalidPidFD, s.running[execProc.Pid()][0].pidfd)
+	isLive, ok = pidFDIsRunning(pidfd)
+	require.False(t, ok)
+	require.False(t, isLive)
+}
+
+func newTestService() *service {
+	return &service{
+		context:              context.Background(),
+		events:               make(chan any, 8),
+		cg2oom:               &fakeOOM{},
+		containers:           make(map[string]*runc.Container),
+		running:              make(map[int][]containerProcess),
+		runningExecs:         make(map[*runc.Container]int),
+		execCountSubscribers: make(map[*runc.Container]chan<- int),
+		containerInitExit:    make(map[*runc.Container]runcC.Exit),
+		exitSubscribers:      make(map[*map[int][]runcC.Exit]struct{}),
+	}
+}
+
+func newTestInit(t *testing.T, id string, pid int) *process.Init {
+	t.Helper()
+
+	p := process.New(id, nil, stdio.Stdio{})
+	p.Platform = fakePlatform{}
+	setUnexportedField(t, p, "pid", pid)
+	return p
+}
+
+func newTestContainer(t *testing.T, id string, initProc *process.Init) *runc.Container {
+	t.Helper()
+
+	c := &runc.Container{ID: id}
+	setUnexportedField(t, c, "process", process.Process(initProc))
+	setUnexportedField(t, c, "processes", make(map[string]process.Process))
+	setUnexportedField(t, c, "reservedProcess", make(map[string]struct{}))
+	return c
+}
+
+func newPrivatePIDBundle(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"linux":{"namespaces":[{"type":"pid"}]}}`), 0o644)
+	require.NoError(t, err)
+	return dir
+}
+
+func injectEarlyExits(s *service, pid int, exits ...runcC.Exit) {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+
+	for subscriber := range s.exitSubscribers {
+		(*subscriber)[pid] = append((*subscriber)[pid], exits...)
+	}
+}
+
+func runProcessExitsOnce(t *testing.T, s *service, exit runcC.Exit) {
+	t.Helper()
+
+	s.ec = make(chan runcC.Exit, 1)
+	done := make(chan struct{})
+	go func() {
+		s.processExits()
+		close(done)
+	}()
+
+	s.ec <- exit
+	close(s.ec)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for processExits")
+	}
+}
+
+func readTaskExit(t *testing.T, s *service) *eventstypes.TaskExit {
+	t.Helper()
+
+	select {
+	case evt := <-s.events:
+		exit, ok := evt.(*eventstypes.TaskExit)
+		require.True(t, ok, "expected TaskExit, got %T", evt)
+		return exit
+	default:
+		t.Fatal("expected TaskExit event")
+		return nil
+	}
+}
+
+func assertNoMoreEvents(t *testing.T, s *service) {
+	t.Helper()
+
+	select {
+	case evt := <-s.events:
+		t.Fatalf("unexpected extra event: %#v", evt)
+	default:
+	}
+}
+
+func setUnexportedField(t *testing.T, target any, field string, value any) {
+	t.Helper()
+
+	v := reflect.ValueOf(target)
+	require.Equal(t, reflect.Ptr, v.Kind(), "target must be a pointer")
+
+	f := v.Elem().FieldByName(field)
+	require.True(t, f.IsValid(), "missing field %q", field)
+
+	reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
+}
+
+type fakePlatform struct{}
+
+func (fakePlatform) CopyConsole(context.Context, console.Console, string, string, string, string, *sync.WaitGroup) (console.Console, error) {
+	return nil, nil
+}
+
+func (fakePlatform) ShutdownConsole(context.Context, console.Console) error {
+	return nil
+}
+
+func (fakePlatform) Close() error {
+	return nil
+}
+
+type fakeOOM struct {
+	stopped []string
+}
+
+func (f *fakeOOM) Add(string, int, oomv2.EventFunc) error {
+	return nil
+}
+
+func (f *fakeOOM) Stop(containerID string) error {
+	f.stopped = append(f.stopped, containerID)
+	return nil
+}
+
+type fakeProcess struct {
+	id             string
+	pid            int
+	status         int
+	exitedAt       time.Time
+	exited         bool
+	setExitedCalls int
+}
+
+func (p *fakeProcess) ID() string {
+	return p.id
+}
+
+func (p *fakeProcess) Pid() int {
+	return p.pid
+}
+
+func (p *fakeProcess) ExitStatus() int {
+	return p.status
+}
+
+func (p *fakeProcess) ExitedAt() time.Time {
+	return p.exitedAt
+}
+
+func (p *fakeProcess) Stdin() io.Closer {
+	return nil
+}
+
+func (p *fakeProcess) Stdio() stdio.Stdio {
+	return stdio.Stdio{}
+}
+
+func (p *fakeProcess) Status(context.Context) (string, error) {
+	if p.exited {
+		return "stopped", nil
+	}
+	return "created", nil
+}
+
+func (p *fakeProcess) Wait(context.Context) error {
+	return nil
+}
+
+func (p *fakeProcess) Resize(console.WinSize) error {
+	return nil
+}
+
+func (p *fakeProcess) Start(context.Context) error {
+	return nil
+}
+
+func (p *fakeProcess) Delete(context.Context) error {
+	return nil
+}
+
+func (p *fakeProcess) Kill(context.Context, uint32, bool) error {
+	return nil
+}
+
+func (p *fakeProcess) SetExited(status int) {
+	p.setExitedCalls++
+	if p.exited {
+		return
+	}
+	p.status = status
+	p.exited = true
+	p.exitedAt = time.Unix(5, 0)
+}

--- a/integration/container_exec_test.go
+++ b/integration/container_exec_test.go
@@ -18,6 +18,7 @@ package integration
 
 import (
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	criruntime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func TestContainerDrainExecIOAfterExit(t *testing.T) {
@@ -69,4 +71,66 @@ func TestContainerDrainExecIOAfterExit(t *testing.T) {
 	t.Log("Exec in container")
 	_, _, err = runtimeService.ExecSync(cn, []string{"sh", "-c", "sleep 2s &"}, 10*time.Second)
 	require.NoError(t, err, "should drain IO in time")
+}
+
+func TestContainerRepeatedExecSyncKeepsContainerRunning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("busybox exec regression coverage is Linux-only")
+	}
+
+	var (
+		testImage     = images.Get(images.BusyBox)
+		containerName = "test-container-repeated-exec"
+	)
+
+	EnsureImageExists(t, testImage)
+
+	sbConfig := PodSandboxConfig("sandbox", Randomize("container-exec-repeated"))
+	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	})
+
+	cnConfig := ContainerConfig(
+		containerName,
+		testImage,
+		WithCommand("sh", "-c", "sleep 365d"),
+	)
+
+	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.NoError(t, err)
+	require.NoError(t, runtimeService.StartContainer(cn))
+
+	type execCase struct {
+		name           string
+		cmd            []string
+		expectedStdout string
+	}
+	for _, tc := range []execCase{
+		{
+			name:           "true",
+			cmd:            []string{"/bin/true"},
+			expectedStdout: "",
+		},
+		{
+			name:           "echo",
+			cmd:            []string{"sh", "-c", "echo -n ok"},
+			expectedStdout: "ok",
+		},
+	} {
+		for i := 0; i < 5; i++ {
+			t.Run(tc.name+"-attempt-"+strconv.Itoa(i), func(t *testing.T) {
+				stdout, stderr, err := runtimeService.ExecSync(cn, tc.cmd, 10*time.Second)
+				require.NoError(t, err)
+				assert.Empty(t, stderr)
+				assert.Equal(t, tc.expectedStdout, string(stdout))
+			})
+		}
+	}
+
+	status, err := runtimeService.ContainerStatus(cn)
+	require.NoError(t, err)
+	assert.Equal(t, criruntime.ContainerState_CONTAINER_RUNNING, status.GetState(), "repeated fast execs should not poison the long-lived container state")
 }

--- a/integration/container_exit_status_linux_test.go
+++ b/integration/container_exit_status_linux_test.go
@@ -1,0 +1,73 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestShortLivedContainerPreservesExitCode(t *testing.T) {
+	const attempts = 5
+
+	testImage := images.Get(images.BusyBox)
+	EnsureImageExists(t, testImage)
+
+	for i := range attempts {
+		t.Run(fmt.Sprintf("attempt-%d", i), func(t *testing.T) {
+			sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "short-lived-exit-status")
+			containerName := fmt.Sprintf("false-container-%d", i)
+			cnConfig := ContainerConfig(
+				containerName,
+				testImage,
+				WithCommand("/bin/false"),
+			)
+
+			cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+			require.NoError(t, err)
+			require.NoError(t, runtimeService.StartContainer(cn))
+
+			status := waitForContainerState(t, cn, runtime.ContainerState_CONTAINER_EXITED, 30*time.Second)
+			require.EqualValues(t, 1, status.GetExitCode(), "short-lived /bin/false should keep exit code 1")
+
+			status, err = runtimeService.ContainerStatus(cn)
+			require.NoError(t, err)
+			require.Equal(t, runtime.ContainerState_CONTAINER_EXITED, status.GetState())
+			require.EqualValues(t, 1, status.GetExitCode(), "exit code should remain stable across repeated status reads")
+		})
+	}
+}
+
+func waitForContainerState(t *testing.T, containerID string, expected runtime.ContainerState, timeout time.Duration) *runtime.ContainerStatus {
+	t.Helper()
+
+	var latest *runtime.ContainerStatus
+	require.NoError(t, Eventually(func() (bool, error) {
+		status, err := runtimeService.ContainerStatus(containerID)
+		if err != nil {
+			return false, err
+		}
+		latest = status
+		return status.GetState() == expected, nil
+	}, time.Second, timeout))
+	return latest
+}


### PR DESCRIPTION
We harden shim exit handling in the presence of PID recycling.

It addresses two related cases in `cmd/containerd-shim-runc-v2/task/service.go`:
- during process start, only the first buffered early-exit event for a PID should be applied
- in `processExits`, if a tracked process still has a live pidfd, a later exit for the same numeric PID should be treated as stale and must not be attributed to that tracked process
 
The change also closes tracked pidfds during shutdown and adds shim and integration regression coverage for duplicate early exits, recycled-PID exit attribution, short-lived `/bin/false` exit-code stability, and repeated fast execs on a long-lived container.

Related:
- https://github.com/containerd/containerd/issues/5630
- https://github.com/containerd/containerd/pull/9218