### PR TITLE
cri: add shutdown function for nri

### DIFF
--- a/internal/cri/nri/nri_api_linux.go
+++ b/internal/cri/nri/nri_api_linux.go
@@ -70,6 +70,14 @@ func (a *API) Register() error {
 	return a.nri.Start()
 }
 
+func (a *API) Stop() {
+	if a.IsDisabled() {
+		return
+	}
+
+	a.nri.Stop()
+}
+
 //
 // CRI-NRI lifecycle hook interface
 //

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -351,6 +351,10 @@ func (c *criService) Run(ready func()) error {
 // TODO(random-liu): Make close synchronous.
 func (c *criService) Close() error {
 	log.L.Info("Stop CRI service")
+
+	//stop nri
+	c.nri.Stop()
+
 	for name, h := range c.cniNetConfMonitor {
 		if err := h.stop(); err != nil {
 			log.L.WithError(err).Errorf("failed to stop cni network conf monitor for %s", name)

--- a/internal/nri/nri.go
+++ b/internal/nri/nri.go
@@ -163,8 +163,10 @@ func (l *local) Stop() {
 	l.Lock()
 	defer l.Unlock()
 
-	l.nri.Stop()
-	l.nri = nil
+	if l.nri != nil {
+		l.nri.Stop()
+		l.nri = nil
+	}
 }
 
 func (l *local) RunPodSandbox(ctx context.Context, pod PodSandbox) error {

--- a/vendor/github.com/containerd/nri/pkg/adaptation/adaptation.go
+++ b/vendor/github.com/containerd/nri/pkg/adaptation/adaptation.go
@@ -175,6 +175,7 @@ func (r *Adaptation) Stop() {
 	r.Lock()
 	defer r.Unlock()
 
+	r.shutdownPlugins()
 	r.stopListener()
 	r.stopPlugins()
 }
@@ -381,6 +382,15 @@ func (r *Adaptation) startPlugins() (retErr error) {
 	r.plugins = plugins
 	r.sortPlugins()
 	return nil
+}
+
+// Shutdown plugins
+func (r *Adaptation) shutdownPlugins() {
+	log.Infof(noCtx, "shutdowning plugins...")
+
+	for _, p := range r.plugins {
+		p.stub.Shutdown(context.Background(), &api.Empty{})
+	}
 }
 
 // Stop plugins.


### PR DESCRIPTION
The current version does not support the Shutdown interface of NRI. Therefore, when the cri exits, the Shutdown function is called first, and then the process of handling the link closure is carried out. This way, the NRI plugin has the opportunity to handle the situation before the connection is closed, rather than the NRI plugin exiting directly as soon as containerd exits.