### PR TITLE
Add section about AI and automation in contributor's guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,18 @@ $ script/setup/install-dev-tools
 $ make install-deps
 ```
 
+## Automated and AI-generated contributions
+
+Pull requests must be opened by a human. Any use of automation to create
+pull requests must be approved by a maintainer. Accounts creating pull requests
+using automation without prior approval may be restricted from the containerd
+organization.
+
+All AI-generated or AI-assisted submissions — whether code, PR descriptions,
+or comments — must be reviewed by the human author before being submitted.
+The human author is responsible for the correctness and quality of all content
+in their pull request and any associated comments.
+
 ## Code style
 
 - Go files adhere to standard Go formatting and styling


### PR DESCRIPTION
Add a section mentioning expectations around AI submissions and use of automation in creation pull requests.

This isn't intended to define a full policy around use of AI in containerd, just some guidelines to follow and to point to when handling low quality AI generated submissions.