### PR TITLE
cri: support runtime config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ is supported by containerd.
 
 For configuring registries, see [registry host configuration documentation](docs/hosts.md)
 
+## Runtime Handler Configuration
+
+For configuring runtime handlers, see the
+[runtime handler configuration documentation](docs/runtime-config.md).
+
 ## Features
 
 For a detailed overview of containerd's core concepts and the features it supports,

--- a/core/runtime/config/config.go
+++ b/core/runtime/config/config.go
@@ -1,0 +1,85 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package config loads runtime handler configuration shared by containerd
+// clients and plugins.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+const configFile = "runtime.toml"
+
+// Runtime contains the runtime handler fields shared by containerd consumers.
+// Consumers may define a superset with additional fields and pass it to Load.
+type Runtime struct {
+	// Type is the runtime type, such as io.containerd.runc.v2.
+	Type string `toml:"runtime_type" json:"runtimeType"`
+	// Path optionally overrides the shim binary path.
+	Path string `toml:"runtime_path" json:"runtimePath"`
+	// Options contains runtime-specific configuration.
+	Options map[string]any `toml:"options" json:"options"`
+	// Snapshotter optionally overrides the snapshotter for this runtime.
+	Snapshotter string `toml:"snapshotter" json:"snapshotter"`
+}
+
+// Load reads runtime configurations from <dir>/<handler>/runtime.toml into T.
+// Consumers can use Runtime for the common schema or define a superset with
+// additional consumer-specific TOML fields. A missing directory is treated as
+// an empty configuration.
+func Load[T any](dir string) (map[string]T, error) {
+	runtimes := make(map[string]T)
+	if dir == "" {
+		return runtimes, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return runtimes, nil
+		}
+		return nil, fmt.Errorf("failed to read runtime config directory %q: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name(), configFile)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read runtime config for %q from %q: %w", entry.Name(), path, err)
+		}
+
+		var runtime T
+		if err := toml.Unmarshal(data, &runtime); err != nil {
+			return nil, fmt.Errorf("failed to decode runtime config for %q from %q: %w", entry.Name(), path, err)
+		}
+		runtimes[entry.Name()] = runtime
+	}
+
+	return runtimes, nil
+}

--- a/core/runtime/config/config_test.go
+++ b/core/runtime/config/config_test.go
@@ -1,0 +1,134 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad(t *testing.T) {
+	t.Run("an empty path loads no runtimes", func(t *testing.T) {
+		runtimes, err := Load[Runtime]("")
+
+		require.NoError(t, err)
+		assert.Empty(t, runtimes)
+	})
+
+	t.Run("a missing directory loads no runtimes", func(t *testing.T) {
+		runtimes, err := Load[Runtime](filepath.Join(t.TempDir(), "missing"))
+
+		require.NoError(t, err)
+		assert.Empty(t, runtimes)
+	})
+
+	t.Run("runtime directories are loaded by handler name", func(t *testing.T) {
+		dir := t.TempDir()
+		writeRuntimeConfig(t, dir, "runc", `
+runtime_type = "io.containerd.runc.v2"
+runtime_path = "/usr/local/bin/containerd-shim-runc-v2"
+snapshotter = "overlayfs"
+pod_annotations = ["example.com/ignored"]
+
+[options]
+  BinaryName = "/usr/local/bin/runc"
+`)
+		writeRuntimeConfig(t, dir, "runhcs", `
+runtime_type = "io.containerd.runhcs.v1"
+`)
+
+		runtimes, err := Load[Runtime](dir)
+
+		require.NoError(t, err)
+		require.Len(t, runtimes, 2)
+		assert.Equal(t, Runtime{
+			Type:        "io.containerd.runc.v2",
+			Path:        "/usr/local/bin/containerd-shim-runc-v2",
+			Snapshotter: "overlayfs",
+			Options: map[string]any{
+				"BinaryName": "/usr/local/bin/runc",
+			},
+		}, runtimes["runc"])
+		assert.Equal(t, "io.containerd.runhcs.v1", runtimes["runhcs"].Type)
+	})
+
+	t.Run("consumer-specific fields are decoded into a superset", func(t *testing.T) {
+		type criRuntime struct {
+			Type           string   `toml:"runtime_type"`
+			PodAnnotations []string `toml:"pod_annotations"`
+		}
+
+		dir := t.TempDir()
+		writeRuntimeConfig(t, dir, "runc", `
+runtime_type = "io.containerd.runc.v2"
+pod_annotations = ["example.com/pod"]
+`)
+
+		runtimes, err := Load[criRuntime](dir)
+
+		require.NoError(t, err)
+		assert.Equal(t, criRuntime{
+			Type:           "io.containerd.runc.v2",
+			PodAnnotations: []string{"example.com/pod"},
+		}, runtimes["runc"])
+	})
+
+	t.Run("entries without runtime config files are ignored", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "not-a-directory"), nil, 0o600))
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "missing-config"), 0o700))
+
+		runtimes, err := Load[Runtime](dir)
+
+		require.NoError(t, err)
+		assert.Empty(t, runtimes)
+	})
+
+	t.Run("an unreadable runtime config returns an error", func(t *testing.T) {
+		dir := t.TempDir()
+		runtimeDir := filepath.Join(dir, "runc")
+		require.NoError(t, os.Mkdir(runtimeDir, 0o700))
+		require.NoError(t, os.Mkdir(filepath.Join(runtimeDir, configFile), 0o700))
+
+		_, err := Load[Runtime](dir)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read runtime config for \"runc\"")
+	})
+
+	t.Run("invalid runtime config returns an error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeRuntimeConfig(t, dir, "runc", "{{{not toml")
+
+		_, err := Load[Runtime](dir)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode runtime config for \"runc\"")
+	})
+}
+
+func writeRuntimeConfig(t *testing.T, dir, handler, contents string) {
+	t.Helper()
+
+	runtimeDir := filepath.Join(dir, handler)
+	require.NoError(t, os.Mkdir(runtimeDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(runtimeDir, configFile), []byte(contents), 0o600))
+}

