### PR TITLE
core/metadata: fixes and optimizations

### DIFF
--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -841,11 +841,11 @@ func writeExpireAt(expire time.Time, bkt *bolt.Bucket) error {
 }
 
 // garbageCollect removes all contents that are no longer used.
-func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, err error) {
+func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, retErr error) {
 	cs.l.Lock()
 	t1 := time.Now()
 	defer func() {
-		if err == nil {
+		if retErr == nil {
 			d = time.Since(t1)
 		}
 		cs.l.Unlock()
@@ -912,7 +912,7 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 		return 0, err
 	}
 
-	err = cs.Store.Walk(ctx, func(info content.Info) error {
+	if err := cs.Store.Walk(ctx, func(info content.Info) error {
 		if _, ok := contentSeen[info.Digest.String()]; !ok {
 			if err := cs.Store.Delete(ctx, info.Digest); err != nil {
 				return err
@@ -920,9 +920,8 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 			log.G(ctx).WithField("digest", info.Digest).Debug("removed content")
 		}
 		return nil
-	})
-	if err != nil {
-		return
+	}); err != nil {
+		return 0, err
 	}
 
 	// If the content store has implemented a more efficient walk function
@@ -932,7 +931,7 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 		WalkStatusRefs(context.Context, func(string) error) error
 	}
 	if w, ok := cs.Store.(statusWalker); ok {
-		err = w.WalkStatusRefs(ctx, func(ref string) error {
+		if err := w.WalkStatusRefs(ctx, func(ref string) error {
 			if _, ok := ingestSeen[ref]; !ok {
 				if err := cs.Store.Abort(ctx, ref); err != nil {
 					return err
@@ -940,21 +939,22 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 				log.G(ctx).WithField("ref", ref).Debug("cleanup aborting ingest")
 			}
 			return nil
-		})
+		}); err != nil {
+			return 0, err
+		}
 	} else {
-		var statuses []content.Status
-		statuses, err = cs.Store.ListStatuses(ctx)
+		statuses, err := cs.Store.ListStatuses(ctx)
 		if err != nil {
 			return 0, err
 		}
 		for _, status := range statuses {
 			if _, ok := ingestSeen[status.Ref]; !ok {
-				if err = cs.Store.Abort(ctx, status.Ref); err != nil {
-					return
+				if err := cs.Store.Abort(ctx, status.Ref); err != nil {
+					return 0, err
 				}
 				log.G(ctx).WithField("ref", status.Ref).Debug("cleanup aborting ingest")
 			}
 		}
 	}
-	return
+	return 0, nil
 }

--- a/core/metadata/db.go
+++ b/core/metadata/db.go
@@ -435,32 +435,27 @@ func (m *DB) GarbageCollect(ctx context.Context) (gc.Stats, error) {
 	if len(m.dirtySS) > 0 {
 		var sl sync.Mutex
 		stats.SnapshotD = map[string]time.Duration{}
-		wg.Add(len(m.dirtySS))
 		for snapshotterName := range m.dirtySS {
 			log.G(ctx).WithField("snapshotter", snapshotterName).Debug("schedule snapshotter cleanup")
-			go func(snapshotterName string) {
+			wg.Go(func() {
 				st1 := time.Now()
 				m.cleanupSnapshotter(ctx, snapshotterName)
 
 				sl.Lock()
 				stats.SnapshotD[snapshotterName] = time.Since(st1)
 				sl.Unlock()
-
-				wg.Done()
-			}(snapshotterName)
+			})
 		}
 		m.dirtySS = map[string]struct{}{}
 	}
 
 	if m.dirtyCS {
-		wg.Add(1)
 		log.G(ctx).Debug("schedule content cleanup")
-		go func() {
+		wg.Go(func() {
 			ct1 := time.Now()
 			m.cleanupContent(ctx)
 			stats.ContentD = time.Since(ct1)
-			wg.Done()
-		}()
+		})
 		m.dirtyCS = false
 	}
 

--- a/core/metadata/db.go
+++ b/core/metadata/db.go
@@ -400,6 +400,10 @@ func (m *DB) GarbageCollect(ctx context.Context) (gc.Stats, error) {
 				// queue event to publish after successful commit
 			case ResourceContent, ResourceIngest:
 				m.dirtyCS = true
+			case ResourceUnknown, ResourceContainer, ResourceTask, ResourceImage,
+				ResourceLease, ResourceStream, ResourceMount,
+				resourceContentFlat, resourceSnapshotFlat, resourceImageFlat, resourceEnd:
+				// nop.
 			}
 
 			if event, err := c.remove(ctx, tx, n); event != nil && err == nil {

--- a/core/metadata/db.go
+++ b/core/metadata/db.go
@@ -147,7 +147,7 @@ func (m *DB) Init(ctx context.Context) error {
 	// back rather than performing a much slower and unnecessary commit.
 	var errSkip = errors.New("skip update")
 
-	err := m.db.Update(func(tx *bolt.Tx) error {
+	if err := m.db.Update(func(tx *bolt.Tx) error {
 		var (
 			// current schema and version
 			schema  = "v0"
@@ -163,9 +163,9 @@ func (m *DB) Init(ctx context.Context) error {
 		i := len(migrations)
 
 		for ; i > 0; i-- {
-			migration := migrations[i-1]
+			mig := migrations[i-1]
 
-			bkt := tx.Bucket([]byte(migration.schema))
+			bkt := tx.Bucket([]byte(mig.schema))
 			if bkt == nil {
 				// Hasn't encountered another schema, go to next migration
 				if schema == "v0" {
@@ -174,7 +174,7 @@ func (m *DB) Init(ctx context.Context) error {
 				break
 			}
 			if schema == "v0" {
-				schema = migration.schema
+				schema = mig.schema
 				vb := bkt.Get(bucketKeyDBVersion)
 				if vb != nil {
 					v, _ := binary.Varint(vb)
@@ -182,7 +182,7 @@ func (m *DB) Init(ctx context.Context) error {
 				}
 			}
 
-			if version >= migration.version {
+			if version >= mig.version {
 				break
 			}
 		}
@@ -196,12 +196,12 @@ func (m *DB) Init(ctx context.Context) error {
 				return errSkip
 			}
 
-			for _, m := range updates {
+			for _, u := range updates {
 				t0 := time.Now()
-				if err := m.migrate(tx); err != nil {
-					return fmt.Errorf("failed to migrate to %s.%d: %w", m.schema, m.version, err)
+				if err := u.migrate(tx); err != nil {
+					return fmt.Errorf("failed to migrate to %s.%d: %w", u.schema, u.version, err)
 				}
-				log.G(ctx).WithField("d", time.Since(t0)).Debugf("finished database migration to %s.%d", m.schema, m.version)
+				log.G(ctx).WithField("d", time.Since(t0)).Debugf("finished database migration to %s.%d", u.schema, u.version)
 			}
 		}
 
@@ -216,11 +216,13 @@ func (m *DB) Init(ctx context.Context) error {
 		}
 
 		return bkt.Put(bucketKeyDBVersion, versionEncoded)
-	})
-	if err == errSkip {
-		err = nil
+	}); err != nil {
+		if errors.Is(err, errSkip) {
+			return nil
+		}
+		return err
 	}
-	return err
+	return nil
 }
 
 // ContentStore returns a namespaced content store
@@ -380,12 +382,12 @@ func (m *DB) GarbageCollect(ctx context.Context) (gc.Stats, error) {
 		return nil, err
 	}
 
-	events := []namespacedEvent{}
+	nsEvents := []namespacedEvent{}
 	if err := m.db.Update(func(tx *bolt.Tx) error {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
-		rm := func(ctx context.Context, n gc.Node) error {
+		if err := c.scanAll(ctx, tx, func(ctx context.Context, n gc.Node) error {
 			if _, ok := marked[n]; ok {
 				return nil
 			}
@@ -400,18 +402,14 @@ func (m *DB) GarbageCollect(ctx context.Context) (gc.Stats, error) {
 				m.dirtyCS = true
 			}
 
-			event, err := c.remove(ctx, tx, n)
-			if event != nil && err == nil {
-				events = append(events,
-					namespacedEvent{
-						namespace: n.Namespace,
-						event:     event,
-					})
+			if event, err := c.remove(ctx, tx, n); event != nil && err == nil {
+				nsEvents = append(nsEvents, namespacedEvent{
+					namespace: n.Namespace,
+					event:     event,
+				})
 			}
 			return err
-		}
-
-		if err := c.scanAll(ctx, tx, rm); err != nil { // From gc context
+		}); err != nil { // From gc context
 			return fmt.Errorf("failed to scan and remove: %w", err)
 		}
 
@@ -427,7 +425,7 @@ func (m *DB) GarbageCollect(ctx context.Context) (gc.Stats, error) {
 
 	// Flush events asynchronously after commit
 	wg.Go(func() {
-		m.publishEvents(events)
+		m.publishEvents(nsEvents)
 	})
 
 	// Reset dirty. Truly don't need to be atomically stored inside of the wlock
@@ -501,7 +499,7 @@ func (m *DB) getMarked(ctx context.Context, c *gcContext) (map[gc.Node]struct{},
 		close(roots)
 		wg.Wait()
 
-		refs := func(n gc.Node) ([]gc.Node, error) {
+		reachable, err := gc.Tricolor(nodes, func(n gc.Node) ([]gc.Node, error) {
 			var sn []gc.Node
 			if err := c.references(ctx, tx, n, func(nn gc.Node) { // From gc context
 				sn = append(sn, nn)
@@ -509,9 +507,7 @@ func (m *DB) getMarked(ctx context.Context, c *gcContext) (map[gc.Node]struct{},
 				return nil, err
 			}
 			return sn, nil
-		}
-
-		reachable, err := gc.Tricolor(nodes, refs)
+		})
 		if err != nil {
 			return err
 		}

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -446,14 +446,12 @@ func (c *gcContext) cancel(ctx context.Context) {
 }
 
 func (c *gcContext) finish(ctx context.Context, wg *sync.WaitGroup) {
-	wg.Add(len(c.contexts))
-	for t, gctx := range c.contexts {
-		go func() {
-			if err := gctx.Finish(); err != nil {
-				log.G(ctx).WithField("type", t).WithError(err).Error("failed to finish collection context")
+	for resourceType, gcCtx := range c.contexts {
+		wg.Go(func() {
+			if err := gcCtx.Finish(); err != nil {
+				log.G(ctx).WithFields(log.Fields{"type": resourceType, "error": err}).Error("failed to finish collection context")
 			}
-			wg.Done()
-		}()
+		})
 	}
 }
 

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -203,11 +203,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCContainerBackRef,
 			bref: func(ns string, k, v []byte, fn func(gc.Node)) {
-				if ks := string(k); ks != string(labelGCContainerBackRef) {
-					// Allow reference naming separated by . or /, ignore names
-					if ks[len(labelGCContainerBackRef)] != '.' && ks[len(labelGCContainerBackRef)] != '/' {
-						return
-					}
+				// Allow reference naming separated by . or /, ignore names
+				rest, ok := bytes.CutPrefix(k, labelGCContainerBackRef)
+				if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+					return
 				}
 
 				fn(gcnode(ResourceContainer, ns, string(v)))
@@ -216,11 +215,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCContentBackRef,
 			bref: func(ns string, k, v []byte, fn func(gc.Node)) {
-				if ks := string(k); ks != string(labelGCContentBackRef) {
-					// Allow reference naming separated by . or /, ignore names
-					if ks[len(labelGCContentBackRef)] != '.' && ks[len(labelGCContentBackRef)] != '/' {
-						return
-					}
+				// Allow reference naming separated by . or /, ignore names
+				rest, ok := bytes.CutPrefix(k, labelGCContentBackRef)
+				if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+					return
 				}
 
 				fn(gcnode(ResourceContent, ns, string(v)))
@@ -229,11 +227,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCImageBackRef,
 			bref: func(ns string, k, v []byte, fn func(gc.Node)) {
-				if ks := string(k); ks != string(labelGCImageBackRef) {
-					// Allow reference naming separated by . or /, ignore names
-					if ks[len(labelGCImageBackRef)] != '.' && ks[len(labelGCImageBackRef)] != '/' {
-						return
-					}
+				// Allow reference naming separated by . or /, ignore names
+				rest, ok := bytes.CutPrefix(k, labelGCImageBackRef)
+				if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+					return
 				}
 
 				fn(gcnode(ResourceImage, ns, string(v)))
@@ -253,11 +250,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCContentRef,
 			fn: func(ns string, k, v []byte, fn func(gc.Node)) {
-				if ks := string(k); ks != string(labelGCContentRef) {
-					// Allow reference naming separated by . or /, ignore names
-					if ks[len(labelGCContentRef)] != '.' && ks[len(labelGCContentRef)] != '/' {
-						return
-					}
+				// Allow reference naming separated by . or /, ignore names
+				rest, ok := bytes.CutPrefix(k, labelGCContentRef)
+				if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+					return
 				}
 
 				fn(gcnode(ResourceContent, ns, string(v)))
@@ -266,11 +262,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCImageRef,
 			fn: func(ns string, k, v []byte, fn func(gc.Node)) {
-				if ks := string(k); ks != string(labelGCImageRef) {
-					// Allow reference naming separated by . or /, ignore names
-					if ks[len(labelGCImageRef)] != '.' && ks[len(labelGCImageRef)] != '/' {
-						return
-					}
+				// Allow reference naming separated by . or /, ignore names
+				rest, ok := bytes.CutPrefix(k, labelGCImageRef)
+				if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+					return
 				}
 
 				fn(gcnode(ResourceImage, ns, string(v)))
@@ -280,10 +275,8 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 			key: labelGCSnapRef,
 			fn: func(ns string, k, v []byte, fn func(gc.Node)) {
 				if rest, ok := bytes.CutPrefix(k, labelGCSnapRef); ok {
-					if i := bytes.IndexByte(rest, '/'); i > 0 {
-						rest = rest[:i]
-					}
-					fn(gcnode(ResourceSnapshot, ns, string(rest)+"/"+string(v)))
+					snapshotterName, _, _ := bytes.Cut(rest, []byte("/"))
+					fn(gcnode(ResourceSnapshot, ns, string(snapshotterName)+"/"+string(v)))
 				}
 			},
 		},
@@ -390,11 +383,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 				labelHandlers = append(labelHandlers, referenceLabelHandler{
 					key: key,
 					fn: func(ns string, k, v []byte, fn func(gc.Node)) {
-						if ks := string(k); ks != string(key) {
-							// Allow reference naming separated by . or /, ignore names
-							if ks[len(key)] != '.' && ks[len(key)] != '/' {
-								return
-							}
+						// Allow reference naming separated by . or /, ignore names
+						rest, ok := bytes.CutPrefix(k, key)
+						if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+							return
 						}
 
 						fn(gcnode(rt, ns, string(v)))

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -1059,23 +1059,24 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 
 // sendLabelRefs sends all snapshot and content references referred to by the labels in the bkt
 func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, cb labelRefCallbacks) error {
-	lbkt := bkt.Bucket(bucketKeyObjectLabels)
-	if lbkt != nil {
+	if lbkt := bkt.Bucket(bucketKeyObjectLabels); lbkt != nil {
 		lc := lbkt.Cursor()
-		for i := range c.labelHandlers {
-			if (cb.bref == nil && c.labelHandlers[i].bref != nil) || (cb.fn == nil && c.labelHandlers[i].fn != nil) || (cb.cond == nil && c.labelHandlers[i].condition != nil) || (cb.condVal == nil && c.labelHandlers[i].conditionalV != nil) {
+		for _, h := range c.labelHandlers {
+			if (cb.bref == nil && h.bref != nil) || (cb.fn == nil && h.fn != nil) || (cb.cond == nil && h.condition != nil) || (cb.condVal == nil && h.conditionalV != nil) {
 				continue
 			}
-			for k, v := lc.Seek(c.labelHandlers[i].key); k != nil && bytes.HasPrefix(k, c.labelHandlers[i].key); k, v = lc.Next() {
-				if c.labelHandlers[i].fn != nil {
-					c.labelHandlers[i].fn(ns, k, v, cb.fn)
-				} else if c.labelHandlers[i].bref != nil {
-					c.labelHandlers[i].bref(ns, k, v, cb.bref)
-				} else if c.labelHandlers[i].condition != nil {
-					c.labelHandlers[i].condition(ns, k, v, cb.cond)
-				} else if c.labelHandlers[i].conditionalV != nil {
-					c.labelHandlers[i].conditionalV(ns, k, v, cb.condVal)
-				} else if cb.root != nil {
+
+			for k, v := lc.Seek(h.key); k != nil && bytes.HasPrefix(k, h.key); k, v = lc.Next() {
+				switch {
+				case h.fn != nil:
+					h.fn(ns, k, v, cb.fn)
+				case h.bref != nil:
+					h.bref(ns, k, v, cb.bref)
+				case h.condition != nil:
+					h.condition(ns, k, v, cb.cond)
+				case h.conditionalV != nil:
+					h.conditionalV(ns, k, v, cb.condVal)
+				case cb.root != nil:
 					cb.root()
 				}
 			}

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -57,10 +57,12 @@ const (
 	ResourceMount
 )
 
+const resourceFlat = 0x20
+
 const (
-	resourceContentFlat  = ResourceContent | 0x20
-	resourceSnapshotFlat = ResourceSnapshot | 0x20
-	resourceImageFlat    = ResourceImage | 0x20
+	resourceContentFlat  gc.ResourceType = ResourceContent | resourceFlat
+	resourceSnapshotFlat gc.ResourceType = ResourceSnapshot | resourceFlat
+	resourceImageFlat    gc.ResourceType = ResourceImage | resourceFlat
 )
 
 var (

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -517,8 +517,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 		nbkt := v1bkt.Bucket(k)
 		ns := string(k)
 
-		lbkt := nbkt.Bucket(bucketKeyObjectLeases)
-		if lbkt != nil {
+		if lbkt := nbkt.Bucket(bucketKeyObjectLeases); lbkt != nil {
 			if err := lbkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -528,8 +527,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 
 				if lblbkt := libkt.Bucket(bucketKeyObjectLabels); lblbkt != nil {
 					if expV := lblbkt.Get(labelGCExpire); expV != nil {
-						exp, err := time.Parse(time.RFC3339, string(expV))
-						if err != nil {
+						if exp, err := time.Parse(time.RFC3339, string(expV)); err != nil {
 							// label not used, log and continue to use lease
 							log.G(ctx).WithError(err).WithField("lease", string(k)).Infof("ignoring invalid expiration value %q", string(expV))
 						} else if expThreshold.After(exp) {
@@ -551,13 +549,11 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 				// no need to allow the lookup to be recursive, handling here
 				// therefore reduces the number of database seeks.
 
-				ctype := ResourceContent
-				if flat {
-					ctype = resourceContentFlat
-				}
-
-				cbkt := libkt.Bucket(bucketKeyObjectContent)
-				if cbkt != nil {
+				if cbkt := libkt.Bucket(bucketKeyObjectContent); cbkt != nil {
+					ctype := ResourceContent
+					if flat {
+						ctype = resourceContentFlat
+					}
 					if err := cbkt.ForEach(func(k, v []byte) error {
 						fn(gcnode(ctype, ns, string(k)))
 						return nil
@@ -566,13 +562,11 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					}
 				}
 
-				stype := ResourceSnapshot
-				if flat {
-					stype = resourceSnapshotFlat
-				}
-
-				sbkt := libkt.Bucket(bucketKeyObjectSnapshots)
-				if sbkt != nil {
+				if sbkt := libkt.Bucket(bucketKeyObjectSnapshots); sbkt != nil {
+					stype := ResourceSnapshot
+					if flat {
+						stype = resourceSnapshotFlat
+					}
 					if err := sbkt.ForEach(func(sk, sv []byte) error {
 						if sv != nil {
 							return nil
@@ -588,8 +582,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					}
 				}
 
-				ibkt := libkt.Bucket(bucketKeyObjectIngests)
-				if ibkt != nil {
+				if ibkt := libkt.Bucket(bucketKeyObjectIngests); ibkt != nil {
 					if err := ibkt.ForEach(func(k, v []byte) error {
 						fn(gcnode(ResourceIngest, ns, string(k)))
 						return nil
@@ -598,13 +591,11 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					}
 				}
 
-				itype := ResourceImage
-				if flat {
-					itype = resourceImageFlat
-				}
-
-				ibkt = libkt.Bucket(bucketKeyObjectImages)
-				if ibkt != nil {
+				if ibkt := libkt.Bucket(bucketKeyObjectImages); ibkt != nil {
+					itype := ResourceImage
+					if flat {
+						itype = resourceImageFlat
+					}
 					if err := ibkt.ForEach(func(k, v []byte) error {
 						fn(gcnode(itype, ns, string(k)))
 						return nil
@@ -621,8 +612,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 			}
 		}
 
-		ibkt := nbkt.Bucket(bucketKeyObjectImages)
-		if ibkt != nil {
+		if ibkt := nbkt.Bucket(bucketKeyObjectImages); ibkt != nil {
 			if err := ibkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -660,10 +650,8 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 			}
 		}
 
-		cbkt := nbkt.Bucket(bucketKeyObjectContent)
-		if cbkt != nil {
-			ibkt := cbkt.Bucket(bucketKeyObjectIngests)
-			if ibkt != nil {
+		if cbkt := nbkt.Bucket(bucketKeyObjectContent); cbkt != nil {
+			if ibkt := cbkt.Bucket(bucketKeyObjectIngests); ibkt != nil {
 				if err := ibkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
@@ -681,14 +669,13 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					return err
 				}
 			}
-			cbkt = cbkt.Bucket(bucketKeyObjectBlob)
-			if cbkt != nil {
-				if err := cbkt.ForEach(func(k, v []byte) error {
+			if cbbkt := cbkt.Bucket(bucketKeyObjectBlob); cbbkt != nil {
+				if err := cbbkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
 					}
 
-					return c.sendLabelRefs(ns, cbkt.Bucket(k), labelRefCallbacks{
+					return c.sendLabelRefs(ns, cbbkt.Bucket(k), labelRefCallbacks{
 						bref: func(n gc.Node) {
 							bref(n, gcnode(ResourceContent, ns, string(k)))
 						},
@@ -705,8 +692,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 			}
 		}
 
-		cbkt = nbkt.Bucket(bucketKeyObjectContainers)
-		if cbkt != nil {
+		if cbkt := nbkt.Bucket(bucketKeyObjectContainers); cbkt != nil {
 			if err := cbkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -724,14 +710,13 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 			}
 		}
 
-		sbkt := nbkt.Bucket(bucketKeyObjectSnapshots)
-		if sbkt != nil {
+		if sbkt := nbkt.Bucket(bucketKeyObjectSnapshots); sbkt != nil {
 			if err := sbkt.ForEach(func(sk, sv []byte) error {
 				if sv != nil {
 					return nil
 				}
-				snbkt := sbkt.Bucket(sk)
 
+				snbkt := sbkt.Bucket(sk)
 				return snbkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
@@ -754,8 +739,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 			}
 		}
 
-		bbkt := nbkt.Bucket(bucketKeyObjectSandboxes)
-		if bbkt != nil {
+		if bbkt := nbkt.Bucket(bucketKeyObjectSandboxes); bbkt != nil {
 			if err := bbkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -832,8 +816,7 @@ func (c *gcContext) references(ctx context.Context, tx *bolt.Tx, node gc.Node, f
 			// Node may be created from dead edge
 			return nil
 		}
-		target := bkt.Bucket(bucketKeyTarget)
-		if target != nil {
+		if target := bkt.Bucket(bucketKeyTarget); target != nil {
 			ctype := ResourceContent
 			if node.Type == resourceImageFlat {
 				// For flat leases, keep the target content only
@@ -858,8 +841,7 @@ func (c *gcContext) references(ctx context.Context, tx *bolt.Tx, node gc.Node, f
 			return nil
 		}
 		// Load expected
-		expected := bkt.Get(bucketKeyExpected)
-		if len(expected) > 0 {
+		if expected := bkt.Get(bucketKeyExpected); len(expected) > 0 {
 			fn(gcnode(ResourceContent, node.Namespace, string(expected)))
 		}
 		return nil
@@ -871,10 +853,9 @@ func (c *gcContext) references(ctx context.Context, tx *bolt.Tx, node gc.Node, f
 			return nil
 		}
 
-		snapshotter := string(bkt.Get(bucketKeySnapshotter))
-		if snapshotter != "" {
+		if ssKey := bkt.Get(bucketKeySnapshotter); len(ssKey) > 0 {
 			ss := string(bkt.Get(bucketKeySnapshotKey))
-			fn(gcnode(ResourceSnapshot, node.Namespace, fmt.Sprintf("%s/%s", snapshotter, ss)))
+			fn(gcnode(ResourceSnapshot, node.Namespace, string(ssKey)+"/"+ss))
 		}
 
 		return c.sendLabelRefs(node.Namespace, bkt, labelRefCallbacks{fn: fn})
@@ -900,8 +881,7 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 		nbkt := v1bkt.Bucket(k)
 		ns := string(k)
 
-		lbkt := nbkt.Bucket(bucketKeyObjectLeases)
-		if lbkt != nil {
+		if lbkt := nbkt.Bucket(bucketKeyObjectLeases); lbkt != nil {
 			if err := lbkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -912,8 +892,7 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 			}
 		}
 
-		sbkt := nbkt.Bucket(bucketKeyObjectSnapshots)
-		if sbkt != nil {
+		if sbkt := nbkt.Bucket(bucketKeyObjectSnapshots); sbkt != nil {
 			if err := sbkt.ForEach(func(sk, sv []byte) error {
 				if sv != nil {
 					return nil
@@ -931,10 +910,8 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 			}
 		}
 
-		cbkt := nbkt.Bucket(bucketKeyObjectContent)
-		if cbkt != nil {
-			ibkt := cbkt.Bucket(bucketKeyObjectIngests)
-			if ibkt != nil {
+		if cbkt := nbkt.Bucket(bucketKeyObjectContent); cbkt != nil {
+			if ibkt := cbkt.Bucket(bucketKeyObjectIngests); ibkt != nil {
 				if err := ibkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
@@ -946,9 +923,8 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 				}
 			}
 
-			cbkt = cbkt.Bucket(bucketKeyObjectBlob)
-			if cbkt != nil {
-				if err := cbkt.ForEach(func(k, v []byte) error {
+			if cbbkt := cbkt.Bucket(bucketKeyObjectBlob); cbbkt != nil {
+				if err := cbbkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
 					}
@@ -960,8 +936,7 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 			}
 		}
 
-		ibkt := nbkt.Bucket(bucketKeyObjectImages)
-		if ibkt != nil {
+		if ibkt := nbkt.Bucket(bucketKeyObjectImages); ibkt != nil {
 			if err := ibkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -999,23 +974,19 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 
 	switch node.Type {
 	case ResourceContent:
-		cbkt := nsbkt.Bucket(bucketKeyObjectContent)
-		if cbkt != nil {
-			cbkt = cbkt.Bucket(bucketKeyObjectBlob)
-		}
-		if cbkt != nil {
-			log.G(ctx).WithField("key", node.Key).Debug("remove content")
-			return nil, cbkt.DeleteBucket([]byte(node.Key))
+		if cbkt := nsbkt.Bucket(bucketKeyObjectContent); cbkt != nil {
+			if cbbkt := cbkt.Bucket(bucketKeyObjectBlob); cbbkt != nil {
+				log.G(ctx).WithField("key", node.Key).Debug("remove content")
+				return nil, cbbkt.DeleteBucket([]byte(node.Key))
+			}
 		}
 	case ResourceSnapshot:
-		sbkt := nsbkt.Bucket(bucketKeyObjectSnapshots)
-		if sbkt != nil {
+		if sbkt := nsbkt.Bucket(bucketKeyObjectSnapshots); sbkt != nil {
 			ss, key, ok := strings.Cut(node.Key, "/")
 			if !ok {
 				return nil, fmt.Errorf("invalid snapshot gc key %s", node.Key)
 			}
-			ssbkt := sbkt.Bucket([]byte(ss))
-			if ssbkt != nil {
+			if ssbkt := sbkt.Bucket([]byte(ss)); ssbkt != nil {
 				log.G(ctx).WithField("key", key).WithField("snapshotter", ss).Debug("remove snapshot")
 				return &eventstypes.SnapshotRemove{
 					Key:         key,
@@ -1024,30 +995,25 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 			}
 		}
 	case ResourceImage:
-		ibkt := nsbkt.Bucket(bucketKeyObjectImages)
-		if ibkt != nil {
+		if ibkt := nsbkt.Bucket(bucketKeyObjectImages); ibkt != nil {
 			log.G(ctx).WithField("key", node.Key).Debug("remove image")
 			return &eventstypes.ImageDelete{
 				Name: node.Key,
 			}, ibkt.DeleteBucket([]byte(node.Key))
 		}
 	case ResourceLease:
-		lbkt := nsbkt.Bucket(bucketKeyObjectLeases)
-		if lbkt != nil {
+		if lbkt := nsbkt.Bucket(bucketKeyObjectLeases); lbkt != nil {
 			return nil, lbkt.DeleteBucket([]byte(node.Key))
 		}
 	case ResourceIngest:
-		ibkt := nsbkt.Bucket(bucketKeyObjectContent)
-		if ibkt != nil {
-			ibkt = ibkt.Bucket(bucketKeyObjectIngests)
-		}
-		if ibkt != nil {
-			log.G(ctx).WithField("ref", node.Key).Debug("remove ingest")
-			return nil, ibkt.DeleteBucket([]byte(node.Key))
+		if cbkt := nsbkt.Bucket(bucketKeyObjectContent); cbkt != nil {
+			if ibkt := cbkt.Bucket(bucketKeyObjectIngests); ibkt != nil {
+				log.G(ctx).WithField("ref", node.Key).Debug("remove ingest")
+				return nil, ibkt.DeleteBucket([]byte(node.Key))
+			}
 		}
 	default:
-		cc, ok := c.contexts[node.Type]
-		if ok {
+		if cc, ok := c.contexts[node.Type]; ok && cc != nil {
 			cc.Remove(node)
 		} else {
 			log.G(ctx).WithField("ref", node.Key).WithField("type", node.Type).Info("no remove defined for resource")
@@ -1085,17 +1051,15 @@ func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, cb labelRefCallba
 	return nil
 }
 
-func isExpiredImage(ctx context.Context, k []byte, bkt *bolt.Bucket, expTheshold time.Time) bool {
-	lbkt := bkt.Bucket(bucketKeyObjectLabels)
-	if lbkt != nil {
-		el := lbkt.Get(labelGCExpire)
-		if el != nil {
+func isExpiredImage(ctx context.Context, k []byte, bkt *bolt.Bucket, expThreshold time.Time) bool {
+	if lbkt := bkt.Bucket(bucketKeyObjectLabels); lbkt != nil {
+		if el := lbkt.Get(labelGCExpire); el != nil {
 			exp, err := time.Parse(time.RFC3339, string(el))
 			if err != nil {
 				log.G(ctx).WithError(err).WithField("image", string(k)).Infof("ignoring invalid expiration value %q", string(el))
 				return false
 			}
-			return expTheshold.After(exp)
+			return expThreshold.After(exp)
 		}
 	}
 	return false

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -525,8 +525,11 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					return nil
 				}
 				libkt := lbkt.Bucket(k)
-				var flat bool
+				if libkt == nil {
+					return nil
+				}
 
+				var flat bool
 				if lblbkt := libkt.Bucket(bucketKeyObjectLabels); lblbkt != nil {
 					if expV := lblbkt.Get(labelGCExpire); expV != nil {
 						if exp, err := time.Parse(time.RFC3339, string(expV)); err != nil {
@@ -574,6 +577,9 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 							return nil
 						}
 						snbkt := sbkt.Bucket(sk)
+						if snbkt == nil {
+							return nil
+						}
 
 						return snbkt.ForEach(func(k, v []byte) error {
 							fn(gcnode(stype, ns, fmt.Sprintf("%s/%s", sk, k)))
@@ -620,19 +626,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					return nil
 				}
 
-				if !isExpiredImage(ctx, k, ibkt.Bucket(k), expThreshold) {
-					fn(gcnode(ResourceImage, ns, string(k)))
-					// Non-expired images are roots, so regular fn/bref refs are
-					// not needed here — they are followed during graph traversal
-					// via references(). Only conditional refs need processing at
-					// scan time since conditions are collected during scan and
-					// evaluated after all values have been gathered.
-					return c.sendLabelRefs(ns, ibkt.Bucket(k), labelRefCallbacks{
-						cond: func(n gc.Node, cv func(conditionalValue) bool) {
-							addCond(gcnode(ResourceImage, ns, string(k)), n, cv)
-						},
-					})
-				} else {
+				if isExpiredImage(ctx, k, ibkt.Bucket(k), expThreshold) {
 					// If the image is expired, still allow it to be referenced from
 					// other resources, the back references are not relevant if the object
 					// is not expired since it is already a root object.
@@ -644,9 +638,19 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 							addCond(gcnode(ResourceImage, ns, string(k)), n, cv)
 						},
 					})
-
 				}
 
+				fn(gcnode(ResourceImage, ns, string(k)))
+				// Non-expired images are roots, so regular fn/bref refs are
+				// not needed here — they are followed during graph traversal
+				// via references(). Only conditional refs need processing at
+				// scan time since conditions are collected during scan and
+				// evaluated after all values have been gathered.
+				return c.sendLabelRefs(ns, ibkt.Bucket(k), labelRefCallbacks{
+					cond: func(n gc.Node, cv func(conditionalValue) bool) {
+						addCond(gcnode(ResourceImage, ns, string(k)), n, cv)
+					},
+				})
 			}); err != nil {
 				return err
 			}
@@ -719,6 +723,10 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 				}
 
 				snbkt := sbkt.Bucket(sk)
+				if snbkt == nil {
+					return nil
+				}
+
 				return snbkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
@@ -747,9 +755,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					return nil
 				}
 
-				sbbkt := bbkt.Bucket(k)
-
-				return c.sendLabelRefs(ns, sbbkt, labelRefCallbacks{fn: fn})
+				return c.sendLabelRefs(ns, bbkt.Bucket(k), labelRefCallbacks{fn: fn})
 			}); err != nil {
 				return err
 			}
@@ -881,8 +887,11 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 			continue
 		}
 		nbkt := v1bkt.Bucket(k)
-		ns := string(k)
+		if nbkt == nil {
+			continue
+		}
 
+		ns := string(k)
 		if lbkt := nbkt.Bucket(bucketKeyObjectLeases); lbkt != nil {
 			if err := lbkt.ForEach(func(k, v []byte) error {
 				if v != nil {
@@ -1027,6 +1036,10 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 
 // sendLabelRefs sends all snapshot and content references referred to by the labels in the bkt
 func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, cb labelRefCallbacks) error {
+	if bkt == nil {
+		return nil
+	}
+
 	if lbkt := bkt.Bucket(bucketKeyObjectLabels); lbkt != nil {
 		lc := lbkt.Cursor()
 		for _, h := range c.labelHandlers {
@@ -1054,6 +1067,9 @@ func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, cb labelRefCallba
 }
 
 func isExpiredImage(ctx context.Context, k []byte, bkt *bolt.Bucket, expThreshold time.Time) bool {
+	if bkt == nil {
+		return false
+	}
 	if lbkt := bkt.Bucket(bucketKeyObjectLabels); lbkt != nil {
 		if el := lbkt.Get(labelGCExpire); el != nil {
 			exp, err := time.Parse(time.RFC3339, string(el))

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -402,8 +402,8 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 			contexts[rt] = c
 		}
 		// Sort labelHandlers to ensure key seeking is always forward
-		sort.Slice(labelHandlers, func(i, j int) bool {
-			return bytes.Compare(labelHandlers[i].key, labelHandlers[j].key) < 0
+		slices.SortFunc(labelHandlers, func(a, b referenceLabelHandler) int {
+			return bytes.Compare(a.key, b.key)
 		})
 	}
 	return &gcContext{

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -242,11 +242,12 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCSnapBackRef,
 			bref: func(ns string, k, v []byte, fn func(gc.Node)) {
-				snapshotter := k[len(labelGCSnapBackRef):]
-				if i := bytes.IndexByte(snapshotter, '/'); i >= 0 {
-					snapshotter = snapshotter[:i]
+				if rest, ok := bytes.CutPrefix(k, labelGCSnapBackRef); ok {
+					if i := bytes.IndexByte(rest, '/'); i > 0 {
+						rest = rest[:i]
+					}
+					fn(gcnode(ResourceSnapshot, ns, string(rest)+"/"+string(v)))
 				}
-				fn(gcnode(ResourceSnapshot, ns, fmt.Sprintf("%s/%s", snapshotter, v)))
 			},
 		},
 		{
@@ -278,11 +279,12 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCSnapRef,
 			fn: func(ns string, k, v []byte, fn func(gc.Node)) {
-				snapshotter := k[len(labelGCSnapRef):]
-				if i := bytes.IndexByte(snapshotter, '/'); i >= 0 {
-					snapshotter = snapshotter[:i]
+				if rest, ok := bytes.CutPrefix(k, labelGCSnapRef); ok {
+					if i := bytes.IndexByte(rest, '/'); i > 0 {
+						rest = rest[:i]
+					}
+					fn(gcnode(ResourceSnapshot, ns, string(rest)+"/"+string(v)))
 				}
-				fn(gcnode(ResourceSnapshot, ns, fmt.Sprintf("%s/%s", snapshotter, v)))
 			},
 		},
 		{

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -865,19 +865,20 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 
 // sendLabelRefs sends all snapshot and content references referred to by the labels in the bkt
 func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, fn func(gc.Node), bref func(gc.Node), root func()) error {
-	lbkt := bkt.Bucket(bucketKeyObjectLabels)
-	if lbkt != nil {
+	if lbkt := bkt.Bucket(bucketKeyObjectLabels); lbkt != nil {
 		lc := lbkt.Cursor()
-		for i := range c.labelHandlers {
-			if (bref == nil && c.labelHandlers[i].bref != nil) || (fn == nil && c.labelHandlers[i].fn != nil) {
+		for _, h := range c.labelHandlers {
+			if (bref == nil && h.bref != nil) || (fn == nil && h.fn != nil) {
 				continue
 			}
-			for k, v := lc.Seek(c.labelHandlers[i].key); k != nil && bytes.HasPrefix(k, c.labelHandlers[i].key); k, v = lc.Next() {
-				if c.labelHandlers[i].fn != nil {
-					c.labelHandlers[i].fn(ns, k, v, fn)
-				} else if c.labelHandlers[i].bref != nil {
-					c.labelHandlers[i].bref(ns, k, v, bref)
-				} else if root != nil {
+
+			for k, v := lc.Seek(h.key); k != nil && bytes.HasPrefix(k, h.key); k, v = lc.Next() {
+				switch {
+				case h.fn != nil:
+					h.fn(ns, k, v, fn)
+				case h.bref != nil:
+					h.bref(ns, k, v, bref)
+				case root != nil:
 					root()
 				}
 			}

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -201,11 +201,12 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCSnapBackRef,
 			bref: func(ns string, k, v []byte, fn func(gc.Node)) {
-				snapshotter := k[len(labelGCSnapBackRef):]
-				if i := bytes.IndexByte(snapshotter, '/'); i >= 0 {
-					snapshotter = snapshotter[:i]
+				if rest, ok := bytes.CutPrefix(k, labelGCSnapBackRef); ok {
+					if i := bytes.IndexByte(rest, '/'); i > 0 {
+						rest = rest[:i]
+					}
+					fn(gcnode(ResourceSnapshot, ns, string(rest)+"/"+string(v)))
 				}
-				fn(gcnode(ResourceSnapshot, ns, fmt.Sprintf("%s/%s", snapshotter, v)))
 			},
 		},
 		{
@@ -237,11 +238,12 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCSnapRef,
 			fn: func(ns string, k, v []byte, fn func(gc.Node)) {
-				snapshotter := k[len(labelGCSnapRef):]
-				if i := bytes.IndexByte(snapshotter, '/'); i >= 0 {
-					snapshotter = snapshotter[:i]
+				if rest, ok := bytes.CutPrefix(k, labelGCSnapRef); ok {
+					if i := bytes.IndexByte(rest, '/'); i > 0 {
+						rest = rest[:i]
+					}
+					fn(gcnode(ResourceSnapshot, ns, string(rest)+"/"+string(v)))
 				}
-				fn(gcnode(ResourceSnapshot, ns, fmt.Sprintf("%s/%s", snapshotter, v)))
 			},
 		},
 		{

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -162,11 +162,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCContainerBackRef,
 			bref: func(ns string, k, v []byte, fn func(gc.Node)) {
-				if ks := string(k); ks != string(labelGCContainerBackRef) {
-					// Allow reference naming separated by . or /, ignore names
-					if ks[len(labelGCContainerBackRef)] != '.' && ks[len(labelGCContainerBackRef)] != '/' {
-						return
-					}
+				// Allow reference naming separated by . or /, ignore names
+				rest, ok := bytes.CutPrefix(k, labelGCContainerBackRef)
+				if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+					return
 				}
 
 				fn(gcnode(ResourceContainer, ns, string(v)))
@@ -175,11 +174,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCContentBackRef,
 			bref: func(ns string, k, v []byte, fn func(gc.Node)) {
-				if ks := string(k); ks != string(labelGCContentBackRef) {
-					// Allow reference naming separated by . or /, ignore names
-					if ks[len(labelGCContentBackRef)] != '.' && ks[len(labelGCContentBackRef)] != '/' {
-						return
-					}
+				// Allow reference naming separated by . or /, ignore names
+				rest, ok := bytes.CutPrefix(k, labelGCContentBackRef)
+				if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+					return
 				}
 
 				fn(gcnode(ResourceContent, ns, string(v)))
@@ -188,11 +186,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCImageBackRef,
 			bref: func(ns string, k, v []byte, fn func(gc.Node)) {
-				if ks := string(k); ks != string(labelGCImageBackRef) {
-					// Allow reference naming separated by . or /, ignore names
-					if ks[len(labelGCImageBackRef)] != '.' && ks[len(labelGCImageBackRef)] != '/' {
-						return
-					}
+				// Allow reference naming separated by . or /, ignore names
+				rest, ok := bytes.CutPrefix(k, labelGCImageBackRef)
+				if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+					return
 				}
 
 				fn(gcnode(ResourceImage, ns, string(v)))
@@ -212,11 +209,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCContentRef,
 			fn: func(ns string, k, v []byte, fn func(gc.Node)) {
-				if ks := string(k); ks != string(labelGCContentRef) {
-					// Allow reference naming separated by . or /, ignore names
-					if ks[len(labelGCContentRef)] != '.' && ks[len(labelGCContentRef)] != '/' {
-						return
-					}
+				// Allow reference naming separated by . or /, ignore names
+				rest, ok := bytes.CutPrefix(k, labelGCContentRef)
+				if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+					return
 				}
 
 				fn(gcnode(ResourceContent, ns, string(v)))
@@ -225,11 +221,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		{
 			key: labelGCImageRef,
 			fn: func(ns string, k, v []byte, fn func(gc.Node)) {
-				if ks := string(k); ks != string(labelGCImageRef) {
-					// Allow reference naming separated by . or /, ignore names
-					if ks[len(labelGCImageRef)] != '.' && ks[len(labelGCImageRef)] != '/' {
-						return
-					}
+				// Allow reference naming separated by . or /, ignore names
+				rest, ok := bytes.CutPrefix(k, labelGCImageRef)
+				if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+					return
 				}
 
 				fn(gcnode(ResourceImage, ns, string(v)))
@@ -239,10 +234,8 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 			key: labelGCSnapRef,
 			fn: func(ns string, k, v []byte, fn func(gc.Node)) {
 				if rest, ok := bytes.CutPrefix(k, labelGCSnapRef); ok {
-					if i := bytes.IndexByte(rest, '/'); i > 0 {
-						rest = rest[:i]
-					}
-					fn(gcnode(ResourceSnapshot, ns, string(rest)+"/"+string(v)))
+					snapshotterName, _, _ := bytes.Cut(rest, []byte("/"))
+					fn(gcnode(ResourceSnapshot, ns, string(snapshotterName)+"/"+string(v)))
 				}
 			},
 		},
@@ -264,11 +257,10 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 				labelHandlers = append(labelHandlers, referenceLabelHandler{
 					key: key,
 					fn: func(ns string, k, v []byte, fn func(gc.Node)) {
-						if ks := string(k); ks != string(key) {
-							// Allow reference naming separated by . or /, ignore names
-							if ks[len(key)] != '.' && ks[len(key)] != '/' {
-								return
-							}
+						// Allow reference naming separated by . or /, ignore names
+						rest, ok := bytes.CutPrefix(k, key)
+						if !ok || (len(rest) > 0 && rest[0] != '.' && rest[0] != '/') {
+							return
 						}
 
 						fn(gcnode(rt, ns, string(v)))

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -371,8 +371,11 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					return nil
 				}
 				libkt := lbkt.Bucket(k)
-				var flat bool
+				if libkt == nil {
+					return nil
+				}
 
+				var flat bool
 				if lblbkt := libkt.Bucket(bucketKeyObjectLabels); lblbkt != nil {
 					if expV := lblbkt.Get(labelGCExpire); expV != nil {
 						if exp, err := time.Parse(time.RFC3339, string(expV)); err != nil {
@@ -420,6 +423,9 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 							return nil
 						}
 						snbkt := sbkt.Bucket(sk)
+						if snbkt == nil {
+							return nil
+						}
 
 						return snbkt.ForEach(func(k, v []byte) error {
 							fn(gcnode(stype, ns, fmt.Sprintf("%s/%s", sk, k)))
@@ -466,20 +472,17 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					return nil
 				}
 
-				if !isExpiredImage(ctx, k, ibkt.Bucket(k), expThreshold) {
-					fn(gcnode(ResourceImage, ns, string(k)))
-				} else {
+				if isExpiredImage(ctx, k, ibkt.Bucket(k), expThreshold) {
 					// If the image is expired, still allow it to be referenced from
 					// other resources, the back references are not relevant if the object
 					// is not expired since it is already a root object.
 					return c.sendLabelRefs(ns, ibkt.Bucket(k), nil, func(n gc.Node) {
 						bref(n, gcnode(ResourceImage, ns, string(k)))
 					}, nil)
-
 				}
 
+				fn(gcnode(ResourceImage, ns, string(k)))
 				return nil
-
 			}); err != nil {
 				return err
 			}
@@ -545,6 +548,10 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 				}
 
 				snbkt := sbkt.Bucket(sk)
+				if snbkt == nil {
+					return nil
+				}
+
 				return snbkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
@@ -567,9 +574,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					return nil
 				}
 
-				sbbkt := bbkt.Bucket(k)
-
-				return c.sendLabelRefs(ns, sbbkt, fn, nil, nil)
+				return c.sendLabelRefs(ns, bbkt.Bucket(k), fn, nil, nil)
 			}); err != nil {
 				return err
 			}
@@ -688,8 +693,11 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 			continue
 		}
 		nbkt := v1bkt.Bucket(k)
-		ns := string(k)
+		if nbkt == nil {
+			continue
+		}
 
+		ns := string(k)
 		if lbkt := nbkt.Bucket(bucketKeyObjectLeases); lbkt != nil {
 			if err := lbkt.ForEach(func(k, v []byte) error {
 				if v != nil {
@@ -833,6 +841,9 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 
 // sendLabelRefs sends all snapshot and content references referred to by the labels in the bkt
 func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, fn func(gc.Node), bref func(gc.Node), root func()) error {
+	if bkt == nil {
+		return nil
+	}
 	if lbkt := bkt.Bucket(bucketKeyObjectLabels); lbkt != nil {
 		lc := lbkt.Cursor()
 		for _, h := range c.labelHandlers {
@@ -856,6 +867,9 @@ func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, fn func(gc.Node),
 }
 
 func isExpiredImage(ctx context.Context, k []byte, bkt *bolt.Bucket, expThreshold time.Time) bool {
+	if bkt == nil {
+		return false
+	}
 	if lbkt := bkt.Bucket(bucketKeyObjectLabels); lbkt != nil {
 		if el := lbkt.Get(labelGCExpire); el != nil {
 			exp, err := time.Parse(time.RFC3339, string(el))

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -276,8 +276,8 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 			contexts[rt] = c
 		}
 		// Sort labelHandlers to ensure key seeking is always forward
-		sort.Slice(labelHandlers, func(i, j int) bool {
-			return bytes.Compare(labelHandlers[i].key, labelHandlers[j].key) < 0
+		slices.SortFunc(labelHandlers, func(a, b referenceLabelHandler) int {
+			return bytes.Compare(a.key, b.key)
 		})
 	}
 	return &gcContext{

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -320,14 +320,12 @@ func (c *gcContext) cancel(ctx context.Context) {
 }
 
 func (c *gcContext) finish(ctx context.Context, wg *sync.WaitGroup) {
-	wg.Add(len(c.contexts))
-	for t, gctx := range c.contexts {
-		go func() {
-			if err := gctx.Finish(); err != nil {
-				log.G(ctx).WithField("type", t).WithError(err).Error("failed to finish collection context")
+	for resourceType, gcCtx := range c.contexts {
+		wg.Go(func() {
+			if err := gcCtx.Finish(); err != nil {
+				log.G(ctx).WithFields(log.Fields{"type": resourceType, "error": err}).Error("failed to finish collection context")
 			}
-			wg.Done()
-		}()
+		})
 	}
 }
 

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -363,8 +363,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 		nbkt := v1bkt.Bucket(k)
 		ns := string(k)
 
-		lbkt := nbkt.Bucket(bucketKeyObjectLeases)
-		if lbkt != nil {
+		if lbkt := nbkt.Bucket(bucketKeyObjectLeases); lbkt != nil {
 			if err := lbkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -374,8 +373,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 
 				if lblbkt := libkt.Bucket(bucketKeyObjectLabels); lblbkt != nil {
 					if expV := lblbkt.Get(labelGCExpire); expV != nil {
-						exp, err := time.Parse(time.RFC3339, string(expV))
-						if err != nil {
+						if exp, err := time.Parse(time.RFC3339, string(expV)); err != nil {
 							// label not used, log and continue to use lease
 							log.G(ctx).WithError(err).WithField("lease", string(k)).Infof("ignoring invalid expiration value %q", string(expV))
 						} else if expThreshold.After(exp) {
@@ -397,13 +395,11 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 				// no need to allow the lookup to be recursive, handling here
 				// therefore reduces the number of database seeks.
 
-				ctype := ResourceContent
-				if flat {
-					ctype = resourceContentFlat
-				}
-
-				cbkt := libkt.Bucket(bucketKeyObjectContent)
-				if cbkt != nil {
+				if cbkt := libkt.Bucket(bucketKeyObjectContent); cbkt != nil {
+					ctype := ResourceContent
+					if flat {
+						ctype = resourceContentFlat
+					}
 					if err := cbkt.ForEach(func(k, v []byte) error {
 						fn(gcnode(ctype, ns, string(k)))
 						return nil
@@ -412,13 +408,11 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					}
 				}
 
-				stype := ResourceSnapshot
-				if flat {
-					stype = resourceSnapshotFlat
-				}
-
-				sbkt := libkt.Bucket(bucketKeyObjectSnapshots)
-				if sbkt != nil {
+				if sbkt := libkt.Bucket(bucketKeyObjectSnapshots); sbkt != nil {
+					stype := ResourceSnapshot
+					if flat {
+						stype = resourceSnapshotFlat
+					}
 					if err := sbkt.ForEach(func(sk, sv []byte) error {
 						if sv != nil {
 							return nil
@@ -434,8 +428,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					}
 				}
 
-				ibkt := libkt.Bucket(bucketKeyObjectIngests)
-				if ibkt != nil {
+				if ibkt := libkt.Bucket(bucketKeyObjectIngests); ibkt != nil {
 					if err := ibkt.ForEach(func(k, v []byte) error {
 						fn(gcnode(ResourceIngest, ns, string(k)))
 						return nil
@@ -444,13 +437,11 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					}
 				}
 
-				itype := ResourceImage
-				if flat {
-					itype = resourceImageFlat
-				}
-
-				ibkt = libkt.Bucket(bucketKeyObjectImages)
-				if ibkt != nil {
+				if ibkt := libkt.Bucket(bucketKeyObjectImages); ibkt != nil {
+					itype := ResourceImage
+					if flat {
+						itype = resourceImageFlat
+					}
 					if err := ibkt.ForEach(func(k, v []byte) error {
 						fn(gcnode(itype, ns, string(k)))
 						return nil
@@ -467,8 +458,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 			}
 		}
 
-		ibkt := nbkt.Bucket(bucketKeyObjectImages)
-		if ibkt != nil {
+		if ibkt := nbkt.Bucket(bucketKeyObjectImages); ibkt != nil {
 			if err := ibkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -493,10 +483,8 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 			}
 		}
 
-		cbkt := nbkt.Bucket(bucketKeyObjectContent)
-		if cbkt != nil {
-			ibkt := cbkt.Bucket(bucketKeyObjectIngests)
-			if ibkt != nil {
+		if cbkt := nbkt.Bucket(bucketKeyObjectContent); cbkt != nil {
+			if ibkt := cbkt.Bucket(bucketKeyObjectIngests); ibkt != nil {
 				if err := ibkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
@@ -514,14 +502,13 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 					return err
 				}
 			}
-			cbkt = cbkt.Bucket(bucketKeyObjectBlob)
-			if cbkt != nil {
-				if err := cbkt.ForEach(func(k, v []byte) error {
+			if cbbkt := cbkt.Bucket(bucketKeyObjectBlob); cbbkt != nil {
+				if err := cbbkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
 					}
 
-					return c.sendLabelRefs(ns, cbkt.Bucket(k), nil, func(n gc.Node) {
+					return c.sendLabelRefs(ns, cbbkt.Bucket(k), nil, func(n gc.Node) {
 						bref(n, gcnode(ResourceContent, ns, string(k)))
 					}, func() {
 						fn(gcnode(ResourceContent, ns, string(k)))
@@ -532,8 +519,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 			}
 		}
 
-		cbkt = nbkt.Bucket(bucketKeyObjectContainers)
-		if cbkt != nil {
+		if cbkt := nbkt.Bucket(bucketKeyObjectContainers); cbkt != nil {
 			if err := cbkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -550,14 +536,13 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 			}
 		}
 
-		sbkt := nbkt.Bucket(bucketKeyObjectSnapshots)
-		if sbkt != nil {
+		if sbkt := nbkt.Bucket(bucketKeyObjectSnapshots); sbkt != nil {
 			if err := sbkt.ForEach(func(sk, sv []byte) error {
 				if sv != nil {
 					return nil
 				}
-				snbkt := sbkt.Bucket(sk)
 
+				snbkt := sbkt.Bucket(sk)
 				return snbkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
@@ -574,8 +559,7 @@ func (c *gcContext) scanRoots(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Nod
 			}
 		}
 
-		bbkt := nbkt.Bucket(bucketKeyObjectSandboxes)
-		if bbkt != nil {
+		if bbkt := nbkt.Bucket(bucketKeyObjectSandboxes); bbkt != nil {
 			if err := bbkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -639,8 +623,7 @@ func (c *gcContext) references(ctx context.Context, tx *bolt.Tx, node gc.Node, f
 			// Node may be created from dead edge
 			return nil
 		}
-		target := bkt.Bucket(bucketKeyTarget)
-		if target != nil {
+		if target := bkt.Bucket(bucketKeyTarget); target != nil {
 			ctype := ResourceContent
 			if node.Type == resourceImageFlat {
 				// For flat leases, keep the target content only
@@ -665,8 +648,7 @@ func (c *gcContext) references(ctx context.Context, tx *bolt.Tx, node gc.Node, f
 			return nil
 		}
 		// Load expected
-		expected := bkt.Get(bucketKeyExpected)
-		if len(expected) > 0 {
+		if expected := bkt.Get(bucketKeyExpected); len(expected) > 0 {
 			fn(gcnode(ResourceContent, node.Namespace, string(expected)))
 		}
 		return nil
@@ -678,10 +660,9 @@ func (c *gcContext) references(ctx context.Context, tx *bolt.Tx, node gc.Node, f
 			return nil
 		}
 
-		snapshotter := string(bkt.Get(bucketKeySnapshotter))
-		if snapshotter != "" {
+		if ssKey := bkt.Get(bucketKeySnapshotter); len(ssKey) > 0 {
 			ss := string(bkt.Get(bucketKeySnapshotKey))
-			fn(gcnode(ResourceSnapshot, node.Namespace, fmt.Sprintf("%s/%s", snapshotter, ss)))
+			fn(gcnode(ResourceSnapshot, node.Namespace, string(ssKey)+"/"+ss))
 		}
 
 		return c.sendLabelRefs(node.Namespace, bkt, fn, nil, nil)
@@ -707,8 +688,7 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 		nbkt := v1bkt.Bucket(k)
 		ns := string(k)
 
-		lbkt := nbkt.Bucket(bucketKeyObjectLeases)
-		if lbkt != nil {
+		if lbkt := nbkt.Bucket(bucketKeyObjectLeases); lbkt != nil {
 			if err := lbkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -719,8 +699,7 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 			}
 		}
 
-		sbkt := nbkt.Bucket(bucketKeyObjectSnapshots)
-		if sbkt != nil {
+		if sbkt := nbkt.Bucket(bucketKeyObjectSnapshots); sbkt != nil {
 			if err := sbkt.ForEach(func(sk, sv []byte) error {
 				if sv != nil {
 					return nil
@@ -738,10 +717,8 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 			}
 		}
 
-		cbkt := nbkt.Bucket(bucketKeyObjectContent)
-		if cbkt != nil {
-			ibkt := cbkt.Bucket(bucketKeyObjectIngests)
-			if ibkt != nil {
+		if cbkt := nbkt.Bucket(bucketKeyObjectContent); cbkt != nil {
+			if ibkt := cbkt.Bucket(bucketKeyObjectIngests); ibkt != nil {
 				if err := ibkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
@@ -753,9 +730,8 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 				}
 			}
 
-			cbkt = cbkt.Bucket(bucketKeyObjectBlob)
-			if cbkt != nil {
-				if err := cbkt.ForEach(func(k, v []byte) error {
+			if cbbkt := cbkt.Bucket(bucketKeyObjectBlob); cbbkt != nil {
+				if err := cbbkt.ForEach(func(k, v []byte) error {
 					if v != nil {
 						return nil
 					}
@@ -767,8 +743,7 @@ func (c *gcContext) scanAll(ctx context.Context, tx *bolt.Tx, fn func(ctx contex
 			}
 		}
 
-		ibkt := nbkt.Bucket(bucketKeyObjectImages)
-		if ibkt != nil {
+		if ibkt := nbkt.Bucket(bucketKeyObjectImages); ibkt != nil {
 			if err := ibkt.ForEach(func(k, v []byte) error {
 				if v != nil {
 					return nil
@@ -806,23 +781,19 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 
 	switch node.Type {
 	case ResourceContent:
-		cbkt := nsbkt.Bucket(bucketKeyObjectContent)
-		if cbkt != nil {
-			cbkt = cbkt.Bucket(bucketKeyObjectBlob)
-		}
-		if cbkt != nil {
-			log.G(ctx).WithField("key", node.Key).Debug("remove content")
-			return nil, cbkt.DeleteBucket([]byte(node.Key))
+		if cbkt := nsbkt.Bucket(bucketKeyObjectContent); cbkt != nil {
+			if cbbkt := cbkt.Bucket(bucketKeyObjectBlob); cbbkt != nil {
+				log.G(ctx).WithField("key", node.Key).Debug("remove content")
+				return nil, cbbkt.DeleteBucket([]byte(node.Key))
+			}
 		}
 	case ResourceSnapshot:
-		sbkt := nsbkt.Bucket(bucketKeyObjectSnapshots)
-		if sbkt != nil {
+		if sbkt := nsbkt.Bucket(bucketKeyObjectSnapshots); sbkt != nil {
 			ss, key, ok := strings.Cut(node.Key, "/")
 			if !ok {
 				return nil, fmt.Errorf("invalid snapshot gc key %s", node.Key)
 			}
-			ssbkt := sbkt.Bucket([]byte(ss))
-			if ssbkt != nil {
+			if ssbkt := sbkt.Bucket([]byte(ss)); ssbkt != nil {
 				log.G(ctx).WithField("key", key).WithField("snapshotter", ss).Debug("remove snapshot")
 				return &eventstypes.SnapshotRemove{
 					Key:         key,
@@ -831,29 +802,24 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 			}
 		}
 	case ResourceImage:
-		ibkt := nsbkt.Bucket(bucketKeyObjectImages)
-		if ibkt != nil {
+		if ibkt := nsbkt.Bucket(bucketKeyObjectImages); ibkt != nil {
 			return &eventstypes.ImageDelete{
 				Name: node.Key,
 			}, ibkt.DeleteBucket([]byte(node.Key))
 		}
 	case ResourceLease:
-		lbkt := nsbkt.Bucket(bucketKeyObjectLeases)
-		if lbkt != nil {
+		if lbkt := nsbkt.Bucket(bucketKeyObjectLeases); lbkt != nil {
 			return nil, lbkt.DeleteBucket([]byte(node.Key))
 		}
 	case ResourceIngest:
-		ibkt := nsbkt.Bucket(bucketKeyObjectContent)
-		if ibkt != nil {
-			ibkt = ibkt.Bucket(bucketKeyObjectIngests)
-		}
-		if ibkt != nil {
-			log.G(ctx).WithField("ref", node.Key).Debug("remove ingest")
-			return nil, ibkt.DeleteBucket([]byte(node.Key))
+		if cbkt := nsbkt.Bucket(bucketKeyObjectContent); cbkt != nil {
+			if ibkt := cbkt.Bucket(bucketKeyObjectIngests); ibkt != nil {
+				log.G(ctx).WithField("ref", node.Key).Debug("remove ingest")
+				return nil, ibkt.DeleteBucket([]byte(node.Key))
+			}
 		}
 	default:
-		cc, ok := c.contexts[node.Type]
-		if ok {
+		if cc, ok := c.contexts[node.Type]; ok && cc != nil {
 			cc.Remove(node)
 		} else {
 			log.G(ctx).WithField("ref", node.Key).WithField("type", node.Type).Info("no remove defined for resource")
@@ -887,17 +853,15 @@ func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, fn func(gc.Node),
 	return nil
 }
 
-func isExpiredImage(ctx context.Context, k []byte, bkt *bolt.Bucket, expTheshold time.Time) bool {
-	lbkt := bkt.Bucket(bucketKeyObjectLabels)
-	if lbkt != nil {
-		el := lbkt.Get(labelGCExpire)
-		if el != nil {
+func isExpiredImage(ctx context.Context, k []byte, bkt *bolt.Bucket, expThreshold time.Time) bool {
+	if lbkt := bkt.Bucket(bucketKeyObjectLabels); lbkt != nil {
+		if el := lbkt.Get(labelGCExpire); el != nil {
 			exp, err := time.Parse(time.RFC3339, string(el))
 			if err != nil {
 				log.G(ctx).WithError(err).WithField("image", string(k)).Infof("ignoring invalid expiration value %q", string(el))
 				return false
 			}
-			return expTheshold.After(exp)
+			return expThreshold.After(exp)
 		}
 	}
 	return false

--- a/core/metadata/images.go
+++ b/core/metadata/images.go
@@ -318,7 +318,7 @@ func (s *imageStore) Delete(ctx context.Context, name string, opts ...images.Del
 			}
 		}
 
-		if err = bkt.DeleteBucket([]byte(name)); err != nil {
+		if err := bkt.DeleteBucket([]byte(name)); err != nil {
 			if err == errbolt.ErrBucketNotFound {
 				err = fmt.Errorf("image %q: %w", name, errdefs.ErrNotFound)
 			}
@@ -381,11 +381,11 @@ func readImage(image *images.Image, bkt *bolt.Bucket) error {
 		return err
 	}
 
-	labels, err := boltutil.ReadLabels(bkt)
+	lbls, err := boltutil.ReadLabels(bkt)
 	if err != nil {
 		return err
 	}
-	image.Labels = labels
+	image.Labels = lbls
 
 	image.Target.Annotations, err = boltutil.ReadAnnotations(bkt)
 	if err != nil {

--- a/core/metadata/images.go
+++ b/core/metadata/images.go
@@ -398,11 +398,9 @@ func readImage(image *images.Image, bkt *bolt.Bucket) error {
 	}
 	return tbkt.ForEach(func(k, v []byte) error {
 		if v == nil {
-			return nil // skip it? a bkt maybe?
+			return nil // skip nested buckets
 		}
 
-		// TODO(stevvooe): This is why we need to use byte values for
-		// keys, rather than full arrays.
 		switch string(k) {
 		case string(bucketKeyDigest):
 			image.Target.Digest = digest.Digest(v)

--- a/core/metadata/images.go
+++ b/core/metadata/images.go
@@ -396,22 +396,18 @@ func readImage(image *images.Image, bkt *bolt.Bucket) error {
 	if tbkt == nil {
 		return errors.New("unable to read target bucket")
 	}
-	return tbkt.ForEach(func(k, v []byte) error {
-		if v == nil {
-			return nil // skip nested buckets
-		}
 
-		switch string(k) {
-		case string(bucketKeyDigest):
-			image.Target.Digest = digest.Digest(v)
-		case string(bucketKeyMediaType):
-			image.Target.MediaType = string(v)
-		case string(bucketKeySize):
-			image.Target.Size, _ = binary.Varint(v)
-		}
+	if v := tbkt.Get(bucketKeyDigest); v != nil {
+		image.Target.Digest = digest.Digest(v)
+	}
+	if v := tbkt.Get(bucketKeyMediaType); v != nil {
+		image.Target.MediaType = string(v)
+	}
+	if v := tbkt.Get(bucketKeySize); v != nil {
+		image.Target.Size, _ = binary.Varint(v)
+	}
 
-		return nil
-	})
+	return nil
 }
 
 func writeImage(bkt *bolt.Bucket, image *images.Image) error {

--- a/core/metadata/leases.go
+++ b/core/metadata/leases.go
@@ -529,35 +529,29 @@ func removeImageLease(ctx context.Context, tx *bolt.Tx, ref string) error {
 }
 
 func parseLeaseResource(r leases.Resource) ([]string, string, error) {
-	var (
-		ref  = r.ID
-		typ  = r.Type
-		keys = strings.Split(typ, "/")
-	)
-
+	keys := strings.Split(r.Type, "/")
 	switch k := keys[0]; k {
-	case string(bucketKeyObjectContent),
-		string(bucketKeyObjectIngests),
-		string(bucketKeyObjectImages):
-
+	case string(bucketKeyObjectContent):
 		if len(keys) != 1 {
-			return nil, "", fmt.Errorf("invalid resource type %s: %w", typ, errdefs.ErrInvalidArgument)
+			return nil, "", fmt.Errorf("invalid resource type %s: %w", r.Type, errdefs.ErrInvalidArgument)
 		}
 
-		if k == string(bucketKeyObjectContent) {
-			dgst, err := digest.Parse(ref)
-			if err != nil {
-				return nil, "", fmt.Errorf("invalid content resource id %s: %v: %w", ref, err, errdefs.ErrInvalidArgument)
-			}
-			ref = dgst.String()
+		dgst, err := digest.Parse(r.ID)
+		if err != nil {
+			return nil, "", fmt.Errorf("invalid content resource id %s: %v: %w", r.ID, err, errdefs.ErrInvalidArgument)
 		}
+		return keys, dgst.String(), nil
+	case string(bucketKeyObjectIngests), string(bucketKeyObjectImages):
+		if len(keys) != 1 {
+			return nil, "", fmt.Errorf("invalid resource type %s: %w", r.Type, errdefs.ErrInvalidArgument)
+		}
+		return keys, r.ID, nil
 	case string(bucketKeyObjectSnapshots):
 		if len(keys) != 2 {
-			return nil, "", fmt.Errorf("invalid snapshot resource type %s: %w", typ, errdefs.ErrInvalidArgument)
+			return nil, "", fmt.Errorf("invalid snapshot resource type %s: %w", r.Type, errdefs.ErrInvalidArgument)
 		}
+		return keys, r.ID, nil
 	default:
-		return nil, "", fmt.Errorf("resource type %s not supported yet: %w", typ, errdefs.ErrNotImplemented)
+		return nil, "", fmt.Errorf("resource type %s not supported yet: %w", r.Type, errdefs.ErrNotImplemented)
 	}
-
-	return keys, ref, nil
 }

--- a/core/metadata/namespaces.go
+++ b/core/metadata/namespaces.go
@@ -117,19 +117,19 @@ func (s *namespaceStore) List(ctx context.Context) ([]string, error) {
 		return nil, nil // no namespaces!
 	}
 
-	var namespaces []string
+	var out []string
 	if err := bkt.ForEach(func(k, v []byte) error {
 		if v != nil {
 			return nil // not a bucket
 		}
 
-		namespaces = append(namespaces, string(k))
+		out = append(out, string(k))
 		return nil
 	}); err != nil {
 		return nil, err
 	}
 
-	return namespaces, nil
+	return out, nil
 }
 
 func (s *namespaceStore) Delete(ctx context.Context, namespace string, opts ...namespaces.DeleteOpts) error {

--- a/core/metadata/snapshot.go
+++ b/core/metadata/snapshot.go
@@ -700,21 +700,18 @@ func (s *snapshotter) Remove(ctx context.Context, key string) error {
 			return fmt.Errorf("snapshot %v does not exist: %w", key, errdefs.ErrNotFound)
 		}
 
-		cbkt := sbkt.Bucket(bucketKeyChildren)
-		if cbkt != nil {
+		if cbkt := sbkt.Bucket(bucketKeyChildren); cbkt != nil {
 			if child, _ := cbkt.Cursor().First(); child != nil {
 				return fmt.Errorf("cannot remove snapshot with child: %w", errdefs.ErrFailedPrecondition)
 			}
 		}
 
-		parent := sbkt.Get(bucketKeyParent)
-		if len(parent) > 0 {
+		if parent := sbkt.Get(bucketKeyParent); len(parent) > 0 {
 			pbkt := bkt.Bucket(parent)
 			if pbkt == nil {
 				return fmt.Errorf("parent snapshot %v does not exist: %w", string(parent), errdefs.ErrNotFound)
 			}
-			cbkt := pbkt.Bucket(bucketKeyChildren)
-			if cbkt != nil {
+			if cbkt := pbkt.Bucket(bucketKeyChildren); cbkt != nil {
 				if err := cbkt.Delete([]byte(key)); err != nil {
 					return fmt.Errorf("failed to remove child link: %w", err)
 				}
@@ -799,8 +796,7 @@ func (s *snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...str
 						},
 					}
 
-					err := boltutil.ReadTimestamps(sbkt, &pair.info.Created, &pair.info.Updated)
-					if err != nil {
+					if err := boltutil.ReadTimestamps(sbkt, &pair.info.Created, &pair.info.Updated); err != nil {
 						return err
 					}
 					pair.info.Labels, err = boltutil.ReadLabels(sbkt)
@@ -860,20 +856,20 @@ func validateSnapshot(info *snapshots.Info) error {
 }
 
 // garbageCollect removes all snapshots that are no longer used.
-func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, err error) {
+func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, retErr error) {
 	s.l.Lock()
 	t1 := time.Now()
 	defer func() {
 		s.l.Unlock()
-		if err == nil {
+		if retErr == nil {
 			if c, ok := s.Snapshotter.(snapshots.Cleaner); ok {
-				err = c.Cleanup(ctx)
-				if errdefs.IsNotImplemented(err) {
-					err = nil
+				retErr = c.Cleanup(ctx)
+				if errdefs.IsNotImplemented(retErr) {
+					retErr = nil
 				}
 			}
 		}
-		if err == nil {
+		if retErr == nil {
 			d = time.Since(t1)
 		}
 	}()
@@ -887,7 +883,6 @@ func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, err 
 
 		// iterate through each namespace
 		v1c := v1bkt.Cursor()
-
 		for k, v := v1c.First(); k != nil; k, v = v1c.Next() {
 			if v != nil {
 				continue
@@ -938,7 +933,7 @@ func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, err 
 		}
 	}
 
-	return
+	return 0, nil
 }
 
 type treeNode struct {


### PR DESCRIPTION
### core/metadata: gcContext.finish: use WaitGroup.Go

### core/metadata: startGCContext: use slices.SortFunc


### core/metadata: startGCContext: use bytes.(Cut|CutPrefix)

Make the code slightly more clear on intent; also make calling the
function conditional; this is mostly theoretical, as the handler should
only be called after checking for the prefix, but to be clearer on intent.


### core/metadata: startGCContext avoid string conversions

Avoid string conversions when matching label keys; use bytes.CutPrefix to
check and strip the prefix, then check for the special cases ("." or "/").
This makes the code slightly more readable, as well as reducing allocations,
and a (theoretical) out-of-bound.


### core/metadata: gcContext.sendLabelRefs refactor for readability


### core/metadata: scope vars locally to reduce shadowing

There's quite some vars that were only used conditionally; scope
them where possible to keep it clear where it's used and to reduce
some shadowing.

Also renaming some vars that shadowed, and reduce naked returns.


### core/metadata: readImage: remove stale TODO

Remove stale TODO from the initial PoC in e53539c58ff53038098d4c6f6301f90ffaedcbd7

As far as I could trace back, the comment referred to byte/string key comparison
in the ForEach, no longer relevant.


### core/metadata: readImage: use direct lookups instead of iterating

Replace the `ForEach` and key matching with `Bucket.Get`; we only read
a fixed set of known keys (`digest`, `mediatype`, `size`), so there's no
need to iterate over all possible entries in the bucket. This also avoids
allocating a new string (`string(xxxx)`) due to the conversion from the
byte-slices.


### core/metadata: DB.GarbageCollect: use WaitGroup.Go

Slightly simplifies the code and improves readability.


### core/metadata: DB.GarbageCollect: make type-switch exhaustive

This allows us to enable the "exhaustive" linter to catch missing types.


### core/metadata: add some missing nil-checks

Mostly defense-in-depth to prevent a panic if any of these would be nil.


### core/metadata: parseLeaseResource: make branches self-contained

This makes the logic slightly easier to read, as well as prevents
repeated string conversions.
