### PR TITLE
cri: exclude cached layer bytes from image_pulling_throughput_mibps

### DIFF
--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -180,11 +180,14 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 	//
 	// Transfer service does not currently support all the CRI image config options.
 	// TODO: Add support for DisableSnapshotAnnotations, DiscardUnpackedLayers, ImagePullWithSyncFs and unpackDuplicationSuppressor
-	var image containerd.Image
+	var (
+		image       containerd.Image
+		bytesPulled uint64
+	)
 	if c.config.UseLocalImagePull {
-		image, err = c.pullImageWithLocalPull(ctx, ref, credentials, snapshotter, labels, imagePullProgressTimeout)
+		image, bytesPulled, err = c.pullImageWithLocalPull(ctx, ref, credentials, snapshotter, labels, imagePullProgressTimeout)
 	} else {
-		image, err = c.pullImageWithTransferService(ctx, ref, credentials, snapshotter, labels, imagePullProgressTimeout)
+		image, bytesPulled, err = c.pullImageWithTransferService(ctx, ref, credentials, snapshotter, labels, imagePullProgressTimeout)
 	}
 
 	if err != nil {
@@ -216,11 +219,9 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 		}
 	}
 
-	const mbToByte = 1024 * 1024
-	size, _ := image.Size(ctx)
-	imagePullingSpeed := float64(size) / mbToByte / time.Since(startTime).Seconds()
-	imagePullThroughput.Observe(imagePullingSpeed)
+	recordImagePullThroughput(imagePullThroughput, bytesPulled, time.Since(startTime))
 
+	size, _ := image.Size(ctx)
 	log.G(ctx).Infof("Pulled image %q with image id %q, repo tag %q, repo digest %q, size %q in %s", name, imageID,
 		repoTag, repoDigest, strconv.FormatInt(size, 10), time.Since(startTime))
 	// NOTE(random-liu): the actual state in containerd is the source of truth, even we maintain
@@ -232,6 +233,10 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 }
 
 // pullImageWithLocalPull handles image pulling using the local client.
+//
+// The returned bytesPulled is the number of bytes actually fetched from the
+// registry — cached layers are not counted because they never trigger an
+// HTTP request.
 func (c *CRIImageService) pullImageWithLocalPull(
 	ctx context.Context,
 	ref string,
@@ -239,7 +244,7 @@ func (c *CRIImageService) pullImageWithLocalPull(
 	snapshotter string,
 	labels map[string]string,
 	imagePullProgressTimeout time.Duration,
-) (containerd.Image, error) {
+) (containerd.Image, uint64, error) {
 	pctx, pcancel := context.WithCancel(ctx)
 	defer pcancel()
 	pullReporter := newPullProgressReporter(ref, pcancel, imagePullProgressTimeout)
@@ -279,12 +284,17 @@ func (c *CRIImageService) pullImageWithLocalPull(
 	image, err := c.client.Pull(pctx, ref, pullOpts...)
 	pcancel()
 	if err != nil {
-		return nil, fmt.Errorf("failed to pull and unpack image %q: %w", ref, err)
+		return nil, 0, fmt.Errorf("failed to pull and unpack image %q: %w", ref, err)
 	}
-	return image, nil
+	_, bytesPulled := pullReporter.reqReporter.status()
+	return image, bytesPulled, nil
 }
 
 // pullImageWithTransferService handles image pulling using the transfer service.
+//
+// The returned bytesPulled is the number of bytes actually fetched from the
+// registry, accumulated from transfer progress events; cached layers emit an
+// "already exists" event that does not increment the counter.
 func (c *CRIImageService) pullImageWithTransferService(
 	ctx context.Context,
 	ref string,
@@ -292,7 +302,7 @@ func (c *CRIImageService) pullImageWithTransferService(
 	snapshotter string,
 	labels map[string]string,
 	imagePullProgressTimeout time.Duration,
-) (containerd.Image, error) {
+) (containerd.Image, uint64, error) {
 	log.G(ctx).Debugf("PullImage %q with snapshotter %s using transfer service", ref, snapshotter)
 	rctx, rcancel := context.WithCancel(ctx)
 	defer rcancel()
@@ -318,7 +328,7 @@ func (c *CRIImageService) pullImageWithTransferService(
 
 	reg, err := registry.NewOCIRegistry(ctx, ref, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create OCI registry: %w", err)
+		return nil, 0, fmt.Errorf("failed to create OCI registry: %w", err)
 	}
 
 	transferProgressReporter.start(rctx)
@@ -326,15 +336,16 @@ func (c *CRIImageService) pullImageWithTransferService(
 	err = c.transferrer.Transfer(rctx, reg, is, transfer.WithProgress(transferProgressReporter.createProgressFunc(rctx)))
 	rcancel()
 	if err != nil {
-		return nil, fmt.Errorf("failed to pull and unpack image %q: %w", ref, err)
+		return nil, 0, fmt.Errorf("failed to pull and unpack image %q: %w", ref, err)
 	}
 
 	// Image should be pulled, unpacked and present in containerd image store at this moment
 	image, err := c.client.GetImage(ctx, ref)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get image %q from containerd image store: %w", ref, err)
+		return nil, 0, fmt.Errorf("failed to get image %q from containerd image store: %w", ref, err)
 	}
-	return image, nil
+	_, bytesPulled := transferProgressReporter.reqReporter.status()
+	return image, bytesPulled, nil
 }
 
 // ParseAuth parses AuthConfig and returns username and password/secret required by containerd.

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -219,11 +219,13 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 		}
 	}
 
-	recordImagePullThroughput(imagePullThroughput, bytesPulled, time.Since(startTime))
+	elapsed := time.Since(startTime)
+	recordImagePullThroughput(imagePullThroughput, bytesPulled, elapsed)
+	recordImagePullThroughput(imagePullThroughputMiBps, bytesPulled, elapsed)
 
 	size, _ := image.Size(ctx)
 	log.G(ctx).Infof("Pulled image %q with image id %q, repo tag %q, repo digest %q, size %q in %s", name, imageID,
-		repoTag, repoDigest, strconv.FormatInt(size, 10), time.Since(startTime))
+		repoTag, repoDigest, strconv.FormatInt(size, 10), elapsed)
 	// NOTE(random-liu): the actual state in containerd is the source of truth, even we maintain
 	// in-memory image store, it's only for in-memory indexing. The image could be removed
 	// by someone else anytime, before/during/after we create the metadata. We should always

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -757,3 +757,66 @@ func TestTransferProgressReporter(t *testing.T) {
 		})
 	}
 }
