### PR TITLE
Parameterize K8s version in node-e2e workflow

### DIFF
--- a/.github/workflows/node-e2e.yml
+++ b/.github/workflows/node-e2e.yml
@@ -1,7 +1,12 @@
 name: E2E
 on:
   workflow_call:
-
+    inputs:
+      k8s_version:
+        description: 'Kubernetes branch or tag to test against'
+        required: false
+        default: 'master'
+        type: string
 permissions:
   contents: read
 
@@ -41,6 +46,7 @@ jobs:
         with:
           repository: kubernetes/kubernetes
           path: src/k8s.io/kubernetes
+          ref: ${{ inputs.k8s_version }}
           fetch-depth: 0
 
       - name: Install Go


### PR DESCRIPTION
Add inputs to workflow_call in node-e2e.yml to allow specifying Kubernetes branch or tag to test against. Update checkout step to use this input, defaulting to master.

This enables testing containerd against specific Kubernetes release branches, which is required for verifying compatibility with extended support windows for Kubernetes distros that require them.

Assisted-by: Antigravity