### PR TITLE
cri: add streaming RPCs

### DIFF
--- a/internal/cri/instrument/instrumented_service.go
+++ b/internal/cri/instrument/instrumented_service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/log"
+	"google.golang.org/grpc"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/pkg/tracing"
@@ -676,4 +677,128 @@ func (in *instrumentedService) UpdatePodSandboxResources(ctx context.Context, r 
 	}()
 	res, err = in.c.UpdatePodSandboxResources(ctrdutil.WithNamespace(ctx), r)
 	return res, errgrpc.ToGRPC(err)
+}
+
+// withNamespaceContext wraps a server streaming server to inject the
+// containerd namespace into its context, matching the unary method pattern.
+func withNamespaceContext[Res any](s grpc.ServerStreamingServer[Res]) grpc.ServerStreamingServer[Res] {
+	return &wrappedServerStreamingServer[Res]{
+		ServerStreamingServer: s,
+		ctx:                   ctrdutil.WithNamespace(s.Context()),
+	}
+}
+
+type wrappedServerStreamingServer[Res any] struct {
+	grpc.ServerStreamingServer[Res]
+	ctx context.Context
+}
+
+func (w *wrappedServerStreamingServer[Res]) Context() context.Context {
+	return w.ctx
+}
+
+func (in *instrumentedService) StreamContainers(r *runtime.StreamContainersRequest, s grpc.ServerStreamingServer[runtime.StreamContainersResponse]) (err error) {
+	if err := in.checkInitialized(); err != nil {
+		return err
+	}
+	ctx := s.Context()
+	log.G(ctx).Tracef("StreamContainers with filter %+v", r.GetFilter())
+	defer func() {
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("StreamContainers with filter %+v failed", r.GetFilter())
+		} else {
+			log.G(ctx).Tracef("StreamContainers returns successfully")
+		}
+	}()
+	err = in.c.StreamContainers(r, withNamespaceContext(s))
+	return errgrpc.ToGRPC(err)
+}
+
+func (in *instrumentedService) StreamPodSandboxes(r *runtime.StreamPodSandboxesRequest, s grpc.ServerStreamingServer[runtime.StreamPodSandboxesResponse]) (err error) {
+	if err := in.checkInitialized(); err != nil {
+		return err
+	}
+	ctx := s.Context()
+	log.G(ctx).Tracef("StreamPodSandboxes with filter %+v", r.GetFilter())
+	defer func() {
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("StreamPodSandboxes with filter %+v failed", r.GetFilter())
+		} else {
+			log.G(ctx).Tracef("StreamPodSandboxes returns successfully")
+		}
+	}()
+	err = in.c.StreamPodSandboxes(r, withNamespaceContext(s))
+	return errgrpc.ToGRPC(err)
+}
+
+func (in *instrumentedService) StreamContainerStats(r *runtime.StreamContainerStatsRequest, s grpc.ServerStreamingServer[runtime.StreamContainerStatsResponse]) (err error) {
+	if err := in.checkInitialized(); err != nil {
+		return err
+	}
+	ctx := s.Context()
+	log.G(ctx).Tracef("StreamContainerStats with filter %+v", r.GetFilter())
+	defer func() {
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("StreamContainerStats with filter %+v failed", r.GetFilter())
+		} else {
+			log.G(ctx).Tracef("StreamContainerStats returns successfully")
+		}
+	}()
+	err = in.c.StreamContainerStats(r, withNamespaceContext(s))
+	return errgrpc.ToGRPC(err)
+}
+
+func (in *instrumentedService) StreamPodSandboxStats(r *runtime.StreamPodSandboxStatsRequest, s grpc.ServerStreamingServer[runtime.StreamPodSandboxStatsResponse]) (err error) {
+	if err := in.checkInitialized(); err != nil {
+		return err
+	}
+	ctx := s.Context()
+	log.G(ctx).Tracef("StreamPodSandboxStats with filter %+v", r.GetFilter())
+	defer func() {
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("StreamPodSandboxStats with filter %+v failed", r.GetFilter())
+		} else {
+			log.G(ctx).Tracef("StreamPodSandboxStats returns successfully")
+		}
+	}()
+	err = in.c.StreamPodSandboxStats(r, withNamespaceContext(s))
+	return errgrpc.ToGRPC(err)
+}
+
+func (in *instrumentedService) StreamPodSandboxMetrics(r *runtime.StreamPodSandboxMetricsRequest, s grpc.ServerStreamingServer[runtime.StreamPodSandboxMetricsResponse]) (err error) {
+	if err := in.checkInitialized(); err != nil {
+		return err
+	}
+	ctx := s.Context()
+	log.G(ctx).Tracef("StreamPodSandboxMetrics")
+	defer func() {
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("StreamPodSandboxMetrics failed")
+		} else {
+			log.G(ctx).Tracef("StreamPodSandboxMetrics returns successfully")
+		}
+	}()
+	err = in.c.StreamPodSandboxMetrics(r, withNamespaceContext(s))
+	return errgrpc.ToGRPC(err)
+}
+
+func (in *instrumentedService) StreamImages(r *runtime.StreamImagesRequest, s grpc.ServerStreamingServer[runtime.StreamImagesResponse]) (err error) {
+	if err := in.checkInitialized(); err != nil {
+		return err
+	}
+	ctx := s.Context()
+	log.G(ctx).Tracef("StreamImages with filter %+v", r.GetFilter())
+	defer func() {
+		if err != nil {
+			err = ctrdutil.SanitizeError(err)
+			log.G(ctx).WithError(err).Errorf("StreamImages with filter %+v failed", r.GetFilter())
+		} else {
+			log.G(ctx).Tracef("StreamImages returns successfully")
+		}
+	}()
+	err = in.c.StreamImages(r, withNamespaceContext(s))
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
+	return errgrpc.ToGRPC(err)
 }

--- a/internal/cri/server/container_stats_stream.go
+++ b/internal/cri/server/container_stats_stream.go
@@ -1,0 +1,44 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criutil "github.com/containerd/containerd/v2/internal/cri/util"
+)
+
+// StreamContainerStats streams stats of all containers matching the filter.
+func (c *criService) StreamContainerStats(r *runtime.StreamContainerStatsRequest, s grpc.ServerStreamingServer[runtime.StreamContainerStatsResponse]) error {
+	ctx := s.Context()
+	listReq := &runtime.ListContainerStatsRequest{
+		Filter: r.GetFilter(),
+	}
+	css, err := c.listContainerStats(ctx, listReq)
+	if err != nil {
+		return fmt.Errorf("failed to fetch containers and stats: %w", err)
+	}
+
+	resp := c.toCRIContainerStats(css)
+
+	return criutil.SendInBatches(ctx, resp.Stats, criutil.DefaultStreamBatchSize, func(batch []*runtime.ContainerStats) error {
+		return s.Send(&runtime.StreamContainerStatsResponse{ContainerStats: batch})
+	})
+}

