### PR TITLE
fix: handle nil spec for hostNetwork containers

### DIFF
--- a/core/runtime/v2/bundle.go
+++ b/core/runtime/v2/bundle.go
@@ -103,12 +103,16 @@ func NewBundle(ctx context.Context, root, state, id string, spec typeurl.Any) (b
 	if err := os.Symlink(work, filepath.Join(b.Path, "work")); err != nil {
 		return nil, err
 	}
-	if spec := spec.GetValue(); spec != nil {
-		// write the spec to the bundle
-		specPath := filepath.Join(b.Path, oci.ConfigFilename)
-		err = os.WriteFile(specPath, spec, 0666)
-		if err != nil {
-			return nil, fmt.Errorf("failed to write bundle spec: %w", err)
+	// Spec may be nil for some sandboxers that do not initialize the spec, for
+	// example the shim sandboxer with a hostNetwork container.
+	if spec != nil {
+		if spec := spec.GetValue(); spec != nil {
+			// write the spec to the bundle
+			specPath := filepath.Join(b.Path, oci.ConfigFilename)
+			err = os.WriteFile(specPath, spec, 0666)
+			if err != nil {
+				return nil, fmt.Errorf("failed to write bundle spec: %w", err)
+			}
 		}
 	}
 	return b, nil


### PR DESCRIPTION
When running hostNetwork containers with the shim sandboxer, the spec passed to NewBundle is never initialized to a typed nil value and is instead a normal golang nil. Fix this by guarding the dereference to avoid crashing when such a container is created.

Fixes: #12983