### PR TITLE
docs: fix typos (compatability → compatibility, dependant → dependent)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,7 +25,7 @@ A codespace will open in a web-based version of Visual Studio Code. The [dev con
 
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
-* Go compiler (download from https://go.dev/dl/). At least one of the two most recent major Go versions are supported. For example, if Go 1.26 is the latest, either 1.26 or 1.25 are supported. It is not uncommon to find issues in early days of the latest go version. The support of the non-latest version is dependant on dependencies supported versions.
+* Go compiler (download from https://go.dev/dl/). At least one of the two most recent major Go versions are supported. For example, if Go 1.26 is the latest, either 1.26 or 1.25 are supported. It is not uncommon to find issues in early days of the latest go version. The support of the non-latest version is dependent on dependencies supported versions.
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 
 > *Note*: On macOS, you need a third party runtime to run containers on containerd

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -402,7 +402,7 @@ As of containerd 2.0, the Go client API documented in
 [godoc](https://godoc.org/github.com/containerd/containerd/v2/client) is stable.
 Note that because the Go client interfaces with the GRPC API, clients building on top
 of the Go client should remain compatible with future server releases implementing the
-same major GRPC API series. For backwards compatability and as a general rule of thumb,
+same major GRPC API series. For backwards compatibility and as a general rule of thumb,
 it is the client's responsibility to handle not implemented errors returned by the containerd daemon.
 
 Any changes to the Go client API should be detectable at compile time, so upgrading will


### PR DESCRIPTION

**Repo:** containerd/containerd (⭐ 17000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Fixes two spelling errors in top-level project documentation: "compatability" → "compatibility" in `RELEASES.md` and "dependant" → "dependent" in `BUILDING.md`. Both are adjective misspellings in user-facing documentation describing Go client API compatibility guarantees and supported Go versions.

## Why
These documents are the canonical references contributors and users read when evaluating supported Go versions and the project's API compatibility policy. Correct spelling improves readability and professionalism of the project docs. No behavioral or API change.

## Testing
Purely documentation text changes; no build or tests needed. Verified context of each sentence reads naturally with the corrected spelling.

## Risk
Low — documentation-only wording fix, no code paths touched.
