### PR TITLE
pkg/sys: enable CloseWrite on Windows named pipe listeners?

### DIFF
--- a/pkg/sys/socket_windows.go
+++ b/pkg/sys/socket_windows.go
@@ -22,9 +22,13 @@ import (
 	"github.com/Microsoft/go-winio"
 )
 
-// GetLocalListener returns a Listernet out of a named pipe.
+// GetLocalListener returns a Listener out of a named pipe.
 // `path` must be of the form of `\\.\pipe\<pipename>`
 // (see https://msdn.microsoft.com/en-us/library/windows/desktop/aa365150)
+//
+// MessageMode is enabled so that accepted connections support CloseWrite,
+// matching the behavior of Unix. This is important for protocols like HTTP
+// that rely on receiving data after a half-close.
 func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
-	return winio.ListenPipe(path, nil)
+	return winio.ListenPipe(path, &winio.PipeConfig{MessageMode: true})
 }

--- a/pkg/sys/socket_windows_test.go
+++ b/pkg/sys/socket_windows_test.go
@@ -1,0 +1,91 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/containerd/containerd/v2/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequiresRoot registers the -test.root flag on Windows.
+// The Linux test files in this package import testutil (which registers the
+// flag), but they are not compiled on Windows. Without this, the Makefile's
+// root-test target fails with "flag provided but not defined: -test.root".
+func TestRequiresRoot(t *testing.T) {
+	testutil.RequiresRoot(t)
+}
+
+type closeWriter interface {
+	CloseWrite() error
+}
+
+func TestGetLocalListenerCloseWrite(t *testing.T) {
+	path := fmt.Sprintf(`\\.\pipe\containerd-test-%d`, rand.Int64())
+
+	l, err := GetLocalListener(path, os.Getuid(), os.Getgid())
+	require.NoError(t, err)
+	defer l.Close()
+
+	type result struct {
+		conn net.Conn
+		err  error
+	}
+	accepted := make(chan result, 1)
+	go func() {
+		conn, err := l.Accept()
+		accepted <- result{conn, err}
+	}()
+
+	client, err := winio.DialPipe(path, nil)
+	require.NoError(t, err)
+	defer client.Close()
+
+	res := <-accepted
+	require.NoError(t, res.err)
+	serverConn := res.conn
+	defer serverConn.Close()
+
+	cw, ok := serverConn.(closeWriter)
+	require.True(t, ok, "accepted connection %T does not implement CloseWrite", serverConn)
+
+	require.NoError(t, cw.CloseWrite())
+
+	// Client can still Write
+	errCh := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		client.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		_, err := client.Write(buf)
+		errCh <- err
+	}()
+	// Server can still Read
+	buf := make([]byte, 1)
+	serverConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, err = serverConn.Read(buf)
+	require.NoError(t, err)
+	require.NoError(t, <-errCh)
+}


### PR DESCRIPTION
This is a minor improvement -- a pre-emptive fix for a "foot gun" that we hit a bunch of times on Docker Desktop on Windows with named pipes.

Unlike TCP and Unix Listeners, the winio named pipe Listeners don't support `CloseWrite()` by default. This tends to go wrong at runtime for protocols that rely on reading data after a half-close (e.g. HTTP). I'm not sure whether this is currently an issue with the protocols in-use here.

go-winio supports CloseWrite() by enabling "MessageMode" on the endpoint, see: https://github.com/Microsoft/go-winio/blob/ad3df93bed29/pipe.go#L492 To avoid this class of problem Docker Desktop always tries to create pipes in this mode which seems to work pretty well.

