### PR TITLE
Fix: TestCgroupNamespace failure on cgroups v1 hosts

### DIFF
--- a/internal/cri/server/container_create_linux_test.go
+++ b/internal/cri/server/container_create_linux_test.go
@@ -487,6 +487,8 @@ func TestPrivilegedBindMount(t *testing.T) {
 	}
 }
 
+// TestCgroupNamespace verifies that a cgroup namespace is only assigned to
+// non-privileged containers on cgroupv2 hosts.
 func TestCgroupNamespace(t *testing.T) {
 	testPid := uint32(1234)
 	c := newTestCRIService()
@@ -498,27 +500,50 @@ func TestCgroupNamespace(t *testing.T) {
 	tests := []struct {
 		desc                  string
 		privileged            bool
+		requireCgroupV2       bool
 		expectCgroupNamespace bool
 	}{
 		{
-			desc:                  "non-privileged container should get cgroup namespace",
+			desc:                  "cgroupv2: non-privileged container should get cgroup namespace",
 			privileged:            false,
+			requireCgroupV2:       true,
 			expectCgroupNamespace: true,
 		},
 		{
-			desc:                  "privileged container should not get cgroup namespace",
+			desc:                  "cgroupv2: privileged container should not get cgroup namespace",
 			privileged:            true,
+			requireCgroupV2:       true,
+			expectCgroupNamespace: false,
+		},
+		{
+			desc:                  "cgroupv1: non-privileged container should not get cgroup namespace",
+			privileged:            false,
+			requireCgroupV2:       false,
+			expectCgroupNamespace: false,
+		},
+		{
+			desc:                  "cgroupv1: privileged container should not get cgroup namespace",
+			privileged:            true,
+			requireCgroupV2:       false,
 			expectCgroupNamespace: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			// Skip if the host's cgroup mode doesn't match what the test case requires.
+			if tt.requireCgroupV2 && !isUnifiedCgroupsMode() {
+				t.Skip("requires cgroups v2")
+			}
+			if !tt.requireCgroupV2 && isUnifiedCgroupsMode() {
+				t.Skip("requires cgroups v1")
+			}
+
 			containerConfig.Linux.SecurityContext.Privileged = tt.privileged
 			sandboxConfig.Linux.SecurityContext.Privileged = tt.privileged
 
 			spec, err := c.buildContainerSpec(currentPlatform, t.Name(), testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			hasCgroupNS := false
 			for _, ns := range spec.Linux.Namespaces {


### PR DESCRIPTION
[TestCgroupNamespace](https://github.com/chrishenzie/containerd/blob/0eef29a1a92474f9dfb9c21e70790b25221cabdc/internal/cri/server/container_create_linux_test.go#L506) fails on hosts running cgroups v1 (e.g., Amazon Linux 2):                                              
                                                                                                                             
``` 
 --- FAIL: TestCgroupNamespace/non-privileged_container_should_get_cgroup_namespace                                         
      Error: Not equal:                                                                                                      
          expected: true                                                                                                     
          actual  : false                                                                                                    
```
The test hardcoded `expectCgroupNamespace: true` for non-privileged containers, but the implementation only adds the cgroup  namespace when `isUnifiedCgroupsMode()` returns true (cgroups v2). On cgroups v1 hosts, the namespace is never added, causing the assertion to fail.  
                                                                                                   
### Root Cause 

The test assumed all non-privileged containers run on hosts with cgroups v2. This is not the case for Amazon Linux 2, which uses cgroups v1.      
                                                                                                     
### Fix                                                                                                                        
Added a `requireCgroupV2` field to each test case to explicitly declare which cgroup version the case is valid for. Each subtest skips itself at runtime if the host's actual cgroup mode (detected via `isUnifiedCgroupsMode()`) does not match what the test case requires. This ensures the correct subset of tests runs on both cgroups v1 and v2 hosts without any hardcoded assumptions about the environment.
