### PR TITLE
fix(erofs): handle orphaned snapshot directories on Windows

### DIFF
--- a/plugins/snapshots/erofs/erofs.go
+++ b/plugins/snapshots/erofs/erofs.go
@@ -580,6 +580,21 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		}
 
 		path = filepath.Join(snapshotDir, snap.ID)
+		// On Windows, os.Rename cannot replace an existing directory, and
+		// orphaned snapshot directories may exist if a previous Remove
+		// failed to delete them (e.g. due to antivirus holding file
+		// handles). Rather than trying to delete the orphan (which would
+		// fail for the same reason), rename it aside so cleanup can
+		// happen later when handles are released.
+		if runtime.GOOS == "windows" {
+			if _, serr := os.Stat(path); serr == nil {
+				orphan := filepath.Join(snapshotDir, fmt.Sprintf(".orphan-%s-%d", snap.ID, time.Now().UnixNano()))
+				log.G(ctx).WithField("path", path).WithField("orphan", orphan).Warn("moving orphaned snapshot directory aside")
+				if rerr := os.Rename(path, orphan); rerr != nil {
+					return fmt.Errorf("failed to move orphaned snapshot directory: %w", rerr)
+				}
+			}
+		}
 		if err = os.Rename(td, path); err != nil {
 			return fmt.Errorf("failed to rename: %w", err)
 		}
