### PR TITLE
use local go toolchain in CI to confirm that build actually uses requ…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   #
   # golangci-lint


### PR DESCRIPTION
…ested toolchain


See explanation and a test here: https://github.com/containerd/containerd/pull/13101#issuecomment-4113867026

If CI was made to confirm that containerd can be built with the listed set of toolchains, we need to force it