### PR TITLE
transfer/streaming: stop stream helper goroutine leaks

### DIFF
--- a/core/transfer/streaming/reader.go
+++ b/core/transfer/streaming/reader.go
@@ -29,6 +29,7 @@ import (
 
 type readByteStream struct {
 	ctx       context.Context
+	cancel    context.CancelFunc
 	stream    streaming.Stream
 	window    int32
 	updated   chan struct{}
@@ -37,18 +38,25 @@ type readByteStream struct {
 }
 
 func ReadByteStream(ctx context.Context, stream streaming.Stream) io.ReadCloser {
+	ctx, cancel := context.WithCancel(ctx)
 	rbs := &readByteStream{
 		ctx:     ctx,
+		cancel:  cancel,
 		stream:  stream,
 		window:  0,
-		errCh:   make(chan error),
+		errCh:   make(chan error, 1),
 		updated: make(chan struct{}, 1),
 	}
 	go func() {
 		for {
+			select {
+			case <-rbs.ctx.Done():
+				return
+			default:
+			}
 			if rbs.window >= windowSize {
 				select {
-				case <-ctx.Done():
+				case <-rbs.ctx.Done():
 					return
 				case <-rbs.updated:
 					continue
@@ -59,13 +67,24 @@ func ReadByteStream(ctx context.Context, stream streaming.Stream) io.ReadCloser 
 			}
 			anyType, err := typeurl.MarshalAny(update)
 			if err != nil {
-				rbs.errCh <- err
+				select {
+				case rbs.errCh <- err:
+				case <-rbs.ctx.Done():
+				default:
+				}
 				return
 			}
 			if err := stream.Send(anyType); err == nil {
 				rbs.window += windowSize
-			} else if !errors.Is(err, io.EOF) {
-				rbs.errCh <- err
+			} else {
+				if !errors.Is(err, io.EOF) {
+					select {
+					case rbs.errCh <- err:
+					case <-rbs.ctx.Done():
+					default:
+					}
+				}
+				return
 			}
 		}
 
@@ -107,7 +126,10 @@ func (r *readByteStream) Read(p []byte) (n int, err error) {
 		}
 		r.window = r.window - int32(n)
 		if r.window < windowSize {
-			r.updated <- struct{}{}
+			select {
+			case r.updated <- struct{}{}:
+			default:
+			}
 		}
 		return n, nil
 	default:
@@ -117,5 +139,8 @@ func (r *readByteStream) Read(p []byte) (n int, err error) {
 }
 
 func (r *readByteStream) Close() error {
+	if r.cancel != nil {
+		r.cancel()
+	}
 	return r.stream.Close()
 }

--- a/core/transfer/streaming/reader_test.go
+++ b/core/transfer/streaming/reader_test.go
@@ -1,0 +1,155 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+)
+
+func TestReadByteStreamLeakScenarios(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "remote close",
+			run: func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				rs, ws := pipeStream()
+				rbs := ReadByteStream(ctx, rs)
+
+				ws.Close()
+
+				buf := make([]byte, 10)
+				if _, err := rbs.Read(buf); err == nil {
+					t.Fatal("expected error after stream close")
+				}
+			},
+		},
+		{
+			name: "context cancel before read",
+			run: func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				rs, _ := pipeStream()
+				_ = ReadByteStream(ctx, rs)
+
+				cancel()
+				time.Sleep(10 * time.Millisecond)
+			},
+		},
+		{
+			name: "read blocked then remote close",
+			run: func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				rs, ws := pipeStream()
+				rbs := ReadByteStream(ctx, rs)
+
+				readDone := make(chan struct{})
+				go func() {
+					buf := make([]byte, 10)
+					_, _ = rbs.Read(buf)
+					close(readDone)
+				}()
+
+				ws.Close()
+
+				select {
+				case <-readDone:
+				case <-time.After(time.Second):
+					t.Fatal("read did not unblock after stream close")
+				}
+			},
+		},
+		{
+			name: "close without parent cancel",
+			run: func(t *testing.T) {
+				rs, _ := pipeStream()
+				rbs := ReadByteStream(context.Background(), rs)
+
+				if err := rbs.Close(); err != nil {
+					t.Fatalf("close read byte stream: %v", err)
+				}
+			},
+		},
+		{
+			name: "write stream remote close",
+			run: func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				rs, ws := pipeStream()
+				wbs := WriteByteStream(ctx, ws)
+
+				rs.Close()
+
+				if _, err := wbs.Write([]byte("foo")); err == nil {
+					t.Fatal("expected error after stream close")
+				}
+
+				if err := wbs.Close(); err != nil {
+					t.Fatalf("close write byte stream: %v", err)
+				}
+			},
+		},
+		{
+			name: "send stream recv side close",
+			run: func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				rs, ws := pipeStream()
+				r, w := io.Pipe()
+
+				done := make(chan struct{})
+				go func() {
+					SendStream(ctx, r, ws)
+					close(done)
+				}()
+
+				rs.Close()
+				go func() {
+					_, _ = w.Write([]byte("foo"))
+					_ = w.Close()
+				}()
+				cancel()
+				_ = r.CloseWithError(context.Canceled)
+
+				select {
+				case <-done:
+				case <-time.After(time.Second):
+					t.Fatal("send stream did not stop")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer goleak.VerifyNone(t)
+			tt.run(t)
+		})
+	}
+}

