### PR TITLE
[release/1.7] Add GitHub Action for k8s node e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,3 +653,12 @@ jobs:
           path: |
             *-junit.xml
             *-gotest.json
+
+  node-e2e:
+    name: E2E K8s ${{ matrix.k8s_version }}
+    strategy:
+      matrix:
+        k8s_version: [release-1.30, release-1.31, release-1.32, release-1.33]
+    uses: ./.github/workflows/node-e2e.yml
+    with:
+      k8s_version: ${{ matrix.k8s_version }}

--- a/.github/workflows/node-e2e.yml
+++ b/.github/workflows/node-e2e.yml
@@ -1,0 +1,123 @@
+name: E2E
+on:
+  workflow_call:
+    inputs:
+      k8s_version:
+        description: 'Kubernetes branch or tag to test against'
+        required: false
+        default: 'master'
+        type: string
+permissions:
+  contents: read
+
+jobs:
+  node-e2e-k8s:
+    name: Kubernetes Node
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout containerd
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: src/github.com/containerd/containerd
+          fetch-depth: 0
+
+      - name: Checkout Kubernetes
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: kubernetes/kubernetes
+          path: src/k8s.io/kubernetes
+          ref: ${{ inputs.k8s_version }}
+
+      - name: Install Go
+        uses: ./src/github.com/containerd/containerd/.github/actions/install-go
+
+      - name: Set Up Environment
+        run: |
+          set -e -x
+          # Disable swap to allow kubelet to start.
+          sudo swapoff -a
+          sudo apt-get update
+          sudo apt-get install -y gperf build-essential pkg-config
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - name: Build and Install containerd
+        working-directory: ./src/github.com/containerd/containerd
+        run: |
+          set -e -x
+          script/setup/install-seccomp
+          script/setup/install-runc
+          script/setup/install-cni
+          make binaries GO_BUILD_FLAGS="-mod=vendor"
+          sudo make install
+
+      - name: Configure and Start containerd
+        run: |
+          set -e -x
+          # Stop and disable pre-existing containerd service to ensure a clean state.
+          if sudo systemctl is-active --quiet containerd; then
+            sudo systemctl stop containerd
+          fi
+          if sudo systemctl is-enabled --quiet containerd; then
+            sudo systemctl disable containerd
+          fi
+
+          sudo mkdir -p /etc/containerd
+          sudo tee /etc/containerd/config.toml > /dev/null <<EOF
+          version = 2
+          required_plugins = ["io.containerd.grpc.v1.cri"]
+          [plugins."io.containerd.grpc.v1.cri".containerd]
+            default_runtime_name = "runc"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+            runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            # Ensure containerd uses the runc binary installed from source.
+            BinaryName = "/usr/local/sbin/runc"
+            SystemdCgroup = true
+          # Required for certain node e2e tests.
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
+            runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.options]
+            # Ensure containerd uses the runc binary installed from source.
+            BinaryName = "/usr/local/sbin/runc"
+            SystemdCgroup = true
+          EOF
+
+          sudo cp ./src/github.com/containerd/containerd/containerd.service /etc/systemd/system/
+          sudo systemctl daemon-reload
+          sudo systemctl start containerd
+
+          # Wait and verify the daemon is ready.
+          sleep 5
+          sudo ctr version
+
+      - name: Run Node E2E Tests
+        working-directory: ./src/k8s.io/kubernetes
+        run: |
+          # TODO: Remove "ResourceMetrics" feature skip once containerd supports ListMetricDescriptors:
+          # https://github.com/kubernetes/kubernetes/blob/v1.33.2/test/e2e_node/resource_metrics_test.go#L67-L71
+          sudo make test-e2e-node \
+            FOCUS='\[NodeConformance\]|\[Feature:.+\]|\[Feature\]' \
+            SKIP='\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:UserNamespacesSupport\]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:ResourceMetrics\]|\[Feature:RelaxedEnvironmentVariableValidation\]|\[Alpha\]|should be able to pull from private registry with secret|should be able to pull from private registry with credential provider' \
+            TEST_ARGS='--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
+
+      - name: Collect Logs on Failure
+        if: failure()
+        run: |
+          ARTIFACT_DIR=./_artifacts
+          mkdir -p ${ARTIFACT_DIR}
+          KUBELET_LOG_SRC=$(sudo find /tmp/_artifacts -name "kubelet.log" | head -n 1)
+          if [ -f "$KUBELET_LOG_SRC" ]; then
+            sudo cp "$KUBELET_LOG_SRC" "${ARTIFACT_DIR}/kubelet.log"
+          else
+            echo "Kubelet log file not found." > "${ARTIFACT_DIR}/kubelet.log"
+          fi
+          sudo journalctl -u containerd --no-pager > "${ARTIFACT_DIR}/containerd.log"
+
+      - name: Upload Log Artifacts
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: e2e-logs
+          path: ./_artifacts/


### PR DESCRIPTION
Backport the k8s node e2e workflow from release/2.2: https://github.com/containerd/containerd/pull/13247. This file does not exist on release/1.7, so a direct copy is simpler than backporting the full history of commits modifying it.

Included is the test matrix for the Kubernetes versions we want to test against for this branch: 1.30 through 1.33.

Additional adjustments made for release/1.7:
- Remove arguments from script/setup/install-cni call to fall back to reading version from script/setup/cni-plugins-version, matching other integration tests on this branch.
- Skip [Feature:RelaxedEnvironmentVariableValidation] tests because this feature is Alpha in Kubernetes 1.31 and disabled by default, causing failures when testing against K8s 1.31.
- Skip private registry tests because they rely on hardcoded credentials that are no longer valid (see https://github.com/kubernetes/kubernetes/issues/133261).

Assisted-by: Antigravity