### PR TITLE
replace one more k8s.io/apimachinery/ reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	k8s.io/cri-api v0.36.0-beta.0
 	k8s.io/cri-streaming v0.36.0-beta.0
 	k8s.io/klog/v2 v2.140.0
+	k8s.io/streaming v0.36.0-beta.0
 	tags.cncf.io/container-device-interface v1.1.0
 )
 
@@ -154,7 +155,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.36.0-beta.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260319004828-5883c5ee87b9 // indirect
-	k8s.io/streaming v0.36.0-beta.0 // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/cri/server/streaming.go
+++ b/internal/cri/server/streaming.go
@@ -22,8 +22,8 @@ import (
 	"io"
 	"math"
 
-	"k8s.io/apimachinery/pkg/util/runtime"
 	remotecommand "k8s.io/cri-streaming/pkg/streaming/remotecommand"
+	"k8s.io/streaming/pkg/runtime"
 
 	executil "github.com/containerd/containerd/v2/internal/cri/executil"
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"


### PR DESCRIPTION
Forgotten rename

We only have 1 more dependency on "k8s.io/apimachinery": 

https://github.com/containerd/containerd/blob/323d16fad8da181eae8b4ef50bed86b4d50c9dc1/internal/cri/config/streaming.go#L70