--- a/internal/cri/server/container_stats_stream_test.go
+++ b/internal/cri/server/container_stats_stream_test.go
@@ -1,0 +1,283 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	goruntime "runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	tasks "github.com/containerd/containerd/api/services/tasks/v1"
+	"github.com/containerd/containerd/api/types"
+	containerd "github.com/containerd/containerd/v2/client"
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+)
+
+// fakeTasksClient implements tasks.TasksClient for testing.
+type fakeTasksClient struct {
+	metricsResp *tasks.MetricsResponse
+	metricsErr  error
+}
+
+func (f *fakeTasksClient) Metrics(_ context.Context, _ *tasks.MetricsRequest, _ ...grpc.CallOption) (*tasks.MetricsResponse, error) {
+	if f.metricsErr != nil {
+		return nil, f.metricsErr
+	}
+	if f.metricsResp != nil {
+		return f.metricsResp, nil
+	}
+	return &tasks.MetricsResponse{}, nil
+}
+
+func (f *fakeTasksClient) Create(context.Context, *tasks.CreateTaskRequest, ...grpc.CallOption) (*tasks.CreateTaskResponse, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) Start(context.Context, *tasks.StartRequest, ...grpc.CallOption) (*tasks.StartResponse, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) Delete(context.Context, *tasks.DeleteTaskRequest, ...grpc.CallOption) (*tasks.DeleteResponse, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) DeleteProcess(context.Context, *tasks.DeleteProcessRequest, ...grpc.CallOption) (*tasks.DeleteResponse, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) Get(context.Context, *tasks.GetRequest, ...grpc.CallOption) (*tasks.GetResponse, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) List(context.Context, *tasks.ListTasksRequest, ...grpc.CallOption) (*tasks.ListTasksResponse, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) Kill(context.Context, *tasks.KillRequest, ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) Exec(context.Context, *tasks.ExecProcessRequest, ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) ResizePty(context.Context, *tasks.ResizePtyRequest, ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) CloseIO(context.Context, *tasks.CloseIORequest, ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) Pause(context.Context, *tasks.PauseTaskRequest, ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) Resume(context.Context, *tasks.ResumeTaskRequest, ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) ListPids(context.Context, *tasks.ListPidsRequest, ...grpc.CallOption) (*tasks.ListPidsResponse, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) Checkpoint(context.Context, *tasks.CheckpointTaskRequest, ...grpc.CallOption) (*tasks.CheckpointTaskResponse, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) Update(context.Context, *tasks.UpdateTaskRequest, ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+func (f *fakeTasksClient) Wait(context.Context, *tasks.WaitRequest, ...grpc.CallOption) (*tasks.WaitResponse, error) {
+	return nil, nil
+}
+
+// newTestCRIServiceWithClient creates a test criService with a containerd client
+// backed by the given mock task service.
+func newTestCRIServiceWithClient(taskSvc tasks.TasksClient) *criService {
+	c := newTestCRIService()
+	cli, err := containerd.New("",
+		containerd.WithServices(
+			containerd.WithTaskClient(taskSvc),
+		),
+	)
+	if err != nil {
+		panic(err)
+	}
+	c.client = cli
+	return c
+}
+
+func TestStreamContainerStatsEmpty(t *testing.T) {
+	if goruntime.GOOS == "darwin" {
+		t.Skip("not implemented on Darwin")
+	}
+
+	c := newTestCRIServiceWithClient(&fakeTasksClient{})
+
+	stream := newFakeStreamServer[runtime.StreamContainerStatsResponse](context.Background())
+	err := c.StreamContainerStats(&runtime.StreamContainerStatsRequest{}, stream)
+	assert.NoError(t, err)
+	assert.Empty(t, stream.sent, "no messages should be sent for empty store")
+}
+
+func TestStreamContainerStatsWithMetrics(t *testing.T) {
+	if goruntime.GOOS == "darwin" {
+		t.Skip("not implemented on Darwin")
+	}
+
+	createdAt := time.Now().UnixNano()
+	sb := sandboxstore.NewSandbox(
+		sandboxstore.Metadata{
+			ID:             "s-1",
+			Name:           "sandbox-1",
+			Config:         &runtime.PodSandboxConfig{Metadata: &runtime.PodSandboxMetadata{Name: "pod-1"}},
+			RuntimeHandler: "runc",
+		},
+		sandboxstore.Status{
+			State: sandboxstore.StateReady,
+		},
+	)
+	sb.Sandboxer = "shim"
+	container, err := containerstore.NewContainer(
+		containerstore.Metadata{
+			ID:        "c-1",
+			Name:      "container-1",
+			SandboxID: "s-1",
+			Config: &runtime.ContainerConfig{
+				Metadata: &runtime.ContainerMetadata{Name: "container-1"},
+			},
+		},
+		containerstore.WithFakeStatus(containerstore.Status{
+			CreatedAt: createdAt,
+			StartedAt: createdAt,
+		}),
+	)
+	require.NoError(t, err)
+
+	taskSvc := &fakeTasksClient{
+		metricsResp: &tasks.MetricsResponse{
+			Metrics: []*types.Metric{
+				{
+					ID:   "c-1",
+					Data: platformBasedMetricsData(t),
+				},
+			},
+		},
+	}
+
+	c := newTestCRIServiceWithClient(taskSvc)
+	require.NoError(t, c.sandboxStore.Add(sb))
+	require.NoError(t, c.containerStore.Add(container))
+
+	stream := newFakeStreamServer[runtime.StreamContainerStatsResponse](context.Background())
+	err = c.StreamContainerStats(&runtime.StreamContainerStatsRequest{}, stream)
+	assert.NoError(t, err)
+	require.NotEmpty(t, stream.sent)
+
+	var stats []*runtime.ContainerStats
+	for _, resp := range stream.sent {
+		stats = append(stats, resp.ContainerStats...)
+	}
+	require.Len(t, stats, 1)
+	assert.Equal(t, "c-1", stats[0].Attributes.Id)
+}
+
+func TestStreamContainerStatsWithFilter(t *testing.T) {
+	if goruntime.GOOS == "darwin" {
+		t.Skip("not implemented on Darwin")
+	}
+
+	createdAt := time.Now().UnixNano()
+	sb := sandboxstore.NewSandbox(
+		sandboxstore.Metadata{
+			ID:             "s-1",
+			Name:           "sandbox-1",
+			Config:         &runtime.PodSandboxConfig{Metadata: &runtime.PodSandboxMetadata{Name: "pod-1"}},
+			RuntimeHandler: "runc",
+		},
+		sandboxstore.Status{
+			State: sandboxstore.StateReady,
+		},
+	)
+	sb.Sandboxer = "shim"
+
+	containers := []containerstore.Metadata{
+		{
+			ID:        "c-1",
+			Name:      "container-1",
+			SandboxID: "s-1",
+			Config: &runtime.ContainerConfig{
+				Metadata: &runtime.ContainerMetadata{Name: "container-1"},
+				Labels:   map[string]string{"app": "web"},
+			},
+		},
+		{
+			ID:        "c-2",
+			Name:      "container-2",
+			SandboxID: "s-1",
+			Config: &runtime.ContainerConfig{
+				Metadata: &runtime.ContainerMetadata{Name: "container-2"},
+				Labels:   map[string]string{"app": "db"},
+			},
+		},
+	}
+
+	taskSvc := &fakeTasksClient{
+		metricsResp: &tasks.MetricsResponse{
+			Metrics: []*types.Metric{
+				{ID: "c-1", Data: platformBasedMetricsData(t)},
+			},
+		},
+	}
+
+	c := newTestCRIServiceWithClient(taskSvc)
+	require.NoError(t, c.sandboxStore.Add(sb))
+	for _, meta := range containers {
+		cntr, err := containerstore.NewContainer(meta, containerstore.WithFakeStatus(containerstore.Status{
+			CreatedAt: createdAt,
+			StartedAt: createdAt,
+		}))
+		require.NoError(t, err)
+		require.NoError(t, c.containerStore.Add(cntr))
+	}
+
+	// Filter by container ID — should only return c-1
+	stream := newFakeStreamServer[runtime.StreamContainerStatsResponse](context.Background())
+	err := c.StreamContainerStats(&runtime.StreamContainerStatsRequest{
+		Filter: &runtime.ContainerStatsFilter{Id: "c-1"},
+	}, stream)
+	assert.NoError(t, err)
+
+	var stats []*runtime.ContainerStats
+	for _, resp := range stream.sent {
+		stats = append(stats, resp.ContainerStats...)
+	}
+	require.Len(t, stats, 1)
+	assert.Equal(t, "c-1", stats[0].Attributes.Id)
+}
+
+func TestStreamContainerStatsMetricsError(t *testing.T) {
+	if goruntime.GOOS == "darwin" {
+		t.Skip("not implemented on Darwin")
+	}
+
+	taskSvc := &fakeTasksClient{
+		metricsErr: assert.AnError,
+	}
+
+	c := newTestCRIServiceWithClient(taskSvc)
+
+	stream := newFakeStreamServer[runtime.StreamContainerStatsResponse](context.Background())
+	err := c.StreamContainerStats(&runtime.StreamContainerStatsRequest{}, stream)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch containers and stats")
+}

--- a/internal/cri/server/container_stream.go
+++ b/internal/cri/server/container_stream.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"time"
+
+	"google.golang.org/grpc"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criutil "github.com/containerd/containerd/v2/internal/cri/util"
+)
+
+// StreamContainers streams all containers matching the filter.
+func (c *criService) StreamContainers(r *runtime.StreamContainersRequest, s grpc.ServerStreamingServer[runtime.StreamContainersResponse]) error {
+	ctx := s.Context()
+	start := time.Now()
+	containersInStore := c.containerStore.List()
+
+	var containers []*runtime.Container
+	for _, container := range containersInStore {
+		containers = append(containers, toCRIContainer(container))
+	}
+
+	containers = c.filterCRIContainers(containers, r.GetFilter())
+
+	err := criutil.SendInBatches(ctx, containers, criutil.DefaultStreamBatchSize, func(batch []*runtime.Container) error {
+		return s.Send(&runtime.StreamContainersResponse{Containers: batch})
+	})
+
+	containerStreamTimer.UpdateSince(start)
+	return err
+}

