### PR TITLE
cri/windows: propagate AffinityCpus through update and status paths

### DIFF
--- a/internal/cri/opts/spec_windows_opts.go
+++ b/internal/cri/opts/spec_windows_opts.go
@@ -197,6 +197,23 @@ func WithWindowsResources(resources *runtime.WindowsContainerResources) oci.Spec
 		if limit != 0 {
 			s.Windows.Resources.Memory.Limit = &limit
 		}
+		if len(resources.GetAffinityCpus()) > 0 {
+			affinities := make([]runtimespec.WindowsCPUGroupAffinity, 0, len(resources.GetAffinityCpus()))
+			for _, a := range resources.GetAffinityCpus() {
+				if a != nil {
+					affinities = append(affinities, runtimespec.WindowsCPUGroupAffinity{
+						Mask:  a.CpuMask,
+						Group: a.CpuGroup,
+					})
+				}
+			}
+			if len(affinities) > 0 {
+				if s.Windows.Resources.CPU == nil {
+					s.Windows.Resources.CPU = &runtimespec.WindowsCPUResources{}
+				}
+				s.Windows.Resources.CPU.Affinity = affinities
+			}
+		}
 		return nil
 	}
 }

--- a/internal/cri/opts/spec_windows_test.go
+++ b/internal/cri/opts/spec_windows_test.go
@@ -220,6 +220,72 @@ func TestWithDevices(t *testing.T) {
 	}
 }
 
