### PR TITLE
allow to pass multiple extra arguments to critest

### DIFF
--- a/script/critest.sh
+++ b/script/critest.sh
@@ -131,4 +131,4 @@ do
     crictl --runtime-endpoint ${BDIR}/c.sock info && break || sleep 1
 done
 
-critest --report-dir "$report_dir" --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8 "${GINKGO_SKIP_TEST[@]}" "${GINKGO_FOCUS_TEST[@]}" "${EXTRA_CRITEST_OPTIONS:-""}"
+critest --report-dir "$report_dir" --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8 "${GINKGO_SKIP_TEST[@]}" "${GINKGO_FOCUS_TEST[@]}" ${EXTRA_CRITEST_OPTIONS:-}


### PR DESCRIPTION
I was running latest critests locally and found this problem. Quoted extra options will be treated as a single command line option and not allowing to pass multiple options