### PR TITLE
blob: fix abort error

### DIFF
--- a/plugins/content/local/store.go
+++ b/plugins/content/local/store.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/google/uuid"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/internal/fsverity"
@@ -627,14 +628,16 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 // be cancelled. Any resources associated with the ingest will be cleaned.
 func (s *store) Abort(ctx context.Context, ref string) error {
 	root := s.ingestRoot(ref)
-	if err := os.RemoveAll(root); err != nil {
+	tempPath := fmt.Sprintf("%s.%s.tmp", root, uuid.New().String())
+	if err := os.Rename(root, tempPath); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(tempPath); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("ingest ref %q: %w", ref, errdefs.ErrNotFound)
 		}
-
 		return err
 	}
-
 	return nil
 }
 
@@ -710,10 +713,10 @@ func writeToCompletion(path string, data []byte, mode os.FileMode) error {
 		return fmt.Errorf("create tmp file: %w", err)
 	}
 	_, err = f.Write(data)
-	f.Close()
 	if err != nil {
 		return fmt.Errorf("write tmp file: %w", err)
 	}
+	f.Close()
 	err = os.Rename(tmp, path)
 	if err != nil {
 		return fmt.Errorf("rename tmp file: %w", err)


### PR DESCRIPTION
fix 
```
2026-03-25T06:07:27.7972537Z     default:     testsuite.go:124: Cleanup failed: failed to abort c1-commiterror-state: unlinkat /var/lib/containerd-test/io.containerd.content.v1.content/ingest/9101c5f249b4cb38a50dddda86a787c09f31099573c87c525fc50774ac21d05d: directory not empty
```