+func TestWithWindowsResources(t *testing.T) {
+	tests := []struct {
+		name         string
+		resources    *runtime.WindowsContainerResources
+		wantAffinity []specs.WindowsCPUGroupAffinity
+	}{
+		{
+			name: "AffinityCpus written to OCI spec",
+			resources: &runtime.WindowsContainerResources{
+				AffinityCpus: []*runtime.WindowsCpuGroupAffinity{
+					{CpuMask: 0x3, CpuGroup: 0},
+					{CpuMask: 0xf, CpuGroup: 1},
+				},
+			},
+			wantAffinity: []specs.WindowsCPUGroupAffinity{
+				{Mask: 0x3, Group: 0},
+				{Mask: 0xf, Group: 1},
+			},
+		},
+		{
+			name:         "no AffinityCpus leaves CPU affinity nil",
+			resources:    &runtime.WindowsContainerResources{},
+			wantAffinity: nil,
+		},
+		{
+			name: "nil entries in AffinityCpus are skipped",
+			resources: &runtime.WindowsContainerResources{
+				AffinityCpus: []*runtime.WindowsCpuGroupAffinity{
+					{CpuMask: 0x3, CpuGroup: 0},
+					nil,
+					{CpuMask: 0xf, CpuGroup: 1},
+				},
+			},
+			wantAffinity: []specs.WindowsCPUGroupAffinity{
+				{Mask: 0x3, Group: 0},
+				{Mask: 0xf, Group: 1},
+			},
+		},
+		{
+			name:      "nil resources is a no-op",
+			resources: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &specs.Spec{}
+			err := WithWindowsResources(tt.resources)(context.Background(), nil, nil, s)
+			require.NoError(t, err)
+			if tt.resources == nil {
+				assert.Nil(t, s.Windows)
+				return
+			}
+			if tt.wantAffinity == nil {
+				if s.Windows != nil && s.Windows.Resources != nil && s.Windows.Resources.CPU != nil {
+					assert.Nil(t, s.Windows.Resources.CPU.Affinity)
+				}
+				return
+			}
+			require.NotNil(t, s.Windows)
+			require.NotNil(t, s.Windows.Resources)
+			require.NotNil(t, s.Windows.Resources.CPU)
+			assert.Equal(t, tt.wantAffinity, s.Windows.Resources.CPU.Affinity)
+		})
+	}
+}
+
 func TestDriveMounts(t *testing.T) {
 	tests := []struct {
 		mnt                   *runtime.Mount

--- a/internal/cri/server/helpers.go
+++ b/internal/cri/server/helpers.go
@@ -336,6 +336,12 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 			if spec.Windows.Resources.CPU.Maximum != nil {
 				status.Resources.Windows.CpuMaximum = int64(*spec.Windows.Resources.CPU.Maximum)
 			}
+			for _, a := range spec.Windows.Resources.CPU.Affinity {
+				status.Resources.Windows.AffinityCpus = append(
+					status.Resources.Windows.AffinityCpus,
+					&runtime.WindowsCpuGroupAffinity{CpuMask: a.Mask, CpuGroup: a.Group},
+				)
+			}
 		}
 
 		if spec.Windows.Resources.Memory != nil {

--- a/internal/cri/server/helpers_test.go
+++ b/internal/cri/server/helpers_test.go
@@ -363,6 +363,28 @@ func TestGetRuntimeOptions(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCopyResourcesToStatusWindowsAffinity(t *testing.T) {
+	spec := &runtimespec.Spec{
+		Windows: &runtimespec.Windows{
+			Resources: &runtimespec.WindowsResources{
+				CPU: &runtimespec.WindowsCPUResources{
+					Affinity: []runtimespec.WindowsCPUGroupAffinity{
+						{Mask: 0x3, Group: 0},
+						{Mask: 0xf, Group: 1},
+					},
+				},
+			},
+		},
+	}
+	status := copyResourcesToStatus(spec, containerstore.Status{})
+	require.NotNil(t, status.Resources)
+	require.NotNil(t, status.Resources.Windows)
+	assert.Equal(t, []*runtime.WindowsCpuGroupAffinity{
+		{CpuMask: 0x3, CpuGroup: 0},
+		{CpuMask: 0xf, CpuGroup: 1},
+	}, status.Resources.Windows.AffinityCpus)
+}
+
 func TestHostNetwork(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cri/store/container/status.go
+++ b/internal/cri/store/container/status.go
@@ -255,6 +255,15 @@ func deepCopyOf(s Status) Status {
 				CpuMaximum:         s.Resources.Windows.CpuMaximum,
 				MemoryLimitInBytes: s.Resources.Windows.MemoryLimitInBytes,
 				RootfsSizeInBytes:  s.Resources.Windows.RootfsSizeInBytes,
+				AffinityCpus: func() []*runtime.WindowsCpuGroupAffinity {
+					cp := make([]*runtime.WindowsCpuGroupAffinity, 0, len(s.Resources.Windows.AffinityCpus))
+					for _, a := range s.Resources.Windows.AffinityCpus {
+						if a != nil {
+							cp = append(cp, &runtime.WindowsCpuGroupAffinity{CpuMask: a.CpuMask, CpuGroup: a.CpuGroup})
+						}
+					}
+					return cp
+				}(),
 			},
 		}
 	}

--- a/internal/cri/store/container/status_test.go
+++ b/internal/cri/store/container/status_test.go
@@ -29,6 +29,30 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
+func TestDeepCopyOfWindowsAffinityCpus(t *testing.T) {
+	orig := Status{
+		Resources: &runtime.ContainerResources{
+			Windows: &runtime.WindowsContainerResources{
+				AffinityCpus: []*runtime.WindowsCpuGroupAffinity{
+					{CpuMask: 0x3, CpuGroup: 0},
+					nil, // test nil handling
+					{CpuMask: 0xf, CpuGroup: 1},
+				},
+			},
+		},
+	}
+	cp := deepCopyOf(orig)
+
+	// Nil entries should be skipped, not copied.
+	assertlib.Equal(t, 2, len(cp.Resources.Windows.AffinityCpus))
+	assertlib.Equal(t, uint64(0x3), cp.Resources.Windows.AffinityCpus[0].CpuMask)
+	assertlib.Equal(t, uint64(0xf), cp.Resources.Windows.AffinityCpus[1].CpuMask)
+
+	// Mutating the copy must not affect the original.
+	cp.Resources.Windows.AffinityCpus[0].CpuMask = 0xff
+	assertlib.Equal(t, uint64(0x3), orig.Resources.Windows.AffinityCpus[0].CpuMask)
+}
+
 func TestContainerState(t *testing.T) {
 	for c, test := range map[string]struct {
 		status Status


### PR DESCRIPTION
Three related bugs prevented Windows CPU affinity from round-tripping through UpdateContainerResources and ContainerStatus:

1. WithWindowsResources silently dropped AffinityCpus, so the kubelet's CPU manager reconcile loop never applied affinity changes to running containers. Add translation from CRI AffinityCpus to OCI WindowsCPUGroupAffinity.

2. copyResourcesToStatus never read the Affinity field from the OCI spec, so the stored container status always had AffinityCpus = nil. Add the read-back loop.

3. deepCopyOf omitted AffinityCpus when snapshotting Windows resources, silently dropping the field on every Status.Get(). Add the deep copy.