@@ -652,10 +667,27 @@ func (s *snapshotter) generateFsMeta(ctx context.Context, snapIDs []string) {
 
 	t1 := time.Now()
 	mergedMeta := s.fsMetaPath(snapIDs[0])
-	// If the empty placeholder cannot be created (mainly due to os.IsExist), just return
-	if _, err := os.OpenFile(mergedMeta, os.O_CREATE|os.O_EXCL, 0644); err != nil {
+	// The empty placeholder doubles as a lock against concurrent generation:
+	// if another goroutine (or a previous successful run) already owns it,
+	// O_EXCL returns EEXIST and we bail.
+	f, err := os.OpenFile(mergedMeta, os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
 		return
 	}
+	f.Close()
+
+	// Any failure after this point must remove the placeholder so a future
+	// Prepare can retry; otherwise the O_EXCL check above would permanently
+	// block fsmeta generation for this snapshot chain after a transient error.
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		if rerr := os.Remove(mergedMeta); rerr != nil && !os.IsNotExist(rerr) {
+			log.G(ctx).WithError(rerr).Warnf("failed to remove fsmeta placeholder for %v", snapIDs[0])
+		}
+	}()
 
 	for i := len(snapIDs) - 1; i >= 0; i-- {
 		blob := s.layerBlobPath(snapIDs[i])
@@ -678,6 +710,7 @@ func (s *snapshotter) generateFsMeta(ctx context.Context, snapIDs []string) {
 		log.G(ctx).Errorf("failed to rename fsmeta: %v", err)
 		return
 	}
+	success = true
 	log.G(ctx).WithFields(log.Fields{
 		"d": time.Since(t1),
 	}).Infof("merged fsmeta for %v generated", snapIDs[0])
@@ -763,6 +796,29 @@ func (s *snapshotter) Mounts(ctx context.Context, key string) (_ []mount.Mount, 
 		return nil, err
 	}
 	return s.mounts(snap, info)
+}
+
+// Cleanup removes any orphaned snapshot directories that are not tracked in
+// the metadata store, including any .orphan-* directories left by
+// createSnapshot when it moved locked directories aside on Windows
+// (.orphan-* names can never be tracked IDs so getCleanupDirectories already
+// returns them).
+func (s *snapshotter) Cleanup(ctx context.Context) error {
+	var cleanup []string
+	if err := s.ms.WithTransaction(ctx, true, func(ctx context.Context) error {
+		var err error
+		cleanup, err = s.getCleanupDirectories(ctx)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	for _, dir := range cleanup {
+		if err := os.RemoveAll(dir); err != nil {
+			log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove orphaned snapshot directory")
+		}
+	}
+	return nil
 }
 
 func (s *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, error) {

--- a/plugins/snapshots/erofs/erofs_windows_test.go
+++ b/plugins/snapshots/erofs/erofs_windows_test.go
@@ -1,0 +1,101 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+)
+
+// TestCleanupRemovesOrphansAndOrphanAside verifies that Cleanup removes both
+// untracked snapshot directories and .orphan-* directories left by
+// createSnapshot's rename-aside path on Windows. Since .orphan-* names can
+// never be valid tracked IDs, getCleanupDirectories returns them as untracked.
+func TestCleanupRemovesOrphansAndOrphanAside(t *testing.T) {
+	root := t.TempDir()
+
+	s, err := NewSnapshotter(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+
+	ctx := namespaces.WithNamespace(context.Background(), "testsuite")
+
+	// Initialize the metadata bucket via a real Prepare so storage.IDMap
+	// works; otherwise getCleanupDirectories returns "bucket does not exist".
+	_, err = s.Prepare(ctx, "tracked-key", "")
+	require.NoError(t, err)
+
+	snapshotsDir := filepath.Join(root, "snapshots")
+	stale := filepath.Join(snapshotsDir, "9999")
+	orphanAside := filepath.Join(snapshotsDir, ".orphan-9999-1700000000000000000")
+	require.NoError(t, os.MkdirAll(stale, 0700))
+	require.NoError(t, os.MkdirAll(orphanAside, 0700))
+
+	cleaner, ok := s.(snapshots.Cleaner)
+	require.True(t, ok, "snapshotter must implement snapshots.Cleaner")
+	require.NoError(t, cleaner.Cleanup(ctx))
+
+	_, err = os.Stat(stale)
+	require.True(t, os.IsNotExist(err), "stale snapshot dir should be removed, got err=%v", err)
+	_, err = os.Stat(orphanAside)
+	require.True(t, os.IsNotExist(err), ".orphan-* dir should be removed, got err=%v", err)
+}
+
+// TestCreateSnapshotRenamesOrphanAside verifies that when Prepare finds a
+// pre-existing directory at the target snapshot path on Windows, it renames
+// the directory aside to .orphan-* instead of failing with "Access is denied".
+func TestCreateSnapshotRenamesOrphanAside(t *testing.T) {
+	root := t.TempDir()
+
+	s, err := NewSnapshotter(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+
+	ctx := namespaces.WithNamespace(context.Background(), "testsuite")
+	snapshotsDir := filepath.Join(root, "snapshots")
+
+	// Seed a stale directory at every plausible next-ID path so that whichever
+	// ID the metadata store allocates, createSnapshot has to rename it aside.
+	for _, id := range []string{"1", "2", "3"} {
+		stale := filepath.Join(snapshotsDir, id)
+		require.NoError(t, os.MkdirAll(stale, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(stale, "sentinel"), []byte(id), 0600))
+	}
+
+	_, err = s.Prepare(ctx, "snap-key", "")
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(snapshotsDir)
+	require.NoError(t, err)
+
+	var orphanSeen bool
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".orphan-") {
+			orphanSeen = true
+			break
+		}
+	}
+	require.True(t, orphanSeen, "expected at least one .orphan-* dir after Prepare, got entries: %v", entries)
+}


### PR DESCRIPTION
On Windows, antivirus and other processes can briefly hold file handles on newly-created `layer.erofs` files. When containerd's `Remove()` tries to delete the snapshot directory, `os.RemoveAll` fails silently (logged as warning) because the handle is still held. The bbolt record is already deleted, leaving an orphaned directory on disk. When a subsequent `Prepare` allocates the same snapshot ID, `os.Rename` fails with `Access is denied` because the target directory still exists and Windows cannot atomically replace directories.

This also fixes a separate handle leak in `generateFsMeta` that caused the same `Access is denied` symptom on `fsmeta.erofs` rename.

## Changes

1. **`createSnapshot`**: when the target directory already exists on Windows, rename it aside to `.orphan-{id}-{timestamp}` instead of trying to delete it. Renaming a directory does not require releasing handles on files inside it.
2. **`generateFsMeta`**: close the leaked file handle on the `fsmeta.erofs` placeholder. The `*os.File` returned by `os.OpenFile` was discarded without `Close()`, keeping the handle open until GC and blocking the subsequent `os.Rename`.
3. **`Cleanup()`**: garbage-collect orphaned snapshot directories not tracked in the metadata store, plus `.orphan-*` directories left by the rename-aside logic. Matches the overlay snapshotter pattern.

Observed downstream impact on a fork consuming this package: ~100% E2E failure rate on Windows runners, with `Access is denied` on `fsmeta.erofs` rename visible in dockerd logs.

## Test plan

- [ ] CI green on `windows/amd64`
- [ ] Repro steps on Windows: create many snapshots crossing `fsMergeThreshold` and verify no `Access is denied` on rename