### PR TITLE
snapshotter/erofs: pass explicit dm-verity metadata path via mount options

### DIFF
--- a/internal/dmverity/dmverity.go
+++ b/internal/dmverity/dmverity.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 )
 
 type DmverityOptions struct {
@@ -57,6 +58,9 @@ func DefaultDmverityOptions() *DmverityOptions {
 }
 
 func MetadataPath(layerBlobPath string) string {
+	if strings.HasSuffix(layerBlobPath, ".dmverity") {
+		return layerBlobPath
+	}
 	return layerBlobPath + ".dmverity"
 }
 

--- a/internal/dmverity/dmverity_test.go
+++ b/internal/dmverity/dmverity_test.go
@@ -253,6 +253,7 @@ func createTempFile(t *testing.T, data []byte) string {
 
 func TestMetadataPath(t *testing.T) {
 	assert.Equal(t, "/path/to/layer.erofs.dmverity", MetadataPath("/path/to/layer.erofs"))
+	assert.Equal(t, "/path/to/layer.erofs.dmverity", MetadataPath("/path/to/layer.erofs.dmverity"))
 }
 
 func TestDevicePath(t *testing.T) {

--- a/plugins/mount/erofs/plugin_linux.go
+++ b/plugins/mount/erofs/plugin_linux.go
@@ -62,19 +62,26 @@ func (h *erofsMountHandler) Mount(ctx context.Context, m mount.Mount, mp string,
 		dmverity.Close(dmverityDevice)
 	}()
 
-	// Check for dmverity mode in mount options
-	dmverityMode := "auto" // default
+	// Parse dm-verity metadata path from mount options
+	metadataPath := ""
 	for _, opt := range m.Options {
-		if mode, ok := strings.CutPrefix(opt, "X-containerd.dmverity="); ok {
-			dmverityMode = mode
+		if path, ok := strings.CutPrefix(opt, "X-containerd.dmverity="); ok {
+			metadataPath = path
 			break
 		}
 	}
 
-	// Check if this layer has dm-verity metadata
-	metadata, err := dmverity.ReadMetadata(m.Source)
-	if err == nil && dmverityMode != "off" {
-		log.G(ctx).WithField("source", m.Source).Debug("detected dm-verity metadata, setting up dm-verity device")
+	// Set up dm-verity device if metadata path is provided
+	if metadataPath != "" {
+		log.G(ctx).WithFields(log.Fields{
+			"source":        m.Source,
+			"metadata-path": metadataPath,
+		}).Debug("setting up dm-verity device from mount option")
+
+		metadata, err := dmverity.ReadMetadata(metadataPath)
+		if err != nil {
+			return mount.ActiveMount{}, fmt.Errorf("failed to read dm-verity metadata from %s: %w", metadataPath, err)
+		}
 
 		devicePath, cleanupName, err := setupDmVerityDevice(ctx, m.Source, metadata)
 		dmverityDevice = cleanupName
@@ -86,7 +93,7 @@ func (h *erofsMountHandler) Mount(ctx context.Context, m mount.Mount, mp string,
 
 	filteredOptions := make([]string, 0, len(m.Options))
 	for _, v := range m.Options {
-		// Skip loop option (handled by loop device setup) and dmverity mode option (already processed)
+		// Skip loop option (handled by loop device setup) and dmverity options (already processed)
 		if v == "loop" || strings.HasPrefix(v, "X-containerd.dmverity=") {
 			continue
 		}
@@ -98,7 +105,7 @@ func (h *erofsMountHandler) Mount(ctx context.Context, m mount.Mount, mp string,
 		return mount.ActiveMount{}, err
 	}
 
-	err = unix.ENOTBLK
+	err := error(unix.ENOTBLK)
 	if !forceloop {
 		// Try to use file-backed mount feature if available (Linux 6.12+) first
 		err = doMount(m, mp)

--- a/plugins/snapshots/erofs/erofs.go
+++ b/plugins/snapshots/erofs/erofs.go
@@ -283,10 +283,24 @@ func (s *snapshotter) mountFsMeta(snap storage.Snapshot, id int) (mount.Mount, b
 }
 
 // applyDmverityPolicy validates and applies dm-verity policy for a layer.
-// Returns the X-containerd.dmverity option if needed, or empty string otherwise.
+// Returns the X-containerd.dmverity mount option with the plain metadata path
+// if dm-verity is applicable, or empty string if dm-verity should not be used.
+// The mount handler and lower runtimes can use the path to read the .dmverity file
+// and get the root hash and other metadata.
 func (s *snapshotter) applyDmverityPolicy(layerBlob string) (string, error) {
+	// If mode is "off", skip dm-verity entirely.
+	if s.dmverityMode == "off" {
+		return "", nil
+	}
+
 	metadataPath := dmverity.MetadataPath(layerBlob)
 	_, metadataErr := os.Stat(metadataPath)
+
+	// Handle stat errors: distinguish between "not found" and other errors
+	// (e.g., I/O errors) to avoid silently bypassing dm-verity.
+	if metadataErr != nil && !os.IsNotExist(metadataErr) {
+		return "", fmt.Errorf("failed to access dm-verity metadata %s: %w", metadataPath, metadataErr)
+	}
 	metadataExists := metadataErr == nil
 
 	// Validate dmverityMode policy: mode "on" requires .dmverity metadata to exist
@@ -297,12 +311,10 @@ func (s *snapshotter) applyDmverityPolicy(layerBlob string) (string, error) {
 			"or set dmverity_mode to 'auto' to allow layers without dm-verity metadata", layerBlob)
 	}
 
-	// Only return option if metadata exists and we need to override the default "auto" behavior
-	// This keeps standard EROFS mounts (without dm-verity) unchanged
-	if metadataExists && s.dmverityMode != "auto" {
-		// Mode "off": disables dm-verity even though metadata exists
-		// Mode "on": explicitly enables dm-verity (though "auto" would do the same)
-		return fmt.Sprintf("X-containerd.dmverity=%s", s.dmverityMode), nil
+	// If metadata exists, return the metadata path to a mount option.
+	// The format is: X-containerd.dmverity=<metadata-path>
+	if metadataExists {
+		return fmt.Sprintf("X-containerd.dmverity=%s", metadataPath), nil
 	}
 
 	return "", nil

--- a/plugins/snapshots/erofs/erofs_linux_test.go
+++ b/plugins/snapshots/erofs/erofs_linux_test.go
@@ -426,8 +426,10 @@ func TestCreateErofsMount(t *testing.T) {
 
 		assert.Equal(t, "erofs", m.Type)
 		assert.Equal(t, layerBlob, m.Source)
-		// X-containerd.dmverity=off overrides auto-detection when metadata exists
-		assert.Contains(t, m.Options, "X-containerd.dmverity=off")
+		// mode "off" skips dm-verity entirely - no dm-verity option in mount options
+		for _, opt := range m.Options {
+			assert.NotContains(t, opt, "X-containerd.dmverity=")
+		}
 	})
 }
 
@@ -663,7 +665,7 @@ func TestApplyDmverityPolicy(t *testing.T) {
 		assert.Empty(t, opt)
 	})
 
-	t.Run("mode off returns dmverity=off when metadata exists", func(t *testing.T) {
+	t.Run("mode off returns empty string when metadata exists", func(t *testing.T) {
 		createDmverityMetadata(t, layerBlob)
 
 		s := &snapshotter{
@@ -672,10 +674,10 @@ func TestApplyDmverityPolicy(t *testing.T) {
 
 		opt, err := s.applyDmverityPolicy(layerBlob)
 		require.NoError(t, err)
-		assert.Equal(t, "X-containerd.dmverity=off", opt)
+		assert.Empty(t, opt)
 	})
 
-	t.Run("mode on returns dmverity=on when metadata exists", func(t *testing.T) {
+	t.Run("mode on returns metadata path when metadata exists", func(t *testing.T) {
 		createDmverityMetadata(t, layerBlob)
 
 		s := &snapshotter{
@@ -684,10 +686,11 @@ func TestApplyDmverityPolicy(t *testing.T) {
 
 		opt, err := s.applyDmverityPolicy(layerBlob)
 		require.NoError(t, err)
-		assert.Equal(t, "X-containerd.dmverity=on", opt)
+		expectedPath := layerBlob + ".dmverity"
+		assert.Equal(t, "X-containerd.dmverity="+expectedPath, opt)
 	})
 
-	t.Run("mode auto returns empty string when metadata exists", func(t *testing.T) {
+	t.Run("mode auto returns metadata path when metadata exists", func(t *testing.T) {
 		createDmverityMetadata(t, layerBlob)
 
 		s := &snapshotter{
@@ -696,6 +699,7 @@ func TestApplyDmverityPolicy(t *testing.T) {
 
 		opt, err := s.applyDmverityPolicy(layerBlob)
 		require.NoError(t, err)
-		assert.Empty(t, opt) // auto mode doesn't add explicit option
+		expectedPath := layerBlob + ".dmverity"
+		assert.Equal(t, "X-containerd.dmverity="+expectedPath, opt)
 	})
 }


### PR DESCRIPTION
- **Background**                                                                      

   
  The EROFS snapshotter integrates dm-verity to provide data integrity protection 
  for container image layers. When a layer is prepared with dm-verity enabled, a
  .dmverity metadata file is generated alongside the layer.erofs blob, containing
  the root hash and hash offset required to verify the layer's integrity at mount
  time.

  Containerd's mount options already support a X-containerd.dmverity= label       
  mechanism to convey dm-verity related information to lower-level runtimes and
  mount handlers.                                                                 
                                                                     

-   **Problem**

  The existing X-containerd.dmverity= label only carries boolean-like values such
  as on or off, indicating whether dm-verity should be enabled. This design
  provides insufficient information for downstream consumers:

  - Lower-level runtimes (e.g., Kata Containers) cannot access the dm-verity
  metadata required to set up verification at their level
  - Mount handlers cannot determine the location of the .dmverity file to read
  root hash and hash offset
  - No mechanism exists to pass the concrete metadata path through the mount
  option chain

-   **Motivation**

  This change transforms the X-containerd.dmverity= label from a simple
  enable/disable flag into a concrete metadata file path. Instead of passing
  abstract values like on/off, the label now carries the full path to the
  .dmverity file (e.g.,
  X-containerd.dmverity=/var/lib/containerd/.../layer.erofs.dmverity).

-   **This enables:**

  1. Mount handlers to read the metadata file directly, extract root hash and hash
   offset, and create dm-verity devices during mount activation
  2. Lower-level runtimes to access dm-verity metadata for their own integrity
  verification mechanisms
  3. Consistent information flow from snapshotter through mount handler to
  runtime, without requiring additional out-of-band communication  