--- a/core/transfer/streaming/stream.go
+++ b/core/transfer/streaming/stream.go
@@ -43,7 +43,8 @@ var bufPool = &sync.Pool{
 }
 
 func SendStream(ctx context.Context, r io.Reader, stream streaming.Stream) {
-	window := make(chan int32)
+	window := make(chan int32, 8)
+	errCh := make(chan error, 1)
 	go func() {
 		defer close(window)
 		for {
@@ -56,7 +57,11 @@ func SendStream(ctx context.Context, r io.Reader, stream streaming.Stream) {
 			anyType, err := stream.Recv()
 			if err != nil {
 				if !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
-					log.G(ctx).WithError(err).Error("send stream ended without EOF")
+					select {
+					case errCh <- err:
+					case <-ctx.Done():
+					default:
+					}
 				}
 				return
 			}
@@ -71,6 +76,7 @@ func SendStream(ctx context.Context, r io.Reader, stream streaming.Stream) {
 				case <-ctx.Done():
 					return
 				case window <- v.Update:
+				default:
 				}
 			default:
 				log.G(ctx).Errorf("unexpected stream object of type %T", i)
@@ -92,6 +98,8 @@ func SendStream(ctx context.Context, r io.Reader, stream streaming.Stream) {
 				case <-ctx.Done():
 					// TODO: Send error message on stream before close to allow remote side to return error
 					return
+				case <-errCh:
+					return
 				case update := <-window:
 					remaining += update
 				default:
@@ -102,7 +110,12 @@ func SendStream(ctx context.Context, r io.Reader, stream streaming.Stream) {
 				case <-ctx.Done():
 					// TODO: Send error message on stream before close to allow remote side to return error
 					return
-				case update := <-window:
+				case <-errCh:
+					return
+				case update, ok := <-window:
+					if !ok {
+						return
+					}
 					remaining = update
 				}
 			}

--- a/core/transfer/streaming/writer.go
+++ b/core/transfer/streaming/writer.go
@@ -29,15 +29,19 @@ import (
 )
 
 func WriteByteStream(ctx context.Context, stream streaming.Stream) io.WriteCloser {
+	ctx, cancel := context.WithCancel(ctx)
 	wbs := &writeByteStream{
 		ctx:     ctx,
+		cancel:  cancel,
 		stream:  stream,
 		updated: make(chan struct{}, 1),
+		errCh:   make(chan error, 1),
 	}
 	go func() {
+		defer cancel()
 		for {
 			select {
-			case <-ctx.Done():
+			case <-wbs.ctx.Done():
 				return
 			default:
 			}
@@ -45,7 +49,11 @@ func WriteByteStream(ctx context.Context, stream streaming.Stream) io.WriteClose
 			anyType, err := stream.Recv()
 			if err != nil {
 				if !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
-					log.G(ctx).WithError(err).Error("send byte stream ended without EOF")
+					select {
+					case wbs.errCh <- err:
+					case <-wbs.ctx.Done():
+					default:
+					}
 				}
 				return
 			}
@@ -58,7 +66,7 @@ func WriteByteStream(ctx context.Context, stream streaming.Stream) io.WriteClose
 			case *transferapi.WindowUpdate:
 				wbs.remaining.Add(v.Update)
 				select {
-				case <-ctx.Done():
+				case <-wbs.ctx.Done():
 					return
 				case wbs.updated <- struct{}{}:
 				default:
@@ -75,9 +83,11 @@ func WriteByteStream(ctx context.Context, stream streaming.Stream) io.WriteClose
 
 type writeByteStream struct {
 	ctx       context.Context
+	cancel    context.CancelFunc
 	stream    streaming.Stream
 	remaining atomic.Int32
 	updated   chan struct{}
+	errCh     chan error
 }
 
 func (wbs *writeByteStream) Write(p []byte) (n int, err error) {
@@ -89,6 +99,8 @@ func (wbs *writeByteStream) Write(p []byte) (n int, err error) {
 			case <-wbs.ctx.Done():
 				// TODO: Send error message on stream before close to allow remote side to return error
 				err = io.ErrShortWrite
+				return
+			case err = <-wbs.errCh:
 				return
 			case <-wbs.updated:
 				continue
@@ -126,5 +138,8 @@ func (wbs *writeByteStream) Write(p []byte) (n int, err error) {
 }
 
 func (wbs *writeByteStream) Close() error {
+	if wbs.cancel != nil {
+		wbs.cancel()
+	}
 	return wbs.stream.Close()
 }


### PR DESCRIPTION
### Summary

This PR addresses critical goroutine leaks in the `transfer/streaming` component, specifically within `ReadByteStream` and `WriteByteStream` helpers.

### Root Cause

Previously, these helpers relied on callers to cancel the parent context to stop background flow-control goroutines. However, in extreme scenarios (e.g., rapid exec shell restarts), the data-path (Reader/Writer) could be closed while background goroutines were still blocked on stream events or window updates. This led to:
- Goroutines outliving their stream wrappers long after `Close()`.
- Blocking or spinning on internal channels after the data path had terminated.

### Changes

- **Self-contained Lifecycle**: Stream helpers now manage their own internal cancellable context.
- **Robust Termination**: `Close()` now explicitly cancels the internal context, ensuring all background goroutines exit immediately.
- **Improved Error Signaling**: Internal error reporting is now non-blocking to prevent deadlocks during shutdown.
- **Regression Tests**: Added comprehensive `goleak` based tests in `core/transfer/streaming/reader_test.go` covering various termination scenarios (remote close, context cancellation, blocked reads, and manual Close).
