### PR TITLE
Implement NRI metrics adaptation layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/opencontainers/selinux v1.13.1
 	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	github.com/tchap/go-patricia/v2 v2.3.3
@@ -132,7 +133,6 @@ require (
 	github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/internal/nri/config.go
+++ b/internal/nri/config.go
@@ -77,6 +77,7 @@ func (c *Config) toOptions() []nri.Option {
 	if c.DefaultValidator != nil {
 		opts = append(opts, nri.WithDefaultValidator(c.DefaultValidator))
 	}
+	opts = append(opts, nri.WithMetrics(newNRIMetrics()))
 	opts = append(opts,
 		nri.WithTTRPCOptions(
 			[]ttrpc.ClientOpts{

--- a/internal/nri/metrics.go
+++ b/internal/nri/metrics.go
@@ -1,0 +1,123 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package nri
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/docker/go-metrics"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	nri "github.com/containerd/nri/pkg/adaptation"
+)
+
+var (
+	nriPluginInvocations metrics.LabeledCounter
+	nriPluginLatency     metrics.LabeledTimer
+	nriPluginAdjustments metrics.LabeledCounter
+	nriActivePlugins     metrics.Gauge
+)
+
+func init() {
+	ns := metrics.NewNamespace("containerd", "nri", nil)
+
+	nriPluginInvocations = ns.NewLabeledCounter("plugin_invocations", "Number of NRI plugin invocations", "plugin", "operation", "status", "error")
+	nriPluginAdjustments = ns.NewLabeledCounter("plugin_adjustments", "Number of adjustment operations from plugins", "plugin", "operation", "type")
+	nriActivePlugins = ns.NewGauge("active_plugins", "Number of currently active NRI plugins", metrics.Total)
+	nriPluginLatency = ns.NewLabeledTimer("plugin_latency", "NRI plugin operation latency", "plugin", "operation")
+
+	metrics.Register(ns)
+}
+
+type nriMetrics struct{}
+
+var _ nri.Metrics = (*nriMetrics)(nil)
+
+func newNRIMetrics() nri.Metrics {
+	return &nriMetrics{}
+}
+
+func (m *nriMetrics) RecordPluginInvocation(pluginName, operation string, err error) {
+	opStatus := "success"
+	errorType := ""
+	if err != nil {
+		opStatus = "error"
+		errorType = getErrorType(err)
+	}
+	nriPluginInvocations.WithValues(pluginName, operation, opStatus, errorType).Inc()
+}
+
+// Prometheus conventions recommend lowercase snake_case for unified label values.
+// Avoids the UpperCamelCase strings returned by gRPC's Code.String() (e.g., "InvalidArgument").
+var grpcCodeToSnake = map[codes.Code]string{
+	codes.OK:                 "ok",
+	codes.Canceled:           "canceled",
+	codes.Unknown:            "unknown",
+	codes.InvalidArgument:    "invalid_argument",
+	codes.DeadlineExceeded:   "deadline_exceeded",
+	codes.NotFound:           "not_found",
+	codes.AlreadyExists:      "already_exists",
+	codes.PermissionDenied:   "permission_denied",
+	codes.ResourceExhausted:  "resource_exhausted",
+	codes.FailedPrecondition: "failed_precondition",
+	codes.Aborted:            "aborted",
+	codes.OutOfRange:         "out_of_range",
+	codes.Unimplemented:      "unimplemented",
+	codes.Internal:           "internal",
+	codes.Unavailable:        "unavailable",
+	codes.DataLoss:           "data_loss",
+	codes.Unauthenticated:    "unauthenticated",
+}
+
+func getErrorType(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "deadline_exceeded"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	if st, ok := status.FromError(err); ok {
+		if s, found := grpcCodeToSnake[st.Code()]; found {
+			return s
+		}
+		return "unknown_code"
+	}
+	return "other"
+}
+
+func (m *nriMetrics) RecordPluginLatency(pluginName, operation string, latency time.Duration) {
+	nriPluginLatency.WithValues(pluginName, operation).Update(latency)
+}
+
+func (m *nriMetrics) RecordPluginAdjustments(pluginName, operation string, _ *nri.ContainerAdjustment, updates, evicts int) {
+	if updates > 0 {
+		nriPluginAdjustments.WithValues(pluginName, operation, "update").Inc(float64(updates))
+	}
+	if evicts > 0 {
+		nriPluginAdjustments.WithValues(pluginName, operation, "evict").Inc(float64(evicts))
+	}
+}
+
+func (m *nriMetrics) UpdatePluginCount(count int) {
+	nriActivePlugins.Set(float64(count))
+}

--- a/internal/nri/metrics_test.go
+++ b/internal/nri/metrics_test.go
@@ -1,0 +1,214 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package nri
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNriMetricsRecordPluginInvocation(t *testing.T) {
+	m := newNRIMetrics()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantLabels map[string]string
+	}{
+		{
+			name:       "success",
+			err:        nil,
+			wantLabels: map[string]string{"status": "success", "error": ""},
+		},
+		{
+			name:       "generic_error",
+			err:        fmt.Errorf("test error"),
+			wantLabels: map[string]string{"status": "error", "error": "other"},
+		},
+		{
+			name:       "deadline_exceeded_error",
+			err:        context.DeadlineExceeded,
+			wantLabels: map[string]string{"status": "error", "error": "deadline_exceeded"},
+		},
+		{
+			name:       "canceled_error",
+			err:        context.Canceled,
+			wantLabels: map[string]string{"status": "error", "error": "canceled"},
+		},
+		{
+			name:       "grpc_error_invalid_argument",
+			err:        status.Error(codes.InvalidArgument, "invalid argument"),
+			wantLabels: map[string]string{"status": "error", "error": "invalid_argument"},
+		},
+		{
+			name:       "grpc_error_not_found",
+			err:        status.Error(codes.NotFound, "not found"),
+			wantLabels: map[string]string{"status": "error", "error": "not_found"},
+		},
+		{
+			name:       "grpc_error_deadline_exceeded",
+			err:        status.Error(codes.DeadlineExceeded, "deadline exceeded"),
+			wantLabels: map[string]string{"status": "error", "error": "deadline_exceeded"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m.RecordPluginInvocation(tt.name, "Synchronize", tt.err)
+
+			labels := map[string]string{
+				"plugin":    tt.name,
+				"operation": "Synchronize",
+			}
+			maps.Copy(labels, tt.wantLabels)
+
+			assertCounter(t, "containerd_nri_plugin_invocations_total", labels, 1.0)
+		})
+	}
+}
+
+func TestNriMetricsRecordPluginLatency(t *testing.T) {
+	m := newNRIMetrics()
+
+	m.RecordPluginLatency("test-plugin-2", "Synchronize", 500*time.Millisecond)
+
+	assertTimer(t, "containerd_nri_plugin_latency_seconds", map[string]string{
+		"plugin":    "test-plugin-2",
+		"operation": "Synchronize",
+	}, 0.5)
+}
+
+func TestNriMetricsRecordPluginAdjustments(t *testing.T) {
+	m := newNRIMetrics()
+
+	// passing nil adjustment is supported by the RecordPluginAdjustments signature
+	m.RecordPluginAdjustments("test-plugin-3", "CreateContainer", nil, 2, 1)
+
+	assertCounter(t, "containerd_nri_plugin_adjustments_total", map[string]string{
+		"plugin":    "test-plugin-3",
+		"operation": "CreateContainer",
+		"type":      "update",
+	}, 2.0)
+
+	assertCounter(t, "containerd_nri_plugin_adjustments_total", map[string]string{
+		"plugin":    "test-plugin-3",
+		"operation": "CreateContainer",
+		"type":      "evict",
+	}, 1.0)
+}
+
+func TestNriMetricsUpdatePluginCount(t *testing.T) {
+	m := newNRIMetrics()
+
+	m.UpdatePluginCount(5)
+
+	assertGauge(t, "containerd_nri_active_plugins_total", 5.0)
+}
+
+func matchesLabels(labels []*dto.LabelPair, expected map[string]string) bool {
+	actual := make(map[string]string)
+	for _, l := range labels {
+		actual[l.GetName()] = l.GetValue()
+	}
+	for k, v := range expected {
+		if val, ok := actual[k]; !ok || val != v {
+			return false
+		}
+	}
+	return true
+}
+
+func assertCounter(t *testing.T, name string, labels map[string]string, wantMin float64) {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.Metric {
+			if matchesLabels(m.Label, labels) {
+				found = true
+				if m.GetCounter() != nil {
+					assert.GreaterOrEqual(t, m.GetCounter().GetValue(), wantMin)
+				} else {
+					t.Fatalf("metric %s is not a counter", name)
+				}
+			}
+		}
+	}
+	assert.True(t, found, "metric %s with labels %v not found", name, labels)
+}
+
+func assertGauge(t *testing.T, name string, want float64) {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.Metric {
+			found = true
+			if m.GetGauge() != nil {
+				assert.Equal(t, want, m.GetGauge().GetValue())
+			} else {
+				t.Fatalf("metric %s is not a gauge", name)
+			}
+		}
+	}
+	assert.True(t, found, "metric %s not found", name)
+}
+
+func assertTimer(t *testing.T, name string, labels map[string]string, wantMinSum float64) {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.Metric {
+			if matchesLabels(m.Label, labels) {
+				found = true
+				if m.GetHistogram() != nil {
+					assert.GreaterOrEqual(t, m.GetHistogram().GetSampleSum(), wantMinSum)
+					assert.GreaterOrEqual(t, m.GetHistogram().GetSampleCount(), uint64(1))
+				} else {
+					t.Fatalf("metric %s with labels %v is not a histogram", name, labels)
+				}
+			}
+		}
+	}
+	assert.True(t, found, "metric %s with labels %v not found", name, labels)
+}


### PR DESCRIPTION
Add metrics for NRI plugin invocations, latency, adjustments, and active count. Map NRI Metrics adaptation layer to containerd's Prometheus metrics system via docker/go-metrics for observability.

Categorize plugin invocation errors into `deadline_exceeded`, `canceled`, and dynamic gRPC status code dimensions to assist troubleshooting.

Assisted-by: Antigravity

@samuelkarp @klihub 