### PR TITLE
fix(windows): verify pipe readiness before returning shim address

### DIFF
--- a/core/runtime/v2/binary.go
+++ b/core/runtime/v2/binary.go
@@ -129,7 +129,7 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 		return nil, err
 	}
 
-	conn, err := makeConnection(ctx, b.bundle.ID, params, onCloseWithShimLog)
+	conn, err := makeConnection(ctx, b.bundle.ID, params, onCloseWithShimLog, client.AnonDialer)
 	if err != nil {
 		return nil, err
 	}

--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -289,8 +289,9 @@ func readBootstrapParams(path string) (*bootapi.BootstrapResult, error) {
 	return parseStartResponse(data)
 }
 
-// makeConnection creates a new TTRPC or GRPC connection object from address.
-// address can be either a socket path for TTRPC or JSON serialized BootstrapParams.
+// makeConnection creates a new TTRPC or GRPC connection using the address and
+// protocol from params. Legacy plain-string or JSON bootstrap responses are
+// normalized by parseStartResponse before calling this function.
 // The dialer parameter controls connection behavior: use AnonDialer for newly
 // started shims (retries if pipe doesn't exist yet) or AnonReconnectDialer for
 // reconnecting to already-running shims (fails fast if pipe is missing).

--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -112,7 +112,7 @@ func loadShim(ctx context.Context, bundle *Bundle, onClose func()) (_ ShimInstan
 		return nil, fmt.Errorf("failed to read bootstrap.json when restoring bundle %q: %w", bundle.ID, err)
 	}
 
-	conn, err := makeConnection(ctx, bundle.ID, params, onCloseWithShimLog)
+	conn, err := makeConnection(ctx, bundle.ID, params, onCloseWithShimLog, client.AnonReconnectDialer)
 	if err != nil {
 		return nil, fmt.Errorf("unable to make connection: %w", err)
 	}