--- a/internal/cri/server/container_stream_test.go
+++ b/internal/cri/server/container_stream_test.go
@@ -1,0 +1,245 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+)
+
+// fakeStreamServer is a mock grpc.ServerStreamingServer that captures sent messages.
+type fakeStreamServer[Res any] struct {
+	ctx      context.Context
+	sent     []*Res
+	sendErr  error
+	sendHook func(*Res) // optional hook called on each Send
+}
+
+func newFakeStreamServer[Res any](ctx context.Context) *fakeStreamServer[Res] {
+	return &fakeStreamServer[Res]{ctx: ctx}
+}
+
+func (f *fakeStreamServer[Res]) Send(msg *Res) error {
+	if f.sendErr != nil {
+		return f.sendErr
+	}
+	if f.sendHook != nil {
+		f.sendHook(msg)
+	}
+	f.sent = append(f.sent, msg)
+	return nil
+}
+
+func (f *fakeStreamServer[Res]) SetHeader(metadata.MD) error  { return nil }
+func (f *fakeStreamServer[Res]) SendHeader(metadata.MD) error { return nil }
+func (f *fakeStreamServer[Res]) SetTrailer(metadata.MD)       {}
+func (f *fakeStreamServer[Res]) Context() context.Context     { return f.ctx }
+func (f *fakeStreamServer[Res]) SendMsg(any) error            { return nil }
+func (f *fakeStreamServer[Res]) RecvMsg(any) error            { return nil }
+
+func TestStreamContainers(t *testing.T) {
+	c := newTestCRIService()
+	sandboxesInStore := []sandboxstore.Sandbox{
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:     "s-1abcdef1234",
+				Name:   "sandboxname-1",
+				Config: &runtime.PodSandboxConfig{Metadata: &runtime.PodSandboxMetadata{Name: "podname-1"}},
+			},
+			sandboxstore.Status{
+				State: sandboxstore.StateReady,
+			},
+		),
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:     "s-2abcdef1234",
+				Name:   "sandboxname-2",
+				Config: &runtime.PodSandboxConfig{Metadata: &runtime.PodSandboxMetadata{Name: "podname-2"}},
+			},
+			sandboxstore.Status{
+				State: sandboxstore.StateNotReady,
+			},
+		),
+	}
+	createdAt := time.Now().UnixNano()
+	startedAt := time.Now().UnixNano()
+	finishedAt := time.Now().UnixNano()
+	containersInStore := []containerForTest{
+		{
+			metadata: containerstore.Metadata{
+				ID:        "c-1container",
+				Name:      "name-1",
+				SandboxID: "s-1abcdef1234",
+				Config:    &runtime.ContainerConfig{Metadata: &runtime.ContainerMetadata{Name: "name-1"}},
+			},
+			status: containerstore.Status{CreatedAt: createdAt},
+		},
+		{
+			metadata: containerstore.Metadata{
+				ID:        "c-2container",
+				Name:      "name-2",
+				SandboxID: "s-1abcdef1234",
+				Config:    &runtime.ContainerConfig{Metadata: &runtime.ContainerMetadata{Name: "name-2"}},
+			},
+			status: containerstore.Status{
+				CreatedAt: createdAt,
+				StartedAt: startedAt,
+			},
+		},
+		{
+			metadata: containerstore.Metadata{
+				ID:        "c-3container",
+				Name:      "name-3",
+				SandboxID: "s-1abcdef1234",
+				Config:    &runtime.ContainerConfig{Metadata: &runtime.ContainerMetadata{Name: "name-3"}},
+			},
+			status: containerstore.Status{
+				CreatedAt:  createdAt,
+				StartedAt:  startedAt,
+				FinishedAt: finishedAt,
+			},
+		},
+		{
+			metadata: containerstore.Metadata{
+				ID:        "c-4container",
+				Name:      "name-4",
+				SandboxID: "s-2abcdef1234",
+				Config:    &runtime.ContainerConfig{Metadata: &runtime.ContainerMetadata{Name: "name-4"}},
+			},
+			status: containerstore.Status{
+				CreatedAt: createdAt,
+			},
+		},
+	}
+
+	expectedContainers := []*runtime.Container{
+		{
+			Id:           "c-1container",
+			PodSandboxId: "s-1abcdef1234",
+			Metadata:     &runtime.ContainerMetadata{Name: "name-1"},
+			State:        runtime.ContainerState_CONTAINER_CREATED,
+			CreatedAt:    createdAt,
+		},
+		{
+			Id:           "c-2container",
+			PodSandboxId: "s-1abcdef1234",
+			Metadata:     &runtime.ContainerMetadata{Name: "name-2"},
+			State:        runtime.ContainerState_CONTAINER_RUNNING,
+			CreatedAt:    createdAt,
+		},
+		{
+			Id:           "c-3container",
+			PodSandboxId: "s-1abcdef1234",
+			Metadata:     &runtime.ContainerMetadata{Name: "name-3"},
+			State:        runtime.ContainerState_CONTAINER_EXITED,
+			CreatedAt:    createdAt,
+		},
+		{
+			Id:           "c-4container",
+			PodSandboxId: "s-2abcdef1234",
+			Metadata:     &runtime.ContainerMetadata{Name: "name-4"},
+			State:        runtime.ContainerState_CONTAINER_CREATED,
+			CreatedAt:    createdAt,
+		},
+	}
+
+	// Inject test sandbox metadata
+	for _, sb := range sandboxesInStore {
+		assert.NoError(t, c.sandboxStore.Add(sb))
+	}
+
+	// Inject test container metadata
+	for _, cntr := range containersInStore {
+		container, err := cntr.toContainer()
+		assert.NoError(t, err)
+		assert.NoError(t, c.containerStore.Add(container))
+	}
+
+	for _, testdata := range []struct {
+		desc   string
+		filter *runtime.ContainerFilter
+		expect []*runtime.Container
+	}{
+		{
+			desc:   "stream without filter",
+			filter: &runtime.ContainerFilter{},
+			expect: expectedContainers,
+		},
+		{
+			desc: "stream filter by sandboxid",
+			filter: &runtime.ContainerFilter{
+				PodSandboxId: "s-1abcdef1234",
+			},
+			expect: expectedContainers[:3],
+		},
+		{
+			desc: "stream filter by truncated sandboxid",
+			filter: &runtime.ContainerFilter{
+				PodSandboxId: "s-1",
+			},
+			expect: expectedContainers[:3],
+		},
+		{
+			desc: "stream filter by containerid",
+			filter: &runtime.ContainerFilter{
+				Id: "c-1container",
+			},
+			expect: expectedContainers[:1],
+		},
+		{
+			desc: "stream filter by truncated containerid",
+			filter: &runtime.ContainerFilter{
+				Id: "c-1",
+			},
+			expect: expectedContainers[:1],
+		},
+	} {
+		t.Run(testdata.desc, func(t *testing.T) {
+			stream := newFakeStreamServer[runtime.StreamContainersResponse](context.Background())
+			err := c.StreamContainers(&runtime.StreamContainersRequest{Filter: testdata.filter}, stream)
+			assert.NoError(t, err)
+			require.NotEmpty(t, stream.sent)
+
+			var containers []*runtime.Container
+			for _, resp := range stream.sent {
+				containers = append(containers, resp.Containers...)
+			}
+			assert.Len(t, containers, len(testdata.expect))
+			for _, cntr := range testdata.expect {
+				assert.Contains(t, containers, cntr)
+			}
+		})
+	}
+}
+
+func TestStreamContainersEmpty(t *testing.T) {
+	c := newTestCRIService()
+
+	stream := newFakeStreamServer[runtime.StreamContainersResponse](context.Background())
+	err := c.StreamContainers(&runtime.StreamContainersRequest{}, stream)
+	assert.NoError(t, err)
+	assert.Empty(t, stream.sent, "no messages should be sent for empty store")
+}

