### PR TITLE
make: fix benchmark target package selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ bin/loopback-v2: integration/failpoint/cmd/loopback-v2 FORCE
 
 benchmark: ## run benchmarks tests
 	@echo "$(WHALE) $@"
-	@$(GO) test ${TESTFLAGS} -bench . -run Benchmark -test.root
+	@$(GO) test ${TESTFLAGS} -bench . -run ^$$ ${PACKAGES}
 
 FORCE:
 


### PR DESCRIPTION
## Summary
Fixes #12973 by making the benchmark Make target run benchmarks across containerd packages instead of invoking go test without package arguments.

### What changed
- Makefile benchmark target now uses:
  - -run ^$ to skip normal tests while running benchmarks
  - ${PACKAGES} so go test gets explicit package arguments
- removed -test.root, which caused root-package handling issues and immediate failure from repo root.

## Reproduction
Before this change:
- make benchmark failed immediately from repo root with:
  - # .
  - no Go files in .../containerd

After this change:
- make -n benchmark expands to go test ... ${PACKAGES}
- make benchmark starts running package benchmarks instead of failing immediately.

## Testing
- make -n benchmark
- make benchmark (started package benchmark execution; long-running suite interrupted locally)
