### PR TITLE
core/remotes/docker: use SystemCertPool on Windows

### DIFF
--- a/core/remotes/docker/config/config_unix.go
+++ b/core/remotes/docker/config/config_unix.go
@@ -19,7 +19,6 @@
 package config
 
 import (
-	"crypto/x509"
 	"path/filepath"
 )
 
@@ -35,8 +34,4 @@ func hostPaths(root, host string) (hosts []string) {
 	)
 
 	return
-}
-
-func rootSystemPool() (*x509.CertPool, error) {
-	return x509.SystemCertPool()
 }

--- a/core/remotes/docker/config/config_windows.go
+++ b/core/remotes/docker/config/config_windows.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"crypto/x509"
 	"path/filepath"
 	"strings"
 )
@@ -34,8 +33,4 @@ func hostPaths(root, host string) (hosts []string) {
 	)
 
 	return
-}
-
-func rootSystemPool() (*x509.CertPool, error) {
-	return x509.NewCertPool(), nil
 }

--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -20,6 +20,7 @@ package config
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
@@ -245,7 +246,7 @@ func updateTLSConfigFromHost(tlsConfig *tls.Config, host *hostConfig) error {
 
 	if host.caCerts != nil {
 		if tlsConfig.RootCAs == nil {
-			rootPool, err := rootSystemPool()
+			rootPool, err := x509.SystemCertPool()
 			if err != nil {
 				return fmt.Errorf("unable to initialize cert pool: %w", err)
 			}


### PR DESCRIPTION
This code was added in [containerd@17b6050] (containerd v1.4.0-beta.0), at which time containerd was using go1.13.8, which didn't support system-pools ([x509.SystemCertPool]) on Windows, so an empty pool was constructed, similar to [docker/go-connections@55aadc3].

Support for system pools on Windows originally added in Go 1.8 (through [golang/go@05471e9]), but reverted, and re-implemented in Go 1.18 (through [golang/go@3544082]).

Go 1.18 and up now implement this, but, unlike Linux, which uses a pure-Go implementation, certificate validation is handled by the system:

> On macOS and Windows, certificate verification is handled by system APIs,
> but the package aims to apply consistent validation rules across operating
> systems.

On macOS and Windows, x509.SystemCertPool returns an empty Pool, with the `systemPool` set to `true` (see [loadSystemRoots]). This must be considered an implementation detail; custom CAs can be appended to this pool, and handled as usual.

This patch removes the special handling on Windows, allowing it to use the system-pool, aligned with Linux.

[containerd@17b6050]: https://github.com/containerd/containerd/commit/17b6050d20bf7d25d15e26ed867f774e8c7c72fe
[docker/go-connections@55aadc3]: https://github.com/docker/go-connections/commit/55aadc3cc561684699edcdd0921b9293c3ee6b49
[golang/go@05471e9]: https://github.com/golang/go/commit/05471e9ee64a300bd2dcc4582ee1043c055893bb
[golang/go@3544082]: https://github.com/golang/go/commit/3544082f75fd3d2df7af237ed9aef3ddd499ab9c
[x509.SystemCertPool]: https://pkg.go.dev/crypto/x509#SystemCertPool
[loadSystemRoots]: https://cs.opensource.google/go/go/+/refs/tags/go1.26.1:src/crypto/x509/root_windows.go;l=15-17