--- a/internal/cri/server/images/image_stream.go
+++ b/internal/cri/server/images/image_stream.go
@@ -1,0 +1,39 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"google.golang.org/grpc"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criutil "github.com/containerd/containerd/v2/internal/cri/util"
+)
+
+// StreamImages streams all existing images.
+func (c *GRPCCRIImageService) StreamImages(r *runtime.StreamImagesRequest, s grpc.ServerStreamingServer[runtime.StreamImagesResponse]) error {
+	ctx := s.Context()
+	imagesInStore := c.imageStore.List()
+
+	var images []*runtime.Image
+	for _, image := range imagesInStore {
+		images = append(images, toCRIImage(image))
+	}
+
+	return criutil.SendInBatches(ctx, images, criutil.DefaultStreamBatchSize, func(batch []*runtime.Image) error {
+		return s.Send(&runtime.StreamImagesResponse{Images: batch})
+	})
+}

--- a/internal/cri/server/images/image_stream_test.go
+++ b/internal/cri/server/images/image_stream_test.go
@@ -1,0 +1,150 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"context"
+	"testing"
+
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
+)
+
+// fakeStreamServer is a mock grpc.ServerStreamingServer that captures sent messages.
+type fakeStreamServer[Res any] struct {
+	ctx  context.Context
+	sent []*Res
+}
+
+func newFakeStreamServer[Res any](ctx context.Context) *fakeStreamServer[Res] {
+	return &fakeStreamServer[Res]{ctx: ctx}
+}
+
+func (f *fakeStreamServer[Res]) Send(msg *Res) error {
+	f.sent = append(f.sent, msg)
+	return nil
+}
+
+func (f *fakeStreamServer[Res]) SetHeader(metadata.MD) error  { return nil }
+func (f *fakeStreamServer[Res]) SendHeader(metadata.MD) error { return nil }
+func (f *fakeStreamServer[Res]) SetTrailer(metadata.MD)       {}
+func (f *fakeStreamServer[Res]) Context() context.Context     { return f.ctx }
+func (f *fakeStreamServer[Res]) SendMsg(any) error            { return nil }
+func (f *fakeStreamServer[Res]) RecvMsg(any) error            { return nil }
+
+func TestStreamImages(t *testing.T) {
+	_, c := newTestCRIService()
+	imagesInStore := []imagestore.Image{
+		{
+			ID:      "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ChainID: "test-chainid-1",
+			References: []string{
+				"gcr.io/library/busybox:latest",
+				"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+			},
+			Size: 1000,
+			ImageSpec: imagespec.Image{
+				Config: imagespec.ImageConfig{
+					User: "root",
+				},
+			},
+		},
+		{
+			ID:      "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ChainID: "test-chainid-2",
+			References: []string{
+				"gcr.io/library/alpine:latest",
+				"gcr.io/library/alpine@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+			},
+			Size: 2000,
+			ImageSpec: imagespec.Image{
+				Config: imagespec.ImageConfig{
+					User: "1234:1234",
+				},
+			},
+		},
+		{
+			ID:      "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ChainID: "test-chainid-3",
+			References: []string{
+				"gcr.io/library/ubuntu:latest",
+				"gcr.io/library/ubuntu@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+			},
+			Size: 3000,
+			ImageSpec: imagespec.Image{
+				Config: imagespec.ImageConfig{
+					User: "nobody",
+				},
+			},
+		},
+	}
+	expect := []*runtime.Image{
+		{
+			Id:          "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			RepoTags:    []string{"gcr.io/library/busybox:latest"},
+			RepoDigests: []string{"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
+			Size:        uint64(1000),
+			Username:    "root",
+		},
+		{
+			Id:          "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			RepoTags:    []string{"gcr.io/library/alpine:latest"},
+			RepoDigests: []string{"gcr.io/library/alpine@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
+			Size:        uint64(2000),
+			Uid:         &runtime.Int64Value{Value: 1234},
+		},
+		{
+			Id:          "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			RepoTags:    []string{"gcr.io/library/ubuntu:latest"},
+			RepoDigests: []string{"gcr.io/library/ubuntu@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
+			Size:        uint64(3000),
+			Username:    "nobody",
+		},
+	}
+
+	var err error
+	c.imageStore, err = imagestore.NewFakeStore(imagesInStore)
+	assert.NoError(t, err)
+
+	stream := newFakeStreamServer[runtime.StreamImagesResponse](context.Background())
+	err = c.StreamImages(&runtime.StreamImagesRequest{}, stream)
+	assert.NoError(t, err)
+	require.NotEmpty(t, stream.sent)
+
+	var images []*runtime.Image
+	for _, resp := range stream.sent {
+		images = append(images, resp.Images...)
+	}
+	assert.Len(t, images, len(expect))
+	for _, img := range expect {
+		assert.Contains(t, images, img)
+	}
+}
+
+func TestStreamImagesEmpty(t *testing.T) {
+	_, c := newTestCRIService()
+
+	stream := newFakeStreamServer[runtime.StreamImagesResponse](context.Background())
+	err := c.StreamImages(&runtime.StreamImagesRequest{}, stream)
+	assert.NoError(t, err)
+	assert.Empty(t, stream.sent, "no messages should be sent for empty store")
+}

--- a/internal/cri/server/metrics.go
+++ b/internal/cri/server/metrics.go
@@ -22,6 +22,7 @@ import (
 
 var (
 	sandboxListTimer          metrics.Timer
+	sandboxStreamTimer        metrics.Timer
 	sandboxCreateNetworkTimer metrics.Timer
 	sandboxDeleteNetwork      metrics.Timer
 
@@ -30,6 +31,7 @@ var (
 	sandboxRemoveTimer        metrics.LabeledTimer
 
 	containerListTimer          metrics.Timer
+	containerStreamTimer        metrics.Timer
 	containerRemoveTimer        metrics.LabeledTimer
 	containerCreateTimer        metrics.LabeledTimer
 	containerStopTimer          metrics.LabeledTimer
@@ -47,6 +49,7 @@ func init() {
 	ns := metrics.NewNamespace("containerd", "cri", nil)
 
 	sandboxListTimer = ns.NewTimer("sandbox_list", "time to list sandboxes")
+	sandboxStreamTimer = ns.NewTimer("stream_sandbox_list", "time to stream sandboxes")
 	sandboxCreateNetworkTimer = ns.NewTimer("sandbox_create_network", "time to create the network for a sandbox")
 	sandboxDeleteNetwork = ns.NewTimer("sandbox_delete_network", "time to delete a sandbox's network")
 
@@ -55,6 +58,7 @@ func init() {
 	sandboxRemoveTimer = ns.NewLabeledTimer("sandbox_remove", "time to remove a sandbox", "runtime")
 
 	containerListTimer = ns.NewTimer("container_list", "time to list containers")
+	containerStreamTimer = ns.NewTimer("stream_container_list", "time to stream containers")
 	containerRemoveTimer = ns.NewLabeledTimer("container_remove", "time to remove a container", "runtime")
 	containerCreateTimer = ns.NewLabeledTimer("container_create", "time to create a container", "runtime")
 	containerStopTimer = ns.NewLabeledTimer("container_stop", "time to stop a container", "runtime")

--- a/internal/cri/server/sandbox_stats_stream.go
+++ b/internal/cri/server/sandbox_stats_stream.go
@@ -1,0 +1,74 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/containerd/ttrpc"
+	"google.golang.org/grpc"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criutil "github.com/containerd/containerd/v2/internal/cri/util"
+)
+
+// StreamPodSandboxStats streams stats of all ready sandboxes matching the filter.
+func (c *criService) StreamPodSandboxStats(r *runtime.StreamPodSandboxStatsRequest, s grpc.ServerStreamingServer[runtime.StreamPodSandboxStatsResponse]) error {
+	ctx := s.Context()
+	listReq := &runtime.ListPodSandboxStatsRequest{
+		Filter: r.GetFilter(),
+	}
+	sandboxes := c.sandboxesForListPodSandboxStatsRequest(listReq)
+	stats, errs := make([]*runtime.PodSandboxStats, len(sandboxes)), make([]error, len(sandboxes))
+
+	var wg sync.WaitGroup
+	for i, sandbox := range sandboxes {
+		wg.Go(func() {
+			sandboxStats, err := c.podSandboxStats(ctx, sandbox) //nolint: staticcheck
+			switch {
+			case errdefs.IsUnavailable(err), errdefs.IsNotFound(err):
+				log.G(ctx).WithField("podsandboxid", sandbox.ID).WithError(err).Debug("failed to get pod sandbox stats, this is likely a transient error")
+			case errors.Is(err, ttrpc.ErrClosed):
+				log.G(ctx).WithField("podsandboxid", sandbox.ID).WithError(err).Debug("failed to get pod sandbox stats, connection closed")
+			case err != nil: //nolint: staticcheck
+				errs[i] = fmt.Errorf("failed to decode sandbox container metrics for sandbox %q: %w", sandbox.ID, err)
+			default:
+				stats[i] = sandboxStats
+			}
+		})
+	}
+	wg.Wait()
+
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+
+	var podSandboxStats []*runtime.PodSandboxStats
+	for _, stat := range stats {
+		if stat != nil {
+			podSandboxStats = append(podSandboxStats, stat)
+		}
+	}
+
+	return criutil.SendInBatches(ctx, podSandboxStats, criutil.DefaultStreamBatchSize, func(batch []*runtime.PodSandboxStats) error {
+		return s.Send(&runtime.StreamPodSandboxStatsResponse{PodSandboxStats: batch})
+	})
+}

--- a/internal/cri/server/sandbox_stats_stream_linux_test.go
+++ b/internal/cri/server/sandbox_stats_stream_linux_test.go
@@ -1,0 +1,185 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+)
+
+func TestStreamPodSandboxStatsEmpty(t *testing.T) {
+	c := newTestCRIService()
+
+	stream := newFakeStreamServer[runtime.StreamPodSandboxStatsResponse](context.Background())
+	err := c.StreamPodSandboxStats(&runtime.StreamPodSandboxStatsRequest{}, stream)
+	assert.NoError(t, err)
+	assert.Empty(t, stream.sent, "no messages should be sent for empty store")
+}
+
+func TestStreamPodSandboxStatsFiltersNotReady(t *testing.T) {
+	c := newTestCRIService()
+
+	// Add a sandbox that is NOT ready — it should be filtered out.
+	sb := sandboxstore.NewSandbox(
+		sandboxstore.Metadata{
+			ID:   "sb-notready",
+			Name: "sandbox-notready",
+			Config: &runtime.PodSandboxConfig{
+				Metadata: &runtime.PodSandboxMetadata{Name: "pod-notready"},
+			},
+		},
+		sandboxstore.Status{
+			CreatedAt: time.Now(),
+			State:     sandboxstore.StateNotReady,
+		},
+	)
+	require.NoError(t, c.sandboxStore.Add(sb))
+
+	stream := newFakeStreamServer[runtime.StreamPodSandboxStatsResponse](context.Background())
+	err := c.StreamPodSandboxStats(&runtime.StreamPodSandboxStatsRequest{}, stream)
+	assert.NoError(t, err)
+	assert.Empty(t, stream.sent, "non-ready sandboxes should be filtered out")
+}
+
+func TestStreamPodSandboxStatsFilterByID(t *testing.T) {
+	c := newTestCRIService()
+
+	sandboxes := []sandboxstore.Sandbox{
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:   "sb-1",
+				Name: "sandbox-1",
+				Config: &runtime.PodSandboxConfig{
+					Metadata: &runtime.PodSandboxMetadata{Name: "pod-1"},
+				},
+			},
+			sandboxstore.Status{
+				CreatedAt: time.Now(),
+				State:     sandboxstore.StateReady,
+			},
+		),
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:   "sb-2",
+				Name: "sandbox-2",
+				Config: &runtime.PodSandboxConfig{
+					Metadata: &runtime.PodSandboxMetadata{Name: "pod-2"},
+				},
+			},
+			sandboxstore.Status{
+				CreatedAt: time.Now(),
+				State:     sandboxstore.StateReady,
+			},
+		),
+	}
+	for _, sb := range sandboxes {
+		require.NoError(t, c.sandboxStore.Add(sb))
+	}
+
+	// Verify sandboxesForListPodSandboxStatsRequest filters by ID.
+	filtered := c.sandboxesForListPodSandboxStatsRequest(&runtime.ListPodSandboxStatsRequest{
+		Filter: &runtime.PodSandboxStatsFilter{Id: "sb-2"},
+	})
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "sb-2", filtered[0].ID)
+}
+
+func TestStreamPodSandboxStatsFilterByLabel(t *testing.T) {
+	c := newTestCRIService()
+
+	sandboxes := []sandboxstore.Sandbox{
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:   "sb-1",
+				Name: "sandbox-1",
+				Config: &runtime.PodSandboxConfig{
+					Metadata: &runtime.PodSandboxMetadata{Name: "pod-1"},
+					Labels:   map[string]string{"env": "prod"},
+				},
+			},
+			sandboxstore.Status{
+				CreatedAt: time.Now(),
+				State:     sandboxstore.StateReady,
+			},
+		),
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:   "sb-2",
+				Name: "sandbox-2",
+				Config: &runtime.PodSandboxConfig{
+					Metadata: &runtime.PodSandboxMetadata{Name: "pod-2"},
+					Labels:   map[string]string{"env": "staging"},
+				},
+			},
+			sandboxstore.Status{
+				CreatedAt: time.Now(),
+				State:     sandboxstore.StateReady,
+			},
+		),
+	}
+	for _, sb := range sandboxes {
+		require.NoError(t, c.sandboxStore.Add(sb))
+	}
+
+	filtered := c.sandboxesForListPodSandboxStatsRequest(&runtime.ListPodSandboxStatsRequest{
+		Filter: &runtime.PodSandboxStatsFilter{
+			LabelSelector: map[string]string{"env": "staging"},
+		},
+	})
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "sb-2", filtered[0].ID)
+}
+
+func TestStreamPodSandboxStatsReadySandboxErrorHandling(t *testing.T) {
+	c := newTestCRIService()
+
+	// Add a ready sandbox. podSandboxStats will fail (no cgroups in test env)
+	// but StreamPodSandboxStats should handle the error gracefully.
+	sb := sandboxstore.NewSandbox(
+		sandboxstore.Metadata{
+			ID:   "sb-ready",
+			Name: "sandbox-ready",
+			Config: &runtime.PodSandboxConfig{
+				Metadata: &runtime.PodSandboxMetadata{Name: "pod-ready"},
+			},
+		},
+		sandboxstore.Status{
+			CreatedAt: time.Now(),
+			State:     sandboxstore.StateReady,
+		},
+	)
+	require.NoError(t, c.sandboxStore.Add(sb))
+
+	stream := newFakeStreamServer[runtime.StreamPodSandboxStatsResponse](context.Background())
+	err := c.StreamPodSandboxStats(&runtime.StreamPodSandboxStatsRequest{}, stream)
+
+	// On platforms where podSandboxStats is not implemented or cgroups are unavailable,
+	// the error is collected and returned via errors.Join. The streaming part still runs
+	// (with empty stats), so the stream itself is not broken.
+	// The error may be nil (on "other" platforms where ErrNotImplemented is treated as
+	// unavailable) or non-nil (on Linux where cgroup loading fails).
+	if err != nil {
+		assert.Contains(t, err.Error(), "sb-ready")
+	}
+}

