### PR TITLE
transfer: fix the differ selection if differ is ""

### DIFF
--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -128,8 +128,14 @@ func init() {
 							continue
 						}
 						var matched bool
-						for _, p := range plugin.Meta.Platforms {
-							if target.Match(p) {
+						for _, pd := range plugin.Meta.Platforms {
+							// Note that we must use the platforms supported by the differ to
+							// match the platform in `UnpackConfiguration`.
+							//
+							// For example, a differ might only support "linux/amd64", while
+							// the platform in `UnpackConfiguration` is "linux(+erofs)/amd64".
+							// If we reverse this logic, this wrong differ will be applied.
+							if platforms.Only(pd).Match(p) {
 								matched = true
 							}
 						}


### PR DESCRIPTION
We must use the platforms supported by the differ to match the platform in `UnpackConfiguration`.

For example, a differ might only support "linux/amd64", while the platform in `UnpackConfiguration` is "linux(+erofs)/amd64";
Currently the logic is reversed, so that the wrong differ will be applied, as below:

```go
// the wrong logic
if target[`linux(+erofs)/amd64`].Match(p[`linux/amd64`]) {
```
And 
```go
func (m *matcher) Match(platform specs.Platform) bool {
	normalized := Normalize(platform)
	if m.OS == normalized.OS &&
		m.Architecture == normalized.Architecture &&
		m.Variant == normalized.Variant &&
		m.matchOSVersion(platform) {
		if len(normalized.OSFeatures) == 0 { // `linux/amd64` should always match incorrectly.
			return true
		}
```

It should use all potential differs' capablities to match the corresponding platform requirements:
```go
if platforms.Only(pd)`linux/amd64`.Match(p`linux(+erofs)/amd64`) {
```

-- A dependency patch of EROFS image osfeature support

