### PR TITLE
Tweak mount info for overlayfs in case of parallel unpack

### DIFF
--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -530,6 +530,15 @@ func (u *Unpacker) unpack(
 			case <-fetchC[i-fetchOffset]:
 			}
 
+			// In case of parallel unpack, the parent snapshot isn't provided to the snapshotter.
+			// The overlayfs will return bind mounts for all layers, we need to convert them
+			// to overlay mounts for the applier to perform whiteout conversion correctly.
+			// TODO: this is a temporary workaround until #13053 lands.
+			// See: https://github.com/containerd/containerd/issues/13030
+			if i > 0 && parallel && unpack.SnapshotterKey == "overlayfs" {
+				mounts = bindToOverlay(mounts)
+			}
+
 			diff, err := a.Apply(ctx, desc, mounts, unpack.ApplyOpts...)
 			if err != nil {
 				cleanup.Do(ctx, abort)
@@ -752,4 +761,24 @@ func uniquePart() string {
 	// Ignore read failures, just decreases uniqueness
 	rand.Read(b[:])
 	return fmt.Sprintf("%d-%s", t.Nanosecond(), base64.URLEncoding.EncodeToString(b[:]))
+}
+
+// TODO: this is a temporary workaround until #13053 lands.
+func bindToOverlay(mounts []mount.Mount) []mount.Mount {
+	if len(mounts) != 1 || mounts[0].Type != "bind" {
+		return mounts
+	}
+
+	m := mount.Mount{
+		Type:   "overlay",
+		Source: "overlay",
+	}
+	for _, o := range mounts[0].Options {
+		if o != "rbind" {
+			m.Options = append(m.Options, o)
+		}
+	}
+	m.Options = append(m.Options, "upperdir="+mounts[0].Source)
+
+	return []mount.Mount{m}
 }

--- a/core/unpack/unpacker_test.go
+++ b/core/unpack/unpacker_test.go
@@ -19,8 +19,10 @@ package unpack
 import (
 	"crypto/rand"
 	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 )
@@ -87,6 +89,90 @@ func BenchmarkUnpackWithChainIDs(b *testing.B) {
 			diffIDs := generateRandomDiffIDs(b, sz)
 			for i := 0; i < b.N; i++ {
 				unpackWithChainIDs(diffIDs)
+			}
+		})
+	}
+}
+
+func TestBindToOverlay(t *testing.T) {
+	testCases := []struct {
+		name   string
+		mounts []mount.Mount
+		expect []mount.Mount
+	}{
+		{
+			name: "single bind mount",
+			mounts: []mount.Mount{
+				{
+					Type:    "bind",
+					Source:  "/path/to/source",
+					Options: []string{"ro", "rbind"},
+				},
+			},
+			expect: []mount.Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"ro",
+						"upperdir=/path/to/source",
+					},
+				},
+			},
+		},
+		{
+			name: "overlay mount",
+			mounts: []mount.Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"lowerdir=/path/to/lower",
+						"upperdir=/path/to/upper",
+					},
+				},
+			},
+			expect: []mount.Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"lowerdir=/path/to/lower",
+						"upperdir=/path/to/upper",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple mounts",
+			mounts: []mount.Mount{
+				{
+					Type:   "bind",
+					Source: "/path/to/source1",
+				},
+				{
+					Type:   "bind",
+					Source: "/path/to/source2",
+				},
+			},
+			expect: []mount.Mount{
+				{
+					Type:   "bind",
+					Source: "/path/to/source1",
+				},
+				{
+					Type:   "bind",
+					Source: "/path/to/source2",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := bindToOverlay(tc.mounts)
+			if !reflect.DeepEqual(result, tc.expect) {
+				t.Errorf("unexpected result: got %v, want %v", result, tc.expect)
 			}
 		})
 	}

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -35,6 +35,7 @@ import (
 	cgroupsv2 "github.com/containerd/cgroups/v3/cgroup2"
 	"github.com/containerd/containerd/api/types/runc/options"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/containerd/containerd/v2/client"
@@ -50,6 +51,7 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 	"golang.org/x/sys/unix"
 )
 
@@ -1811,4 +1813,71 @@ func TestIssue10589(t *testing.T) {
 	t.Logf("task status: %s", status.Status)
 	require.NoError(t, err, "container status")
 	assert.Equal(t, Stopped, status.Status)
+}
+
+// TestIssue13030 is a regression test for parallel image unpacking.
+// The test validates that when multiple layers are unpacked in parallel,
+// that whiteout files are properly processed and do not cause files to
+// be unexpectedly present in the final rootfs.
+//
+// https://github.com/containerd/containerd/issues/13030
+func TestIssue13030(t *testing.T) {
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { client.Close() })
+
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	image, err := client.Pull(ctx,
+		images.Get(images.Whiteout),
+		WithPlatformMatcher(platforms.Default()),
+		WithPullUnpack,
+		WithUnpackOpts([]UnpackOpt{WithUnpackLimiter(semaphore.NewWeighted(3))}),
+	)
+	t.Cleanup(func() {
+		client.ImageService().Delete(ctx, images.Get(images.Whiteout))
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	container, err := client.NewContainer(ctx, t.Name(),
+		WithNewSnapshot(t.Name(), image),
+		WithNewSpec(oci.WithImageConfig(image),
+			withProcessArgs("/bin/sh", "-e", "-c", "test ! -e /file-to-delete && test ! -e /dir-to-delete")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		container.Delete(ctx, WithSnapshotCleanup)
+	})
+
+	task, err := container.NewTask(ctx, empty())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		task.Delete(ctx)
+	})
+
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = task.Start(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := <-statusC
+	code, _, err := status.Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 0 {
+		t.Errorf("expected status 0 from wait but received %d", code)
+	}
 }

--- a/integration/images/image_list.go
+++ b/integration/images/image_list.go
@@ -38,6 +38,7 @@ type ImageList struct {
 	VolumeOwnership  string
 	ArgsEscaped      string
 	Nginx            string
+	Whiteout         string
 }
 
 var (
@@ -57,6 +58,7 @@ func initImages(imageListFile string) {
 		VolumeOwnership:  "ghcr.io/containerd/volume-ownership:2.1",
 		ArgsEscaped:      "cplatpublic.azurecr.io/args-escaped-test-image-ns:1.0",
 		Nginx:            "ghcr.io/containerd/nginx:1.27.0",
+		Whiteout:         "ghcr.io/containerd/whiteout-test:1.0",
 	}
 
 	if imageListFile != "" {
@@ -96,6 +98,8 @@ const (
 	ArgsEscaped
 	// Nginx image
 	Nginx
+	// Whiteout image
+	Whiteout
 )
 
 func initImageMap(imageList ImageList) map[int]string {
@@ -108,6 +112,7 @@ func initImageMap(imageList ImageList) map[int]string {
 	images[VolumeOwnership] = imageList.VolumeOwnership
 	images[ArgsEscaped] = imageList.ArgsEscaped
 	images[Nginx] = imageList.Nginx
+	images[Whiteout] = imageList.Whiteout
 	return images
 }
 


### PR DESCRIPTION
Fixes: https://github.com/containerd/containerd/issues/13030

Alternative to: https://github.com/containerd/containerd/pull/13044

Instead of changing overlay snapshotter itself, this PR updates unpacker logic to tweak the mount info returned by overlay in the parallel case.

