### PR TITLE
cri: fix repeated stop podsandbox operations

### DIFF
--- a/internal/cri/server/sandbox_stop.go
+++ b/internal/cri/server/sandbox_stop.go
@@ -81,6 +81,11 @@ func (c *criService) stopPodSandbox(ctx context.Context, sandbox sandboxstore.Sa
 
 	// Only stop sandbox container when it's running or unknown.
 	state := sandbox.Status.Get().State
+	if state == sandboxstore.StateStopped {
+		log.G(ctx).Warnf("sandbox %q is already stopped", id)
+		return nil
+	}
+
 	if state == sandboxstore.StateReady || state == sandboxstore.StateUnknown {
 		if err := c.sandboxService.StopSandbox(ctx, sandbox.Sandboxer, id); err != nil {
 			// Log and ignore the error if controller already removed the sandbox
@@ -135,6 +140,12 @@ func (c *criService) stopPodSandbox(ctx context.Context, sandbox sandboxstore.Sa
 	err = c.cleanupImageMounts(ctx, id)
 	if err != nil {
 		return fmt.Errorf("failed to cleanup image mounts for sandbox %q: %w", id, err)
+	}
+	if err := sandbox.Status.Update(func(status sandboxstore.Status) (sandboxstore.Status, error) {
+		status.State = sandboxstore.StateStopped
+		return status, nil
+	}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/cri/store/sandbox/status.go
+++ b/internal/cri/store/sandbox/status.go
@@ -76,6 +76,8 @@ const (
 	// StateUnknown is unknown state. Sandbox only goes
 	// into unknown state when its status fails to be loaded.
 	StateUnknown
+	// StateStopped means the Sandbox has been stopped successfully
+	StateStopped
 )
 
 // String returns the string representation of the state
@@ -88,6 +90,9 @@ func (s State) String() string {
 	case StateUnknown:
 		// PodSandboxState doesn't have an unknown state, but State does, so return a string using the same convention
 		return "SANDBOX_UNKNOWN"
+	case StateStopped:
+		// PodSandboxState doesn't have a stopped state, but State does, so return a string using the same convention
+		return "SANDBOX_STOPPED"
 	default:
 		return "invalid sandbox state value: " + strconv.Itoa(int(s))
 	}


### PR DESCRIPTION
In some scenarios, the kubelet attempts to stop the same PodSandbox multiple times even after it has already been terminated. To address this issue, a StateStopped state is introduced to avoid duplicate pod stop operations.