### PR TITLE
apparmor: Set abi conditionally

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -40,8 +40,8 @@ import (
 const dir = "/etc/apparmor.d"
 
 const defaultTemplate = `
-abi <abi/3.0>,
-
+{{if .Abi}}abi <{{.Abi}}>,
+{{end}}
 {{range $value := .Imports}}
 {{$value}}
 {{end}}
@@ -96,6 +96,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 `
 
 type data struct {
+	Abi           string
 	Name          string
 	Imports       []string
 	InnerImports  []string
@@ -116,6 +117,11 @@ func cleanProfileName(profile string) string {
 func loadData(name string) (*data, error) {
 	p := data{
 		Name: name,
+	}
+
+	const abi = "abi/3.0"
+	if macroExists(abi) {
+		p.Abi = abi
 	}
 
 	if macroExists("tunables/global") {


### PR DESCRIPTION
The "abi" keyword was added for apparmor 3.0
The original change to add this ended up breaking versions < 3.0. The abi itself is a macro in /etc/apparmor.d so we can check if the macro exists to determine if we *can* set an abi in the template.