### PR TITLE
[release/1.7] oci: make WithPidsLimit runtime-spec compatible

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1503,8 +1504,39 @@ func WithPidsLimit(limit int64) SpecOpts {
 		if s.Linux.Resources.Pids == nil {
 			s.Linux.Resources.Pids = &specs.LinuxPids{}
 		}
-		s.Linux.Resources.Pids.Limit = limit
+		if err := setLinuxPidsLimit(s.Linux.Resources.Pids, limit); err != nil {
+			return err
+		}
 		return nil
+	}
+}
+
+// setLinuxPidsLimit supports runtime-spec layouts where LinuxPids.Limit is
+// either int64 (older versions) or *int64 (newer versions).
+func setLinuxPidsLimit(pids *specs.LinuxPids, limit int64) error {
+	v := reflect.ValueOf(pids)
+	if !v.IsValid() || v.Kind() != reflect.Ptr || v.IsNil() {
+		return errors.New("linux pids is nil")
+	}
+
+	limitField := v.Elem().FieldByName("Limit")
+	if !limitField.IsValid() || !limitField.CanSet() {
+		return errors.New("linux pids limit field is not settable")
+	}
+
+	switch limitField.Kind() {
+	case reflect.Int64:
+		limitField.SetInt(limit)
+		return nil
+	case reflect.Ptr:
+		if limitField.Type().Elem().Kind() != reflect.Int64 {
+			return fmt.Errorf("unsupported linux pids limit pointer type: %s", limitField.Type())
+		}
+		l := limit
+		limitField.Set(reflect.ValueOf(&l))
+		return nil
+	default:
+		return fmt.Errorf("unsupported linux pids limit kind: %s", limitField.Kind())
 	}
 }
 

--- a/oci/spec_opts_test.go
+++ b/oci/spec_opts_test.go
@@ -700,6 +700,35 @@ func TestWithoutMounts(t *testing.T) {
 	}
 }
 
+func TestWithPidsLimit(t *testing.T) {
+	spec := Spec{
+		Version: specs.Version,
+		Root:    &specs.Root{},
+		Linux:   &specs.Linux{},
+	}
+
+	const expected int64 = 1234
+	err := WithPidsLimit(expected)(nil, nil, nil, &spec)
+	require.NoError(t, err)
+	require.NotNil(t, spec.Linux)
+	require.NotNil(t, spec.Linux.Resources)
+	require.NotNil(t, spec.Linux.Resources.Pids)
+
+	limitField := reflect.ValueOf(spec.Linux.Resources.Pids).Elem().FieldByName("Limit")
+	require.True(t, limitField.IsValid())
+
+	switch limitField.Kind() {
+	case reflect.Int64:
+		assert.Equal(t, expected, limitField.Int())
+	case reflect.Ptr:
+		require.False(t, limitField.IsNil())
+		require.Equal(t, reflect.Int64, limitField.Elem().Kind())
+		assert.Equal(t, expected, limitField.Elem().Int())
+	default:
+		t.Fatalf("unexpected LinuxPids.Limit kind: %s", limitField.Kind())
+	}
+}
+
 func TestWithWindowsDevice(t *testing.T) {
 	testcases := []struct {
 		name   string


### PR DESCRIPTION
## Summary
- make `WithPidsLimit` compatible with runtime-spec layouts where `LinuxPids.Limit` is either `int64` (older) or `*int64` (newer)
- route `WithPidsLimit` through a small compatibility helper that sets the field via reflection based on its runtime shape
- add `TestWithPidsLimit` that validates behavior without assuming a single concrete `Limit` type

## Why
Issue #12493 reports that consumers importing `github.com/containerd/containerd` from the release-1.7 line can fail to build depending on the resolved `opencontainers/runtime-spec` version and the `LinuxPids.Limit` type shape.

This keeps release-1.7 resilient to that type difference while preserving existing behavior.

## Testing
- `go test ./oci -run 'TestWithPidsLimit|TestWithWindowsDevice'`
- `go test ./oci`

Refs #12493
