### PR TITLE
#10681 by-digest `ctr image export` of `org.opencontainers.image.ref.name` 

### DIFF
--- a/core/images/archive/reference.go
+++ b/core/images/archive/reference.go
@@ -91,12 +91,14 @@ func familiarizeReference(ref string) (string, error) {
 }
 
 func ociReferenceName(name string) string {
-	// OCI defines the reference name as only a tag excluding the
+	// OCI suggests the reference name as only a tag excluding the
 	// repository. The containerd annotation contains the full image name
 	// since the tag is insufficient for correctly naming and referring to an
-	// image
+	// image. In the case of a by-digest image referencing only a SHA hash,
+	// the full image name with hash is preferred to match the required
+	// grammar of the OCI spec.
 	var ociRef string
-	if spec, err := reference.Parse(name); err == nil {
+	if spec, err := reference.Parse(name); err == nil && spec.Object != "" && spec.Object[0] != '@' {
 		ociRef = spec.Object
 	} else {
 		ociRef = name

--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -42,7 +42,7 @@ import (
 var (
 	testImage             = images.Get(images.BusyBox)
 	testMultiLayeredImage = images.Get(images.VolumeCopyUp)
-	testImageByDigest = images.Get(images.BusyBoxByDigest)
+	testImageByDigest     = images.Get(images.BusyBoxByDigest)
 	shortCommand          = withProcessArgs("true")
 	// NOTE: The TestContainerPids needs two running processes in one
 	// container. But busybox:1.36 sh shell, the `sleep` is a builtin.

--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -42,6 +42,7 @@ import (
 var (
 	testImage             = images.Get(images.BusyBox)
 	testMultiLayeredImage = images.Get(images.VolumeCopyUp)
+	testImageByDigest = images.Get(images.BusyBoxByDigest)
 	shortCommand          = withProcessArgs("true")
 	// NOTE: The TestContainerPids needs two running processes in one
 	// container. But busybox:1.36 sh shell, the `sleep` is a builtin.

--- a/integration/client/client_windows_test.go
+++ b/integration/client/client_windows_test.go
@@ -22,12 +22,14 @@ import (
 	"path/filepath"
 
 	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/containerd/containerd/v2/integration/images"
 )
 
 var (
 	defaultRoot           = filepath.Join(os.Getenv("programfiles"), "containerd", "root-test")
 	defaultState          = filepath.Join(os.Getenv("programfiles"), "containerd", "state-test")
 	testImage             string
+	testImageByDigest     = images.Get(images.BusyBoxByDigest)
 	testMultiLayeredImage = "ghcr.io/containerd/volume-copy-up:2.1"
 	shortCommand          = withTrue()
 	longCommand           = withProcessArgs("ping", "-t", "localhost")

--- a/integration/client/export_test.go
+++ b/integration/client/export_test.go
@@ -19,6 +19,7 @@ package client
 import (
 	"archive/tar"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -236,6 +237,25 @@ func TestExportAllCases(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "export image setting ocispec.AnnotationRefName",
+			prepare: func(ctx context.Context, t *testing.T, client *Client) images.Image {
+				img, err := client.Fetch(ctx, testImageByDigest)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return img
+			},
+			check: func(ctx context.Context, t *testing.T, client *Client, dstFile *os.File, img images.Image) {
+				err := client.Export(ctx, dstFile, archive.WithImage(client.ImageService(), testImageByDigest), archive.WithPlatform(platforms.All))
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				dstFile.Seek(0, 0)
+				assertOCIIndexAnnotationRefName(t, dstFile, img.Name)
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -358,5 +378,41 @@ func assertOCITar(t *testing.T, r io.Reader, docker bool) {
 		t.Error("manifest.json not found")
 	} else if !docker && foundManifestJSON {
 		t.Error("manifest.json found")
+	}
+}
+
+func assertOCIIndexAnnotationRefName(t *testing.T, r io.Reader, imageName string) {
+	t.Helper()
+	tr := tar.NewReader(r)
+	foundIndexJSON := false
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if h.Name == ocispec.ImageIndexFile {
+			foundIndexJSON = true
+			var idx ocispec.Index
+			if err := json.NewDecoder(tr).Decode(&idx); err != nil {
+				t.Fatal(err)
+			}
+			for _, m := range idx.Manifests {
+				if m.Annotations == nil {
+					t.Errorf("manifest does not have %s annotation", ocispec.AnnotationRefName)
+				} else if ref, ok := m.Annotations[ocispec.AnnotationRefName]; !ok {
+					t.Errorf("manifest does not have %s annotation", ocispec.AnnotationRefName)
+				} else if !OCIAnnotationRegex.MatchString(ref) {
+					t.Errorf("manifest annotation %s=%q does not match required grammar", ocispec.AnnotationRefName, ref)
+				}
+			}
+
+			break
+		}
+	}
+	if !foundIndexJSON {
+		t.Error("index.json not found")
 	}
 }

--- a/integration/client/export_test.go
+++ b/integration/client/export_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"slices"
 	"strings"
@@ -247,13 +248,14 @@ func TestExportAllCases(t *testing.T) {
 				return img
 			},
 			check: func(ctx context.Context, t *testing.T, client *Client, dstFile *os.File, img images.Image) {
-				err := client.Export(ctx, dstFile, archive.WithImage(client.ImageService(), testImageByDigest), archive.WithPlatform(platforms.All))
-				if err != nil {
+				if err := client.Export(ctx, dstFile, archive.WithImage(client.ImageService(), testImageByDigest), archive.WithPlatform(platforms.All)); err != nil {
 					t.Fatal(err)
 				}
 
-				dstFile.Seek(0, 0)
-				assertOCIIndexAnnotationRefName(t, dstFile, img.Name)
+				if _, err := dstFile.Seek(0, io.SeekStart); err != nil {
+					t.Fatal(err)
+				}
+				assertOCIIndexAnnotationRefName(t, dstFile)
 			},
 		},
 	} {
@@ -381,7 +383,12 @@ func assertOCITar(t *testing.T, r io.Reader, docker bool) {
 	}
 }
 
-func assertOCIIndexAnnotationRefName(t *testing.T, r io.Reader, imageName string) {
+func assertOCIIndexAnnotationRefName(t *testing.T, r io.Reader) {
+
+	// The required grammar of the well-known org.opencontainer.image.ref.name annotation as specified at
+	// https://github.com/opencontainers/image-spec/blob/v1.1.1/annotations.md#pre-defined-annotation-keys
+	var ociImageRefNameRegex = regexp.MustCompile(`^[A-Za-z0-9]+(?:(?:[-._:@+]|--)[A-Za-z0-9]+)*(?:/[A-Za-z0-9]+(?:(?:[-._:@+]|--)[A-Za-z0-9]+)*)*$`)
+
 	t.Helper()
 	tr := tar.NewReader(r)
 	foundIndexJSON := false
@@ -399,12 +406,13 @@ func assertOCIIndexAnnotationRefName(t *testing.T, r io.Reader, imageName string
 			if err := json.NewDecoder(tr).Decode(&idx); err != nil {
 				t.Fatal(err)
 			}
+			if len(idx.Manifests) == 0 {
+				t.Error("index contains no manifests to verify")
+			}
 			for _, m := range idx.Manifests {
-				if m.Annotations == nil {
+				if ref, ok := m.Annotations[ocispec.AnnotationRefName]; !ok {
 					t.Errorf("manifest does not have %s annotation", ocispec.AnnotationRefName)
-				} else if ref, ok := m.Annotations[ocispec.AnnotationRefName]; !ok {
-					t.Errorf("manifest does not have %s annotation", ocispec.AnnotationRefName)
-				} else if !OCIAnnotationRegex.MatchString(ref) {
+				} else if !ociImageRefNameRegex.MatchString(ref) {
 					t.Errorf("manifest annotation %s=%q does not match required grammar", ocispec.AnnotationRefName, ref)
 				}
 			}

--- a/integration/client/helpers_unix_test.go
+++ b/integration/client/helpers_unix_test.go
@@ -21,7 +21,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"regexp"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/cio"
@@ -30,8 +29,6 @@ import (
 )
 
 const newLine = "\n"
-
-var OCIAnnotationRegex = regexp.MustCompile(`^[A-Za-z0-9]+(?:(?:[-._:@+]|--)[A-Za-z0-9]+)*(?:/[A-Za-z0-9]+(?:(?:[-._:@+]|--)[A-Za-z0-9]+)*)*$`)
 
 func withExitStatus(es int) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {

--- a/integration/client/helpers_unix_test.go
+++ b/integration/client/helpers_unix_test.go
@@ -21,6 +21,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/cio"
@@ -29,6 +30,8 @@ import (
 )
 
 const newLine = "\n"
+
+var OCIAnnotationRegex = regexp.MustCompile(`^[A-Za-z0-9]+(?:(?:[-._:@+]|--)[A-Za-z0-9]+)*(?:/[A-Za-z0-9]+(?:(?:[-._:@+]|--)[A-Za-z0-9]+)*)*$`)
 
 func withExitStatus(es int) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {

--- a/integration/images/image_list.go
+++ b/integration/images/image_list.go
@@ -32,6 +32,7 @@ var imageListFile = flag.String("image-list", "", "The TOML file containing the 
 type ImageList struct {
 	Alpine           string
 	BusyBox          string
+	BusyBoxByDigest  string
 	Pause            string
 	ResourceConsumer string
 	VolumeCopyUp     string
@@ -52,6 +53,7 @@ func initImages(imageListFile string) {
 	imageList = ImageList{
 		Alpine:           "ghcr.io/containerd/alpine:3.14.0",
 		BusyBox:          "ghcr.io/containerd/busybox:1.36",
+		BusyBoxByDigest:  "ghcr.io/containerd/busybox@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c",
 		Pause:            "registry.k8s.io/pause:3.10.2",
 		ResourceConsumer: "registry.k8s.io/e2e-test-images/resource-consumer:1.10",
 		VolumeCopyUp:     "ghcr.io/containerd/volume-copy-up:2.2",
@@ -86,6 +88,8 @@ const (
 	Alpine
 	// BusyBox image
 	BusyBox
+	// BusyBox by digest
+	BusyBoxByDigest
 	// Pause image
 	Pause
 	// ResourceConsumer image
@@ -106,6 +110,7 @@ func initImageMap(imageList ImageList) map[int]string {
 	images := map[int]string{}
 	images[Alpine] = imageList.Alpine
 	images[BusyBox] = imageList.BusyBox
+	images[BusyBoxByDigest] = imageList.BusyBoxByDigest
 	images[Pause] = imageList.Pause
 	images[ResourceConsumer] = imageList.ResourceConsumer
 	images[VolumeCopyUp] = imageList.VolumeCopyUp


### PR DESCRIPTION
Fixes #10681 

Adds an integration test and fixes the issue where `ctr image export`s for images by digest had a non-valid grammar set in their `org.opencontainers.image.ref.name` field in their index.json.

The way I chose to handle this is so that if an export is called for something that has only a sha256 digest, it will return the full name (as requested in the issue), but that in all other cases it stays the same (which in general would mean that this would refer to the image's `tag`, or the `tag@sha256:<hash>`.  (see examples below)

Alternatively, I could change it to always prefer the full name in all of those cases, which is implied to be requested in the issue, if we don't like this. However, if we want to discuss that please check the Implementer's Note at the [index.json spec in OCI image-spec](https://github.com/opencontainers/image-spec/blob/84ee56daf3cd7d93658737412d5e4d9b1c2d7b16/image-layout.md#indexjson-file), which to me makes it seem like it may be beneficial to leave this as the tag as often as possible.

PS: I spent some time writing tests against import since the ociAnnotationRef function is used there, but its only in a specific case (docker image layouts) and it seems to not work (or at least not be very testable with the test harness for import we have).

Current behavior / bad
```bash
# digest only (the bad one!)
laura@k8s-dev-station:~/go/src/containerd$ ctr image export - docker.io/library/python@sha256:4651409ff55024245f70920259ecee27f2109b0dc0e502a10bce541f1072cd66 | tar -x --to-stdout index.json | jq "[.manifests[0].annotations]"
[
  {
    "containerd.io/distribution.source.docker.io": "library/python",
    "io.containerd.image.name": "docker.io/library/python@sha256:4651409ff55024245f70920259ecee27f2109b0dc0e502a10bce541f1072cd66",
    "org.opencontainers.image.ref.name": "@sha256:4651409ff55024245f70920259ecee27f2109b0dc0e502a10bce541f1072cd66"
  }
]

# tag only
laura@k8s-dev-station:~/go/src/containerd$ ctr image export -  docker.io/library/python:latest | tar -x --to-stdout index.json | jq "[.manifests[0].annotations]"
[
  {
    "containerd.io/distribution.source.docker.io": "library/python",
    "io.containerd.image.name": "docker.io/library/python:latest",
    "org.opencontainers.image.ref.name": "latest"
  }
]
# tag and digest
laura@k8s-dev-station:~/go/src/containerd$ ctr image export - docker.io/library/python:3.13.13-slim@sha256:f96eb0214ceab47efc2558b8351888ca01acf6193f4050ee7594c8250516cc8b | tar -x --to-stdout index.json | jq "[.manifests[0].annotations]"
[
  {
    "containerd.io/distribution.source.docker.io": "library/python",
    "io.containerd.image.name": "docker.io/library/python:3.13.13-slim@sha256:f96eb0214ceab47efc2558b8351888ca01acf6193f4050ee7594c8250516cc8b",
    "org.opencontainers.image.ref.name": "3.13.13-slim@sha256:f96eb0214ceab47efc2558b8351888ca01acf6193f4050ee7594c8250516cc8b"
  }
]
```

Behavior in this PR / good

```bash
# digest only (different now!)
laura@k8s-dev-station:~/go/src/containerd$ ctr image export - docker.io/library/python@sha256:4651409ff55024245f70920259ecee27f2109b0dc0e502a10bce541f1072cd66 | tar -x --to-stdout index.json | jq "[.manifests[0].annotations]"
[
  {
    "containerd.io/distribution.source.docker.io": "library/python",
    "io.containerd.image.name": "docker.io/library/python@sha256:4651409ff55024245f70920259ecee27f2109b0dc0e502a10bce541f1072cd66",
    "org.opencontainers.image.ref.name": "docker.io/library/python@sha256:4651409ff55024245f70920259ecee27f2109b0dc0e502a10bce541f1072cd66"
  }
]

# tag only (same)
laura@k8s-dev-station:~/go/src/containerd$ ctr image export -  docker.io/library/python:latest | tar -x --to-stdout index.json | jq "[.manifests[0].annotations]"
[
  {
    "containerd.io/distribution.source.docker.io": "library/python",
    "io.containerd.image.name": "docker.io/library/python:latest",
    "org.opencontainers.image.ref.name": "latest"
  }
]

# tag and digest (same)
laura@k8s-dev-station:~/go/src/containerd$ ctr image export - docker.io/library/python:3.13.13-slim@sha256:f96eb0214ceab47efc2558b8351888ca01acf6193f4050ee7594c8250516cc8b | tar -x --to-stdout index.json | jq "[.manifests[0].annotations]"
[
  {
    "containerd.io/distribution.source.docker.io": "library/python",
    "io.containerd.image.name": "docker.io/library/python:3.13.13-slim@sha256:f96eb0214ceab47efc2558b8351888ca01acf6193f4050ee7594c8250516cc8b",
    "org.opencontainers.image.ref.name": "3.13.13-slim@sha256:f96eb0214ceab47efc2558b8351888ca01acf6193f4050ee7594c8250516cc8b"
  }
]
```

```release-note
Fix generation of `org.opencontainers.image.ref.name` annotations for digest based image exports
```