### PR TITLE
fix linter issues

### DIFF
--- a/core/snapshots/storage/bolt.go
+++ b/core/snapshots/storage/bolt.go
@@ -418,7 +418,7 @@ func CommitActive(ctx context.Context, key, name string, usage snapshots.Usage, 
 
 			// Updates parent back link to use new key
 			if err := pbkt.Put(parentKey(pid, id), []byte(name)); err != nil {
-				return fmt.Errorf("failed to update parent link %q from %q to %q: %w", pid, key, name, err)
+				return fmt.Errorf("failed to update parent link %v from %q to %q: %w", pid, key, name, err)
 			}
 		}
 

--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -123,7 +123,7 @@ func init() {
 					applier = inst.(diff.Applier)
 				} else {
 					var applierID string
-					for name, plugin := range ic.GetAll() {
+					for _, plugin := range ic.GetAll() {
 						if plugin.Registration.Type != plugins.DiffPlugin {
 							continue
 						}
@@ -152,7 +152,7 @@ func init() {
 						}
 						inst, err := plugin.Instance()
 						if err != nil {
-							return nil, fmt.Errorf("failed to get instance for diff plugin %q: %w", name, err)
+							return nil, fmt.Errorf("failed to get instance for diff plugin %q: %w", plugin.Registration.ID, err)
 						}
 						applier = inst.(diff.Applier)
 						applierID = plugin.Registration.ID

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -21,6 +21,6 @@ set -eu -o pipefail
 
 go install github.com/containerd/protobuild/cmd/go-fix-acronym@v0.3.0
 go install github.com/cpuguy83/go-md2man/v2@v2.0.7
-go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.5
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
 go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@v1.2.7
 go install github.com/bufbuild/buf/cmd/buf@v1.63.0


### PR DESCRIPTION
Part of https://github.com/containerd/containerd/pull/13076 that is just basic branch clean up

```
│ level=warning msg="[runner/nolint_filter] Found unknown linters in //nolint directives: varcheck"                               │
│ core/snapshots/storage/bolt.go:421:53: printf: fmt.Errorf format %q has arg pid of wrong type uint64 (govet)                    │
│                 return fmt.Errorf("failed to update parent link %q from %q to %q: %w", pid, key, name, err)                     │
│                                                                 ^                                                               │
│ plugins/transfer/plugin.go:155:71: printf: fmt.Errorf format %q has arg name of wrong type int (govet)                          │
│                             return nil, fmt.Errorf("failed to get instance for diff plugin %q: %w", name, err)                  │
│                                                                                            ^                                    │
│ 2 issues:                                                                                                                       │
│ * govet: 2    
```