### PR TITLE
cri/images: avoid false pull timeout on transfer progress events

### DIFF
--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -976,6 +976,10 @@ func (reporter *transferProgressReporter) handleProgress(p transfer.Progress) {
 	default:
 		return
 	}
+
+	// Any valid transfer progress event should refresh liveness. This avoids
+	// timing out while downloads are still being reported but byte deltas are flat.
+	reporter.lastSeenTimestamp = time.Now()
 }
 
 func (reporter *transferProgressReporter) IncBytesRead(bytes int64) {

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -757,3 +757,47 @@ func TestTransferProgressReporter(t *testing.T) {
 		})
 	}
 }
+
+func TestTransferProgressReporterProgressEventRefreshesTimeout(t *testing.T) {
+	t.Helper()
+
+	ctx := context.Background()
+	cancelCalled := make(chan struct{}, 1)
+	reporter := &transferProgressReporter{
+		reqReporter: pullRequestReporter{},
+		statuses:    make(map[string]*transfer.Progress),
+		ref:         "test-image:latest",
+		timeout:     50 * time.Millisecond,
+		cancel: func() {
+			select {
+			case cancelCalled <- struct{}{}:
+			default:
+			}
+		},
+		lastSeenBytesRead: 123,
+		lastSeenTimestamp: time.Now().Add(-time.Second),
+	}
+
+	reporter.reqReporter.activeReqs.Store(1)
+	reporter.reqReporter.totalBytesRead.Store(123)
+
+	reporter.handleProgress(transfer.Progress{
+		Name: "layer1",
+		Desc: &ocispec.Descriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+			Digest:    "sha256:abcdef",
+			Size:      1000,
+		},
+		Total:    1000,
+		Progress: 123,
+		Event:    "waiting",
+	})
+
+	reporter.checkProgress(ctx, 10*time.Millisecond)
+
+	select {
+	case <-cancelCalled:
+		t.Fatal("cancel should not be called when recent progress events are received")
+	default:
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #12811 by preventing pull timeout cancellation when transfer progress events are still flowing but byte deltas are temporarily flat.

## Problem
`transferProgressReporter` used byte-delta-only liveness to decide timeout cancellation. In multipart download workflows, this can misclassify an active pull as stalled if progress events continue but the sampled `totalBytesRead` does not advance in the timeout window.

## Changes
- Refresh timeout liveness timestamp on each valid transfer progress event handled by `transferProgressReporter`.
- Keep existing byte-delta logic unchanged.
- Add regression test `TestTransferProgressReporterProgressEventRefreshesTimeout`.

## Testing
- `go test ./internal/cri/server/images -run 'TestTransferProgressReporter|TestTransferProgressReporterProgressEventRefreshesTimeout'`
- `go test ./internal/cri/server/images`