+
+// fakeObserver records every Observe call so tests can assert both the
+// presence and the value of observations without touching the real histogram.
+type fakeObserver struct {
+	samples []float64
+}
+
+func (f *fakeObserver) Observe(v float64) {
+	f.samples = append(f.samples, v)
+}
+
+func TestRecordImagePullThroughput(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		bytesPulled uint64
+		duration    time.Duration
+		wantSamples int
+		wantValue   float64 // only checked when wantSamples == 1
+	}{
+		{
+			name:        "fully cached pull is not observed",
+			bytesPulled: 0,
+			duration:    2 * time.Second,
+			wantSamples: 0,
+		},
+		{
+			name:        "zero duration is not observed",
+			bytesPulled: 10 * mbToByte,
+			duration:    0,
+			wantSamples: 0,
+		},
+		{
+			name:        "cold pull observes MB/s from fetched bytes",
+			bytesPulled: 10 * mbToByte,
+			duration:    2 * time.Second,
+			wantSamples: 1,
+			wantValue:   5.0,
+		},
+		{
+			name:        "partial cache hit observes only fetched bytes",
+			// 200 MB image, 150 MB cached, 50 MB actually fetched over 1s.
+			bytesPulled: 50 * mbToByte,
+			duration:    1 * time.Second,
+			wantSamples: 1,
+			wantValue:   50.0,
+		},
+		{
+			name:        "sub-second pull observes correctly",
+			bytesPulled: 25 * mbToByte,
+			duration:    500 * time.Millisecond,
+			wantSamples: 1,
+			wantValue:   50.0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obs := &fakeObserver{}
+			recordImagePullThroughput(obs, tc.bytesPulled, tc.duration)
+			if assert.Len(t, obs.samples, tc.wantSamples) && tc.wantSamples == 1 {
+				assert.InDelta(t, tc.wantValue, obs.samples[0], 0.001)
+			}
+		})
+	}
+}

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -834,3 +834,66 @@ func TestPullProgressReporter(t *testing.T) {
 		}
 	})
 }
