### PR TITLE
Add no_sync option to mount manager and erofs snapshotter bolt DBs

### DIFF
--- a/plugins/metadata/plugin.go
+++ b/plugins/metadata/plugin.go
@@ -156,7 +156,7 @@ func init() {
 						options.NoSync = true
 						options.NoGrowSync = true
 
-						log.G(ic.Context).Warn("using async mode for boltdb")
+						log.G(ic.Context).WithField("plugin", "bolt").Warn("using async mode for boltdb")
 					}
 				}
 			}

--- a/plugins/mount/manager.go
+++ b/plugins/mount/manager.go
@@ -36,15 +36,29 @@ import (
 	"github.com/containerd/containerd/v2/plugins"
 )
 
+// Config defines the bolt database configuration for the mount manager plugin.
+type Config struct {
+	// NoSync enables optimizations that improve database write performance by:
+	// 1. Disabling fsync calls after every write, which prevents ensuring that data is immediately flushed
+	//    to disk but significantly improves write throughput (NoSync).
+	// 2. Preventing automatic growth of the memory-mapped file during writes, further improving performance
+	//    in environments where the database size is stable (NoGrowSync).
+	//
+	// These settings can improve performance, but introduce a risk of data loss during crashes. Use with care!
+	NoSync bool `toml:"no_sync"`
+}
+
 func init() {
 	registry.Register(&plugin.Registration{
-		Type: plugins.MountManagerPlugin,
-		ID:   "bolt",
+		Type:   plugins.MountManagerPlugin,
+		ID:     "bolt",
+		Config: &Config{},
 		Requires: []plugin.Type{
 			plugins.MetadataPlugin,
 			plugins.MountHandlerPlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (any, error) {
+			cfg := ic.Config.(*Config)
 			md, err := ic.GetSingle(plugins.MetadataPlugin)
 			if err != nil {
 				return nil, err
@@ -81,7 +95,13 @@ func init() {
 
 			metadb := filepath.Join(root, "mounts.db")
 
-			db, err := bolt.Open(metadb, 0600, nil)
+			boltOpts := *bolt.DefaultOptions
+			if cfg.NoSync {
+				boltOpts.NoSync = true
+				boltOpts.NoGrowSync = true
+				log.G(ic.Context).Warn("mount manager: using async mode for boltdb")
+			}
+			db, err := bolt.Open(metadb, 0600, &boltOpts)
 			if err != nil {
 				return nil, fmt.Errorf("failed to open database file: %w", err)
 			}

--- a/plugins/mount/manager.go
+++ b/plugins/mount/manager.go
@@ -99,7 +99,7 @@ func init() {
 			if cfg.NoSync {
 				boltOpts.NoSync = true
 				boltOpts.NoGrowSync = true
-				log.G(ic.Context).Warn("mount manager: using async mode for boltdb")
+				log.G(ic.Context).WithField("plugin", "mount").Warn("using async mode for boltdb")
 			}
 			db, err := bolt.Open(metadb, 0600, &boltOpts)
 			if err != nil {

--- a/plugins/snapshots/erofs/erofs.go
+++ b/plugins/snapshots/erofs/erofs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	bolt "go.etcd.io/bbolt"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -49,6 +50,7 @@ type SnapshotterConfig struct {
 	remapIDs    bool
 	// dmverityMode controls dm-verity behavior: "auto" (use if .dmverity exists), "on" (require .dmverity), "off" (disable)
 	dmverityMode string
+	noSync       bool
 }
 
 // Opt is an option to configure the erofs snapshotter
@@ -93,6 +95,14 @@ func WithDefaultSize(size int64) Opt {
 func WithRemapIDs() Opt {
 	return func(config *SnapshotterConfig) {
 		config.remapIDs = true
+	}
+}
+
+// WithNoSync disables fsync on the snapshotter's metadata bolt database,
+// improving write throughput at the cost of durability.
+func WithNoSync() Opt {
+	return func(config *SnapshotterConfig) {
+		config.noSync = true
 	}
 }
 
@@ -169,7 +179,15 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		return nil, fmt.Errorf("setting IMMUTABLE_FL is only supported on Linux")
 	}
 
-	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"))
+	var msOpts []storage.Opt
+	if config.noSync {
+		msOpts = append(msOpts, func(o *bolt.Options) error {
+			o.NoSync = true
+			o.NoGrowSync = true
+			return nil
+		})
+	}
+	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"), msOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/snapshots/erofs/plugin/plugin.go
+++ b/plugins/snapshots/erofs/plugin/plugin.go
@@ -55,6 +55,15 @@ type Config struct {
 	// DmverityMode controls dm-verity behavior: "auto" (use if available), "on" (require), "off" (disable)
 	// Linux only
 	DmverityMode string `toml:"dmverity_mode"`
+
+	// NoSync enables optimizations that improve database write performance by:
+	// 1. Disabling fsync calls after every write, which prevents ensuring that data is immediately flushed
+	//    to disk but significantly improves write throughput (NoSync).
+	// 2. Preventing automatic growth of the memory-mapped file during writes, further improving performance
+	//    in environments where the database size is stable (NoGrowSync).
+	//
+	// These settings can improve performance, but introduce a risk of data loss during crashes. Use with care!
+	NoSync bool `toml:"no_sync"`
 }
 
 func init() {
@@ -105,6 +114,10 @@ func init() {
 			if ok, err := supportsIDMappedMounts(); err == nil && ok {
 				opts = append(opts, erofs.WithRemapIDs())
 				ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaRemapIDs)
+			}
+
+			if config.NoSync {
+				opts = append(opts, erofs.WithNoSync())
 			}
 
 			ic.Meta.Exports[plugins.SnapshotterRootDir] = root

--- a/plugins/snapshots/erofs/plugin/plugin.go
+++ b/plugins/snapshots/erofs/plugin/plugin.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
@@ -118,6 +119,7 @@ func init() {
 
 			if config.NoSync {
 				opts = append(opts, erofs.WithNoSync())
+				log.G(ic.Context).WithField("plugin", "erofs").Warn("using async mode for boltdb")
 			}
 
 			ic.Meta.Exports[plugins.SnapshotterRootDir] = root


### PR DESCRIPTION
The metadata plugin already exposes a no_sync option (PR #10745) that disables F_FULLFSYNC on its bolt DB. This extends the same pattern to two more bolt databases: the mount manager (mounts.db) and the erofs snapshotter (metadata.db).

On macOS, F_FULLFSYNC costs ~8ms per bolt transaction, particularly affecting nerdbox, see this benchmark (Apple M-series, bbolt v1.4.3):

```golang
mkdir /tmp/test
cat > /tmp/test/main.go <<EOT
    package main
    import (
        "fmt"; "os"; "path/filepath"; "time"
        bolt "go.etcd.io/bbolt"
    )
    func bench(label string, noSync bool) {
        dir, _ := os.MkdirTemp("", "bolt-*")
        defer os.RemoveAll(dir)
        db, _ := bolt.Open(filepath.Join(dir, "t.db"), 0600,
            &bolt.Options{NoSync: noSync, NoGrowSync: noSync})
        defer db.Close()
        db.Update(func(tx *bolt.Tx) error { _, e := tx.CreateBucket([]byte("b")); return e })
        const N = 200
        start := time.Now()
        for i := range N {
            db.Update(func(tx *bolt.Tx) error {
                return tx.Bucket([]byte("b")).Put([]byte(fmt.Sprintf("k%d", i)), []byte("v"))
            })
        }
        d := time.Since(start)
        fmt.Printf("%-10s %d writes in %v (%.0f ops/s, %.2f ms/op)\n",
            label, N, d.Round(time.Millisecond), float64(N)/d.Seconds(), float64(d.Milliseconds())/float64(N))
    }
    func main() { bench("sync:", false); bench("no_sync:", true) }
EOT
cd /tmp/test
go mod init test
go mod tidy
go run main.go
```

Results:

```
    sync:      200 writes in 1.605s (125 ops/s, 8.03 ms/op)
    no_sync:   200 writes in 3ms (74203 ops/s, 0.01 ms/op)
```

Configuration:

```
    [plugins.'io.containerd.mount-manager.v1.bolt']
      no_sync = true

    [plugins.'io.containerd.snapshotter.v1.erofs']
      no_sync = true
```