### PR TITLE
Skip more tests on s390x

### DIFF
--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -476,6 +476,11 @@ func TestImagePullWithTracing(t *testing.T) {
 }
 
 func TestImagePullWithConcurrentUnpacks(t *testing.T) {
+	// ghcr.io/containerd/volume-copy-up:2.2 is not available on s390x
+	if runtime.GOARCH == "s390x" {
+		t.Skip("test image not available on s390x")
+	}
+
 	client, err := newClient(t, address)
 	if err != nil {
 		t.Fatal(err)

--- a/integration/client/container_idmapped_linux_test.go
+++ b/integration/client/container_idmapped_linux_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -33,6 +34,11 @@ import (
 )
 
 func TestIDMappedOverlay(t *testing.T) {
+	// ghcr.io/containerd/volume-copy-up:2.2 is not available on s390x
+	if runtime.GOARCH == "s390x" {
+		t.Skip("test image not available on s390x")
+	}
+
 	if ok, err := overlayutils.SupportsIDMappedMounts(); err != nil || !ok {
 		t.Skip("overlayfs doesn't support idmapped mounts")
 	}

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -1104,6 +1105,11 @@ func TestContainerKillInitPidHost(t *testing.T) {
 }
 
 func TestUserNamespaces(t *testing.T) {
+	// ghcr.io/containerd/volume-ownership:2.1 is not available on s390x
+	if runtime.GOARCH == "s390x" {
+		t.Skip("test image not available on s390x")
+	}
+
 	for name, test := range map[string]struct {
 		testCmd  oci.SpecOpts
 		roRootFS bool


### PR DESCRIPTION
These images are not available for s390x:
- ghcr.io/containerd/volume-copy-up:2.2
- ghcr.io/containerd/volume-ownership:2.1

Otherwise tests fail for containerd v2.2.1 on s390x.