### PR TITLE
core/remotes: MakeRefKey: update godoc and change Warn to Debug logs

### DIFF
--- a/core/remotes/handlers.go
+++ b/core/remotes/handlers.go
@@ -55,9 +55,27 @@ func WithMediaTypeKeyPrefix(ctx context.Context, mediaType, prefix string) conte
 	return context.WithValue(ctx, refKeyPrefix{}, values)
 }
 
-// MakeRefKey returns a unique reference for the descriptor. This reference can be
-// used to lookup ongoing processes related to the descriptor. This function
-// may look to the context to namespace the reference appropriately.
+// MakeRefKey returns a stable ingest reference for desc.
+//
+// The returned key is used as a content-store reference to correlate ongoing
+// fetch and push operations for the same descriptor. The key is derived from
+// the descriptor digest and, when present, the
+// [ocispec.AnnotationRefName] annotation.
+//
+// By default, the key is prefixed according to the descriptor media type:
+//
+//   - "manifest-" for manifest media types recognized by [images.IsManifestType]
+//   - "index-" for index media types recognized by [images.IsIndexType]
+//   - "layer-" for layer media types recognized by [images.IsLayerType]
+//   - "config-" for config media types recognized by [images.IsKnownConfig]
+//   - "attestation-" for attestation media types recognized by [images.IsAttestationType]
+//
+// Additional exact media type mappings may be provided through
+// [WithMediaTypeKeyPrefix]. A context-provided mapping takes precedence over the
+// built-in classification.
+//
+// If the media type is not recognized and no context override exists,
+// MakeRefKey falls back to the "unknown-" prefix.
 func MakeRefKey(ctx context.Context, desc ocispec.Descriptor) string {
 	key := desc.Digest.String()
 	if desc.Annotations != nil {
@@ -85,7 +103,11 @@ func MakeRefKey(ctx context.Context, desc ocispec.Descriptor) string {
 	case images.IsAttestationType(desc.MediaType):
 		return "attestation-" + key
 	default:
-		log.G(ctx).Warnf("reference for unknown type: %s", desc.MediaType)
+		log.G(ctx).WithFields(log.Fields{
+			"digest":       desc.Digest,
+			"mediatype":    desc.MediaType,
+			"artifactType": desc.ArtifactType,
+		}).Debug("using generic reference key prefix for unclassified descriptor")
 		return "unknown-" + key
 	}
 }


### PR DESCRIPTION
relates to

- https://github.com/moby/moby/issues/52158
- https://github.com/moby/moby/pull/52200


Scary warnings were printed for any mediaType that wasn't mapped;

    INFO[2026-03-10T11:39:45.677430346Z] Docker daemon                                 commit=83bca51 containerd-snapshotter=true storage-driver=overlayfs version=29.3.0
    ...
    INFO[2026-03-10T11:39:45.689383471Z] API listen on /var/run/docker.sock
    WARN[2026-03-10T11:40:32.382484965Z] reference for unknown type: application/vnd.oci.empty.v1+json  digest="sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a" mediatype=application/vnd.oci.empty.v1+json size=2
    WARN[2026-03-10T11:40:32.445406215Z] reference for unknown type: application/vnd.oci.empty.v1+json
    WARN[2026-03-10T11:40:32.695256132Z] reference for unknown type: application/vnd.dev.sigstore.bundle.v0.3+json  digest="sha256:7e8cf55036d9be9d6a0d720a2e78468401cc0e01946dbbcb1cd7622ae854a0a3" mediatype=application/vnd.dev.sigstore.bundle.v0.3+json size=10491
    WARN[2026-03-10T11:40:32.695314215Z] reference for unknown type: application/vnd.oci.empty.v1+json  digest="sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a" mediatype=application/vnd.oci.empty.v1+json size=2
    WARN[2026-03-10T11:40:32.745608673Z] reference for unknown type: application/vnd.dev.sigstore.bundle.v0.3+json
    WARN[2026-03-10T11:40:32.745629632Z] reference for unknown type: application/vnd.oci.empty.v1+json
    WARN[2026-03-10T11:40:32.845403049Z] reference for unknown type: application/vnd.dev.sigstore.bundle.v0.3+json
    WARN[2026-03-10T11:40:32.945182007Z] reference for unknown type: application/vnd.dev.sigstore.bundle.v0.3+json
    INFO[2026-03-10T11:40:34.714635924Z] image pulled                                  digest="sha256:37539dd4d60fc70968d164d3850d903a2c56f6402214a1953fbf9fcb81ada731" remote="docker.io/moby/buildkit:latest

These cases are not actionable by the user, and not critical, so let's change them to a debug-message, but add more context. Also update the GoDoc for this function to better cover its functionality.