### PR TITLE
Add: ResponseHeaderTimeout to image pull HTTP transport

### DIFF
--- a/core/remotes/docker/registry.go
+++ b/core/remotes/docker/registry.go
@@ -264,5 +264,6 @@ func DefaultHTTPTransport(defaultTLSConfig *tls.Config) *http.Transport {
 		TLSHandshakeTimeout:   10 * time.Second,
 		TLSClientConfig:       defaultTLSConfig,
 		ExpectContinueTimeout: 5 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
 	}
 }


### PR DESCRIPTION
## Description
Current cri image pull transport sets dial and tls handshake timeouts, but not a response header timeout. This can leave pulls waiting for minutes when a registry connection is established but the registry server became temporarily unresponsive before sending response. This change adds `ResponseHeaderTimeout` to `DefaultHTTPTransport()`so that this allows the client to fail fast and retry sooner, instead of waiting minutes on a stalled connection.


### fixes: #13006