--- a/internal/cri/server/sandbox_stream.go
+++ b/internal/cri/server/sandbox_stream.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"time"
+
+	"google.golang.org/grpc"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criutil "github.com/containerd/containerd/v2/internal/cri/util"
+)
+
+// StreamPodSandboxes streams all pod sandboxes matching the filter.
+func (c *criService) StreamPodSandboxes(r *runtime.StreamPodSandboxesRequest, s grpc.ServerStreamingServer[runtime.StreamPodSandboxesResponse]) error {
+	ctx := s.Context()
+	start := time.Now()
+	sandboxesInStore := c.sandboxStore.List()
+
+	var sandboxes []*runtime.PodSandbox
+	for _, sandboxInStore := range sandboxesInStore {
+		sandboxes = append(sandboxes, toCRISandbox(
+			sandboxInStore.Metadata,
+			sandboxInStore.Status.Get(),
+		))
+	}
+
+	sandboxes = c.filterCRISandboxes(sandboxes, r.GetFilter())
+
+	err := criutil.SendInBatches(ctx, sandboxes, criutil.DefaultStreamBatchSize, func(batch []*runtime.PodSandbox) error {
+		return s.Send(&runtime.StreamPodSandboxesResponse{PodSandboxes: batch})
+	})
+
+	sandboxStreamTimer.UpdateSince(start)
+	return err
+}

