### PR TITLE
import: Apply distribution source labels to imported content

### DIFF
--- a/client/import.go
+++ b/client/import.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/archive"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	digest "github.com/opencontainers/go-digest"
@@ -236,6 +237,7 @@ func (c *Client) Import(ctx context.Context, reader io.Reader, opts ...ImportOpt
 		return idx.Manifests, nil
 	}
 
+	handler = docker.DistributionSourceHandler(cs, handler)
 	handler = images.FilterPlatforms(handler, platformMatcher)
 	if iopts.referrers != nil {
 		handler = images.SetReferrers(iopts.referrers, handler)

--- a/core/remotes/docker/handler.go
+++ b/core/remotes/docker/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/reference"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -43,14 +44,76 @@ func AppendDistributionSourceLabel(manager content.Manager, ref string) (images.
 	}
 
 	source, repo := u.Hostname(), strings.TrimPrefix(u.Path, "/")
+	key := distributionSourceLabelKey(source)
 	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		info, err := manager.Info(ctx, desc.Digest)
+		return nil, applyDistributionSourceLabels(ctx, manager, desc, map[string]string{key: repo})
+	}, nil
+}
+
+// DistributionSourceHandler is a handler wrapper that applies distribution
+// source annotations from each descriptor to the corresponding content labels,
+// and propagates them to child descriptors.
+//
+// During OCI image export, distribution source labels are preserved as
+// annotations on the top-level index descriptors. This handler restores them
+// as content labels during import and propagates them down the content tree
+// so that all children (manifests, configs, layers) are labeled correctly.
+func DistributionSourceHandler(manager content.Manager, f images.HandlerFunc) images.HandlerFunc {
+	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		children, err := f(ctx, desc)
 		if err != nil {
-			return nil, err
+			return children, err
 		}
 
-		key := distributionSourceLabelKey(source)
+		srcLabels := distributionSourceAnnotations(desc.Annotations)
+		if len(srcLabels) == 0 {
+			return children, nil
+		}
 
+		if err := applyDistributionSourceLabels(ctx, manager, desc, srcLabels); err != nil {
+			if !errdefs.IsNotFound(err) {
+				return nil, err
+			}
+		}
+
+		// Propagate distribution source annotations to children.
+		for i := range children {
+			for k, v := range srcLabels {
+				if children[i].Annotations == nil {
+					children[i].Annotations = map[string]string{}
+				}
+				if _, exists := children[i].Annotations[k]; !exists {
+					children[i].Annotations[k] = v
+				}
+			}
+		}
+
+		return children, nil
+	}
+}
+
+func distributionSourceAnnotations(annotations map[string]string) map[string]string {
+	var result map[string]string
+	for k, v := range annotations {
+		if strings.HasPrefix(k, labels.LabelDistributionSource+".") {
+			if result == nil {
+				result = map[string]string{}
+			}
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func applyDistributionSourceLabels(ctx context.Context, manager content.Manager, desc ocispec.Descriptor, srcLabels map[string]string) error {
+	info, err := manager.Info(ctx, desc.Digest)
+	if err != nil {
+		return err
+	}
+
+	updateLabels := map[string]string{}
+	var fields []string
+	for key, repo := range srcLabels {
 		originLabel := ""
 		if info.Labels != nil {
 			originLabel = info.Labels[key]
@@ -62,18 +125,22 @@ func AppendDistributionSourceLabel(manager content.Manager, ref string) (images.
 		// is used as the very, very common layer.
 		if err := labels.Validate(key, value); err != nil {
 			log.G(ctx).Warnf("skip to append distribution label: %s", err)
-			return nil, nil
+			continue
 		}
 
-		info = content.Info{
-			Digest: desc.Digest,
-			Labels: map[string]string{
-				key: value,
-			},
-		}
-		_, err = manager.Update(ctx, info, fmt.Sprintf("labels.%s", key))
-		return nil, err
-	}, nil
+		updateLabels[key] = value
+		fields = append(fields, fmt.Sprintf("labels.%s", key))
+	}
+
+	if len(fields) == 0 {
+		return nil
+	}
+
+	_, err = manager.Update(ctx, content.Info{
+		Digest: desc.Digest,
+		Labels: updateLabels,
+	}, fields...)
+	return err
 }
 
 func appendDistributionSourceLabel(originLabel, repo string) string {

--- a/core/transfer/local/import.go
+++ b/core/transfer/local/import.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/core/unpack"
 )
@@ -86,6 +87,8 @@ func (ts *localTransferService) importStream(ctx context.Context, i transfer.Ima
 	if f, ok := is.(transfer.ImageFilterer); ok {
 		handlerFunc = f.ImageFilter(handlerFunc, ts.content)
 	}
+
+	handlerFunc = docker.DistributionSourceHandler(ts.content, handlerFunc)
 
 	handler = images.Handlers(handlerFunc)
 

--- a/integration/client/import_test.go
+++ b/integration/client/import_test.go
@@ -822,3 +822,111 @@ func hash64(s string) int64 {
 	h.Write([]byte(s))
 	return int64(h.Sum64())
 }
+
+func TestImportDistributionSourceLabels(t *testing.T) {
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	tc := tartest.TarContext{}
+
+	bb, _ := createContent(128, 42)
+	cb, _ := createConfig("linux", "amd64", "dist-source-test")
+	mb, mDigest, _ := createManifest(cb, [][]byte{bb})
+
+	distSourceLabel := "containerd.io/distribution.source.docker.io"
+	distSourceLabel2 := "containerd.io/distribution.source.registry.other.io"
+
+	idx := ocispec.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		Manifests: []ocispec.Descriptor{
+			{
+				MediaType: ocispec.MediaTypeImageManifest,
+				Digest:    mDigest,
+				Size:      int64(len(mb)),
+				Annotations: map[string]string{
+					images.AnnotationImageName: "docker.io/library/ubuntu:latest",
+					ocispec.AnnotationRefName:  "latest",
+					distSourceLabel:            "library/ubuntu",
+					distSourceLabel2:           "other/repo",
+				},
+			},
+		},
+	}
+	ib, _ := json.Marshal(idx)
+
+	files := tartest.TarAll(
+		tc.Dir(ocispec.ImageBlobsDir, 0755),
+		tc.Dir(ocispec.ImageBlobsDir+"/sha256", 0755),
+		tc.File(ocispec.ImageBlobsDir+"/sha256/"+digest.FromBytes(bb).Encoded(), bb, 0644),
+		tc.File(ocispec.ImageBlobsDir+"/sha256/"+digest.FromBytes(cb).Encoded(), cb, 0644),
+		tc.File(ocispec.ImageBlobsDir+"/sha256/"+mDigest.Encoded(), mb, 0644),
+		tc.File(ocispec.ImageBlobsDir+"/sha256/"+digest.FromBytes(ib).Encoded(), ib, 0644),
+		tc.File(ocispec.ImageIndexFile, ib, 0644),
+		tc.File(ocispec.ImageLayoutFile, []byte(`{"imageLayoutVersion":"`+ocispec.ImageLayoutVersion+`"}`), 0644),
+	)
+
+	expectedLabels := map[string]string{
+		distSourceLabel:  "library/ubuntu",
+		distSourceLabel2: "other/repo",
+	}
+
+	t.Run("ClientImport", func(t *testing.T) {
+		ctx := namespaces.WithNamespace(ctx, uuid.New().String())
+
+		imgs, err := client.Import(ctx, tartest.TarFromWriterTo(files))
+		require.NoError(t, err)
+		require.NotEmpty(t, imgs)
+
+		checkDistributionSourceLabels(ctx, t, client.ContentStore(), imgs[0].Target, expectedLabels)
+	})
+
+	t.Run("TransferImport", func(t *testing.T) {
+		ctx := namespaces.WithNamespace(ctx, uuid.New().String())
+
+		r := tartest.TarFromWriterTo(files)
+		defer r.Close()
+
+		is := image.NewStore("docker.io/library/ubuntu", image.WithNamedPrefix("docker.io/library/ubuntu", true))
+		iis := tarchive.NewImageImportStream(r, "")
+
+		err := client.Transfer(ctx, iis, is)
+		require.NoError(t, err)
+
+		img, err := client.ImageService().Get(ctx, "docker.io/library/ubuntu:latest")
+		require.NoError(t, err)
+
+		checkDistributionSourceLabels(ctx, t, client.ContentStore(), img.Target, expectedLabels)
+	})
+}
+
+func checkDistributionSourceLabels(ctx context.Context, t *testing.T, cs content.Store, target ocispec.Descriptor, expectedLabels map[string]string) {
+	t.Helper()
+
+	var checked int
+	err := images.Walk(ctx, images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		info, err := cs.Info(ctx, desc.Digest)
+		if err != nil {
+			return nil, err
+		}
+		for key, want := range expectedLabels {
+			val, ok := info.Labels[key]
+			if !ok {
+				t.Errorf("content %s missing label %s", desc.Digest, key)
+			} else if val != want {
+				t.Errorf("content %s: %s = %q, want %q", desc.Digest, key, val, want)
+			}
+		}
+		checked++
+		return images.Children(ctx, cs, desc)
+	}), target)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, checked, 3, "expected manifest + config + layer")
+}


### PR DESCRIPTION
- fixes: #12883

Apply distribution source labels during image import so imported content carries the same repository source metadata.

Update both client and transfer import paths to label imported content for valid image references, and add integration tests covering both paths.