### PR TITLE
fix: add nil check for sandbox spec in hostNetwork pod creation

### DIFF
--- a/core/runtime/v2/bundle.go
+++ b/core/runtime/v2/bundle.go
@@ -103,12 +103,14 @@ func NewBundle(ctx context.Context, root, state, id string, spec typeurl.Any) (b
 	if err := os.Symlink(work, filepath.Join(b.Path, "work")); err != nil {
 		return nil, err
 	}
-	if spec := spec.GetValue(); spec != nil {
-		// write the spec to the bundle
-		specPath := filepath.Join(b.Path, oci.ConfigFilename)
-		err = os.WriteFile(specPath, spec, 0666)
-		if err != nil {
-			return nil, fmt.Errorf("failed to write bundle spec: %w", err)
+	if spec != nil {
+		if value := spec.GetValue(); value != nil {
+			// write the spec to the bundle
+			specPath := filepath.Join(b.Path, oci.ConfigFilename)
+			err = os.WriteFile(specPath, value, 0666)
+			if err != nil {
+				return nil, fmt.Errorf("failed to write bundle spec: %w", err)
+			}
 		}
 	}
 	return b, nil


### PR DESCRIPTION
## Summary
- Add nil check for `sandboxInfo.Spec` before calling `GetValue()`
- Prevents panic when running hostNetwork pods with shim sandboxer

## Root Cause
When `hostNetwork=true` and the sandboxer is `shim`, `sandboxInfo.Spec` is not set before `CreateSandbox`. Calling `spec.GetValue()` on a nil spec causes a nil pointer dereference panic.

## Testing
- Verified the nil check prevents the panic

Fixes #12983

Made with [Cursor](https://cursor.com)