@@ -291,7 +291,10 @@ func readBootstrapParams(path string) (*bootapi.BootstrapResult, error) {
 
 // makeConnection creates a new TTRPC or GRPC connection object from address.
 // address can be either a socket path for TTRPC or JSON serialized BootstrapParams.
-func makeConnection(ctx context.Context, id string, params *bootapi.BootstrapResult, onClose func()) (_ io.Closer, retErr error) {
+// The dialer parameter controls connection behavior: use AnonDialer for newly
+// started shims (retries if pipe doesn't exist yet) or AnonReconnectDialer for
+// reconnecting to already-running shims (fails fast if pipe is missing).
+func makeConnection(ctx context.Context, id string, params *bootapi.BootstrapResult, onClose func(), dialer func(string, time.Duration) (net.Conn, error)) (_ io.Closer, retErr error) {
 	log.G(ctx).WithFields(log.Fields{
 		"address":  params.Address,
 		"protocol": params.Protocol,
@@ -300,7 +303,7 @@ func makeConnection(ctx context.Context, id string, params *bootapi.BootstrapRes
 
 	switch strings.ToLower(params.Protocol) {
 	case "ttrpc":
-		conn, err := client.Connect(params.Address, client.AnonReconnectDialer)
+		conn, err := client.Connect(params.Address, dialer)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create TTRPC connection: %w", err)
 		}

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -292,6 +292,15 @@ func run(ctx context.Context, manager Shim, config Config) error {
 			return err
 		}
 
+		// On Windows, the shim daemon may not have created its named pipe
+		// yet when this start helper returns. Wait for it to be connectable
+		// before writing the bootstrap result to stdout.
+		// Similar to hcsshim's readiness pattern (microsoft/hcsshim notifyReady).
+		// On Unix this is a no-op: domain sockets appear atomically.
+		if err := awaitPipeReady(result.Address); err != nil {
+			return fmt.Errorf("shim pipe not ready: %w", err)
+		}
+
 		data, err := proto.Marshal(result)
 		if err != nil {
 			return fmt.Errorf("failed to marshal bootstrap params: %w", err)

--- a/pkg/shim/shim_unix.go
+++ b/pkg/shim/shim_unix.go
@@ -110,3 +110,10 @@ func handleExitSignals(ctx context.Context, logger *log.Entry, cancel context.Ca
 func openLog(ctx context.Context, _ string) (io.Writer, error) {
 	return fifo.OpenFifoDup2(ctx, "log", unix.O_WRONLY, 0700, int(os.Stderr.Fd()))
 }
+
+// awaitPipeReady is a no-op on Unix. Unix domain sockets appear atomically
+// when net.Listen("unix", path) is called, so there is no race between the
+// shim creating its endpoint and the parent connecting to it.
+func awaitPipeReady(_ string) error {
+	return nil
+}

--- a/pkg/shim/shim_windows.go
+++ b/pkg/shim/shim_windows.go
@@ -18,10 +18,13 @@ package shim
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"os"
+	"time"
 
+	winio "github.com/Microsoft/go-winio"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
@@ -55,4 +58,37 @@ func handleExitSignals(ctx context.Context, logger *log.Entry, cancel context.Ca
 
 func openLog(ctx context.Context, _ string) (io.Writer, error) {
 	return nil, errdefs.ErrNotImplemented
+}
+
+// awaitPipeReady polls a named pipe address until it is connectable,
+// retrying for up to 5 seconds with 10ms intervals.
+//
+// The shim "start" helper returns the pipe address before the long-lived
+// daemon has called winio.ListenPipe(). Unlike Unix domain sockets (which
+// appear atomically on Listen), Windows named pipes may take measurable
+// time to appear — especially under load. See #3659, microsoft/hcsshim.
+func awaitPipeReady(address string) error {
+	if address == "" {
+		return nil
+	}
+	deadline := time.After(5 * time.Second)
+	for {
+		// Use a 1s per-attempt timeout to avoid blocking indefinitely if
+		// the pipe exists but all instances are busy.
+		dialTimeout := time.Second
+		conn, err := winio.DialPipe(address, &dialTimeout)
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+		if !os.IsNotExist(err) {
+			return err
+		}
+		select {
+		case <-deadline:
+			return fmt.Errorf("pipe %s not found after 5s: %w", address, os.ErrNotExist)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
 }

--- a/pkg/shim/shim_windows.go
+++ b/pkg/shim/shim_windows.go
@@ -71,7 +71,10 @@ func awaitPipeReady(address string) error {
 	if address == "" {
 		return nil
 	}
-	deadline := time.After(5 * time.Second)
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
+	var lastErr error
 	for {
 		// Use a 1s per-attempt timeout to avoid blocking indefinitely if
 		// the pipe exists but all instances are busy.
@@ -81,12 +84,15 @@ func awaitPipeReady(address string) error {
 			conn.Close()
 			return nil
 		}
-		if !os.IsNotExist(err) {
+		lastErr = err
+		// Retry on both "pipe not found" and "pipe busy / deadline exceeded"
+		// — the pipe may still be starting up or temporarily at capacity.
+		if !os.IsNotExist(err) && err != context.DeadlineExceeded {
 			return err
 		}
 		select {
-		case <-deadline:
-			return fmt.Errorf("pipe %s not found after 5s: %w", address, os.ErrNotExist)
+		case <-timer.C:
+			return fmt.Errorf("pipe %s not ready after 5s: %w", address, lastErr)
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}

--- a/pkg/shim/util_windows.go
+++ b/pkg/shim/util_windows.go
@@ -33,7 +33,20 @@ func getSysProcAttr() *syscall.SysProcAttr {
 	return nil
 }
 
-// AnonReconnectDialer returns a dialer for an existing npipe on containerd reconnection
+// AnonReconnectDialer connects to a named pipe that should already exist.
+// It fails immediately if the pipe is not found, rather than retrying.
+//
+// Use this when reconnecting to a shim that is expected to be running
+// (e.g. after a containerd restart). If the pipe doesn't exist, the shim
+// is dead and there's no point waiting.
+//
+// This fail-fast behavior is critical on Windows: the Service Control Manager
+// enforces a ~30s startup deadline on containerd. If reconnecting to many dead
+// shims, a 5s retry per shim (as in AnonDialer) could exceed that budget and
+// cause the SCM to kill containerd. See #3659.
+//
+// On Unix, this function simply calls AnonDialer since Unix domain sockets
+// appear atomically and the distinction is unnecessary.
 func AnonReconnectDialer(address string, timeout time.Duration) (net.Conn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -49,7 +62,17 @@ func AnonReconnectDialer(address string, timeout time.Duration) (net.Conn, error
 	return c, nil
 }
 
-// AnonDialer returns a dialer for a npipe
+// AnonDialer connects to a named pipe, retrying for up to 5 seconds if the
+// pipe does not yet exist.
+//
+// Use this when connecting to a newly started shim. The shim's "start" helper
+// returns the pipe address before the long-lived shim daemon has created the
+// pipe, so a brief retry window is expected. 5 seconds is generous enough for
+// any healthy shim to begin serving.
+//
+// Unlike Unix domain sockets (which appear atomically on Listen), Windows named
+// pipes may take measurable time to appear — especially under load on CI
+// runners. See #2519, #2692.
 func AnonDialer(address string, timeout time.Duration) (net.Conn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()


### PR DESCRIPTION
## Summary

On Windows, the shim "start" helper returns the named pipe address before the
daemon process has created the pipe via `winio.ListenPipe()`. On busy systems,
containerd tries to connect before the pipe exists, causing intermittent failures:

```
failed to create TTRPC connection: npipe not found on reconnect: file does not exist
```

- Add `awaitPipeReady()` — start helper polls pipe until connectable before returning
- Parameterize `makeConnection()` with a dialer as a client-side safety net
- Add doc comments explaining the two Windows dialers and their history

This fix is roughly based on the [notifyReady signa](https://github.com/microsoft/hcsshim/blob/7accc8d706a48e897ee857897fcc8dd65bdf036b/internal/shim/shim_windows.go#L43)l in https://github.com/microsoft/hcsshim

## What Changed

- **Readiness check in start helper** (`pkg/shim/shim.go`, `shim_windows.go`): after
  `manager.Start()` returns the pipe address, `awaitPipeReady()` polls the address (up to
  5s, 10ms intervals, 1s per-attempt timeout) before writing the bootstrap result to stdout.
  This follows hcsshim's readiness pattern where the shim verifies its endpoint before
  signaling the parent. On Unix this is a no-op — domain sockets appear atomically on
  `Listen()`.

- **Client-side safety net** (`core/runtime/v2/shim.go`, `binary.go`): `makeConnection()`
  now accepts a dialer parameter. `binary.Start()` (new shim) uses `AnonDialer` (retries
  5s), `loadShim()` (reconnect) keeps `AnonReconnectDialer` (fail-fast per #3659 for the
  Windows SCM startup deadline).

- **Doc comments** (`pkg/shim/util_windows.go`): explains when to use each dialer, the SCM
  motivation (#3659), and the retry logic history (#2519, #2692).

## Latency impact

**Happy path**: pipe appears in milliseconds, `awaitPipeReady` returns instantly. Total container start time unchanged — the wait moved from client-side (`AnonDialer` retry) to the start helper

**Failure path**: if the shim daemon crashes, the start helper waits up to 5s before failing. This matches `AnonDialer`'s existing timeout, so no worse than before.

**Unix**: no impact — `awaitPipeReady` is a no-op.

## Testing

Validated on Windows Server 2025 CI (8-core, 32GB runner): 0 pipe failures across 7 CI
attempts running 6 affected tests × 3 repetitions each. Previously ~50% failure rate.

Refs: #3659, #2519, #2692, #5597