### PR TITLE
Chore: Add unit tests to Vagrant CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,6 +654,8 @@ jobs:
             rm -f /tmp/fedora43.box
           fi
           sudo BOX=$BOX RUNC_FLAVOR=$RUNC_FLAVOR vagrant up --no-tty
+      - name: test-unit
+        run: sudo BOX=$BOX vagrant up --provision-with=selinux,install-gotestsum,test-unit
       - name: test-integration
         run: sudo BOX=$BOX RUNC_FLAVOR=$RUNC_FLAVOR vagrant up --provision-with=selinux,install-runc,install-gotestsum,test-integration
       - name: test-cri-integration

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -344,4 +344,27 @@ EOF
     SHELL
   end
 
+  # Usage:
+  #   # First provision the VM and install test dependencies:
+  #   vagrant up
+  #   # Then re-run only the unit-test provisioner:
+  #   vagrant up --provision-with=test-unit
+  #   SELINUX=Disabled vagrant up --provision-with=selinux,test-unit
+  #
+  config.vm.provision "test-unit", type: "shell", run: "never" do |sh|
+    sh.upload_path = "/tmp/test-unit"
+    sh.env = {
+        'GOTEST': ENV['GOTEST'] || "gotestsum --",
+    }
+    sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        source /etc/environment
+        source /etc/profile.d/sh.local
+        set -eux -o pipefail
+        cd ${GOPATH}/src/github.com/containerd/containerd
+        make BUILDTAGS="no_btrfs no_devmapper no_zfs" test
+        make BUILDTAGS="no_btrfs no_devmapper no_zfs" root-test
+    SHELL
+  end
+
 end

--- a/internal/cri/server/container_create_linux_test.go
+++ b/internal/cri/server/container_create_linux_test.go
@@ -487,6 +487,8 @@ func TestPrivilegedBindMount(t *testing.T) {
 	}
 }
 
+// TestCgroupNamespace verifies that a cgroup namespace is only assigned to
+// non-privileged containers on cgroupv2 hosts.
 func TestCgroupNamespace(t *testing.T) {
 	testPid := uint32(1234)
 	c := newTestCRIService()
@@ -498,27 +500,50 @@ func TestCgroupNamespace(t *testing.T) {
 	tests := []struct {
 		desc                  string
 		privileged            bool
+		requireCgroupV2       bool
 		expectCgroupNamespace bool
 	}{
 		{
-			desc:                  "non-privileged container should get cgroup namespace",
+			desc:                  "cgroupv2: non-privileged container should get cgroup namespace",
 			privileged:            false,
+			requireCgroupV2:       true,
 			expectCgroupNamespace: true,
 		},
 		{
-			desc:                  "privileged container should not get cgroup namespace",
+			desc:                  "cgroupv2: privileged container should not get cgroup namespace",
 			privileged:            true,
+			requireCgroupV2:       true,
+			expectCgroupNamespace: false,
+		},
+		{
+			desc:                  "cgroupv1: non-privileged container should not get cgroup namespace",
+			privileged:            false,
+			requireCgroupV2:       false,
+			expectCgroupNamespace: false,
+		},
+		{
+			desc:                  "cgroupv1: privileged container should not get cgroup namespace",
+			privileged:            true,
+			requireCgroupV2:       false,
 			expectCgroupNamespace: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			// Skip if the host's cgroup mode doesn't match what the test case requires.
+			if tt.requireCgroupV2 && !isUnifiedCgroupsMode() {
+				t.Skip("requires cgroups v2")
+			}
+			if !tt.requireCgroupV2 && isUnifiedCgroupsMode() {
+				t.Skip("requires cgroups v1")
+			}
+
 			containerConfig.Linux.SecurityContext.Privileged = tt.privileged
 			sandboxConfig.Linux.SecurityContext.Privileged = tt.privileged
 
 			spec, err := c.buildContainerSpec(currentPlatform, t.Name(), testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			hasCgroupNS := false
 			for _, ns := range spec.Linux.Namespaces {

--- a/plugins/snapshots/erofs/erofs_linux_test.go
+++ b/plugins/snapshots/erofs/erofs_linux_test.go
@@ -588,6 +588,9 @@ func testDmverityEndToEndWithMode(t *testing.T, useTarIndex bool) {
 // TestDmverityModeValidation tests dm-verity mode validation during snapshotter creation
 func TestDmverityModeValidation(t *testing.T) {
 	testutil.RequiresRoot(t)
+	if !FindErofs() {
+		t.Skip("erofs not supported")
+	}
 	tmpDir := t.TempDir()
 
 	t.Run("rejects invalid dmverity mode", func(t *testing.T) {


### PR DESCRIPTION
Add a test-unit provisioner to the Vagrantfile and wire it into the Vagrant integration job in ci.yml. This ensures unit tests run on AlmaLinux 8/9/10 and Fedora, catching failures that only manifest on cgroups v1 hosts (e.g., TestCgroupNamespace).

Previously, unit tests only ran on Ubuntu GitHub runners (cgroups v2), so environment-specific failures on cgroups v1 were not caught.