### PR TITLE
Temporarily disable uploading logs to GCP for windows periodic tests until GCP credentials are renewed

### DIFF
--- a/.github/workflows/windows-hyperv-periodic-trigger.yml
+++ b/.github/workflows/windows-hyperv-periodic-trigger.yml
@@ -13,10 +13,8 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
 
   triggerWinIntegration:
-    # NOTE: the following permissions are required by `google-github-actions/auth`:
     permissions:
       contents: 'read'
-      id-token: 'write'
     if: github.repository == 'containerd/containerd'
     # NOTE(aznashwan, 11/24/21): GitHub actions do not currently support referencing
     # or evaluating any kind of variables in the `uses` clause, but this will
@@ -28,5 +26,3 @@ jobs:
     secrets:
       AZURE_SUB_ID: "${{ secrets.AZURE_SUB_ID }}"
       AZURE_CREDS: "${{ secrets.AZURE_CREDS }}"
-      GCP_SERVICE_ACCOUNT: "${{ secrets.GCP_SERVICE_ACCOUNT }}"
-      GCP_WORKLOAD_IDENTITY_PROVIDER: "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}"

--- a/.github/workflows/windows-hyperv-periodic.yml
+++ b/.github/workflows/windows-hyperv-periodic.yml
@@ -10,10 +10,6 @@ on:
         required: true
       AZURE_CREDS:
         required: true
-      GCP_SERVICE_ACCOUNT:
-        required: true
-      GCP_WORKLOAD_IDENTITY_PROVIDER:
-        required: true
 
 env:
   AZURE_DEFAULT_LOCATION: westeurope
@@ -33,10 +29,8 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   winIntegration:
-    # NOTE: the following permissions are required by `google-github-actions/auth`:
     permissions:
       contents: 'read'
-      id-token: 'write'
     strategy:
       # NOTE(aznashwan): this will permit all other jobs from the matrix to finish and
       # upload their results even if one has a failing non-test-task:
@@ -48,7 +42,6 @@ jobs:
         - win_ver: ltsc2022
           AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:latest"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2022-${{ github.run_id }}
-          GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2022-hyperv/"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -289,40 +282,6 @@ jobs:
               xmlstarlet ed -d "/testsuites/testsuite/properties" $f > ${{ env.LOGS_DIR }}/$(basename $f)
               mv ${{ env.LOGS_DIR }}/$(basename $f) $f
           done
-
-      - name: FinishJob
-        run: |
-          jq -n --arg result SUCCESS --arg timestamp $(date +%s) '$timestamp|tonumber|{timestamp:.,$result}' > ${{ env.LOGS_DIR }}/finished.json
-          echo "${{ env.STARTED_TIME }}" > ${{ github.workspace }}/latest-build.txt
-
-      - name: AssignGcpCreds
-        id: AssignGcpCreds
-        run: |
-          echo 'GCP_SERVICE_ACCOUNT=${{ secrets.GCP_SERVICE_ACCOUNT }}' >> $GITHUB_OUTPUT
-          echo 'GCP_WORKLOAD_IDENTITY_PROVIDER=${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}' >> $GITHUB_OUTPUT
-
-      - name: AuthGcp
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        if: steps.AssignGcpCreds.outputs.GCP_SERVICE_ACCOUNT && steps.AssignGcpCreds.outputs.GCP_WORKLOAD_IDENTITY_PROVIDER
-        with:
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-
-      - name: UploadJobReport
-        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
-        if: steps.AssignGcpCreds.outputs.GCP_SERVICE_ACCOUNT && steps.AssignGcpCreds.outputs.GCP_WORKLOAD_IDENTITY_PROVIDER
-        with:
-          path: ${{ github.workspace }}/latest-build.txt
-          destination: ${{ matrix.GOOGLE_BUCKET }}
-          parent: false
-
-      - name: UploadLogsDir
-        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
-        if: steps.AssignGcpCreds.outputs.GCP_SERVICE_ACCOUNT && steps.AssignGcpCreds.outputs.GCP_WORKLOAD_IDENTITY_PROVIDER
-        with:
-          path: ${{ env.LOGS_DIR }}
-          destination: ${{ matrix.GOOGLE_BUCKET }}${{ env.STARTED_TIME}}
-          parent: false
 
       - name: Check all CI stages succeeded
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/windows-periodic-trigger.yml
+++ b/.github/workflows/windows-periodic-trigger.yml
@@ -13,10 +13,8 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
 
   triggerWinIntegration:
-    # NOTE: the following permissions are required by `google-github-actions/auth`:
     permissions:
       contents: 'read'
