### PR TITLE
ci: add riscv64 to Linux integration test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,10 +376,11 @@ jobs:
         runtime:
           - io.containerd.runc.v2
         runc: [runc]  # crun can be added here to debug crun issues
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, ubuntu-24.04-riscv]
         cgroup_driver: [cgroupfs, systemd]
         exclude:
           - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
+          - os: ${{ github.event.repository.private && 'ubuntu-24.04-riscv' || '' }}
 
     env:
       GOTEST: gotestsum --
@@ -400,7 +401,7 @@ jobs:
           script/setup/install-failpoint-binaries
 
       # Disable criu testing on arm64 until we can solve the consistent failures of restore testing
-      - if: matrix.os != 'ubuntu-24.04-arm'
+      - if: matrix.os != 'ubuntu-24.04-arm' && matrix.os != 'ubuntu-24.04-riscv'
         name: Install criu
         run: |
           sudo add-apt-repository -y ppa:criu/ppa
@@ -410,6 +411,7 @@ jobs:
       # "apt-get install erofs-utils" installs an older version (1.7.1 as of 2025-09-18)
       # Build and install erofs-utils 1.8.10 from source to get a newer version
       - name: Build and install erofs-utils from source
+        if: matrix.os != 'ubuntu-24.04-riscv'
         run: |
           # Install dependencies
           sudo apt-get update
@@ -438,6 +440,7 @@ jobs:
           mkfs.erofs --version
 
       - name: Load EROFS kernel module
+        if: matrix.os != 'ubuntu-24.04-riscv'
         run: |
           sudo modprobe erofs
 
@@ -528,10 +531,10 @@ jobs:
         # ubuntu-24.04-arm images. buildah and podman  is needed to convert the
         # Kubernetes checkpoint archive to an OCI image.
         # See contrib/checkpoint/checkpoint-restore-cri-test.sh
-        if: matrix.os == 'ubuntu-24.04-arm'
+        if: matrix.os == 'ubuntu-24.04-arm' || matrix.os == 'ubuntu-24.04-riscv'
         run: sudo apt-get install -y buildah podman
 
-      - if: matrix.os != 'ubuntu-24.04-arm'
+      - if: matrix.os != 'ubuntu-24.04-arm' && matrix.os != 'ubuntu-24.04-riscv'
         name: Checkpoint/Restore via CRI
         env:
           TEST_RUNTIME: ${{ matrix.runtime }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,7 +446,7 @@ jobs:
 
       - name: Load dm-verity kernel module
         run: |
-          sudo modprobe dm_verity
+          sudo modprobe dm_verity || lsmod | grep -q dm_verity
 
       - name: Install containerd
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,7 +446,7 @@ jobs:
 
       - name: Load dm-verity kernel module
         run: |
-          sudo modprobe dm_verity || lsmod | grep -q dm_verity
+          sudo modprobe dm_verity || grep -q dm_verity /proc/modules
 
 
       - name: Install containerd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,6 +448,11 @@ jobs:
         run: |
           sudo modprobe dm_verity || lsmod | grep -q dm_verity
 
+      - name: Reset OOM score adjustment (RISE runner workaround)
+        if: matrix.os == 'ubuntu-24.04-riscv'
+        run: |
+          echo 0 | sudo tee /proc/1/oom_score_adj || true
+
       - name: Install containerd
         env:
           CGO_ENABLED: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,10 +448,6 @@ jobs:
         run: |
           sudo modprobe dm_verity || lsmod | grep -q dm_verity
 
-      - name: Reset OOM score adjustment (RISE runner workaround)
-        if: matrix.os == 'ubuntu-24.04-riscv'
-        run: |
-          echo 0 | sudo tee /proc/1/oom_score_adj || true
 
       - name: Install containerd
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,7 +400,7 @@ jobs:
           script/setup/install-critools
           script/setup/install-failpoint-binaries
 
-      # Disable criu testing on arm64 until we can solve the consistent failures of restore testing
+      # Disable criu testing on arm64 and riscv64 until we can solve the consistent failures of restore testing
       - if: matrix.os != 'ubuntu-24.04-arm' && matrix.os != 'ubuntu-24.04-riscv'
         name: Install criu
         run: |
@@ -528,7 +528,7 @@ jobs:
 
       - name: Install tools
         # The GitHub Actions image already has buildah and podman included. Not the
-        # ubuntu-24.04-arm images. buildah and podman  is needed to convert the
+        # ubuntu-24.04-arm or ubuntu-24.04-riscv images. buildah and podman is needed to convert the
         # Kubernetes checkpoint archive to an OCI image.
         # See contrib/checkpoint/checkpoint-restore-cri-test.sh
         if: matrix.os == 'ubuntu-24.04-arm' || matrix.os == 'ubuntu-24.04-riscv'


### PR DESCRIPTION
## What

Adds `ubuntu-24.04-riscv` to the Linux integration test matrix in CI. containerd already ships riscv64 release binaries but the CI test matrix does not cover this architecture.

## Changes

- Add `ubuntu-24.04-riscv` to the integration-linux OS matrix
- Skip criu on riscv64 (not available for this architecture, [criu#1702](https://github.com/checkpoint-restore/criu/issues/1702))
- Skip erofs build and kernel module load on riscv64 (module not in the runner image)
- Skip checkpoint/restore on riscv64 (depends on criu)
- Install buildah/podman on riscv64 (not pre-installed, same as arm64)
- Check `dm_verity` through `/proc/modules` rather than `lsmod`

The `ubuntu-24.04-riscv` runners are provided by the [RISE Project](https://riseproject.dev), free for open source, same setup as `ubuntu-24.04-arm` and `ubuntu-24.04-s390x`. A containerd org admin has to install https://github.com/apps/rise-risc-v-runners before jobs on that label can pick up a runner. Nothing else to configure.

## Status (2026-08-08)

Not mergeable yet, and it needs a rebase. I am holding the rebase until the two blockers below clear rather than force-pushing every week.

**Blocker 1, not riscv64-specific.** #13562 added `sudo udevadm control --children-max=500` to the Tests step, which runs under `bash -e`. The RISE runner image runs no udevd, so udevadm exits 1 and the step aborts before `make test` starts. A `|| true` guard on that line is enough, and I will send it as its own PR since it is a tuning knob rather than a correctness requirement.

**Blocker 2, runner side.** `TestSetPositiveOomScoreAdjustment` fails. Baseline `oom_score_adj` in the runner pod is 1000, which is what Kubernetes gives a BestEffort QoS pod, so writing 123 is a decrease, and lowering it needs CAP_SYS_RESOURCE outside a user namespace. On GitHub-hosted VMs the baseline is 0 and the same test passes with no privilege. Tracked at [riseproject-dev/riscv-runner#19](https://github.com/riseproject-dev/riscv-runner/issues/19).

## Test results

Latest fork run with the udevd guard applied locally, 2026-08-01: **1993 tests, 83 skipped, 1 failure** on both cgroupfs and systemd, the failure being blocker 2 above. Without the guard the job runs 0 tests at all.

Earlier runner image gaps are fixed: erofs module ([riscv-runner#24](https://github.com/riseproject-dev/riscv-runner/issues/24)), missing `lsmod` ([riscv-runner#27](https://github.com/riseproject-dev/riscv-runner/issues/27)). Those issues were transferred out of the now-archived `riscv-runner-images` repo, so the numbers in the original description here no longer resolved.

Relates to #13020.