+
+// fakeObserver records every Observe call so tests can assert both the
+// presence and the value of observations without touching the real histogram.
+type fakeObserver struct {
+	samples []float64
+}
+
+func (f *fakeObserver) Observe(v float64) {
+	f.samples = append(f.samples, v)
+}
+
+func TestRecordImagePullThroughput(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		bytesPulled uint64
+		duration    time.Duration
+		wantSamples int
+		wantValue   float64 // only checked when wantSamples == 1
+	}{
+		{
+			name:        "fully cached pull is not observed",
+			bytesPulled: 0,
+			duration:    2 * time.Second,
+			wantSamples: 0,
+		},
+		{
+			name:        "zero duration is not observed",
+			bytesPulled: 10 * mbToByte,
+			duration:    0,
+			wantSamples: 0,
+		},
+		{
+			name:        "cold pull observes MB/s from fetched bytes",
+			bytesPulled: 10 * mbToByte,
+			duration:    2 * time.Second,
+			wantSamples: 1,
+			wantValue:   5.0,
+		},
+		{
+			name:        "partial cache hit observes only fetched bytes",
+			// 200 MB image, 150 MB cached, 50 MB actually fetched over 1s.
+			bytesPulled: 50 * mbToByte,
+			duration:    1 * time.Second,
+			wantSamples: 1,
+			wantValue:   50.0,
+		},
+		{
+			name:        "sub-second pull observes correctly",
+			bytesPulled: 25 * mbToByte,
+			duration:    500 * time.Millisecond,
+			wantSamples: 1,
+			wantValue:   50.0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obs := &fakeObserver{}
+			recordImagePullThroughput(obs, tc.bytesPulled, tc.duration)
+			if assert.Len(t, obs.samples, tc.wantSamples) && tc.wantSamples == 1 {
+				assert.InDelta(t, tc.wantValue, obs.samples[0], 0.001)
+			}
+		})
+	}
+}

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -861,28 +861,28 @@ func TestRecordImagePullThroughput(t *testing.T) {
 		},
 		{
 			name:        "zero duration is not observed",
-			bytesPulled: 10 * mbToByte,
+			bytesPulled: 10 * mibToByte,
 			duration:    0,
 			wantSamples: 0,
 		},
 		{
-			name:        "cold pull observes MB/s from fetched bytes",
-			bytesPulled: 10 * mbToByte,
+			name:        "cold pull observes MiB/s from fetched bytes",
+			bytesPulled: 10 * mibToByte,
 			duration:    2 * time.Second,
 			wantSamples: 1,
 			wantValue:   5.0,
 		},
 		{
-			name:        "partial cache hit observes only fetched bytes",
-			// 200 MB image, 150 MB cached, 50 MB actually fetched over 1s.
-			bytesPulled: 50 * mbToByte,
+			name: "partial cache hit observes only fetched bytes",
+			// 200 MiB image, 150 MiB cached, 50 MiB actually fetched over 1s.
+			bytesPulled: 50 * mibToByte,
 			duration:    1 * time.Second,
 			wantSamples: 1,
 			wantValue:   50.0,
 		},
 		{
 			name:        "sub-second pull observes correctly",
-			bytesPulled: 25 * mbToByte,
+			bytesPulled: 25 * mibToByte,
 			duration:    500 * time.Millisecond,
 			wantSamples: 1,
 			wantValue:   50.0,

--- a/internal/cri/server/images/metrics.go
+++ b/internal/cri/server/images/metrics.go
@@ -17,14 +17,20 @@
 package images
 
 import (
+	"time"
+
 	"github.com/docker/go-metrics"
 	prom "github.com/prometheus/client_golang/prometheus"
 )
 
+const mbToByte = 1024 * 1024
+
 var (
 	imagePulls           metrics.LabeledCounter
 	inProgressImagePulls metrics.Gauge
-	// image size in MB / image pull duration in seconds
+	// imagePullThroughput observes one MB/s sample per image pull (not per
+	// layer): fetched bytes over end-to-end pull duration (includes
+	// extraction). Fully-cached pulls are skipped.
 	imagePullThroughput prom.Histogram
 )
 
@@ -44,10 +50,24 @@ func init() {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "image_pulling_throughput",
-			Help:      "image pull throughput",
+			Help:      "image pull throughput in MB/s (fetched bytes / pull duration; cached layers excluded)",
 			Buckets:   prom.DefBuckets,
 		},
 	)
 	ns.Add(imagePullThroughput)
 	metrics.Register(ns)
+}
+
+// recordImagePullThroughput observes a single pull throughput sample in MB/s.
+// bytesPulled is the bytes actually fetched from the registry — cached layers
+// never trigger a fetch, so they're naturally excluded. duration is the
+// end-to-end pull duration (includes extraction, not just network transfer).
+//
+// Pulls that fetched nothing (fully cached) are skipped rather than recorded
+// as zero or near-infinite samples, which would pollute the histogram.
+func recordImagePullThroughput(obs prom.Observer, bytesPulled uint64, duration time.Duration) {
+	if bytesPulled == 0 || duration <= 0 {
+		return
+	}
+	obs.Observe(float64(bytesPulled) / mbToByte / duration.Seconds())
 }