-      id-token: 'write'
     if: github.repository == 'containerd/containerd'
     # NOTE(aznashwan, 11/24/21): GitHub actions do not currently support referencing
     # or evaluating any kind of variables in the `uses` clause, but this will
@@ -28,5 +26,3 @@ jobs:
     secrets:
       AZURE_SUB_ID: "${{ secrets.AZURE_SUB_ID }}"
       AZURE_CREDS: "${{ secrets.AZURE_CREDS }}"
-      GCP_SERVICE_ACCOUNT: "${{ secrets.GCP_SERVICE_ACCOUNT }}"
-      GCP_WORKLOAD_IDENTITY_PROVIDER: "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}"

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -10,10 +10,6 @@ on:
         required: true
       AZURE_CREDS:
         required: true
-      GCP_SERVICE_ACCOUNT:
-        required: true
-      GCP_WORKLOAD_IDENTITY_PROVIDER:
-        required: true
 
 env:
   AZURE_DEFAULT_LOCATION: westeurope
@@ -32,10 +28,8 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   winIntegration:
-    # NOTE: the following permissions are required by `google-github-actions/auth`:
     permissions:
       contents: 'read'
-      id-token: 'write'
     strategy:
       # NOTE(aznashwan): this will permit all other jobs from the matrix to finish and
       # upload their results even if one has a failing non-test-task:
@@ -47,7 +41,6 @@ jobs:
         - win_ver: ltsc2022
           AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:latest"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2022-${{ github.run_id }}
-          GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2022/"
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -239,40 +232,6 @@ jobs:
               xmlstarlet ed -d "/testsuites/testsuite/properties" $f > ${{ env.LOGS_DIR }}/$(basename $f)
               mv ${{ env.LOGS_DIR }}/$(basename $f) $f
           done
-
-      - name: FinishJob
-        run: |
-          jq -n --arg result SUCCESS --arg timestamp $(date +%s) '$timestamp|tonumber|{timestamp:.,$result}' > ${{ env.LOGS_DIR }}/finished.json
-          echo "${{ env.STARTED_TIME }}" > ${{ github.workspace }}/latest-build.txt
-
-      - name: AssignGcpCreds
-        id: AssignGcpCreds
-        run: |
-          echo 'GCP_SERVICE_ACCOUNT=${{ secrets.GCP_SERVICE_ACCOUNT }}' >> $GITHUB_OUTPUT
-          echo 'GCP_WORKLOAD_IDENTITY_PROVIDER=${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}' >> $GITHUB_OUTPUT
-
-      - name: AuthGcp
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        if: steps.AssignGcpCreds.outputs.GCP_SERVICE_ACCOUNT && steps.AssignGcpCreds.outputs.GCP_WORKLOAD_IDENTITY_PROVIDER
-        with:
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-
-      - name: UploadJobReport
-        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
-        if: steps.AssignGcpCreds.outputs.GCP_SERVICE_ACCOUNT && steps.AssignGcpCreds.outputs.GCP_WORKLOAD_IDENTITY_PROVIDER
-        with:
-          path: ${{ github.workspace }}/latest-build.txt
-          destination: ${{ matrix.GOOGLE_BUCKET }}
-          parent: false
-
-      - name: UploadLogsDir
-        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
-        if: steps.AssignGcpCreds.outputs.GCP_SERVICE_ACCOUNT && steps.AssignGcpCreds.outputs.GCP_WORKLOAD_IDENTITY_PROVIDER
-        with:
-          path: ${{ env.LOGS_DIR }}
-          destination: ${{ matrix.GOOGLE_BUCKET }}${{ env.STARTED_TIME}}
-          parent: false
 
       - name: Check all CI stages succeeded
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
Windows Periodic tests CI fails with error:
 Uploading /home/runner/work/containerd/containerd/latest-build.txt to gs://containerd-integration/logs/windows-ltsc2022/latest-build.txt
  (node:3615) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
  Error: google-github-actions/upload-cloud-storage failed with: not found; Gaia id not found for email ***

The GCP account was created by cloudbase through https://github.com/containerd/containerd/pull/6397#issuecomment-1008695286
But engineer who created GCP account does not have access to GCP account now.
It seems the results are pushed to google account for TestGrid as part of the Kubernetes SIG-Windows CI signal
windows workflow logs are uploaded to GCS and then read by TestGrid → displayed at [testgrid.k8s.io/sig-windows-containerd-runtime-signal](http://testgrid.k8s.io/sig-windows-containerd-runtime-signal)

Temporarily disable upload to GCP for windows periodic tests until we find a way to renew GCP credentials.