### PR TITLE
 Create a plugin to integrate with systemd watchdog for daemon health

### DIFF
--- a/cmd/containerd/builtins/builtins_linux.go
+++ b/cmd/containerd/builtins/builtins_linux.go
@@ -27,4 +27,5 @@ import (
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/erofs/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/native/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/overlay/plugin"
+	_ "github.com/containerd/containerd/v2/plugins/watchdog"
 )

--- a/plugins/watchdog/watchdog_linux.go
+++ b/plugins/watchdog/watchdog_linux.go
@@ -43,7 +43,7 @@ type Config struct {
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.InternalPlugin,
-		ID: "watchdog",
+		ID:   "watchdog",
 		Requires: []plugin.Type{
 			plugins.MetadataPlugin,
 			plugins.ContentPlugin,
@@ -128,7 +128,6 @@ func(w *watchdog) healthCheck(ctx context.Context) error {
 		return fmt.Errorf("content store: %w",err)
 	}
 	return nil
-	// return fmt.Errorf("forced failure")
 }
 
 func(w *watchdog) checkMetadataDB(_ context.Context) error {

--- a/plugins/watchdog/watchdog_linux.go
+++ b/plugins/watchdog/watchdog_linux.go
@@ -1,0 +1,148 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/daemon"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/metadata"
+	"github.com/containerd/containerd/v2/internal/tomlext"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	bolt "go.etcd.io/bbolt"
+)
+
+var errWatchdogHealthCheckDone = errors.New("watchdog: content store health check done")
+
+type Config struct {
+	HealthCheckTimeout tomlext.Duration `toml:"health_check_timeout"`
+}
+
+func init() {
+	registry.Register(&plugin.Registration{
+		Type: plugins.InternalPlugin,
+		ID: "watchdog",
+		Requires: []plugin.Type{
+			plugins.MetadataPlugin,
+			plugins.ContentPlugin,
+		},
+		//Default configuration for Timeout
+		Config: &Config{
+			HealthCheckTimeout:tomlext.FromStdTime(5 * time.Second),
+		},
+		InitFn: func(ic *plugin.InitContext) (any,error) {
+			mdRaw, err := ic.GetSingle(plugins.MetadataPlugin)
+			if err != nil {
+				return nil, fmt.Errorf("watchdog: failed to get metadata plugin: %w",err)
+			}
+			mdb := mdRaw.(*metadata.DB)
+
+			csRaw, err := ic.GetSingle(plugins.ContentPlugin)
+			if err != nil {
+				return nil, fmt.Errorf("watchdog: failed to get content plugin: %w",err)
+			}
+			cs := csRaw.(content.Store)
+
+			cfg := ic.Config.(*Config)
+			w := &watchdog{
+				mdb: mdb,
+				cs: cs,
+				timeout: tomlext.ToStdTime(cfg.HealthCheckTimeout),
+			}
+			go w.run(ic.Context)
+			return w, nil
+		},
+	})
+}
+
+type watchdog struct {
+	mdb *metadata.DB
+	cs content.Store
+	timeout time.Duration
+}
+
+func (w *watchdog) run(ctx context.Context) {
+	interval, err := daemon.SdWatchdogEnabled(false)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("watchdog: failed to read WATCHDOG_USEC from the env")
+		return
+	}
+	if interval == 0 {
+		log.G(ctx).Debug("watchdog: systemd watchdog not enabled")
+		return
+	}
+	pingInterval := interval/2;
+
+	for {
+		select{
+		case <-ctx.Done():
+			log.G(ctx).Debug("watchdog: context cancelled, stopping watchdog loop")
+			return
+		case <-time.After(pingInterval):
+		}
+		checkCtx, cancel := context.WithTimeout(ctx, w.timeout)
+		healthErr := w.healthCheck(checkCtx)
+		cancel()
+
+		if healthErr != nil {
+			log.G(ctx).WithError(healthErr).Warn("watchdog: health check failed,")
+			continue
+		}
+		notified, err := daemon.SdNotify(false, daemon.SdNotifyWatchdog)
+		if err != nil {
+			log.G(ctx).WithError(err).Warn("watchdog: failed to watchdog notifiaction to systemd")
+		}else{
+			log.G(ctx).WithField("notified",notified).Infof("watchdog: sent WATCHDOG=1 ping")
+
+		}
+	}
+}
+
+func(w *watchdog) healthCheck(ctx context.Context) error {
+	if err := w.checkMetadataDB(ctx); err != nil {
+		return fmt.Errorf("metadata store: %w",err)
+	}
+	if err := w.checkContentStore(ctx); err != nil {
+		return fmt.Errorf("content store: %w",err)
+	}
+	return nil
+	// return fmt.Errorf("forced failure")
+}
+
+func(w *watchdog) checkMetadataDB(_ context.Context) error {
+	return w.mdb.View(func(_ *bolt.Tx)error{
+		return nil;
+	})
+}
+
+func(w *watchdog) checkContentStore(ctx context.Context) error {
+	err := w.cs.Walk(ctx, func(_ content.Info)error{
+		return errWatchdogHealthCheckDone
+	})
+	if errors.Is(err, errWatchdogHealthCheckDone){
+		return nil
+	}
+	return err
+}

