### PR TITLE
Fix vagrant on CI

### DIFF
--- a/script/resize-vagrant-root.sh
+++ b/script/resize-vagrant-root.sh
@@ -23,7 +23,8 @@ df_line=$(df -T / | grep '^/dev/')
 if [[ "$df_line" =~ ^/dev/([a-z]+)([0-9+]) ]]; then
     dev="${BASH_REMATCH[1]}"
     part="${BASH_REMATCH[2]}"
-    growpart "/dev/$dev" "$part"
+    # growpart prints "NOCHANGE" when the partition is already at max size
+    out=$(growpart "/dev/$dev" "$part" 2>&1) || grep -q "^NOCHANGE:" <<< "$out"
 
     fstype=$(echo "$df_line" | awk '{print $2}')
     if [[ "$fstype" = 'btrfs' ]]; then


### PR DESCRIPTION
Recent jobs started to fail:

```bash
    default: NOCHANGE: partition 4 is size 123318239. it cannot be grown
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

- https://github.com/containerd/containerd/actions/runs/23276654538/job/67681274802
- https://github.com/containerd/containerd/actions/runs/23273699658/job/67672196780
- https://github.com/containerd/containerd/actions/runs/23273684057/job/67683270990