### PR TITLE
Skip TestExportAndImportMultiLayer on s390x

### DIFF
--- a/integration/client/import_test.go
+++ b/integration/client/import_test.go
@@ -65,6 +65,10 @@ func TestExportAndImport(t *testing.T) {
 // images remain sane, and that the Garbage Collector won't delete part of its
 // content.
 func TestExportAndImportMultiLayer(t *testing.T) {
+	// ghcr.io/containerd/volume-copy-up:2.1 is not available on s390x
+	if runtime.GOARCH == "s390x" {
+		t.Skip("test image not available on s390x")
+	}
 	testExportImport(t, testMultiLayeredImage)
 }
 


### PR DESCRIPTION
Skip TestExportAndImportMultiLayer on s390x

The test image `ghcr.io/containerd/volume-copy-up:2.1` does not include a manifest for s390x, causing the test to fail with:
"no manifest found for platform: not found".