### PR TITLE
Set the default of runtimeFeatures.UserNamespacesHostNetwork to true

### DIFF
--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	goruntime "runtime"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -281,7 +282,8 @@ func NewCRIService(options *CRIServiceOptions) (CRIService, runtime.RuntimeServi
 	}
 
 	c.runtimeFeatures = &runtime.RuntimeFeatures{
-		SupplementalGroupsPolicy: true,
+		SupplementalGroupsPolicy:  true,
+		UserNamespacesHostNetwork: goruntime.GOOS == "linux",
 	}
 
 	if c.config.EnableCDI != nil && !*c.config.EnableCDI {


### PR DESCRIPTION
This is a follow-up to #12518, after it is merged.

Due to the integration with NodeDeclaredFeatures, the kubelet needs to know exactly which version of containerd provides this feature. Therefore, I added the `UserNamespacesHostNetwork` field in CRI. Now we just need to set it to true and merge it in the same version as #12518.

```release-note
Set default runtimeFeatures.UserNamespacesHostNetwork to true
```