--- a/internal/cri/server/images/metrics.go
+++ b/internal/cri/server/images/metrics.go
@@ -23,15 +23,23 @@ import (
 	prom "github.com/prometheus/client_golang/prometheus"
 )
 
-const mbToByte = 1024 * 1024
+const mibToByte = 1024 * 1024
 
 var (
 	imagePulls           metrics.LabeledCounter
 	inProgressImagePulls metrics.Gauge
-	// imagePullThroughput observes one MB/s sample per image pull (not per
-	// layer): fetched bytes over end-to-end pull duration (includes
-	// extraction). Fully-cached pulls are skipped.
+	// imagePullThroughput observes one MiB/s sample per image pull: bytes
+	// actually fetched from the registry over end-to-end pull duration.
+	// Fully-cached pulls are skipped.
+	//
+	// Deprecated: use imagePullThroughputMiBps instead. The new metric has
+	// the same semantics but more useful buckets — DefBuckets tops out at
+	// 10 MiB/s and saturates almost immediately on real hardware.
 	imagePullThroughput prom.Histogram
+	// imagePullThroughputMiBps observes one MiB/s sample per image pull (not
+	// per layer): bytes actually fetched from the registry over end-to-end
+	// pull duration (includes extraction). Fully-cached pulls are skipped.
+	imagePullThroughputMiBps prom.Histogram
 )
 
 func init() {
@@ -50,18 +58,34 @@ func init() {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "image_pulling_throughput",
-			Help:      "image pull throughput in MB/s (fetched bytes / pull duration; cached layers excluded)",
+			Help:      "Deprecated: use image_pulling_throughput_mibps instead. Image pull throughput in MiB/s (fetched bytes / pull duration; cached layers excluded).",
 			Buckets:   prom.DefBuckets,
 		},
 	)
+	imagePullThroughputMiBps = prom.NewHistogram(
+		prom.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "image_pulling_throughput_mibps",
+			Help:      "image pull throughput in MiB/s (fetched bytes / pull duration; cached layers excluded)",
+			// Buckets cover everything from slow registry pulls (0.1 MiB/s)
+			// to 4000 MiB/s (~31 Gbps), enough for modern 10G+ NICs. The
+			// top end is intentionally generous: past ~4 GiB/s, disk write
+			// throughput becomes the bottleneck rather than the network, so
+			// we don't need finer buckets above that.
+			Buckets: []float64{0.1, 1, 10, 25, 75, 150, 300, 500, 1000, 2000, 4000},
+		},
+	)
 	ns.Add(imagePullThroughput)
+	ns.Add(imagePullThroughputMiBps)
 	metrics.Register(ns)
 }
 
-// recordImagePullThroughput observes a single pull throughput sample in MB/s.
-// bytesPulled is the bytes actually fetched from the registry — cached layers
-// never trigger a fetch, so they're naturally excluded. duration is the
-// end-to-end pull duration (includes extraction, not just network transfer).
+// recordImagePullThroughput observes one MiB/s sample on obs (intended for
+// imagePullThroughputMiBps). bytesPulled is bytes actually fetched from the
+// registry — cached layers never trigger a fetch, so they are excluded.
+// duration is the end-to-end pull duration (includes extraction, not just
+// network transfer).
 //
 // Pulls that fetched nothing (fully cached) are skipped rather than recorded
 // as zero or near-infinite samples, which would pollute the histogram.
@@ -69,5 +93,5 @@ func recordImagePullThroughput(obs prom.Observer, bytesPulled uint64, duration t
 	if bytesPulled == 0 || duration <= 0 {
 		return
 	}
-	obs.Observe(float64(bytesPulled) / mbToByte / duration.Seconds())
+	obs.Observe(float64(bytesPulled) / mibToByte / duration.Seconds())
 }


### PR DESCRIPTION
Addresses #13244.

`image_pulling_throughput` metric currently calculates  `full image size / wall-clock pull duration`. This inflates the metric when there are cached layers in the content store, and produces near-infinite data points for noop pulls.

* This change plumbs the bytes actually fetched (`totalBytesRead` from `pullRequestReporter`, which is already maintained for progress/timeout checks in both pull paths) out of `pullImageWithLocalPull` and `pullImageWithTransferService`, and uses that in place of `image.Size(ctx)`. Fully-cached pulls (`bytesPulled == 0`) are skipped.

* To prevent a breaking change in time-series buckets, we introduce a new `image_pulling_throughput_mibps` metric; and deprecate the `image_pulling_throughput`.

* Also updates the metric's `Help` text to note that the denominator spans the whole pull including extraction, not just network transfer.


See #13244 for motivation and considered alternatives (zero-sample, `cached` label, ingester wrapper).