### PR TITLE
registry: fix server has empty tls Certificate and verity host.toml

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -399,6 +400,7 @@ func parseHostsFile(baseDir string, b []byte) ([]hostConfig, error) {
 		return nil, err
 	}
 
+	var parseHost []string
 	// Parse hosts array
 	for _, host := range orderedHosts {
 		config := c.HostConfigs[host]
@@ -408,6 +410,7 @@ func parseHostsFile(baseDir string, b []byte) ([]hostConfig, error) {
 			return nil, err
 		}
 		hosts = append(hosts, parsed)
+		parseHost = append(parseHost, parsed.host)
 	}
 
 	// Parse root host config and append it as the last element
@@ -415,7 +418,14 @@ func parseHostsFile(baseDir string, b []byte) ([]hostConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	hosts = append(hosts, parsed)
+
+	// If server is empty skip to add it to hosts
+	if parsed.host != "" {
+		if slices.Contains(parseHost, parsed.host) {
+			return nil, fmt.Errorf("conflict server %s already exist in host", parsed.host)
+		}
+		hosts = append(hosts, parsed)
+	}
 
 	return hosts, nil
 }


### PR DESCRIPTION
E0410 13:52:06.357868 2972303 log.go:32] "PullImage from image service failed" err="rpc error: code = Unknown desc = failed to pull and unpack image \"my-registry:2524/admin/image/test:v2\": failed to resolve reference \"my-registry:2524/admin/image/test:v2\": failed to do request: Head \"https://my-registry:2524/v2/admin/image/test/manifests/v2\": remote error: tls: certificate required" image="my-registry:2524/admin/image/test:v2"
FATA[0000] pulling image: failed to pull and unpack image "my-registry:2524/admin/image/test:v2": failed to resolve reference "my-registry:2524/admin/image/test:v2": failed to do request: Head "https://my-registry:2524/v2/admin/image/test/manifests/v2": remote error: tls: certificate required



cat /etc/containerd/certs.d/my-registry:2524/hosts.toml 
use the following configuration  should not failed if server is empty
```
[host."https://my-registry:2524"]
  capabilities = ["pull", "resolve", "push"]
  ca = "/etc/containerd/certs.d/my-registry:2524/ca.crt"
  client = [["/etc/containerd/certs.d/my-registry:2524/client.cert", "/etc/containerd/certs.d/my-registry:2524/client.key"]]
```
and use conflict config  should return an error
```
server = "https://my-registry:2524"

[host."https://my-registry:2524"]
  capabilities = ["pull", "resolve", "push"]
  ca = "/etc/containerd/certs.d/my-registry:2524/ca.crt"
  client = [["/etc/containerd/certs.d/my-registry:2524/client.cert", "/etc/containerd/certs.d/my-registry:2524/client.key"]]
```

@mxpv  @mikebrow  I'm not sure whether it's a bug.