### PR TITLE
cri: mirror cadvisor UsageNanoCores semantics

### DIFF
--- a/internal/cri/server/container_stats_list.go
+++ b/internal/cri/server/container_stats_list.go
@@ -156,14 +156,18 @@ func (c *criService) toContainerStats(
 		}
 
 		if cs.stats.Cpu != nil && cs.stats.Cpu.UsageCoreNanoSeconds != nil {
-			// UsageNanoCores is a calculated value and should be computed for all OSes
+			// UsageNanoCores is a calculated value and should be computed for all OSes.
+			// Leave it unset when there is not enough data to compute an instantaneous
+			// rate yet, which mirrors cAdvisor's CpuInst behavior.
 			nanoUsage, err := c.getUsageNanoCores(cntr.Metadata.ID, false, cs.stats.Cpu.UsageCoreNanoSeconds.Value, time.Unix(0, cs.stats.Cpu.Timestamp))
 			if err != nil {
 				// If an error occurred when getting nano cores usage, skip the container
 				log.G(ctx).WithError(err).Warnf("failed to get usage nano cores for container %q", cntr.ID)
 				continue
 			}
-			cs.stats.Cpu.UsageNanoCores = &runtime.UInt64Value{Value: nanoUsage}
+			if nanoUsage != nil {
+				cs.stats.Cpu.UsageNanoCores = &runtime.UInt64Value{Value: *nanoUsage}
+			}
 		}
 		css = append(css, cs)
 	}
@@ -178,13 +182,13 @@ func (c *criService) toCRIContainerStats(css []containerStats) *runtime.ListCont
 	return containerStats
 }
 
