### PR TITLE
shim: fix send on closed channel race in task service

### DIFF
--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -94,10 +94,6 @@ func NewTaskService(ctx context.Context, publisher shim.Publisher, sd shutdown.S
 		return nil, fmt.Errorf("failed to initialized platform behavior: %w", err)
 	}
 	go s.forward(ctx, publisher)
-	sd.RegisterCallback(func(context.Context) error {
-		close(s.events)
-		return nil
-	})
 
 	if address, err := shim.ReadAddress("address"); err == nil {
 		sd.RegisterCallback(func(context.Context) error {
@@ -710,7 +706,10 @@ func (s *service) oomEvent(id string) {
 }
 
 func (s *service) send(evt any) {
-	s.events <- evt
+	select {
+	case s.events <- evt:
+	case <-s.shutdown.Done():
+	}
 }
 
 // handleInitExit processes container init process exits.
@@ -813,13 +812,29 @@ func (s *service) getContainerPids(ctx context.Context, container *runc.Containe
 func (s *service) forward(ctx context.Context, publisher shim.Publisher) {
 	ns, _ := namespaces.Namespace(ctx)
 	ctx = namespaces.WithNamespace(context.Background(), ns)
-	for e := range s.events {
-		err := publisher.Publish(ctx, runtime.GetTopic(e), e)
-		if err != nil {
+	defer publisher.Close()
+
+	publish := func(e any) {
+		if err := publisher.Publish(ctx, runtime.GetTopic(e), e); err != nil {
 			log.G(ctx).WithError(err).Error("post event")
 		}
 	}
-	publisher.Close()
+
+	for {
+		select {
+		case e := <-s.events:
+			publish(e)
+		case <-s.shutdown.Done():
+			for {
+				select {
+				case e := <-s.events:
+					publish(e)
+				default:
+					return
+				}
+			}
+		}
+	}
 }
 
 func (s *service) getContainer(id string) (*runc.Container, error) {


### PR DESCRIPTION
I iterated this quite a bit but not entirely sure this is the right solution (to the panic presented below). Happy to make changes as needed.

Tested locally with ctr and my patched shim.

---

The runc v2 shim's event forwarding has a race condition between send() and the shutdown callback that closes the events channel. When a Delete or processExit RPC runs concurrently with shim shutdown, the following panic occurs:

  panic: send on closed channel

  goroutine 153 [running]:
  github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/task.(*service).send(...)
          /containerd/cmd/containerd-shim-runc-v2/task/service.go:694
  github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/task.(*service).Delete(0xc000228120, ...)
          /containerd/cmd/containerd-shim-runc-v2/task/service.go:366 +0x229

The root cause is that send() performs a bare channel send on s.events with no synchronization:

  func (s *service) send(evt any) {
      s.events <- evt
  }

Meanwhile, a shutdown callback registered in NewTaskService closes the same channel:

  sd.RegisterCallback(func(context.Context) error {
      close(s.events)
      return nil
  })

Since shutdownService.Shutdown() runs all callbacks concurrently via errgroup, close(s.events) can execute while a Delete, Start, Create, Exec, Pause, Resume, or handleProcessExit goroutine is in send().

This was observed in CI on a Kind cluster (containerd v2.1.1) under heavy pod churn: the shim panic crashed containerd on the worker node, breaking the kubectl attach stream to the test pod and causing the CI job to fail.

Fix this by removing the close(s.events) shutdown callback entirely and instead using select with s.shutdown.Done() in both send() and forward(), which is the established pattern for shutdown-safe channel operations throughout the containerd codebase (see client/events.go, core/events/exchange/exchange.go). The events channel is never closed; it is garbage collected when the shim process exits after shutdown.

In forward(), after s.shutdown.Done() fires, remaining buffered events are drained with a non-blocking receive loop before returning, preserving the previous behavior where range over the closed channel would drain buffered items.

Alternative designs considered:

- recover() in send(): while compact, this pattern is not used anywhere in the containerd codebase for closed-channel protection, and silently swallowing panics makes the code harder to reason about.

- RWMutex guarding the channel send (RLock) and close (WLock): this would work correctly and allows concurrent sends, but no existing containerd code uses a mutex to guard channel send+close. It also adds lock contention on every event send during normal operation.

- select with a dedicated "closing" channel closed before s.events: this does not work in Go because select panics on a send to a closed channel regardless of whether other cases are ready (verified empirically).