### PR TITLE
Improve support for non-canonical digests (sha512, etc)

### DIFF
--- a/plugins/content/local/store.go
+++ b/plugins/content/local/store.go
@@ -545,8 +545,13 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 
 	path, refp, data := s.ingestPaths(ref)
 
+	// if we get passed an expected digest, we need to use the same algorithm (sha512, etc)
+	digestAlg := digest.Canonical
+	if expected != "" && expected.Algorithm().Available() {
+		digestAlg = expected.Algorithm()
+	}
 	var (
-		digester  = digest.Canonical.Digester()
+		digester  = digestAlg.Digester()
 		offset    int64
 		startedAt time.Time
 		updatedAt time.Time

--- a/plugins/content/local/store_test.go
+++ b/plugins/content/local/store_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/rand"
 	_ "crypto/sha256" // required for digest package
+	_ "crypto/sha512" // required for sha512 digest support
 	"fmt"
 	"io"
 	"os"
@@ -140,109 +141,112 @@ func TestInvalidPermissionRootDir(t *testing.T) {
 }
 
 func TestContentWriter(t *testing.T) {
-	ctx, tmpdir, cs, cleanup := contentStoreEnv(t)
-	defer cleanup()
-	defer testutil.DumpDirOnFailure(t, tmpdir)
+	for _, alg := range []digest.Algorithm{digest.SHA256, digest.SHA512} {
+		t.Run(alg.String(), func(t *testing.T) {
+			ctx, tmpdir, cs, cleanup := contentStoreEnv(t)
+			defer cleanup()
+			defer testutil.DumpDirOnFailure(t, tmpdir)
 
-	cw, err := cs.Writer(ctx, content.WithRef("myref"))
-	if err != nil {
-		t.Fatal(err)
+			cw, err := cs.Writer(ctx, content.WithRef("myref"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := cw.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := os.Stat(filepath.Join(tmpdir, "ingest")); os.IsNotExist(err) {
+				t.Fatal("ingest dir should be created", err)
+			}
+
+			// reopen, so we can test things
+			cw, err = cs.Writer(ctx, content.WithRef("myref"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// make sure that second resume also fails
+			if _, err = cs.Writer(ctx, content.WithRef("myref")); err == nil {
+				// TODO(stevvooe): This also works across processes. Need to find a way
+				// to test that, as well.
+				t.Fatal("no error on second resume")
+			}
+
+			// we should also see this as an active ingestion
+			ingestions, err := cs.ListStatuses(ctx, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// clear out the time and meta cause we don't care for this test
+			for i := range ingestions {
+				ingestions[i].UpdatedAt = time.Time{}
+				ingestions[i].StartedAt = time.Time{}
+			}
+
+			if !reflect.DeepEqual(ingestions, []content.Status{
+				{
+					Ref:    "myref",
+					Offset: 0,
+				},
+			}) {
+				t.Fatalf("unexpected ingestion set: %v", ingestions)
+			}
+
+			p := make([]byte, 4<<20)
+			if _, err := rand.Read(p); err != nil {
+				t.Fatal(err)
+			}
+			expected := alg.FromBytes(p)
+
+			checkCopy(t, int64(len(p)), cw, bufio.NewReader(io.NopCloser(bytes.NewReader(p))))
+
+			if err := cw.Commit(ctx, int64(len(p)), expected); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := cw.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			cw, err = cs.Writer(ctx, content.WithRef("aref"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// now, attempt to write the same data again
+			checkCopy(t, int64(len(p)), cw, bufio.NewReader(io.NopCloser(bytes.NewReader(p))))
+			if err := cw.Commit(ctx, int64(len(p)), expected); err == nil {
+				t.Fatal("expected already exists error")
+			} else if !errdefs.IsAlreadyExists(err) {
+				t.Fatal(err)
+			}
+
+			path := checkBlobPath(t, cs, expected)
+
+			// read the data back, make sure its the same
+			pp, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(p, pp) {
+				t.Fatal("mismatched data written to disk")
+			}
+
+			// ensure fsverity is enabled on blob if fsverity is supported
+			ok, err := fsverity.IsSupported(tmpdir)
+			if !ok || err != nil {
+				t.Log("fsverity not supported, skipping fsverity check")
+				return
+			}
+
+			ok, err = fsverity.IsEnabled(path)
+			if !ok || err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
-	if err := cw.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := os.Stat(filepath.Join(tmpdir, "ingest")); os.IsNotExist(err) {
-		t.Fatal("ingest dir should be created", err)
-	}
-
-	// reopen, so we can test things
-	cw, err = cs.Writer(ctx, content.WithRef("myref"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// make sure that second resume also fails
-	if _, err = cs.Writer(ctx, content.WithRef("myref")); err == nil {
-		// TODO(stevvooe): This also works across processes. Need to find a way
-		// to test that, as well.
-		t.Fatal("no error on second resume")
-	}
-
-	// we should also see this as an active ingestion
-	ingestions, err := cs.ListStatuses(ctx, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// clear out the time and meta cause we don't care for this test
-	for i := range ingestions {
-		ingestions[i].UpdatedAt = time.Time{}
-		ingestions[i].StartedAt = time.Time{}
-	}
-
-	if !reflect.DeepEqual(ingestions, []content.Status{
-		{
-			Ref:    "myref",
-			Offset: 0,
-		},
-	}) {
-		t.Fatalf("unexpected ingestion set: %v", ingestions)
-	}
-
-	p := make([]byte, 4<<20)
-	if _, err := rand.Read(p); err != nil {
-		t.Fatal(err)
-	}
-	expected := digest.FromBytes(p)
-
-	checkCopy(t, int64(len(p)), cw, bufio.NewReader(io.NopCloser(bytes.NewReader(p))))
-
-	if err := cw.Commit(ctx, int64(len(p)), expected); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := cw.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	cw, err = cs.Writer(ctx, content.WithRef("aref"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// now, attempt to write the same data again
-	checkCopy(t, int64(len(p)), cw, bufio.NewReader(io.NopCloser(bytes.NewReader(p))))
-	if err := cw.Commit(ctx, int64(len(p)), expected); err == nil {
-		t.Fatal("expected already exists error")
-	} else if !errdefs.IsAlreadyExists(err) {
-		t.Fatal(err)
-	}
-
-	path := checkBlobPath(t, cs, expected)
-
-	// read the data back, make sure its the same
-	pp, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(p, pp) {
-		t.Fatal("mismatched data written to disk")
-	}
-
-	// ensure fsverity is enabled on blob if fsverity is supported
-	ok, err := fsverity.IsSupported(tmpdir)
-	if !ok || err != nil {
-		t.Log("fsverity not supported, skipping fsverity check")
-		return
-	}
-
-	ok, err = fsverity.IsEnabled(path)
-	if !ok || err != nil {
-		t.Fatal(err)
-	}
-
 }
 
 func TestWalkBlobs(t *testing.T) {
@@ -324,8 +328,9 @@ func generateBlobs(t checker, nblobs, maxsize int64) map[digest.Digest][]byte {
 			t.Fatal(err)
 		}
 
-		dgst := digest.FromBytes(p)
-		blobs[dgst] = p
+		for _, alg := range []digest.Algorithm{digest.SHA256, digest.SHA512} {
+			blobs[alg.FromBytes(p)] = p
+		}
 	}
 
 	return blobs

--- a/plugins/content/local/writer.go
+++ b/plugins/content/local/writer.go
@@ -113,6 +113,20 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	}
 
 	dgst := w.digester.Digest()
+	if expected != "" && expected.Algorithm() != dgst.Algorithm() && expected.Algorithm().Available() {
+		// Writer was opened without a descriptor specifying the digest algorithm (but we got a non-canonical one here in commit), so we have to re-hash our now completed and closed content to compare
+		f, err := os.Open(filepath.Join(w.path, "data"))
+		if err != nil {
+			return fmt.Errorf("failed to open ingest data for re-hashing to %s: %w", expected.Algorithm().String(), err)
+		}
+		w.digester = expected.Algorithm().Digester()
+		_, err = io.Copy(w.digester.Hash(), f)
+		f.Close()
+		if err != nil {
+			return fmt.Errorf("failed to re-hash ingest data to %s: %w", expected.Algorithm().String(), err)
+		}
+		dgst = w.digester.Digest()
+	}
 	if expected != "" && expected != dgst {
 		return fmt.Errorf("unexpected commit digest %s, expected %s: %w", dgst, expected, errdefs.ErrFailedPrecondition)
 	}

--- a/plugins/content/local/writer.go
+++ b/plugins/content/local/writer.go
@@ -115,6 +115,7 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	dgst := w.digester.Digest()
 	if expected != "" && expected.Algorithm() != dgst.Algorithm() && expected.Algorithm().Available() {
 		// Writer was opened without a descriptor specifying the digest algorithm (but we got a non-canonical one here in commit), so we have to re-hash our now completed and closed content to compare
+		start := time.Now()
 		f, err := os.Open(filepath.Join(w.path, "data"))
 		if err != nil {
 			return fmt.Errorf("failed to open ingest data for re-hashing to %s: %w", expected.Algorithm().String(), err)
@@ -126,6 +127,9 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 			return fmt.Errorf("failed to re-hash ingest data to %s: %w", expected.Algorithm().String(), err)
 		}
 		dgst = w.digester.Digest()
+		if duration := time.Since(start); duration > 250*time.Millisecond {
+			log.G(ctx).WithField("digest", dgst).WithField("duration", duration).Warnf("commit for blob required expensive re-hash")
+		}
 	}
 	if expected != "" && expected != dgst {
 		return fmt.Errorf("unexpected commit digest %s, expected %s: %w", dgst, expected, errdefs.ErrFailedPrecondition)


### PR DESCRIPTION
This is all specific to the content store -- prior to this change, `ctr content fetch docker.io/tianon/test:sha512-blobs` fails with errors about `sha256` digests, and after this change it succeeds and ingests the `sha512` blobs successfully.

In the interest of full disclosure, this change was mostly authored by myself without any AI-assistance, but Claude was used to find the appropriate tests to update and to understand why the metadata service would clear out `Digest` when passing details to the content store and thus the appropriate fix being in the Writer's Commit method (re-hashing after Close when the digest algorithm was previously unknown but is known and non-canonical during Commit).  I had a very active hand in instructing Claude on exactly which changes to make and where to make them, and I spent a lot of time reviewing them to make sure I not only understand but agree with the changes that it authored.

Of course, as always, I'm happy to rebase, amend, adjust, etc as desired.

Related:

- https://github.com/containerd/containerd/pull/13036  
  (I believe these changes are orthogonal / complementary, though -- they certainly do not conflict)