### PR TITLE
Support both styles of volatile mount option

### DIFF
--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -202,6 +202,52 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 			},
 		},
 		{
+			desc: "remove fsync=volatile option from overlay mounts, ignore non overlay",
+			input: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"workdir=/path/to/snapshots/4/work",
+						"upperdir=/path/to/snapshots/4/fs",
+						"lowerdir=/path/to/snapshots/1/fs",
+						"fsync=volatile",
+					},
+				},
+				{
+					Type:   "underlay",
+					Source: "underlay",
+					Options: []string{
+						"index=on",
+						"lowerdir=/another/path/to/snapshots/2/fs",
+						"fsync=volatile",
+					},
+				},
+			},
+			expected: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"workdir=/path/to/snapshots/4/work",
+						"upperdir=/path/to/snapshots/4/fs",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
+				{
+					Type:   "underlay",
+					Source: "underlay",
+					Options: []string{
+						"index=on",
+						"lowerdir=/another/path/to/snapshots/2/fs",
+						"fsync=volatile",
+					},
+				},
+			},
+		},
+		{
 			desc: "return original slice since no volatile options on overlay",
 			input: []Mount{
 				{

--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -88,7 +88,7 @@ func RemoveVolatileOption(mounts []Mount) []Mount {
 			continue
 		}
 		for j, opt := range m.Options {
-			if opt == "volatile" {
+			if opt == "volatile" || opt == "fsync=volatile" {
 				if out == nil {
 					out = copyMounts(mounts)
 				}

--- a/integration/image_volume_linux_test.go
+++ b/integration/image_volume_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -247,7 +248,8 @@ func TestImageVolumeCheckVolatileOption(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mpInfo.Mountpoint, imageVolumeMount)
 	require.Equal(t, "overlay", mpInfo.FSType)
-	require.Contains(t, strings.Split(mpInfo.VFSOptions, ","), "volatile")
+	vfsOpts := strings.Split(mpInfo.VFSOptions, ",")
+	require.True(t, slices.Contains(vfsOpts, "volatile") || slices.Contains(vfsOpts, "fsync=volatile"), "VFSOptions should contain either 'volatile' or 'fsync=volatile'")
 }
 
 func TestImageVolumeSetupIfContainerdRestarts(t *testing.T) {

--- a/internal/cri/server/container_image_mount_linux.go
+++ b/internal/cri/server/container_image_mount_linux.go
@@ -53,7 +53,7 @@ func addVolatileOptionOnImageVolumeMount(mounts []mount.Mount) []mount.Mount {
 	}
 
 	for i, m := range mounts {
-		if m.Type != "overlay" || slices.Contains(m.Options, "volatile") {
+		if m.Type != "overlay" || slices.Contains(m.Options, "volatile") || slices.Contains(m.Options, "fsync=volatile") {
 			continue
 		}
 		mounts[i].Options = append(mounts[i].Options, "volatile")


### PR DESCRIPTION
Kernel 6.12.80+ returns `fsync=volatile` instead of just `volatile` in mount options, which breaks containerd's exact string matching checks.

Fixes this issue by adding support for `fsync=volatile` in addition to the existing `volatile` check in `RemoveVolatileOption` and `addVolatileOptionOnImageVolumeMount`.

Fixes: https://github.com/containerd/containerd/issues/13250

Assisted-by: Antigravity