--- a/internal/cri/server/sandbox_stream_test.go
+++ b/internal/cri/server/sandbox_stream_test.go
@@ -1,0 +1,217 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+)
+
+func TestStreamPodSandboxes(t *testing.T) {
+	c := newTestCRIService()
+	sandboxes := []sandboxstore.Sandbox{
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:   "1abcdef",
+				Name: "sandboxname-1",
+				Config: &runtime.PodSandboxConfig{
+					Metadata: &runtime.PodSandboxMetadata{
+						Name:      "podname-1",
+						Uid:       "uid-1",
+						Namespace: "ns-1",
+						Attempt:   1,
+					},
+				},
+				RuntimeHandler: "test-runtime-handler",
+			},
+			sandboxstore.Status{
+				CreatedAt: time.Now(),
+				State:     sandboxstore.StateReady,
+			},
+		),
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:   "2abcdef",
+				Name: "sandboxname-2",
+				Config: &runtime.PodSandboxConfig{
+					Metadata: &runtime.PodSandboxMetadata{
+						Name:      "podname-2",
+						Uid:       "uid-2",
+						Namespace: "ns-2",
+						Attempt:   2,
+					},
+					Labels: map[string]string{"a": "b"},
+				},
+				RuntimeHandler: "test-runtime-handler",
+			},
+			sandboxstore.Status{
+				CreatedAt: time.Now(),
+				State:     sandboxstore.StateNotReady,
+			},
+		),
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:   "3abcdef",
+				Name: "sandboxname-3",
+				Config: &runtime.PodSandboxConfig{
+					Metadata: &runtime.PodSandboxMetadata{
+						Name:      "podname-2",
+						Uid:       "uid-2",
+						Namespace: "ns-2",
+						Attempt:   2,
+					},
+					Labels: map[string]string{"c": "d"},
+				},
+				RuntimeHandler: "test-runtime-handler",
+			},
+			sandboxstore.Status{
+				CreatedAt: time.Now(),
+				State:     sandboxstore.StateReady,
+			},
+		),
+	}
+
+	// Create expected PodSandboxes
+	testSandboxes := []*runtime.PodSandbox{}
+	for _, sb := range sandboxes {
+		testSandboxes = append(testSandboxes, toCRISandbox(sb.Metadata, sb.Status.Get()))
+	}
+
+	// Inject test sandbox metadata
+	for _, sb := range sandboxes {
+		assert.NoError(t, c.sandboxStore.Add(sb))
+	}
+
+	for _, test := range []struct {
+		desc   string
+		filter *runtime.PodSandboxFilter
+		expect []*runtime.PodSandbox
+	}{
+		{
+			desc:   "stream no filter",
+			expect: testSandboxes,
+		},
+		{
+			desc:   "stream id filter",
+			filter: &runtime.PodSandboxFilter{Id: "2abcdef"},
+			expect: []*runtime.PodSandbox{testSandboxes[1]},
+		},
+		{
+			desc:   "stream truncid filter",
+			filter: &runtime.PodSandboxFilter{Id: "2"},
+			expect: []*runtime.PodSandbox{testSandboxes[1]},
+		},
+		{
+			desc: "stream state filter",
+			filter: &runtime.PodSandboxFilter{
+				State: &runtime.PodSandboxStateValue{
+					State: runtime.PodSandboxState_SANDBOX_READY,
+				},
+			},
+			expect: []*runtime.PodSandbox{testSandboxes[0], testSandboxes[2]},
+		},
+		{
+			desc: "stream label filter",
+			filter: &runtime.PodSandboxFilter{
+				LabelSelector: map[string]string{"a": "b"},
+			},
+			expect: []*runtime.PodSandbox{testSandboxes[1]},
+		},
+		{
+			desc: "stream mixed filter not matched",
+			filter: &runtime.PodSandboxFilter{
+				Id:            "1",
+				LabelSelector: map[string]string{"a": "b"},
+			},
+			expect: []*runtime.PodSandbox{},
+		},
+		{
+			desc: "stream mixed filter matched",
+			filter: &runtime.PodSandboxFilter{
+				State: &runtime.PodSandboxStateValue{
+					State: runtime.PodSandboxState_SANDBOX_READY,
+				},
+				LabelSelector: map[string]string{"c": "d"},
+			},
+			expect: []*runtime.PodSandbox{testSandboxes[2]},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			stream := newFakeStreamServer[runtime.StreamPodSandboxesResponse](context.Background())
+			err := c.StreamPodSandboxes(&runtime.StreamPodSandboxesRequest{Filter: test.filter}, stream)
+			assert.NoError(t, err)
+
+			var sandboxes []*runtime.PodSandbox
+			for _, resp := range stream.sent {
+				sandboxes = append(sandboxes, resp.PodSandboxes...)
+			}
+			assert.Len(t, sandboxes, len(test.expect))
+			for _, sb := range test.expect {
+				assert.Contains(t, sandboxes, sb)
+			}
+		})
+	}
+}
+
+func TestStreamPodSandboxesEmpty(t *testing.T) {
+	c := newTestCRIService()
+
+	stream := newFakeStreamServer[runtime.StreamPodSandboxesResponse](context.Background())
+	err := c.StreamPodSandboxes(&runtime.StreamPodSandboxesRequest{}, stream)
+	assert.NoError(t, err)
+	assert.Empty(t, stream.sent, "no messages should be sent for empty store")
+}
+
+func TestStreamPodSandboxesBatching(t *testing.T) {
+	c := newTestCRIService()
+
+	// Add more sandboxes than the batch size to verify batching
+	for i := 0; i < 3; i++ {
+		sb := sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:   fmt.Sprintf("sb-%d", i),
+				Name: fmt.Sprintf("sandbox-%d", i),
+				Config: &runtime.PodSandboxConfig{
+					Metadata: &runtime.PodSandboxMetadata{
+						Name: fmt.Sprintf("pod-%d", i),
+					},
+				},
+			},
+			sandboxstore.Status{
+				CreatedAt: time.Now(),
+				State:     sandboxstore.StateReady,
+			},
+		)
+		require.NoError(t, c.sandboxStore.Add(sb))
+	}
+
+	stream := newFakeStreamServer[runtime.StreamPodSandboxesResponse](context.Background())
+	err := c.StreamPodSandboxes(&runtime.StreamPodSandboxesRequest{}, stream)
+	assert.NoError(t, err)
+
+	// With 3 sandboxes and batch size of 5000, should be 1 batch
+	require.Len(t, stream.sent, 1)
+	assert.Len(t, stream.sent[0].PodSandboxes, 3)
+}

