### PR TITLE
contrib/apparmor: align whitespace parsing with libapparmor

### DIFF
--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -63,7 +63,7 @@ func LoadDefaultProfile(name string) error {
 	if err != nil {
 		return err
 	}
-	f, err := os.CreateTemp(os.Getenv("XDG_RUNTIME_DIR"), p.Name)
+	f, err := os.CreateTemp(os.Getenv("XDG_RUNTIME_DIR"), p.name)
 	if err != nil {
 		return err
 	}

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -46,7 +46,7 @@ const defaultTemplate = `
 {{$value}}
 {{end}}
 
-profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
+profile "{{.Name}}" flags=(attach_disconnected,mediate_deleted) {
 {{range $value := .InnerImports}}
   {{$value}}
 {{end}}
@@ -62,12 +62,12 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   # crun may send signals to container processes.
   signal (receive) peer=crun,
   # Manager may send signals to container processes.
-  signal (receive) peer={{.DaemonProfile}},
+  signal (receive) peer="{{.DaemonProfile}}",
   # Container processes may send signals amongst themselves.
-  signal (send,receive) peer={{.Name}},
+  signal (send,receive) peer="{{.Name}}",
 {{if .RootlessKit}}
   # https://github.com/containerd/nerdctl/issues/2730
-  signal (receive) peer={{.RootlessKit}},
+  signal (receive) peer="{{.RootlessKit}}",
 {{end}}
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
@@ -91,7 +91,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 
   # allow processes within the container to trace each other,
   # provided all other LSM and yama setting allow it.
-  ptrace (trace,tracedby,read,readby) peer={{.Name}},
+  ptrace (trace,tracedby,read,readby) peer="{{.Name}}",
 }
 `
 
@@ -104,14 +104,53 @@ type data struct {
 	RootlessKit   string
 }
 
+// cleanProfileName returns the AppArmor profile name from a confinement
+// context as reported by /proc/self/attr/current.
+//
+// The value may be either a bare profile name, "unconfined", or a profile name
+// with a trailing mode suffix of the form " (<mode>)". If profile is empty,
+// cleanProfileName returns "unconfined".
 func cleanProfileName(profile string) string {
-	// Normally profiles are suffixed by " (enforce)". AppArmor profiles cannot
-	// contain spaces so this doesn't restrict daemon profile names.
-	profile, _, _ = strings.Cut(profile, " ")
-	if profile == "" {
-		profile = "unconfined"
+	label, _ := splitCon(profile)
+	if label == "" {
+		return "unconfined"
 	}
-	return profile
+	return label
+}
+
+// splitCon splits an AppArmor confinement context into a label and mode,
+// similar to libapparmor [splitcon]. splitCon follows libapparmor's parsing
+// semantics and does not validate the returned mode.
+//
+// /proc/self/attr/current returns the current confinement context for the
+// process. Unlike /sys/kernel/security/apparmor/profiles, this value may not
+// include a " (<mode>)" suffix.
+//
+// Supported forms:
+//
+//	<profile>
+//	<profile> (<mode>)
+//	unconfined
+//
+// splitCon strips one trailing newline before parsing.
+//
+// [splitcon]: https://gitlab.com/apparmor/apparmor/-/blob/v5.0.1/libraries/libapparmor/src/kernel.c#L562-615
+func splitCon(con string) (label, mode string) {
+	// Value includes a trailing newline.
+	con = strings.TrimSuffix(con, "\n")
+	if con == "" || con == "unconfined" {
+		return con, ""
+	}
+
+	if strings.HasSuffix(con, ")") {
+		// Profile names may contain spaces, so split on the last " (" before
+		// the trailing ")" rather than the first space.
+		if i := strings.LastIndex(con[:len(con)-1], " ("); i >= 0 {
+			return con[:i], con[i+2 : len(con)-1]
+		}
+	}
+
+	return con, ""
 }
 
 func loadData(name string) (*data, error) {
@@ -187,19 +226,20 @@ func isLoaded(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
-	r := bufio.NewReader(f)
-	for {
-		p, err := r.ReadString('\n')
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return false, err
-		}
-		if strings.HasPrefix(p, name+" ") {
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Entries are of the form "<profile> (<mode>)", e.g. "foo (enforce)".
+		// Profile names may contain spaces (quoted names are supported in AppArmor);
+		// use splitCon to correctly handle profile names containing spaces and/or parentheses.
+		label, _ := splitCon(scanner.Text())
+		if label == name {
 			return true, nil
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
 	}
 	return false, nil
 }

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -96,41 +96,119 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 `
 
 type data struct {
-	Abi           string
-	Name          string
-	Imports       []string
-	InnerImports  []string
-	DaemonProfile string
-	RootlessKit   string
+	abi           string
+	name          string
+	imports       []string
+	innerImports  []string
+	daemonProfile string
+	rootlessKit   string
 }
 
-func cleanProfileName(profile string) string {
-	// Normally profiles are suffixed by " (enforce)". AppArmor profiles cannot
-	// contain spaces so this doesn't restrict daemon profile names.
-	profile, _, _ = strings.Cut(profile, " ")
-	if profile == "" {
-		profile = "unconfined"
+func (d data) Abi() string {
+	return d.abi
+}
+
+func (d data) Name() string {
+	return quote(d.name)
+}
+
+func (d data) Imports() []string {
+	return d.imports
+}
+
+func (d data) InnerImports() []string {
+	return d.innerImports
+}
+
+func (d data) DaemonProfile() string {
+	return quote(d.daemonProfile)
+}
+
+func (d data) RootlessKit() string {
+	return quote(d.rootlessKit)
+}
+
+// quote returns s as an AppArmor quoted identifier. Embedded backslashes
+// and double quotes are escaped; empty strings are returned unchanged.
+//
+// AppArmor quoted identifiers may contain any character other than NUL.
+// See ALLOWED_QUOTED_ID and QUOTED_ID in parser/parser_lex.l:
+// https://gitlab.com/apparmor/apparmor/-/blob/v5.0.2/parser/parser_lex.l?ref_type=tags#L286-287
+func quote(s string) string {
+	if s == "" {
+		return ""
 	}
-	return profile
+
+	// Callers are expected to pass valid profile names, which excludes NUL.
+	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s) + `"`
+}
+
+// cleanProfileName returns the AppArmor profile name from a confinement
+// context as reported by /proc/self/attr/current.
+//
+// The value may be either a bare profile name, "unconfined", or a profile name
+// with a trailing mode suffix of the form " (<mode>)". If profile is empty,
+// cleanProfileName returns "unconfined".
+func cleanProfileName(profile string) string {
+	label, _ := splitCon(profile)
+	if label == "" {
+		return "unconfined"
+	}
+	return label
+}
+
+// splitCon splits an AppArmor confinement context into a label and mode,
+// similar to libapparmor [splitcon]. splitCon follows libapparmor's parsing
+// semantics and does not validate the returned mode.
+//
+// /proc/self/attr/current returns the current confinement context for the
+// process. Unlike /sys/kernel/security/apparmor/profiles, this value may not
+// include a " (<mode>)" suffix.
+//
+// Supported forms:
+//
+//	<profile>
+//	<profile> (<mode>)
+//	unconfined
+//
+// splitCon strips one trailing newline before parsing.
+//
+// [splitcon]: https://gitlab.com/apparmor/apparmor/-/blob/v5.0.1/libraries/libapparmor/src/kernel.c#L562-615
+func splitCon(con string) (label, mode string) {
+	// Value includes a trailing newline.
+	con = strings.TrimSuffix(con, "\n")
+	if con == "" || con == "unconfined" {
+		return con, ""
+	}
+
+	if strings.HasSuffix(con, ")") {
+		// Profile names may contain spaces, so split on the last " (" before
+		// the trailing ")" rather than the first space.
+		if i := strings.LastIndex(con[:len(con)-1], " ("); i >= 0 {
+			return con[:i], con[i+2 : len(con)-1]
+		}
+	}
+
+	return con, ""
 }
 
 func loadData(name string) (*data, error) {
 	p := data{
-		Name: name,
+		name: name,
 	}
 
 	const abi = "abi/3.0"
 	if macroExists(abi) {
-		p.Abi = abi
+		p.abi = abi
 	}
 
 	if macroExists("tunables/global") {
-		p.Imports = append(p.Imports, "#include <tunables/global>")
+		p.imports = append(p.imports, "#include <tunables/global>")
 	} else {
-		p.Imports = append(p.Imports, "@{PROC}=/proc/")
+		p.imports = append(p.imports, "@{PROC}=/proc/")
 	}
 	if macroExists("abstractions/base") {
-		p.InnerImports = append(p.InnerImports, "#include <abstractions/base>")
+		p.innerImports = append(p.innerImports, "#include <abstractions/base>")
 	}
 
 	// Figure out the daemon profile.
@@ -140,17 +218,17 @@ func loadData(name string) (*data, error) {
 		// unconfined which is generally the default.
 		currentProfile = nil
 	}
-	p.DaemonProfile = cleanProfileName(string(currentProfile))
+	p.daemonProfile = cleanProfileName(string(currentProfile))
 
 	// If we were running in Rootless mode, we could read `/proc/$(cat ${ROOTLESSKIT_STATE_DIR}/child_pid)/exe`,
 	// but `nerdctl apparmor load` has to be executed as the root.
 	// So, do not check ${ROOTLESSKIT_STATE_DIR} (nor EUID) here.
-	p.RootlessKit, err = exec.LookPath("rootlesskit")
+	p.rootlessKit, err = exec.LookPath("rootlesskit")
 	if err != nil {
 		log.L.WithError(err).Debug("apparmor: failed to determine the RootlessKit binary path")
-		p.RootlessKit = ""
+		p.rootlessKit = ""
 	}
-	log.L.Debugf("apparmor: RootlessKit=%q", p.RootlessKit)
+	log.L.Debugf("apparmor: RootlessKit=%q", p.rootlessKit)
 
 	return &p, nil
 }
@@ -187,19 +265,20 @@ func isLoaded(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
-	r := bufio.NewReader(f)
-	for {
-		p, err := r.ReadString('\n')
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return false, err
-		}
-		if strings.HasPrefix(p, name+" ") {
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Entries are of the form "<profile> (<mode>)", e.g. "foo (enforce)".
+		// Profile names may contain spaces (quoted names are supported in AppArmor);
+		// use splitCon to correctly handle profile names containing spaces and/or parentheses.
+		label, _ := splitCon(scanner.Text())
+		if label == name {
 			return true, nil
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
 	}
 	return false, nil
 }

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -24,8 +24,18 @@ func TestCleanProfileName(t *testing.T) {
 			want:    "unconfined",
 		},
 		{
+			doc:     "unconfined newline",
+			profile: "unconfined\n",
+			want:    "unconfined",
+		},
+		{
 			doc:     "unconfined enforce",
 			profile: "unconfined (enforce)",
+			want:    "unconfined",
+		},
+		{
+			doc:     "unconfined enforce newline",
+			profile: "unconfined (enforce)\n",
 			want:    "unconfined",
 		},
 		{
@@ -37,6 +47,21 @@ func TestCleanProfileName(t *testing.T) {
 			doc:     "simple enforce",
 			profile: "docker-default (enforce)",
 			want:    "docker-default",
+		},
+		{
+			doc:     "spaces",
+			profile: "with spaces (enforce)",
+			want:    "with spaces",
+		},
+		{
+			doc:     "parentheses in name",
+			profile: "foo (bar) (enforce)",
+			want:    "foo (bar)",
+		},
+		{
+			doc:     "unknown mode",
+			profile: "foo (anything)",
+			want:    "foo",
 		},
 	}
 

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -9,10 +9,40 @@ import (
 )
 
 func TestCleanProfileName(t *testing.T) {
-	assert.Equal(t, cleanProfileName(""), "unconfined")
-	assert.Equal(t, cleanProfileName("unconfined"), "unconfined")
-	assert.Equal(t, cleanProfileName("unconfined (enforce)"), "unconfined")
-	assert.Equal(t, cleanProfileName("docker-default"), "docker-default")
-	assert.Equal(t, cleanProfileName("foo"), "foo")
-	assert.Equal(t, cleanProfileName("foo (enforce)"), "foo")
+	tests := []struct {
+		doc     string
+		profile string
+		want    string
+	}{
+		{
+			doc:  "empty",
+			want: "unconfined",
+		},
+		{
+			doc:     "unconfined",
+			profile: "unconfined",
+			want:    "unconfined",
+		},
+		{
+			doc:     "unconfined enforce",
+			profile: "unconfined (enforce)",
+			want:    "unconfined",
+		},
+		{
+			doc:     "simple",
+			profile: "docker-default",
+			want:    "docker-default",
+		},
+		{
+			doc:     "simple enforce",
+			profile: "docker-default (enforce)",
+			want:    "docker-default",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			assert.Equal(t, tc.want, cleanProfileName(tc.profile))
+		})
+	}
 }

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -24,8 +24,18 @@ func TestCleanProfileName(t *testing.T) {
 			want:    "unconfined",
 		},
 		{
+			doc:     "unconfined newline",
+			profile: "unconfined\n",
+			want:    "unconfined",
+		},
+		{
 			doc:     "unconfined enforce",
 			profile: "unconfined (enforce)",
+			want:    "unconfined",
+		},
+		{
+			doc:     "unconfined enforce newline",
+			profile: "unconfined (enforce)\n",
 			want:    "unconfined",
 		},
 		{
@@ -38,11 +48,75 @@ func TestCleanProfileName(t *testing.T) {
 			profile: "docker-default (enforce)",
 			want:    "docker-default",
 		},
+		{
+			doc:     "spaces",
+			profile: "with spaces (enforce)",
+			want:    "with spaces",
+		},
+		{
+			doc:     "parentheses in name",
+			profile: "foo (bar) (enforce)",
+			want:    "foo (bar)",
+		},
+		{
+			doc:     "unknown mode",
+			profile: "foo (anything)",
+			want:    "foo",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
 			assert.Equal(t, tc.want, cleanProfileName(tc.profile))
+		})
+	}
+}
+
+func TestQuote(t *testing.T) {
+	tests := []struct {
+		doc   string
+		value string
+		want  string
+	}{
+		{
+			doc:  "empty",
+			want: "",
+		},
+		{
+			doc:   "simple",
+			value: "default-profile",
+			want:  `"default-profile"`,
+		},
+		{
+			doc:   "spaces",
+			value: "with spaces",
+			want:  `"with spaces"`,
+		},
+		{
+			doc:   "double quote",
+			value: `foo"bar`,
+			want:  `"foo\"bar"`,
+		},
+		{
+			doc:   "backslash",
+			value: `foo\bar`,
+			want:  `"foo\\bar"`,
+		},
+		{
+			doc:   "escape sequence",
+			value: `foo\nbar`,
+			want:  `"foo\\nbar"`,
+		},
+		{
+			doc:   "AARE pattern",
+			value: `foo*bar`,
+			want:  `"foo*bar"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			assert.Equal(t, tc.want, quote(tc.value))
 		})
 	}
 }


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/13270#issuecomment-4304772978

### contrib/apparmor: fix whitespace handling in profile names

The profile we read from /proc/self/attr/current will contain a newline,
resulting in a stray newline to be added to the profile;

    Diff:
    --- Expected
    +++ Actual
    @@ -16,3 +16,4 @@
       # Manager may send signals to container processes.
    -  signal (receive) peer=unconfined,
    +  signal (receive) peer=unconfined
    +,
       # Container processes may send signals amongst themselves.

Trim whitespace to account for newlines and fix handling of whitespace as
AppArmor profile names are allowed to contain spaces when quoted; from the
[apparmor.d(5)] man-page:

    PROFILE NAME ( UNQUOTED PROFILE NAME | QUOTED PROFILE NAME )

    QUOTED PROFILE NAME = '"' UNQUOTED PROFILE NAME '"'

    UNQUOTED PROFILE NAME = (must start with alphanumeric character (after
    variable expansion), or '/' AARE have special meanings; see below. May
    include VARIABLE. Rules with embedded spaces or tabs must be quoted.)

While we don't use those names in our code, let's make the code correct.

[apparmor.d(5)]: https://manpages.ubuntu.com/manpages/xenial/man5/apparmor.d.5.html
