### PR TITLE
pkg/sys: use Size=1 for noop process uid/gid mapping

### DIFF
--- a/pkg/sys/unshare_linux.go
+++ b/pkg/sys/unshare_linux.go
@@ -173,14 +173,20 @@ func startProcessWithUsernsLocked(targetHostUID int, unshareFlags uintptr, uidMa
 		return -1, -1, fmt.Errorf("failed to restore capabilities: %w", err)
 	}
 
+	// The noop process only holds the user namespace open; it does not need the
+	// real pod uid/gid mapping. Use HostID=0 (always valid) and Size=1.
+	// The OCI runtime applies the real container uid/gid mapping on startup.
+	noopUIDMaps := []syscall.SysProcIDMap{{ContainerID: 0, HostID: 0, Size: 1}}
+	noopGIDMaps := []syscall.SysProcIDMap{{ContainerID: 0, HostID: 0, Size: 1}}
+
 	var pidfd int
 	proc, err := os.StartProcess("/proc/self/exe", []string{"UnshareAfterEnterUserns"}, &os.ProcAttr{
 		Sys: &syscall.SysProcAttr{
 			// clone new user namespace first and then unshare
 			Cloneflags:                 unix.CLONE_NEWUSER,
 			Unshareflags:               unshareFlags,
-			UidMappings:                uidMaps,
-			GidMappings:                gidMaps,
+			UidMappings:                noopUIDMaps,
+			GidMappings:                noopGIDMaps,
 			GidMappingsEnableSetgroups: true,
 			// NOTE: It's reexec but it's not heavy because subprocess
 			// be in PTRACE_TRACEME mode before performing execve.

--- a/pkg/sys/unshare_linux_test.go
+++ b/pkg/sys/unshare_linux_test.go
@@ -82,11 +82,11 @@ func testUnshareAfterEnterUsernsShouldWork(t *testing.T) {
 
 		data, err := os.ReadFile(fmt.Sprintf("/proc/%d/uid_map", pid))
 		require.NoError(t, err)
-		require.Equal(t, "         0       1000         10\n", string(data))
+		require.Equal(t, "         0          0          1\n", string(data))
 
 		data, err = os.ReadFile(fmt.Sprintf("/proc/%d/gid_map", pid))
 		require.NoError(t, err)
-		require.Equal(t, "         0       1000         10\n", string(data))
+		require.Equal(t, "         0          0          1\n", string(data))
 
 		data, err = os.ReadFile(fmt.Sprintf("/proc/%d/setgroups", pid))
 		require.NoError(t, err)


### PR DESCRIPTION
## Problem

When containerd runs inside a rootless container (e.g. a k3s cluster deployed via rootless Podman), creating a pod sandbox with `hostUsers: false` fails:

```
failed to start noop process for unshare: fork/exec /proc/self/exe: operation not permitted
```

## Root cause

`startProcessWithUsernsLocked` passes the full caller-supplied `uidMaps`/`gidMaps` (typically `Size: 65536` from kubelet's user namespace allocation) to the noop process. In a rootless cluster container, the container's uid_map only covers UIDs `0..65536`. Kubelet allocates the first pod's user namespace starting at `HostID: 65536` with `Size: 65536`, requiring container UIDs `65536..131071` in the parent namespace. Those UIDs don't exist in a typical rootless container's uid_map, so the kernel rejects the uid_map write with `EPERM`.

## Fix

The noop process only holds the user namespace open long enough for containerd to bind-mount the network namespace path — it doesn't need the full uid/gid mapping. Using `Size: 1` is sufficient: the kernel requires a non-empty uid_map, and a single-entry mapping stays within the available sub-UID range. The real container's full uid/gid mapping is applied by the OCI runtime when the actual pod container starts.

## Verification

Tested by injecting Go test binaries into a running rootless Podman k3s cluster container:

```
HostId=65536, Size=65536 (current): FAIL — fork/exec /proc/self/exe: operation not permitted
HostId=65536, Size=1    (this fix):  OK
```

Fixes: #13074

Signed-off-by: Grzegorz Grasza <xek@redhat.com>