### PR TITLE
Set fuzztime to 60s in go-test-fuzz.sh

### DIFF
--- a/script/go-test-fuzz.sh
+++ b/script/go-test-fuzz.sh
@@ -21,7 +21,7 @@
 set -euo pipefail
 set -x
 
-fuzztime=30s
+fuzztime=60s
 # keep the filename and Fuzz function name so we can run every fuzz test
 # in a package separately (`go test -fuzz` only supports single fuzz function)
 pkgs=$(git grep 'func Fuzz.*testing\.F' | grep -o '.*testing\.F)' | grep -v -E "vendor" | sort | uniq)


### PR DESCRIPTION
Bumping the timeout for fuzztests to 60s to prevent intermittent failures in CI.

```
+ go test -fuzz=FuzzDiffApply ./contrib/fuzz/ -fuzztime=30s
warning: starting with empty corpus
fuzz: elapsed: 0s, execs: 0 (0/sec), new interesting: 0 (total: 0)
fuzz: elapsed: 3s, execs: 7509 (2503/sec), new interesting: 10 (total: 10)
fuzz: elapsed: 6s, execs: 15964 (2818/sec), new interesting: 13 (total: 13)
fuzz: elapsed: 9s, execs: 26948 (3662/sec), new interesting: 21 (total: 21)
fuzz: elapsed: 12s, execs: 36341 (3131/sec), new interesting: 26 (total: 26)
fuzz: elapsed: 15s, execs: 47268 (3643/sec), new interesting: 29 (total: 29)
fuzz: elapsed: 18s, execs: 56738 (3156/sec), new interesting: 30 (total: 30)
fuzz: elapsed: 21s, execs: 67797 (3687/sec), new interesting: 31 (total: 31)
fuzz: elapsed: 24s, execs: 84429 (5544/sec), new interesting: 33 (total: 33)
fuzz: elapsed: 27s, execs: 92743 (2771/sec), new interesting: 34 (total: 34)
fuzz: elapsed: 30s, execs: 101343 (2865/sec), new interesting: 36 (total: 36)
fuzz: elapsed: 31s, execs: 101343 (0/sec), new interesting: 36 (total: 36)
--- FAIL: FuzzDiffApply (31.00s)
    context deadline exceeded
FAIL
exit status 1
FAIL	github.com/containerd/containerd/v2/contrib/fuzz	31.021s
```