### PR TITLE
runc-shim: fix exec PID error message and fmt verb

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/exec.go
+++ b/cmd/containerd-shim-runc-v2/process/exec.go
@@ -238,7 +238,7 @@ func (e *execProcess) start(ctx context.Context) (err error) {
 	}
 	pid, err := pidFile.Read()
 	if err != nil {
-		return fmt.Errorf("failed to retrieve OCI runtime exec pi: %wd", err)
+		return fmt.Errorf("failed to retrieve OCI runtime exec pid: %w", err)
 	}
 	e.pid.pid = pid
 	return nil


### PR DESCRIPTION
Correct the typo in the error string (pi -> pid) and use %w for error wrapping instead of the invalid %wd verb when reading the exec PID file.