-func (c *criService) getUsageNanoCores(containerID string, isSandbox bool, currentUsageCoreNanoSeconds uint64, currentTimestamp time.Time) (uint64, error) {
+func (c *criService) getUsageNanoCores(containerID string, isSandbox bool, currentUsageCoreNanoSeconds uint64, currentTimestamp time.Time) (*uint64, error) {
 	// First, try to get pre-calculated UsageNanoCores from the background stats collector.
 	// This ensures we have valid data even on the first query (as the collector runs
 	// continuously in the background, similar to cAdvisor's housekeeping).
 	if c.statsCollector != nil {
 		if usageNanoCores, ok := c.statsCollector.GetUsageNanoCores(containerID); ok {
-			return usageNanoCores, nil
+			return &usageNanoCores, nil
 		}
 	}
 
@@ -195,13 +199,13 @@ func (c *criService) getUsageNanoCores(containerID string, isSandbox bool, curre
 	if isSandbox {
 		sandbox, err := c.sandboxStore.Get(containerID)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get sandbox container: %s: %w", containerID, err)
+			return nil, fmt.Errorf("failed to get sandbox container: %s: %w", containerID, err)
 		}
 		oldStats = sandbox.Stats
 	} else {
 		container, err := c.containerStore.Get(containerID)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get container ID: %s: %w", containerID, err)
+			return nil, fmt.Errorf("failed to get container ID: %s: %w", containerID, err)
 		}
 		oldStats = container.Stats
 	}
@@ -214,27 +218,27 @@ func (c *criService) getUsageNanoCores(containerID string, isSandbox bool, curre
 		if isSandbox {
 			err := c.sandboxStore.UpdateContainerStats(containerID, newStats)
 			if err != nil {
-				return 0, fmt.Errorf("failed to update sandbox stats container ID: %s: %w", containerID, err)
+				return nil, fmt.Errorf("failed to update sandbox stats container ID: %s: %w", containerID, err)
 			}
 		} else {
 			err := c.containerStore.UpdateContainerStats(containerID, newStats)
 			if err != nil {
-				return 0, fmt.Errorf("failed to update container stats ID: %s: %w", containerID, err)
+				return nil, fmt.Errorf("failed to update container stats ID: %s: %w", containerID, err)
 			}
 		}
-		return 0, nil
+		return nil, nil
 	}
 
 	nanoSeconds := currentTimestamp.UnixNano() - oldStats.Timestamp.UnixNano()
 
 	// zero or negative interval
 	if nanoSeconds <= 0 {
-		return 0, nil
+		return nil, nil
 	}
 
 	// can't go backwards, this value might come in as 0 if the container was just removed
 	if currentUsageCoreNanoSeconds < oldStats.UsageCoreNanoSeconds {
-		return 0, nil
+		return nil, nil
 	}
 
 	newUsageNanoCores := uint64(float64(currentUsageCoreNanoSeconds-oldStats.UsageCoreNanoSeconds) /
@@ -247,16 +251,16 @@ func (c *criService) getUsageNanoCores(containerID string, isSandbox bool, curre
 	if isSandbox {
 		err := c.sandboxStore.UpdateContainerStats(containerID, newStats)
 		if err != nil {
-			return 0, fmt.Errorf("failed to update sandbox container stats: %s: %w", containerID, err)
+			return nil, fmt.Errorf("failed to update sandbox container stats: %s: %w", containerID, err)
 		}
 	} else {
 		err := c.containerStore.UpdateContainerStats(containerID, newStats)
 		if err != nil {
-			return 0, fmt.Errorf("failed to update container stats ID: %s: %w", containerID, err)
+			return nil, fmt.Errorf("failed to update container stats ID: %s: %w", containerID, err)
 		}
 	}
 
-	return newUsageNanoCores, nil
+	return &newUsageNanoCores, nil
 }
 
 func (c *criService) normalizeContainerStatsFilter(filter *runtime.ContainerStatsFilter) {

--- a/internal/cri/server/container_stats_list_test.go
+++ b/internal/cri/server/container_stats_list_test.go
@@ -49,24 +49,24 @@ func TestContainerMetricsCPUNanoCoreUsage(t *testing.T) {
 		desc                        string
 		firstCPUValue               uint64
 		secondCPUValue              uint64
-		expectedNanoCoreUsageFirst  uint64
-		expectedNanoCoreUsageSecond uint64
+		expectedNanoCoreUsageFirst  *uint64
+		expectedNanoCoreUsageSecond *uint64
 	}{
 		{
 			id:                          "id1",
-			desc:                        "metrics",
+			desc:                        "normal increase",
 			firstCPUValue:               50,
 			secondCPUValue:              500,
-			expectedNanoCoreUsageFirst:  0,
-			expectedNanoCoreUsageSecond: 45,
+			expectedNanoCoreUsageFirst:  nil,
+			expectedNanoCoreUsageSecond: uint64Ptr(45),
 		},
 		{
 			id:                          "id2",
-			desc:                        "metrics",
+			desc:                        "counter goes backwards",
 			firstCPUValue:               234235,
 			secondCPUValue:              0,
-			expectedNanoCoreUsageFirst:  0,
-			expectedNanoCoreUsageSecond: 0,
+			expectedNanoCoreUsageFirst:  nil,
+			expectedNanoCoreUsageSecond: nil,
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
@@ -97,6 +97,8 @@ func TestContainerMetricsCPUNanoCoreUsage(t *testing.T) {
 		})
 	}
 }
+
+func uint64Ptr(v uint64) *uint64 { return &v }
 
 func TestGetWorkingSet(t *testing.T) {
 	for _, test := range []struct {

--- a/internal/cri/server/sandbox_stats_linux.go
+++ b/internal/cri/server/sandbox_stats_linux.go
@@ -68,7 +68,9 @@ func (c *criService) podSandboxStats(
 		if err != nil {
 			return nil, fmt.Errorf("failed to get usage nano cores: %w", err)
 		}
-		cpuStats.UsageNanoCores = &runtime.UInt64Value{Value: nanoUsage}
+		if nanoUsage != nil {
+			cpuStats.UsageNanoCores = &runtime.UInt64Value{Value: *nanoUsage}
+		}
 	}
 	podSandboxStats.Linux.Cpu = cpuStats
 

--- a/internal/cri/server/stats_collector.go
+++ b/internal/cri/server/stats_collector.go
@@ -271,7 +271,7 @@ func (c *StatsCollector) addSample(id string, timestamp time.Time, usageCoreNano
 	store.Add(timestamp, usageCoreNanoSeconds)
 }
 
-// GetUsageNanoCores returns the latest calculated UsageNanoCores for the given
+// GetUsageNanoCores returns the latest instantaneous UsageNanoCores rate for the given
 // container/sandbox ID. Returns 0 and false if no data is available or if
 // there aren't enough samples to calculate the rate.
 func (c *StatsCollector) GetUsageNanoCores(id string) (uint64, bool) {


### PR DESCRIPTION
Mirror cAdvisor's instantaneous CPU rate behavior for CRI stats.

Compute UsageNanoCores from the latest two samples only, and leave the field unset when there is not yet enough data to calculate an instantaneous rate. This avoids publishing an authoritative zero before a valid rate exists while keeping containerd aligned with cAdvisor semantics.

Context:
- Job: `ci-kubernetes-node-e2e-containerd-alpha-features` ( https://testgrid.k8s.io/sig-node-containerd#ci-node-e2e-containerd-alpha-features )
- Test: `Summary API [NodeConformance] when querying /stats/summary should report resource usage through the stats api`
- Feature gates: `AllAlpha=true`, `PodAndContainerStatsFromCRI=true`, `EventedPLEG=false`
- Symptom: `UsageNanoCores` is reported as `0` where the test expects a non-zero recent CPU usage value

With `PodAndContainerStatsFromCRI=true`, kubelet consumes CRI CPU stats directly instead of using cAdvisor-backed values for this path. The failure happens when containerd publishes `UsageNanoCores` before there is enough data to compute an instantaneous rate, or otherwise returns an explicit zero that kubelet then treats as authoritative.

This change mirrors cAdvisor's `CpuInst` behavior: only report an instantaneous CPU rate when it can be computed from consecutive samples, and otherwise leave the field unset.