--- a/internal/cri/server/stream_pod_sandbox_metrics.go
+++ b/internal/cri/server/stream_pod_sandbox_metrics.go
@@ -1,0 +1,37 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"google.golang.org/grpc"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criutil "github.com/containerd/containerd/v2/internal/cri/util"
+)
+
+// StreamPodSandboxMetrics streams pod sandbox metrics.
+func (c *criService) StreamPodSandboxMetrics(r *runtime.StreamPodSandboxMetricsRequest, s grpc.ServerStreamingServer[runtime.StreamPodSandboxMetricsResponse]) error {
+	ctx := s.Context()
+	resp, err := c.ListPodSandboxMetrics(ctx, &runtime.ListPodSandboxMetricsRequest{})
+	if err != nil {
+		return err
+	}
+
+	return criutil.SendInBatches(ctx, resp.PodMetrics, criutil.DefaultStreamBatchSize, func(batch []*runtime.PodSandboxMetrics) error {
+		return s.Send(&runtime.StreamPodSandboxMetricsResponse{PodSandboxMetrics: batch})
+	})
+}

--- a/internal/cri/server/stream_pod_sandbox_metrics_linux_test.go
+++ b/internal/cri/server/stream_pod_sandbox_metrics_linux_test.go
@@ -1,0 +1,95 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+)
+
+func TestStreamPodSandboxMetricsEmpty(t *testing.T) {
+	c := newTestCRIService()
+
+	stream := newFakeStreamServer[runtime.StreamPodSandboxMetricsResponse](context.Background())
+	err := c.StreamPodSandboxMetrics(&runtime.StreamPodSandboxMetricsRequest{}, stream)
+	assert.NoError(t, err)
+	assert.Empty(t, stream.sent, "no messages should be sent for empty store")
+}
+
+func TestStreamPodSandboxMetricsSkipsNotReady(t *testing.T) {
+	c := newTestCRIService()
+
+	// Add a not-ready sandbox — ListPodSandboxMetrics should skip it.
+	sb := sandboxstore.NewSandbox(
+		sandboxstore.Metadata{
+			ID:   "sb-notready",
+			Name: "sandbox-notready",
+			Config: &runtime.PodSandboxConfig{
+				Metadata: &runtime.PodSandboxMetadata{Name: "pod-notready"},
+			},
+		},
+		sandboxstore.Status{
+			CreatedAt: time.Now(),
+			State:     sandboxstore.StateNotReady,
+		},
+	)
+	require.NoError(t, c.sandboxStore.Add(sb))
+
+	stream := newFakeStreamServer[runtime.StreamPodSandboxMetricsResponse](context.Background())
+	err := c.StreamPodSandboxMetrics(&runtime.StreamPodSandboxMetricsRequest{}, stream)
+	assert.NoError(t, err)
+	assert.Empty(t, stream.sent, "not-ready sandboxes should be skipped")
+}
+
+func TestStreamPodSandboxMetricsContextCancelled(t *testing.T) {
+	c := newTestCRIService()
+
+	// Add ready sandboxes so the rate limiter is reached on Linux.
+	for i := 0; i < 3; i++ {
+		sb := sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
+				ID:   fmt.Sprintf("sb-%d", i),
+				Name: fmt.Sprintf("sandbox-%d", i),
+				Config: &runtime.PodSandboxConfig{
+					Metadata: &runtime.PodSandboxMetadata{Name: fmt.Sprintf("pod-%d", i)},
+				},
+			},
+			sandboxstore.Status{
+				CreatedAt: time.Now(),
+				State:     sandboxstore.StateReady,
+			},
+		)
+		require.NoError(t, c.sandboxStore.Add(sb))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	stream := newFakeStreamServer[runtime.StreamPodSandboxMetricsResponse](ctx)
+	err := c.StreamPodSandboxMetrics(&runtime.StreamPodSandboxMetricsRequest{}, stream)
+
+	// With a cancelled context the rate limiter detects context cancellation and returns an error.
+	assert.Error(t, err)
+}

