### PR TITLE
ctr: fix image names with dashes displayed as spaces in progress output

### DIFF
--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -463,11 +463,17 @@ func prefixes(index, length int) (prefix string, childPrefix string) {
 }
 
 func displayName(name string) string {
-	parts := strings.Split(name, "-")
-	for i := range parts {
-		parts[i] = shortenName(parts[i])
+	// Progress names from MakeRefKey use the form "prefix-sha256:…"
+	// (e.g. "manifest-sha256:abc…", "layer-sha256:abc…").  Split on
+	// the first dash only when the remainder starts with a digest
+	// reference so that image names containing dashes (e.g.
+	// "quay.io/calico/kube-controllers:v3.30.6") are preserved.
+	if prefix, rest, ok := strings.Cut(name, "-"); ok {
+		if strings.HasPrefix(rest, "sha256:") || strings.HasPrefix(rest, "sha384:") || strings.HasPrefix(rest, "sha512:") {
+			return prefix + " " + shortenName(rest)
+		}
 	}
-	return strings.Join(parts, " ")
+	return shortenName(name)
 }
 
 func shortenName(name string) string {

--- a/cmd/ctr/commands/images/pull_test.go
+++ b/cmd/ctr/commands/images/pull_test.go
@@ -1,0 +1,72 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import "testing"
+
+func TestDisplayName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "image ref with dashes preserved",
+			input:    "quay.io/calico/kube-controllers:v3.30.6",
+			expected: "quay.io/calico/kube-controllers:v3.30.6",
+		},
+		{
+			name:     "manifest digest shortened",
+			input:    "manifest-sha256:c6434b5f0e811aabb1f41fd8d1b00a38f25d991c18f52e9a31fa34e4dada0fb7",
+			expected: "manifest (c6434b5f0e81)",
+		},
+		{
+			name:     "layer digest shortened",
+			input:    "layer-sha256:c6434b5f0e811aabb1f41fd8d1b00a38f25d991c18f52e9a31fa34e4dada0fb7",
+			expected: "layer (c6434b5f0e81)",
+		},
+		{
+			name:     "config digest shortened",
+			input:    "config-sha256:c6434b5f0e811aabb1f41fd8d1b00a38f25d991c18f52e9a31fa34e4dada0fb7",
+			expected: "config (c6434b5f0e81)",
+		},
+		{
+			name:     "plain sha256 digest shortened",
+			input:    "sha256:c6434b5f0e811aabb1f41fd8d1b00a38f25d991c18f52e9a31fa34e4dada0fb7",
+			expected: "(c6434b5f0e81)",
+		},
+		{
+			name:     "simple name without dashes",
+			input:    "nginx:latest",
+			expected: "nginx:latest",
+		},
+		{
+			name:     "image ref with multiple dashes",
+			input:    "docker.io/my-org/my-app-server:v1.2.3-rc1",
+			expected: "docker.io/my-org/my-app-server:v1.2.3-rc1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := displayName(tc.input)
+			if got != tc.expected {
+				t.Errorf("displayName(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`ctr image import` (and `pull`, `push`) replaces dashes in image names with spaces in the progress output:

```
# ctr image import /tmp/archive.tar
quay.io/calico/kube controllers:v3.30.6    saved    # wrong: dash became space
```

## Why

`displayName()` splits the progress entry name on every `-` and rejoins with spaces. This is intended for digest-based keys from `MakeRefKey` (`manifest-sha256:abc...` → `manifest (abc...)`), but it also corrupts image reference names like `kube-controllers`.

## Fix

Only split on the first dash when the remainder starts with a digest algorithm prefix (`sha256:`, `sha384:`, `sha512:`). All other names pass through unchanged.

**Before:** `quay.io/calico/kube controllers:v3.30.6`
**After:** `quay.io/calico/kube-controllers:v3.30.6`

## Tests

Added `TestDisplayName` with 7 cases covering image refs with dashes, digest keys, and plain names.

Fixes #13097