--- a/core/runtime/config/example_test.go
+++ b/core/runtime/config/example_test.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config_test
+
+import (
+	"fmt"
+	"log"
+
+	runtimeconfig "github.com/containerd/containerd/v2/core/runtime/config"
+)
+
+func ExampleLoad() {
+	runtimes, err := runtimeconfig.Load[runtimeconfig.Runtime]("/etc/containerd/runtimes")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	runtime := runtimes["kata"]
+	fmt.Printf("%s uses %s\n", runtime.Type, runtime.Snapshotter)
+}
+
+func ExampleLoad_consumerSpecificFields() {
+	type criRuntime struct {
+		Type                 string   `toml:"runtime_type"`
+		PodAnnotations       []string `toml:"pod_annotations"`
+		ContainerAnnotations []string `toml:"container_annotations"`
+	}
+
+	runtimes, err := runtimeconfig.Load[criRuntime]("/etc/containerd/runtimes")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	runtime := runtimes["kata"]
+	fmt.Printf("%s accepts pod annotations %v\n", runtime.Type, runtime.PodAnnotations)
+}

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -159,6 +159,42 @@ spec:
 
 See also [the Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/runtime-class/).
 
+### Runtime Config Directory (since containerd v2.4)
+
+Starting with containerd v2.4, runtime configurations can be added via a config directory
+instead of (or in addition to) the main `config.toml`. By default the directory is
+`/etc/containerd/runtimes`.
+
+Each runtime handler is a subdirectory containing a `runtime.toml` file:
+
+```
+/etc/containerd/runtimes/
+  my-runtime/
+    runtime.toml
+  another-runtime/
+    runtime.toml
+```
+
+The directory format is shared with other containerd consumers. The CRI plugin
+decodes each `runtime.toml` using the same format as a runtime entry under
+`[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.<name>]`:
+
+```toml
+runtime_type = "io.containerd.runc.v2"
+runtime_path = "/usr/local/bin/containerd-shim-runc-v2"
+```
+
+Runtimes defined in the main `config.toml` take precedence over those in the config
+directory. A containerd restart is required for changes to the directory to take effect.
+See [Runtime Handler Configuration](../runtime-config.md) for the common fields
+and how the directory differs from top-level containerd config imports.
+
+The config directory path can be customized:
+
+```toml
+[plugins.'io.containerd.cri.v1.runtime'.containerd]
+  runtime_config_dir = '/etc/containerd/runtimes'
+```
 
 ## Image Pull Configuration (since containerd v2.1)
 
