### PR TITLE
Hide image tags without explicit registries from CRI

### DIFF
--- a/integration/images_visibility_test.go
+++ b/integration/images_visibility_test.go
@@ -1,0 +1,129 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	coreimages "github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/containerd/errdefs"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestImageTagWithoutRegistryNotVisibleInCRI(t *testing.T) {
+	baseImage := images.Get(images.BusyBox) // ghcr.io/containerd/busybox:1.36
+
+	t.Logf("Pulling base image %s", baseImage)
+	img, err := containerdClient.Pull(t.Context(), baseImage)
+	require.NoError(t, err)
+
+	t.Run("ShortTag_Hidden", func(t *testing.T) {
+		shortTag := fmt.Sprintf("busybox:hidden-%s", strings.ReplaceAll(t.Name(), "/", "-"))
+		t.Logf("Tagging as short tag %s", shortTag)
+		createTag(t, t.Context(), img, shortTag)
+
+		t.Logf("Verifying short tag is not visible in CRI Status")
+		criImage, err := imageService.ImageStatus(&runtime.ImageSpec{Image: shortTag})
+		require.NoError(t, err)
+		require.Nil(t, criImage, "Short tag should not be visible in CRI Status")
+
+		t.Logf("Verifying short tag is not visible in CRI ListImages")
+		criImages, err := imageService.ListImages(nil)
+		require.NoError(t, err)
+		require.False(t, containsTag(criImages, shortTag), "Short tag should not be listed in CRI ListImages")
+	})
+
+	t.Run("FullTag_Visible", func(t *testing.T) {
+		fullTag := fmt.Sprintf("docker.io/library/busybox:visible-%s", strings.ReplaceAll(t.Name(), "/", "-"))
+		t.Logf("Tagging as full tag %s", fullTag)
+		createTag(t, t.Context(), img, fullTag)
+
+		t.Logf("Verifying full tag is visible in CRI Status")
+		require.NoError(t, Eventually(func() (bool, error) {
+			criImage, err := imageService.ImageStatus(&runtime.ImageSpec{Image: fullTag})
+			if err != nil {
+				return false, err
+			}
+			return criImage != nil, nil
+		}, 100*time.Millisecond, 10*time.Second), "Image did not become visible in CRI status")
+
+		t.Logf("Verifying RepoTags contains %s", fullTag)
+		criImage, err := imageService.ImageStatus(&runtime.ImageSpec{Image: fullTag})
+		require.NoError(t, err)
+		require.NotNil(t, criImage)
+		require.Contains(t, criImage.RepoTags, fullTag)
+
+		t.Logf("Verifying full tag is visible in CRI ListImages")
+		var criImages []*runtime.Image
+		require.NoError(t, Eventually(func() (bool, error) {
+			criImages, err = imageService.ListImages(nil)
+			if err != nil {
+				return false, err
+			}
+			return containsTag(criImages, fullTag), nil
+		}, 100*time.Millisecond, 10*time.Second), "Image did not become listed in CRI images")
+	})
+}
+
+// createTag programmatically creates a containerd image object for testing visibility without CRI.
+// It automatically registers cleanup for both containerd and CRI to prevent residual state.
+func createTag(t *testing.T, ctx context.Context, img containerd.Image, tagName string) {
+	t.Helper()
+
+	// Registering cleanup *before* Create ensures that even if creation fails midway,
+	// or the test terminates abruptly, we still attempt to delete. Deleting a non-existent
+	// image is safe due to errdefs.IsNotFound.
+	t.Cleanup(func() {
+		err := imageService.RemoveImage(&runtime.ImageSpec{Image: tagName})
+		if err != nil && !errdefs.IsNotFound(err) {
+			require.NoError(t, err)
+		}
+	})
+
+	t.Cleanup(func() {
+		err := containerdClient.ImageService().Delete(context.Background(), tagName)
+		if err != nil && !errdefs.IsNotFound(err) {
+			require.NoError(t, err)
+		}
+	})
+
+	tagImage := coreimages.Image{
+		Name:   tagName,
+		Target: img.Target(),
+	}
+	_, err := containerdClient.ImageService().Create(ctx, tagImage)
+	require.NoError(t, err)
+}
+
+// containsTag checks if a list of CRI images contains a specific tag.
+func containsTag(images []*runtime.Image, tag string) bool {
+	for _, img := range images {
+		for _, t := range img.RepoTags {
+			if t == tag {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/cri/server/images/image_list.go
+++ b/internal/cri/server/images/image_list.go
@@ -33,7 +33,9 @@ func (c *GRPCCRIImageService) ListImages(ctx context.Context, r *runtime.ListIma
 	for _, image := range imagesInStore {
 		// TODO(random-liu): [P0] Make sure corresponding snapshot exists. What if snapshot
 		// doesn't exist?
-		images = append(images, toCRIImage(image))
+		if criImage := toCRIImage(image); criImage != nil {
+			images = append(images, criImage)
+		}
 	}
 
 	return &runtime.ListImagesResponse{Images: images}, nil

--- a/internal/cri/server/images/image_status.go
+++ b/internal/cri/server/images/image_status.go
@@ -48,6 +48,9 @@ func (c *CRIImageService) ImageStatus(ctx context.Context, r *runtime.ImageStatu
 	// doesn't exist?
 
 	runtimeImage := toCRIImage(image)
+	if runtimeImage == nil {
+		return &runtime.ImageStatusResponse{}, nil
+	}
 	info, err := c.toCRIImageInfo(ctx, &image, r.GetVerbose())
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate image info: %w", err)
@@ -60,8 +63,12 @@ func (c *CRIImageService) ImageStatus(ctx context.Context, r *runtime.ImageStatu
 }
 
 // toCRIImage converts internal image object to CRI runtime.Image.
+// Returns nil if the image has no qualified references.
 func toCRIImage(image imagestore.Image) *runtime.Image {
 	repoTags, repoDigests := util.ParseImageReferences(image.References)
+	if len(repoTags) == 0 && len(repoDigests) == 0 {
+		return nil
+	}
 	runtimeImage := &runtime.Image{
 		Id:          image.ID,
 		RepoTags:    repoTags,

--- a/internal/cri/util/references.go
+++ b/internal/cri/util/references.go
@@ -17,12 +17,14 @@
 package util
 
 import (
+	"strings"
+
 	reference "github.com/distribution/reference"
 	imagedigest "github.com/opencontainers/go-digest"
 )
 
 // ParseImageReferences parses a list of arbitrary image references and returns
-// the repotags and repodigests
+// the repotags and repodigests. It filters out references without an explicit registry.
 func ParseImageReferences(refs []string) ([]string, []string) {
 	var tags, digests []string
 	for _, ref := range refs {
@@ -30,6 +32,20 @@ func ParseImageReferences(refs []string) ([]string, []string) {
 		if err != nil {
 			continue
 		}
+
+		// CRI should only see images with fully-qualified registries. Intercept
+		// the raw string here before any normalization happens, to prevent "short
+		// tags" (like busybox:fixed) from being shown with an automatic
+		// "docker.io" prefix.
+		named, ok := parsed.(reference.Named)
+		if !ok {
+			continue
+		}
+		domain := reference.Domain(named)
+		if domain == "" || !strings.HasPrefix(ref, domain+"/") {
+			continue
+		}
+
 		if _, ok := parsed.(reference.Canonical); ok {
 			digests = append(digests, parsed.String())
 		} else if _, ok := parsed.(reference.Tagged); ok {

--- a/internal/cri/util/references_test.go
+++ b/internal/cri/util/references_test.go
@@ -30,7 +30,11 @@ func TestParseImageReferences(t *testing.T) {
 		"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 		"gcr.io/library/busybox:1.2",
 		"sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+		"busybox:fixed",
 		"arbitrary-ref",
+		"library/docker.io",
+		"library/docker.io:v1",
+		"busybox:docker.io",
 	}
 	expectedTags := []string{
 		"gcr.io/library/busybox:1.2",


### PR DESCRIPTION
Hide image tags without explicit registries from CRI Image references without an explicit registry (e.g., `"busybox:fixed"`) are often used for internal containerd tagging. However, when parsed by the distribution library, they are automatically normalized to include a default registry (e.g., `"docker.io/library/busybox:fixed"`). This causes them to leak into CRI views like `ImageStatus` and `ListImages`.

This commit filters out image references without an explicit registry domain during parsing in `ParseImageReferences`. It verifies that the raw reference string starts with the parsed domain followed by a slash (e.g. `"docker.io/"`), preventing false positives from domain substrings in tags or paths.

If an image has no qualified references remaining, it is hidden from CRI entirely: `ListImages` will skip listing it, and `ImageStatus` will return an empty "not found" response.

Tested via unit tests (`go test ./internal/cri/...`) and integration test (`FOCUS=TestImageTagWithoutRegistryNotVisibleInCRI make cri-integration`).

Assisted-by: Antigravity