### PR TITLE
Make utils.sh nounset-safe by never expanding unset CGROUP_DRIVER on Windows

### DIFF
--- a/script/test/utils.sh
+++ b/script/test/utils.sh
@@ -163,7 +163,7 @@ fi
 # To allow the cri-integration test to run via CLI without explicitly setting CGROUP_DRIVER
 if [ $IS_WINDOWS -eq 0 ] && [ ! -v CGROUP_DRIVER ]; then
   echo "CGROUP_DRIVER is unset"
-elif [ "$CGROUP_DRIVER" = "systemd" ]; then
+elif [ "${CGROUP_DRIVER:-}" = "systemd" ]; then
   cat >> ${CONTAINERD_CONFIG_FILE} << EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
    SystemdCgroup = true


### PR DESCRIPTION
The Windows periodic job failed the CRI integration stage with:
./script/test/utils.sh: line 166: CGROUP_DRIVER: unbound variable

if [ $IS_WINDOWS -eq 0 ] && [ ! -v CGROUP_DRIVER ]; then
  echo "CGROUP_DRIVER is unset"
elif [ "$CGROUP_DRIVER" = "systemd" ]; then
  ...
fi

script/test/cri-integration.sh enables strict bash mode including nounset (set -o nounset), then sources script/test/utils.sh
On Windows, IS_WINDOWS=1, so the first if condition is false, and bash evaluates the elif condition next, which expands $CGROUP_DRIVER. Since CGROUP_DRIVER is typically unset on Windows (and doesn’t need to be), nounset aborts the script with “unbound variable”.