### PR TITLE
containerd: reduce memory usage with zero-copy splice

### DIFF
--- a/core/runtime/v2/binary.go
+++ b/core/runtime/v2/binary.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	gruntime "runtime"
@@ -102,16 +101,9 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 	// open the log pipe and block until the writer is ready
 	// this helps with synchronization of the shim
 	// copy the shim's logs to containerd's output
+	done := make(chan struct{})
 	go func() {
-		defer f.Close()
-		_, err := io.Copy(os.Stderr, f)
-		// To prevent flood of error messages, the expected error
-		// should be reset, like os.ErrClosed or os.ErrNotExist, which
-		// depends on platform.
-		err = checkCopyShimLogError(ctx, err)
-		if err != nil {
-			log.G(ctx).WithError(err).Error("copy shim log")
-		}
+		copyShimlog(ctx, filepath.Join(b.bundle.Path, "log"), f, done)
 	}()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -123,6 +115,7 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 		onClose()
 		cancelShimLog()
 		f.Close()
+		close(done)
 	}
 	// Save runtime binary path for restore.
 	if err := os.WriteFile(filepath.Join(b.bundle.Path, "shim-binary-path"), []byte(b.runtime), 0600); err != nil {

--- a/core/runtime/v2/binary_linux.go
+++ b/core/runtime/v2/binary_linux.go
@@ -1,0 +1,61 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func copyShimlog(_ context.Context, path string, _ io.ReadCloser, done chan struct{}) error {
+	fifo, err := os.OpenFile(path, os.O_RDONLY, 0700)
+	if err != nil {
+		return err
+	}
+	defer fifo.Close()
+	for {
+		select {
+		case <-done:
+			return nil
+		default:
+			n, err := unix.Splice(
+				int(fifo.Fd()),
+				nil,
+				int(os.Stderr.Fd()),
+				nil,
+				1024*4,
+				0,
+			)
+			if err != nil {
+				if err == unix.EAGAIN {
+					continue
+				}
+				if errors.Is(err, unix.EPIPE) || errors.Is(err, os.ErrClosed) {
+					return nil
+				}
+				return err
+			}
+			if n == 0 {
+				continue
+			}
+		}
+	}
+}

--- a/core/runtime/v2/binary_others.go
+++ b/core/runtime/v2/binary_others.go
@@ -1,0 +1,40 @@
+//go:build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/containerd/log"
+)
+
+func copyShimlog(ctx context.Context, _ string, f io.ReadCloser, _ chan struct{}) error {
+	defer f.Close()
+	_, err := io.Copy(os.Stderr, f)
+	// To prevent flood of error messages, the expected error
+	// should be reset, like os.ErrClosed or os.ErrNotExist, which
+	// depends on platform.
+	err = checkCopyShimLogError(ctx, err)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("copy shim log")
+	}
+	return nil
+}


### PR DESCRIPTION
this pr  will reduce containerd memory when try to read shim fifo log
or we can try to use splice  reduce runc-shim memory on  container log.

todo:  refactor the func copyPipes by  using zero-copy in sim logic
```
func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, wg, cwg *sync.WaitGroup)
```


create 200 pod 
before this commit 
```
root@Swift-SF314-512:/home/nmx/containerd# ps -auxf |grep containerd|grep -v shim
root       76768 11.8  1.3 11557992 214428 pts/4 Sl+  21:10   0:07  |   |               \_ containerd
```
after this commit

```
root@swift-SF314-512:/home/nmx/containerd# ps -auxf |grep containerd|grep -v shim
root       32893  1.4  1.2 11500624 196180 pts/4 Sl+  21:01   0:06  |   |               \_ containerd
```
rss reduce about 8.5%