### PR TITLE
Honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/plugins/cri/runtime/plugin.go
+++ b/plugins/cri/runtime/plugin.go
@@ -178,6 +178,13 @@ func setGLogLevel() error {
 	l := log.GetLevel()
 	fs := flag.NewFlagSet("klog", flag.PanicOnError)
 	klog.InitFlags(fs)
+	// Opt into fixed stderrthreshold behavior (kubernetes/klog#212).
+	if err := fs.Set("legacy_stderr_threshold_behavior", "false"); err != nil {
+		return err
+	}
+	if err := fs.Set("stderrthreshold", "INFO"); err != nil {
+		return err
+	}
 	if err := fs.Set("logtostderr", "true"); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

klog has a long-standing bug where setting `-logtostderr=true` (as the CRI plugin does in `setGLogLevel()`) causes the `-stderrthreshold` flag to be silently ignored. All log messages are sent to stderr regardless of their severity.

klog v2.140.0 introduced two new flags that allow callers to opt into the correct behavior:
- `-legacy_stderr_threshold_behavior=false`
- `-stderrthreshold=INFO`

This PR sets them in `setGLogLevel()` (inside `plugins/cri/runtime/plugin.go`), right after `klog.InitFlags()` and before any other flag configuration.

### Note

The containerd go.mod already has `k8s.io/klog/v2 v2.140.0`, so no dependency bump is needed.

Reference: kubernetes/klog#212

/cc @mikebrow @dcantah