@@ -278,6 +314,7 @@ version = 3
 
     [plugins.'io.containerd.cri.v1.runtime'.containerd]
       default_runtime_name = 'runc'
+      runtime_config_dir = '/etc/containerd/runtimes'
       ignore_blockio_not_enabled_errors = false
       ignore_rdt_not_enabled_errors = false
 

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -1,0 +1,59 @@
+# Runtime Handler Configuration
+
+Runtime handlers can be described in a shared configuration directory. The
+directory format is available to containerd clients and plugins through the
+`core/runtime/config` Go package.
+
+Each handler has a subdirectory containing a `runtime.toml` file:
+
+```text
+/etc/containerd/runtimes/
+  runc/
+    runtime.toml
+  kata/
+    runtime.toml
+```
+
+The common fields are:
+
+```toml
+runtime_type = "io.containerd.runc.v2"
+runtime_path = "/usr/local/bin/containerd-shim-runc-v2"
+snapshotter = "overlayfs"
+
+[options]
+  BinaryName = "/usr/local/bin/runc"
+  SystemdCgroup = true
+```
+
+- `runtime_type` identifies the runtime shim.
+- `runtime_path` optionally overrides the shim binary path.
+- `snapshotter` optionally selects a snapshotter for the handler.
+- `options` contains runtime-specific options.
+
+Consumers may define additional fields in `runtime.toml`. For example, the CRI
+plugin accepts the additional fields from its
+`containerd.runtimes.<handler>` configuration.
+
+This directory is different from top-level containerd
+[`imports`](man/containerd-config.toml.5.md#imports). Imports load complete
+containerd configuration fragments, and imported values override values in the
+main configuration. The runtime configuration directory contains one runtime
+handler per file; each consumer decides how those handlers are merged and when
+changes are loaded.
+
+## CRI
+
+Starting with containerd v2.4, the CRI plugin loads runtime handlers from
+`/etc/containerd/runtimes` at startup. Runtime handlers in the main
+`config.toml` take precedence over handlers with the same name in the runtime
+configuration directory.
+
+The directory can be changed in the CRI runtime configuration:
+
+```toml
+[plugins.'io.containerd.cri.v1.runtime'.containerd]
+  runtime_config_dir = '/etc/containerd/runtimes'
+```
+
+A containerd restart is required for the CRI plugin to load changes.

--- a/integration/remote/remote_runtime.go
+++ b/integration/remote/remote_runtime.go
@@ -148,6 +148,13 @@ func (r *RuntimeService) PodSandboxStatus(podSandboxID string, _ ...grpc.CallOpt
 	return resp.GetStatus(), nil
 }
 
+func (r *RuntimeService) PodSandboxStatusVerbose(podSandboxID string, opts ...grpc.CallOption) (*runtimeapi.PodSandboxStatusResponse, error) {
+	return r.runtimeClient.PodSandboxStatus(context.Background(), &runtimeapi.PodSandboxStatusRequest{
+		PodSandboxId: podSandboxID,
+		Verbose:      true,
+	}, opts...)
+}
+
 func (r *RuntimeService) ListPodSandbox(filter *runtimeapi.PodSandboxFilter, _ ...grpc.CallOption) ([]*runtimeapi.PodSandbox, error) {
 	return r.runtimeService.ListPodSandbox(context.Background(), filter)
 }

--- a/integration/runtime_config_dir_linux_test.go
+++ b/integration/runtime_config_dir_linux_test.go
@@ -1,0 +1,101 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	podsandboxtypes "github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
+)
+
+func TestRuntimeConfigDir(t *testing.T) {
+	const (
+		podAnnotation      = "io.containerd.test.runtime-config-dir"
+		podAnnotationValue = "loaded-from-runtime-config-dir"
+	)
+
+	workDir := t.TempDir()
+
+	runtimesDir := filepath.Join(workDir, "runtimes")
+	myRuncDir := filepath.Join(runtimesDir, "my-runc")
+	require.NoError(t, os.MkdirAll(myRuncDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(myRuncDir, "runtime.toml"),
+		[]byte(`runtime_type = "io.containerd.runc.v2"
+pod_annotations = ["io.containerd.test.runtime-config-dir"]
+`),
+		0o600,
+	))
+
+	cfgPath := filepath.Join(workDir, "config.toml")
+	cfg := fmt.Sprintf(`
+version = 3
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd]
+  default_runtime_name = "runc"
+  runtime_config_dir = %q
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+`, runtimesDir)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o600))
+
+	ctrd := newCtrdProc(t, *containerdBin, workDir, nil)
+	require.NoError(t, ctrd.isReady())
+
+	rSvc := ctrd.criRuntimeService(t)
+	iSvc := ctrd.criImageService(t)
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Log("Dumping containerd config and logs due to test failure")
+			dumpFileContent(t, ctrd.configPath())
+			dumpFileContent(t, ctrd.logPath())
+		}
+		cleanupPods(t, rSvc)
+		assert.NoError(t, ctrd.kill(syscall.SIGTERM))
+		assert.NoError(t, ctrd.wait(5*time.Minute))
+	})
+
+	testImage := images.Get(images.BusyBox)
+	pullImagesByCRI(t, iSvc, testImage)
+
+	sbCfg := PodSandboxConfig("runtime-config-dir-pod", "runtime-config-dir-test")
+	sbCfg.Annotations[podAnnotation] = podAnnotationValue
+	sbID, err := rSvc.RunPodSandbox(sbCfg, "my-runc")
+	require.NoError(t, err, "RunPodSandbox with handler 'my-runc' from runtime config dir should succeed")
+
+	sbStatus, err := rSvc.PodSandboxStatus(sbID)
+	require.NoError(t, err)
+	assert.Equal(t, "my-runc", sbStatus.RuntimeHandler)
+
+	sbStatusResp, err := rSvc.PodSandboxStatusVerbose(sbID)
+	require.NoError(t, err)
+	var sandboxInfo podsandboxtypes.SandboxInfo
+	require.NoError(t, json.Unmarshal([]byte(sbStatusResp.GetInfo()["info"]), &sandboxInfo))
+	assert.Equal(t, podAnnotationValue, sandboxInfo.RuntimeSpec.Annotations[podAnnotation])
+}

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -32,6 +32,7 @@ import (
 	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	runcoptions "github.com/containerd/containerd/api/types/runc/options"
 	runtimeoptions "github.com/containerd/containerd/api/types/runtimeoptions/v1"
+	runtimeconfig "github.com/containerd/containerd/v2/core/runtime/config"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	"github.com/containerd/containerd/v2/internal/cri/opts"
 	"github.com/containerd/containerd/v2/pkg/deprecation"
@@ -138,6 +139,13 @@ type Runtime struct {
 	IOType string `toml:"io_type" json:"io_type"`
 }
 
+func (r *Runtime) setDefaults() {
+	// If empty, use default podSandbox mode
+	if len(r.Sandboxer) == 0 {
+		r.Sandboxer = string(ModePodSandbox)
+	}
+}
+
 // ContainerdConfig contains toml config related to containerd
 type ContainerdConfig struct {
 	// DefaultRuntimeName is the default runtime name to use from the runtimes table.
@@ -145,7 +153,15 @@ type ContainerdConfig struct {
 
 	// Runtimes is a map from CRI RuntimeHandler strings, which specify types of runtime
 	// configurations, to the matching configurations.
+	// Runtimes specified here that conflict with runtimes in the RuntimeConfigDir will
+	// take precedence.
 	Runtimes map[string]Runtime `toml:"runtimes" json:"runtimes"`
+
+	// RuntimeConfigDir is a directory of runtime configurations.
+	// Runtime configs are loaded from <RuntimeConfigDir>/<runtime_name>/runtime.toml
+	// at startup and merged into the Runtimes map (a containerd restart is required
+	// for changes to take effect).
+	RuntimeConfigDir string `toml:"runtime_config_dir" json:"runtimeConfigDir"`
 
 	// IgnoreBlockIONotEnabledErrors is a boolean flag to ignore
 	// blockio related errors when blockio support has not been
@@ -635,6 +651,13 @@ func ValidateRuntimeConfig(ctx context.Context, c *RuntimeConfig) ([]deprecation
 		c.ContainerdConfig.Runtimes = make(map[string]Runtime)
 	}
 
+	// Load runtimes from the runtime config directory and merge them into the
+	// Runtimes map before validation. Runtimes defined in the main config take
+	// precedence over those in the directory.
+	if err := c.ContainerdConfig.loadRuntimesFromDir(ctx); err != nil {
+		return warnings, fmt.Errorf("failed to load runtime configs from directory: %w", err)
+	}
+
 	// Validation for default_runtime_name
 	if c.ContainerdConfig.DefaultRuntimeName == "" {
 		return warnings, errors.New("`default_runtime_name` is empty")
@@ -673,11 +696,9 @@ func ValidateRuntimeConfig(ctx context.Context, c *RuntimeConfig) ([]deprecation
 		if !r.PrivilegedWithoutHostDevices && r.PrivilegedWithoutHostDevicesAllDevicesAllowed {
 			return warnings, errors.New("`privileged_without_host_devices_all_devices_allowed` requires `privileged_without_host_devices` to be enabled")
 		}
-		// If empty, use default podSandbox mode
-		if len(r.Sandboxer) == 0 {
-			r.Sandboxer = string(ModePodSandbox)
-			c.ContainerdConfig.Runtimes[k] = r
-		}
+
+		r.setDefaults()
+		c.ContainerdConfig.Runtimes[k] = r
 
 		if len(r.IOType) == 0 {
 			r.IOType = IOTypeFifo
@@ -727,6 +748,26 @@ func ValidateServerConfig(ctx context.Context, c *ServerConfig) ([]deprecation.W
 		}
 	}
 	return warnings, nil
+}
+
+func (c *ContainerdConfig) loadRuntimesFromDir(ctx context.Context) error {
+	runtimes, err := runtimeconfig.Load[Runtime](c.RuntimeConfigDir)
+	if err != nil {
+		return err
+	}
+
+	for name, runtime := range runtimes {
+		if _, ok := c.Runtimes[name]; ok {
+			log.G(ctx).WithField("handler", name).Warn("Runtime handler already defined in config, skipping config from directory")
+			continue
+		}
+
+		runtime.setDefaults()
+		c.Runtimes[name] = runtime
+		log.G(ctx).WithField("handler", name).Info("Loaded runtime handler from config directory")
+	}
+
+	return nil
 }
 
 func (config *Config) GetSandboxRuntime(podSandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (Runtime, error) {

--- a/internal/cri/config/config_test.go
+++ b/internal/cri/config/config_test.go
@@ -18,12 +18,16 @@ package config
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	criruntime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	runtimeconfig "github.com/containerd/containerd/v2/core/runtime/config"
 	"github.com/containerd/containerd/v2/internal/cri/opts"
 	"github.com/containerd/containerd/v2/pkg/deprecation"
 )
@@ -539,4 +543,89 @@ func TestDefaultConfigEnableCRIU(t *testing.T) {
 	cfg := DefaultRuntimeConfig()
 	assert.NotNil(t, cfg.EnableCRIU)
 	assert.True(t, *cfg.EnableCRIU)
+}
+
+func TestLoadRuntimesFromDir(t *testing.T) {
+	t.Run("CRI runtime fields are loaded from the shared directory", func(t *testing.T) {
+		dir := t.TempDir()
+		writeRuntimeConfig(t, dir, "my-runtime", `
+runtime_type = "io.containerd.runc.v2"
+runtime_path = "/usr/bin/my-shim"
+snapshotter = "native"
+pod_annotations = ["example.com/pod"]
+
+[options]
+  BinaryName = "/usr/bin/my-runc"
+`)
+
+		sharedRuntimes, err := runtimeconfig.Load[runtimeconfig.Runtime](dir)
+		require.NoError(t, err)
+		assert.Equal(t, runtimeconfig.Runtime{
+			Type:        "io.containerd.runc.v2",
+			Path:        "/usr/bin/my-shim",
+			Snapshotter: "native",
+			Options: map[string]any{
+				"BinaryName": "/usr/bin/my-runc",
+			},
+		}, sharedRuntimes["my-runtime"])
+
+		c := &ContainerdConfig{
+			RuntimeConfigDir: dir,
+			Runtimes:         map[string]Runtime{},
+		}
+		err = c.loadRuntimesFromDir(context.Background())
+		require.NoError(t, err)
+		require.Contains(t, c.Runtimes, "my-runtime")
+		assert.Equal(t, "io.containerd.runc.v2", c.Runtimes["my-runtime"].Type)
+		assert.Equal(t, "/usr/bin/my-shim", c.Runtimes["my-runtime"].Path)
+		assert.Equal(t, "native", c.Runtimes["my-runtime"].Snapshotter)
+		assert.Equal(t, []string{"example.com/pod"}, c.Runtimes["my-runtime"].PodAnnotations)
+		assert.Equal(t, string(ModePodSandbox), c.Runtimes["my-runtime"].Sandboxer)
+	})
+
+	t.Run("a runtime in the main config takes precedence", func(t *testing.T) {
+		dir := t.TempDir()
+		writeRuntimeConfig(t, dir, "existing", `
+runtime_type = "io.containerd.runc.v2"
+runtime_path = "/usr/bin/from-dir"
+`)
+
+		c := &ContainerdConfig{
+			RuntimeConfigDir: dir,
+			Runtimes: map[string]Runtime{
+				"existing": {
+					Type: "io.containerd.runc.v2",
+					Path: "/usr/bin/from-config",
+				},
+			},
+		}
+		err := c.loadRuntimesFromDir(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "/usr/bin/from-config", c.Runtimes["existing"].Path)
+	})
+
+	t.Run("a directory runtime may be the default runtime", func(t *testing.T) {
+		dir := t.TempDir()
+		writeRuntimeConfig(t, dir, "custom-default", `
+runtime_type = "io.containerd.runc.v2"
+`)
+
+		cfg := &RuntimeConfig{
+			ContainerdConfig: ContainerdConfig{
+				DefaultRuntimeName: "custom-default",
+				RuntimeConfigDir:   dir,
+			},
+		}
+		_, err := ValidateRuntimeConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.Contains(t, cfg.ContainerdConfig.Runtimes, "custom-default")
+	})
+}
+
+func writeRuntimeConfig(t *testing.T, dir, handler, contents string) {
+	t.Helper()
+
+	runtimeDir := filepath.Join(dir, handler)
+	require.NoError(t, os.Mkdir(runtimeDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(runtimeDir, "runtime.toml"), []byte(contents), 0o600))
 }

--- a/internal/cri/config/config_unix.go
+++ b/internal/cri/config/config_unix.go
@@ -19,6 +19,8 @@
 package config
 
 import (
+	"path/filepath"
+
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/pelletier/go-toml/v2"
 )
@@ -89,6 +91,7 @@ func DefaultRuntimeConfig() RuntimeConfig {
 		},
 		ContainerdConfig: ContainerdConfig{
 			DefaultRuntimeName: "runc",
+			RuntimeConfigDir:   filepath.Join(defaults.DefaultConfigDir, "runtimes"),
 			Runtimes: map[string]Runtime{
 				"runc": {
 					Type:      "io.containerd.runc.v2",

--- a/internal/cri/config/config_windows.go
+++ b/internal/cri/config/config_windows.go
@@ -55,6 +55,7 @@ func DefaultRuntimeConfig() RuntimeConfig {
 		},
 		ContainerdConfig: ContainerdConfig{
 			DefaultRuntimeName: "runhcs-wcow-process",
+			RuntimeConfigDir:   filepath.Join(defaults.DefaultConfigDir, "runtimes"),
 			Runtimes: map[string]Runtime{
 				"runhcs-wcow-process": {
 					Type:                 "io.containerd.runhcs.v1",


### PR DESCRIPTION
Add a shared runtime handler configuration directory backed by one `runtime.toml` file per handler:

```text
/etc/containerd/runtimes/
  runc/runtime.toml
  kata/runtime.toml
```

The public `core/runtime/config` package loads the common runtime fields (`runtime_type`, `runtime_path`, `snapshotter`, and `options`) while allowing each consumer to decode additional fields into its own schema. This keeps the directory usable by containerd clients and plugins without coupling the format to CRI.

CRI loads this directory at startup through the shared package and continues to support its existing per-runtime settings, including pod and container annotation filters, CNI configuration, sandbox selection, and I/O configuration. Runtime handlers defined explicitly in the main `config.toml` take precedence over handlers with the same name in the directory; ignored duplicates produce a warning. CRI defaults the directory to `/etc/containerd/runtimes` and requires a containerd restart to load changes.

This differs from top-level config imports: imports contain complete containerd configuration fragments and imported values override the main configuration, while this directory contains one runtime handler per file and leaves merge and reload policy to each consumer.

This is the static-loading subset of the work originally proposed in #11742, without dynamic runtime loading.