### PR TITLE
Fix typos in comments found by codespell

### DIFF
--- a/core/metadata/db.go
+++ b/core/metadata/db.go
@@ -42,7 +42,7 @@ const (
 	// schemaVersion represents the schema version of
 	// the database. This schema version represents the
 	// structure of the data in the database. The schema
-	// can envolve at any time but any backwards
+	// can evolve at any time but any backwards
 	// incompatible changes or structural changes require
 	// bumping the schema version.
 	schemaVersion = "v1"

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -805,7 +805,7 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 
 	nsbkt := v1bkt.Bucket([]byte(node.Namespace))
 	if nsbkt == nil {
-		// Still remove object if refenced outside the db
+		// Still remove object if referenced outside the db
 		if cc, ok := c.contexts[node.Type]; ok {
 			cc.Remove(node)
 		}

--- a/core/mount/manager.go
+++ b/core/mount/manager.go
@@ -94,7 +94,7 @@ func WithLabels(labels map[string]string) ActivateOpt {
 	}
 }
 
-// WithAllowMountType indicates the mount types that the peformer
+// WithAllowMountType indicates the mount types that the performer
 // of the mounts will support. Even if there is a custom handler
 // registered for the mount type to the mount handler, these mounts
 // should not performed unless required to support subsequent mounts.

--- a/core/mount/manager/manager_test.go
+++ b/core/mount/manager/manager_test.go
@@ -144,7 +144,7 @@ func (h *errOnceHandler) Unmount(_ context.Context, mp string) error {
 	return nil
 }
 
-// TestGC tests the garbage collecion features of the mount manager,
+// TestGC tests the garbage collection features of the mount manager,
 // ensuring that mounts are properly cleaned up when no longer needed.
 func TestGC(t *testing.T) {
 	type gcrun struct {

--- a/integration/client/restart_monitor_test.go
+++ b/integration/client/restart_monitor_test.go
@@ -212,7 +212,7 @@ func testRestartMonitorAlways(t *testing.T, client *Client, interval time.Durati
 
 	// Wait for task exit. If the task takes longer to exit, we risc
 	// wrongfully determining that the task has been restarted when we
-	// check the status in the for loop bellow and find that it's still
+	// check the status in the for loop below and find that it's still
 	// running.
 	select {
 	case <-statusC:

--- a/integration/issue10467_linux_test.go
+++ b/integration/issue10467_linux_test.go
@@ -116,6 +116,6 @@ func TestIssue10467(t *testing.T) {
 	}))
 	require.NoError(t, db.Close())
 
-	t.Log("Verifing")
+	t.Log("Verifying")
 	upgradeCaseFunc(t, currentProc.criRuntimeService(t), currentProc.criImageService(t))
 }

--- a/integration/release_upgrade_linux_test.go
+++ b/integration/release_upgrade_linux_test.go
@@ -168,7 +168,7 @@ func runUpgradeTestCaseWithExistingConfig(
 		})
 
 		for idx, upgradeCaseFunc := range upgradeCaseFuncs {
-			t.Logf("Verifing upgrade case %d", idx+1)
+			t.Logf("Verifying upgrade case %d", idx+1)
 			upgradeCaseFunc(t, currentProc.criRuntimeService(t), currentProc.criImageService(t))
 
 			if idx == len(upgradeCaseFuncs)-1 {
@@ -672,7 +672,7 @@ func (pCtx *podTCtx) createContainer(name, imageRef string, wantedState crirunti
 		require.NoError(t, pCtx.rSvc.StartContainer(cnID))
 		require.NoError(t, pCtx.rSvc.StopContainer(cnID, 0))
 	default:
-		t.Fatalf("unsupport state %s", wantedState)
+		t.Fatalf("unsupported state %s", wantedState)
 	}
 	return cnID
 }

--- a/integration/remote/util/util_windows.go
+++ b/integration/remote/util/util_windows.go
@@ -147,7 +147,7 @@ func IsUnixDomainSocket(filePath string) (bool, error) {
 	// Due to the absence of golang support for os.ModeSocket in Windows (https://github.com/golang/go/issues/33357)
 	// we need to dial the file and check if we receive an error to determine if a file is Unix Domain Socket file.
 
-	// Note that querrying for the Reparse Points (https://docs.microsoft.com/en-us/windows/win32/fileio/reparse-points)
+	// Note that querying for the Reparse Points (https://docs.microsoft.com/en-us/windows/win32/fileio/reparse-points)
 	// for the file (using FSCTL_GET_REPARSE_POINT) and checking for reparse tag: reparseTagSocket
 	// does NOT work in 1809 if the socket file is created within a bind mounted directory by a container
 	// and the FSCTL is issued in the host by the kubelet.

--- a/integration/shim_dial_unix_test.go
+++ b/integration/shim_dial_unix_test.go
@@ -154,7 +154,7 @@ func newTestListener(t testing.TB, abstract bool) (string, net.Listener, func())
 	// The shim stores the abstract socket file without abstract socket
 	// prefix and `unix://`. For the existing shim, if the socket file
 	// only contains the path, it will indicate that it is abstract socket.
-	// Otherwise, it will be normal socket file formated in `unix:///xyz'.
+	// Otherwise, it will be normal socket file formatted in `unix:///xyz'.
 	addr := filepath.Join(tmpDir, "uds.socket")
 	if abstract {
 		addr = abstractSocketPrefix + addr

--- a/internal/cleanup/context.go
+++ b/internal/cleanup/context.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// Package cleanup provides utilies to help cleanup.
+// Package cleanup provides utilities to help cleanup.
 package cleanup
 
 import (

--- a/internal/cri/resourcequantity/amount_test.go
+++ b/internal/cri/resourcequantity/amount_test.go
@@ -132,9 +132,9 @@ func TestInt64AmountMul(t *testing.T) {
 		c := test.a
 		ok := c.Mul(test.b)
 		if ok && !test.ok {
-			t.Errorf("unextected success: %v", c)
+			t.Errorf("unexpected success: %v", c)
 		} else if !ok && test.ok {
-			t.Errorf("unexpeted failure: %v", c)
+			t.Errorf("unexpected failure: %v", c)
 		} else if ok {
 			if c != test.c {
 				t.Errorf("%v: unexpected result: %d", test, c)

--- a/internal/cri/streamingserver/server.go
+++ b/internal/cri/streamingserver/server.go
@@ -305,7 +305,7 @@ func (s *server) serveExec(req *restful.Request, resp *restful.Response) {
 		req.Request,
 		s.runtime,
 		"", // unused: podName
-		"", // unusued: podUID
+		"", // unused: podUID
 		exec.ContainerId,
 		exec.Cmd,
 		streamOpts,
@@ -338,7 +338,7 @@ func (s *server) serveAttach(req *restful.Request, resp *restful.Response) {
 		req.Request,
 		s.runtime,
 		"", // unused: podName
-		"", // unusued: podUID
+		"", // unused: podUID
 		attach.ContainerId,
 		streamOpts,
 		s.config.StreamIdleTimeout,

--- a/internal/randutil/randutil.go
+++ b/internal/randutil/randutil.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// Package randutil provides utilities for [cyrpto/rand].
+// Package randutil provides utilities for [crypto/rand].
 package randutil
 
 import (

--- a/plugins/cri/runtime/plugin.go
+++ b/plugins/cri/runtime/plugin.go
@@ -173,7 +173,7 @@ func loadOCISpec(filename string) (*oci.Spec, error) {
 }
 
 // Set glog level.
-// TODO: mikebrow remove this klog inititialization func once we are no longer vendoring k8s.io/klog
+// TODO: mikebrow remove this klog initialization func once we are no longer vendoring k8s.io/klog
 func setGLogLevel() error {
 	l := log.GetLevel()
 	fs := flag.NewFlagSet("klog", flag.PanicOnError)

--- a/plugins/snapshots/windows/common.go
+++ b/plugins/snapshots/windows/common.go
@@ -35,7 +35,7 @@ import (
 )
 
 // windowsBaseSnapshotter is a type that implements common functionality required by both windows & cimfs
-// snapshotters (sort of a base type that windows & cimfs snapshotter types derive from - however, windowsBaseSnapshotter does NOT impelement the full Snapshotter interface).  Some functions
+// snapshotters (sort of a base type that windows & cimfs snapshotter types derive from - however, windowsBaseSnapshotter does NOT implement the full Snapshotter interface).  Some functions
 // (like Stat, Update) that are identical for both snapshotters are directly implemented in this base
 // snapshotter and such functions handle database transaction creation etc. However, the functions that are
 // not common don't create a transaction to allow the caller the flexibility of deciding whether to commit or


### PR DESCRIPTION
## Summary

Fix spelling mistakes found by [codespell](https://github.com/codespell-project/codespell) in comments across 15 files:

- `peformer` → `performer` (core/mount/manager.go)
- `envolve` → `evolve` (core/metadata/db.go)
- `refenced` → `referenced` (core/metadata/gc.go)
- `collecion` → `collection` (core/mount/manager/manager_test.go)
- `unusued` → `unused` (internal/cri/streamingserver/server.go)
- `cyrpto` → `crypto` (internal/randutil/randutil.go)
- `utilies` → `utilities` (internal/cleanup/context.go)
- `impelement` → `implement` (plugins/snapshots/windows/common.go)
- `inititialization` → `initialization` (plugins/cri/runtime/plugin.go)
- `Verifing` → `Verifying` (integration tests)
- `unsupport` → `unsupported` (integration/release_upgrade_linux_test.go)
- `unexpeted`/`unextected` → `unexpected` (internal/cri/resourcequantity/amount_test.go)
- `querrying` → `querying` (integration/remote/util/util_windows.go)
- `bellow` → `below` (integration/client/restart_monitor_test.go)
- `formated` → `formatted` (integration/shim_dial_unix_test.go)

All changes are in comments only — no logic is affected.