### PR TITLE
runtime/v2: wrap shim process tree in Job Object on Windows

### DIFF
--- a/core/runtime/v2/binary.go
+++ b/core/runtime/v2/binary.go
@@ -108,7 +108,7 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 			log.G(ctx).WithError(err).Error("copy shim log")
 		}
 	}()
-	out, err := cmd.CombinedOutput()
+	out, err := b.runShimStart(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", out, err)
 	}

--- a/core/runtime/v2/binary_nowindows.go
+++ b/core/runtime/v2/binary_nowindows.go
@@ -1,0 +1,27 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+//go:build !windows
+
+package v2
+
+import "os/exec"
+
+// runShimStart executes the shim start command and returns its combined output.
+// On non-Windows platforms this is a straightforward exec.
+func (b *binary) runShimStart(cmd *exec.Cmd) ([]byte, error) {
+	return cmd.CombinedOutput()
+}

--- a/core/runtime/v2/binary_windows.go
+++ b/core/runtime/v2/binary_windows.go
@@ -1,0 +1,105 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+//go:build windows
+
+package v2
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"sync"
+	"unsafe"
+
+	"github.com/containerd/log"
+	"golang.org/x/sys/windows"
+)
+
+// runShimStart executes the shim start command inside a Windows Job Object.
+// The Job Object is configured with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so
+// that closing the handle terminates the entire process tree (shim + VM).
+// Child processes of the shim inherit Job Object membership automatically.
+//
+// The cleanup function is stored on b.bundle.Cleanup so that both
+// binary.Delete (dead-shim path) and shim.Delete (graceful path) can
+// close the Job Object before attempting to remove the bundle directory.
+func (b *binary) runShimStart(cmd *exec.Cmd) ([]byte, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		log.L.WithError(err).Warn("failed to create job object for shim, falling back to default start")
+		return cmd.CombinedOutput()
+	}
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		windows.CloseHandle(job)
+		log.L.WithError(err).Warn("failed to configure job object for shim, falling back to default start")
+		return cmd.CombinedOutput()
+	}
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Start(); err != nil {
+		windows.CloseHandle(job)
+		return buf.Bytes(), err
+	}
+
+	processHandle, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
+		false,
+		uint32(cmd.Process.Pid),
+	)
+	if err != nil {
+		// Process may have already exited — continue without job assignment.
+		windows.CloseHandle(job)
+		log.L.WithError(err).Warn("failed to open shim process handle for job object assignment")
+	} else {
+		if err := windows.AssignProcessToJobObject(job, processHandle); err != nil {
+			windows.CloseHandle(processHandle)
+			windows.CloseHandle(job)
+			log.L.WithError(err).Warn("failed to assign shim process to job object")
+		} else {
+			windows.CloseHandle(processHandle)
+			var once sync.Once
+			b.bundle.Cleanup = func() {
+				once.Do(func() {
+					log.L.WithField("bundle", b.bundle.ID).Debug("closing shim job object")
+					if err := windows.CloseHandle(job); err != nil {
+						log.L.WithError(err).WithField("bundle", b.bundle.ID).Warn("failed to close shim job object")
+					}
+				})
+			}
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return buf.Bytes(), fmt.Errorf("%s: %w", buf.Bytes(), err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/core/runtime/v2/bundle.go
+++ b/core/runtime/v2/bundle.go
@@ -135,6 +135,13 @@ type Bundle struct {
 
 // Delete a bundle atomically
 func (b *Bundle) Delete() error {
+	// Run platform-specific cleanup before deleting bundle files.
+	// On Windows, this closes the Job Object containing the shim process
+	// tree, which terminates all processes and releases file handles.
+	if b.Cleanup != nil {
+		b.Cleanup()
+	}
+
 	work, werr := os.Readlink(filepath.Join(b.Path, "work"))
 	rootfs := filepath.Join(b.Path, "rootfs")
 	if err := mount.UnmountRecursive(rootfs, 0); err != nil {

--- a/core/runtime/v2/bundle.go
+++ b/core/runtime/v2/bundle.go
@@ -126,6 +126,11 @@ type Bundle struct {
 	Path string
 	// Namespace of the bundle
 	Namespace string
+	// Cleanup is an optional platform-specific cleanup function called
+	// before deleting the bundle directory. On Windows, this closes the
+	// Job Object that contains the shim process tree, ensuring all
+	// processes are terminated and file handles are released.
+	Cleanup func()
 }
 
 // Delete a bundle atomically


### PR DESCRIPTION
## Summary

- On Windows, when a shim disconnects (e.g. sandbox auto-stop), `Bundle.Delete()` fails because files in the bundle directory are still locked by the exiting shim process or its children (e.g. the VM process)
- This adds a Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` around the shim process tree during start, ensuring deterministic process termination when the bundle is deleted
- `Bundle.Cleanup` is called at the start of `Bundle.Delete()` to close the Job Object handle, which kills the entire process tree and releases all file handles before `atomicDelete` runs

## Details

The shim bootstrap process is assigned to a Job Object immediately after `cmd.Start()`. Child processes (the real shim, the VM) inherit Job Object membership automatically. The cleanup closure is stored on `Bundle.Cleanup` so both the `binary.Delete` (dead-shim) and `shim.Delete` (graceful) paths can use it.

If Job Object creation fails at any point, the shim starts normally without process tree containment (graceful degradation).

The `Cleanup` closure is protected by `sync.Once` to prevent double-close of the Job Object handle.

## Test plan

- [ ] Verify `go build ./core/runtime/v2/` compiles on Windows and Linux
- [ ] Manual: start a container, let it auto-stop, restart — confirm no file lock errors from `Bundle.Delete()`
- [ ] Manual: verify shim process tree is terminated when Job Object handle is closed