--- a/plugins/watchdog/watchdog_linux.go
+++ b/plugins/watchdog/watchdog_linux.go
@@ -50,25 +50,25 @@ func init() {
 		},
 		//Default configuration for Timeout
 		Config: &Config{
-			HealthCheckTimeout:tomlext.FromStdTime(5 * time.Second),
+			HealthCheckTimeout: tomlext.FromStdTime(5 * time.Second),
 		},
-		InitFn: func(ic *plugin.InitContext) (any,error) {
+		InitFn: func(ic *plugin.InitContext) (any, error) {
 			mdRaw, err := ic.GetSingle(plugins.MetadataPlugin)
 			if err != nil {
-				return nil, fmt.Errorf("watchdog: failed to get metadata plugin: %w",err)
+				return nil, fmt.Errorf("watchdog: failed to get metadata plugin: %w", err)
 			}
 			mdb := mdRaw.(*metadata.DB)
 
 			csRaw, err := ic.GetSingle(plugins.ContentPlugin)
 			if err != nil {
-				return nil, fmt.Errorf("watchdog: failed to get content plugin: %w",err)
+				return nil, fmt.Errorf("watchdog: failed to get content plugin: %w", err)
 			}
 			cs := csRaw.(content.Store)
 
 			cfg := ic.Config.(*Config)
 			w := &watchdog{
-				mdb: mdb,
-				cs: cs,
+				mdb:     mdb,
+				cs:      cs,
 				timeout: tomlext.ToStdTime(cfg.HealthCheckTimeout),
 			}
 			go w.run(ic.Context)
@@ -78,8 +78,8 @@ func init() {
 }
 
 type watchdog struct {
-	mdb *metadata.DB
-	cs content.Store
+	mdb     *metadata.DB
+	cs      content.Store
 	timeout time.Duration
 }
 
@@ -93,10 +93,10 @@ func (w *watchdog) run(ctx context.Context) {
 		log.G(ctx).Debug("watchdog: systemd watchdog not enabled")
 		return
 	}
-	pingInterval := interval/2;
+	pingInterval := interval / 2
 
 	for {
-		select{
+		select {
 		case <-ctx.Done():
 			log.G(ctx).Debug("watchdog: context cancelled, stopping watchdog loop")
 			return
@@ -113,34 +113,34 @@ func (w *watchdog) run(ctx context.Context) {
 		notified, err := daemon.SdNotify(false, daemon.SdNotifyWatchdog)
 		if err != nil {
 			log.G(ctx).WithError(err).Warn("watchdog: failed to watchdog notifiaction to systemd")
-		}else{
-			log.G(ctx).WithField("notified",notified).Infof("watchdog: sent WATCHDOG=1 ping")
+		} else {
+			log.G(ctx).WithField("notified", notified).Infof("watchdog: sent WATCHDOG=1 ping")
 
 		}
 	}
 }
 
-func(w *watchdog) healthCheck(ctx context.Context) error {
+func (w *watchdog) healthCheck(ctx context.Context) error {
 	if err := w.checkMetadataDB(ctx); err != nil {
-		return fmt.Errorf("metadata store: %w",err)
+		return fmt.Errorf("metadata store: %w", err)
 	}
 	if err := w.checkContentStore(ctx); err != nil {
-		return fmt.Errorf("content store: %w",err)
+		return fmt.Errorf("content store: %w", err)
 	}
 	return nil
 }
 
-func(w *watchdog) checkMetadataDB(_ context.Context) error {
-	return w.mdb.View(func(_ *bolt.Tx)error{
-		return nil;
+func (w *watchdog) checkMetadataDB(_ context.Context) error {
+	return w.mdb.View(func(_ *bolt.Tx) error {
+		return nil
 	})
 }
 
-func(w *watchdog) checkContentStore(ctx context.Context) error {
-	err := w.cs.Walk(ctx, func(_ content.Info)error{
+func (w *watchdog) checkContentStore(ctx context.Context) error {
+	err := w.cs.Walk(ctx, func(_ content.Info) error {
 		return errWatchdogHealthCheckDone
 	})
-	if errors.Is(err, errWatchdogHealthCheckDone){
+	if errors.Is(err, errWatchdogHealthCheckDone) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
This PR adds a watchdog plugin to containerd that integrates with the systemd watchdog.
The plugin performs lightweight internal health checks and sends WATCHDOG=1 notifications only when the daemon is healthy. If containerd becomes unresponsive, notifications stop and systemd restarts the service.

Now here we are healthchecking for metadata store and content store because MetadataPlugin stores all persistent state: container records, image manifests, snapshot references, lease data everything. ContentPlugin stores the actual image layer blobs.

#### How this health check is done?
 - Metadata store: Uses a BoltDB read transaction (mdb.View) to verify database accessibility, lock availability, and detect potential deadlocks or I/O stalls.
 - Content store: Uses content.Store.Walk to ensure the content service and backend storage are responsive. The walk exits early after the first item, making the check lightweight while still exercising the full request path.
 
 I have tested this in my setup by setting up WatchdogSec = 60s in container.service.d.
 Fix - #10329
 
<img width="944" height="136" alt="image" src="https://github.com/user-attachments/assets/7831f985-6e8b-4af1-95e4-ae456c8b380d" />