--- a/internal/cri/util/stream.go
+++ b/internal/cri/util/stream.go
@@ -1,0 +1,37 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package util
+
+import "context"
+
+const DefaultStreamBatchSize = 5000
+
+// SendInBatches sends items in batches using the provided send function.
+// It checks for context cancellation before sending each batch.
+// Returns nil immediately if items is empty (gRPC closes the stream with EOF).
+func SendInBatches[T any](ctx context.Context, items []*T, batchSize int, sendFn func([]*T) error) error {
+	for i := 0; i < len(items); i += batchSize {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := min(i+batchSize, len(items))
+		if err := sendFn(items[i:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cri/util/stream_test.go
+++ b/internal/cri/util/stream_test.go
@@ -1,0 +1,181 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendInBatches(t *testing.T) {
+	type item struct{ id int }
+
+	makeItems := func(n int) []*item {
+		items := make([]*item, n)
+		for i := range items {
+			items[i] = &item{id: i}
+		}
+		return items
+	}
+
+	for _, test := range []struct {
+		desc      string
+		numItems  int
+		batchSize int
+		// expected number of send calls
+		expectBatches int
+		// expected sizes of each batch
+		expectBatchSizes []int
+	}{
+		{
+			desc:             "empty items",
+			numItems:         0,
+			batchSize:        5,
+			expectBatches:    0,
+			expectBatchSizes: nil,
+		},
+		{
+			desc:             "items less than batch size",
+			numItems:         3,
+			batchSize:        5,
+			expectBatches:    1,
+			expectBatchSizes: []int{3},
+		},
+		{
+			desc:             "items equal to batch size",
+			numItems:         5,
+			batchSize:        5,
+			expectBatches:    1,
+			expectBatchSizes: []int{5},
+		},
+		{
+			desc:             "items greater than batch size",
+			numItems:         12,
+			batchSize:        5,
+			expectBatches:    3,
+			expectBatchSizes: []int{5, 5, 2},
+		},
+		{
+			desc:             "single item",
+			numItems:         1,
+			batchSize:        5,
+			expectBatches:    1,
+			expectBatchSizes: []int{1},
+		},
+		{
+			desc:             "items exactly double batch size",
+			numItems:         10,
+			batchSize:        5,
+			expectBatches:    2,
+			expectBatchSizes: []int{5, 5},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			items := makeItems(test.numItems)
+			var batches [][]*item
+			err := SendInBatches(context.Background(), items, test.batchSize, func(batch []*item) error {
+				batches = append(batches, batch)
+				return nil
+			})
+			assert.NoError(t, err)
+			assert.Len(t, batches, test.expectBatches)
+			for i, expectedSize := range test.expectBatchSizes {
+				assert.Len(t, batches[i], expectedSize, "batch %d", i)
+			}
+			// Verify all items are included in order
+			var allItems []*item
+			for _, batch := range batches {
+				allItems = append(allItems, batch...)
+			}
+			if test.numItems == 0 {
+				assert.Empty(t, allItems)
+			} else {
+				assert.Equal(t, items, allItems)
+			}
+		})
+	}
+}
+
+func TestSendInBatchesContextCancelled(t *testing.T) {
+	type item struct{ id int }
+	items := make([]*item, 10)
+	for i := range items {
+		items[i] = &item{id: i}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	var sendCount int
+	err := SendInBatches(ctx, items, 3, func(batch []*item) error {
+		sendCount++
+		return nil
+	})
+	assert.Error(t, err)
+	assert.Equal(t, context.Canceled, err)
+	assert.Equal(t, 0, sendCount, "should not send any batches when context is already cancelled")
+}
+
+func TestSendInBatchesSendError(t *testing.T) {
+	type item struct{ id int }
+	items := make([]*item, 10)
+	for i := range items {
+		items[i] = &item{id: i}
+	}
+
+	sendErr := fmt.Errorf("send failed")
+	var sendCount int
+	err := SendInBatches(context.Background(), items, 3, func(batch []*item) error {
+		sendCount++
+		if sendCount == 2 {
+			return sendErr
+		}
+		return nil
+	})
+	assert.ErrorIs(t, err, sendErr)
+	assert.Equal(t, 2, sendCount, "should stop after send error")
+}
+
+func TestSendInBatchesContextCancelledMidStream(t *testing.T) {
+	type item struct{ id int }
+	items := make([]*item, 10)
+	for i := range items {
+		items[i] = &item{id: i}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var sendCount int
+	err := SendInBatches(ctx, items, 3, func(batch []*item) error {
+		sendCount++
+		if sendCount == 2 {
+			cancel() // cancel after second batch
+		}
+		return nil
+	})
+
+	// Context cancellation is checked before each batch send, so:
+	// - Batch 1 (items 0-2): sent ok
+	// - Batch 2 (items 3-5): sent ok, then cancel() called
+	// - Batch 3 (items 6-8): context check fails, returns error
+	require.Error(t, err)
+	assert.Equal(t, context.Canceled, err)
+	assert.Equal(t, 2, sendCount)
+}


### PR DESCRIPTION
Implements CRI List Streaming
 - https://github.com/kubernetes/enhancements/issues/5825

Add server-streaming variants of CRI list RPCs (StreamContainers, StreamPodSandboxes, StreamContainerStats, StreamPodSandboxStats, StreamPodSandboxMetrics, StreamImages) that send results in batches of 5000 items (it's half of the estimated limit https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5825-cri-pagination#motivation)

Size calculation will slow down the RPCs. See https://github.com/kubernetes/kubernetes/pull/136987#issuecomment-4040837305 for the details.

Fixes https://github.com/containerd/containerd/issues/12814

cc @samuelkarp @SergeyKanzhelev 