### PR TITLE
Propagate OpenTelemetry traces in outgoing RPCs from plugin clients

### DIFF
--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -555,6 +555,7 @@ func (pc *proxyClients) getClient(address string) (*grpc.ClientConn, error) {
 		Backoff: backoffConfig,
 	}
 	gopts := []grpc.DialOption{
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithConnectParams(connParams),
 		grpc.WithContextDialer(dialer.ContextDialer),


### PR DESCRIPTION
While incoming gRPC requests are already being traced via the server-side handler, outgoing RPCs to proxy plugins are missing the client-side equivalent. Adding `otelgrpc.NewClientHandler()` ensures trace context is successfully propagated to the plugins.

Solves #13112