### PR TITLE
runtime/v2: self-heal existing bundle path in NewBundle

### DIFF
--- a/core/runtime/v2/bundle.go
+++ b/core/runtime/v2/bundle.go
@@ -71,8 +71,16 @@ func NewBundle(ctx context.Context, root, state, id string, spec typeurl.Any) (b
 	if err := os.MkdirAll(filepath.Dir(b.Path), 0711); err != nil {
 		return nil, err
 	}
+	// On Windows, a crashed shim or failed atomicDelete may leave the bundle
+	// path behind; mirror the work-dir handling below to self-heal.
 	if err := os.Mkdir(b.Path, 0700); err != nil {
-		return nil, err
+		if !os.IsExist(err) {
+			return nil, err
+		}
+		os.RemoveAll(b.Path)
+		if err := os.Mkdir(b.Path, 0700); err != nil {
+			return nil, err
+		}
 	}
 	if typeurl.Is(spec, &specs.Spec{}) {
 		if err := prepareBundleDirectoryPermissions(b.Path, spec.GetValue()); err != nil {

--- a/core/runtime/v2/bundle.go
+++ b/core/runtime/v2/bundle.go
@@ -77,7 +77,9 @@ func NewBundle(ctx context.Context, root, state, id string, spec typeurl.Any) (b
 		if !os.IsExist(err) {
 			return nil, err
 		}
-		os.RemoveAll(b.Path)
+		if err := os.RemoveAll(b.Path); err != nil {
+			return nil, fmt.Errorf("failed to remove stale bundle path %q: %w", b.Path, err)
+		}
 		if err := os.Mkdir(b.Path, 0700); err != nil {
 			return nil, err
 		}
@@ -101,7 +103,9 @@ func NewBundle(ctx context.Context, root, state, id string, spec typeurl.Any) (b
 		if !os.IsExist(err) {
 			return nil, err
 		}
-		os.RemoveAll(work)
+		if err := os.RemoveAll(work); err != nil {
+			return nil, fmt.Errorf("failed to remove stale work dir %q: %w", work, err)
+		}
 		if err := os.Mkdir(work, 0711); err != nil {
 			return nil, err
 		}

--- a/core/runtime/v2/bundle_test.go
+++ b/core/runtime/v2/bundle_test.go
@@ -17,7 +17,42 @@
 package v2
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 	// When testutil is imported for one platform (bundle_linux_test.go) it
 	// should be imported for all platforms.
 	_ "github.com/containerd/containerd/v2/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestNewBundleSelfHealsExistingPath verifies that NewBundle recovers when a
+// previous task's bundle state directory is left behind on disk. On Windows,
+// atomicDelete's os.Rename can fail while a still-exiting shim holds file
+// handles on bundle files, leaving the directory in place; the next NewTask
+// must not fail with "file already exists".
+func TestNewBundleSelfHealsExistingPath(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	state := filepath.Join(dir, "state")
+	const id = "self-heal"
+
+	ctx := namespaces.WithNamespace(context.Background(), namespaces.Default)
+
+	// Simulate a leftover bundle directory from a previous run, including a
+	// stale file inside it to prove RemoveAll runs.
+	stalePath := filepath.Join(state, namespaces.Default, id)
+	require.NoError(t, os.MkdirAll(stalePath, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(stalePath, "stale"), []byte("x"), 0600))
+
+	b, err := NewBundle(ctx, root, state, id, nil)
+	require.NoError(t, err, "NewBundle should self-heal a pre-existing bundle path")
+	require.NotNil(t, b)
+
+	_, err = os.Stat(filepath.Join(b.Path, "stale"))
+	assert.True(t, os.IsNotExist(err), "stale file should have been cleared by self-heal")
+}


### PR DESCRIPTION
## Summary

On Windows, `NewBundle` can fail with:

```
mkdir <state>/io.containerd.runtime.v2.task/<ns>/<id>: Cannot create a file when that file already exists
```

when a previous task's bundle state directory has been left behind on disk. This happens because `Bundle.Delete`'s `atomicDelete` uses `os.Rename`, which fails on Windows (`ERROR_ACCESS_DENIED`) while a still-exiting shim holds file handles under the bundle directory. The directory survives the delete, and the next `NewTask` trips over it at `os.Mkdir(b.Path, 0700)` in `NewBundle`.

This PR mirrors the `work`-dir handling 20 lines below in the same function: if the `Mkdir` returns `IsExist`, `RemoveAll` and retry once. The two `Mkdir`s in `NewBundle` are now consistent, and a new task can recover from a leftover bundle path without requiring callers to clean it up out-of-band.

This is a defense-in-depth fix for the Windows race; it improves the error surface and makes `NewBundle` robust against leftover state from any source (crash, interrupted delete, OS-level locking). Follow-up work to address the root cause — waiting for the shim process to exit before `Bundle.Delete` — can be tracked separately.

## Test plan

- [x] Added `TestNewBundleSelfHealsExistingPath` — cross-platform, pre-creates a stale bundle dir with a stale file and asserts `NewBundle` succeeds and clears it.
- [x] Verified the test reproduces the exact original error (`Cannot create a file when that file already exists`) against unpatched code on Windows.
- [x] Verified the test passes with the fix on Windows.
- [x] Full `./core/runtime/v2/` package test suite still passes.

## Notes

Opened as a **draft** pending internal verification. The change is self-contained and low-risk regardless.