### PR TITLE
contrib/apparmor: load profile without using tempfile

### DIFF
--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -19,10 +19,13 @@
 package apparmor
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
@@ -74,7 +77,7 @@ func LoadDefaultProfile(name string) error {
 	if err := generate(p, f); err != nil {
 		return err
 	}
-	if err := load(path); err != nil {
+	if err := loadProfile(path); err != nil {
 		return fmt.Errorf("load apparmor profile %s: %w", path, err)
 	}
 	return nil
@@ -92,4 +95,40 @@ func DumpDefaultProfile(name string) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func isLoaded(name string) (bool, error) {
+	f, err := os.Open("/sys/kernel/security/apparmor/profiles")
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Entries are of the form "<profile> (<mode>)", e.g. "foo (enforce)".
+		// Profile names may contain spaces (quoted names are supported in AppArmor),
+		// so split on " (" rather than the first space.
+		if prefix, _, ok := strings.Cut(scanner.Text(), " ("); ok && prefix == name {
+			return true, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+// loadProfile runs "apparmor_parser -Kr" on a specified AppArmor profile to
+// replace the profile. The "-K" is necessary to make sure that apparmor_parser
+// doesn't try to write to a read-only filesystem.
+func loadProfile(profilePath string) error {
+	c := exec.Command("apparmor_parser", "-Kr", profilePath) // #nosec G204 G702 -- Ignore "Subprocess launched with variable (gosec)"
+	c.Dir = ""
+
+	if out, err := c.CombinedOutput(); err != nil {
+		return fmt.Errorf("parser error(%q): %w", strings.TrimSpace(string(out)), err)
+	}
+
+	return nil
 }

--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -43,8 +44,8 @@ func WithProfile(profile string) oci.SpecOpts {
 // WithDefaultProfile will generate a default apparmor profile under the provided name
 // for the container.  It is only generated if a profile under that name does not exist.
 func WithDefaultProfile(name string) oci.SpecOpts {
-	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
-		if err := LoadDefaultProfile(name); err != nil {
+	return func(ctx context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		if err := loadDefaultProfile(ctx, name); err != nil {
 			return err
 		}
 		s.Process.ApparmorProfile = name
@@ -55,6 +56,10 @@ func WithDefaultProfile(name string) oci.SpecOpts {
 // LoadDefaultProfile ensures the default profile to be loaded with the given name.
 // Returns nil error if the profile is already loaded.
 func LoadDefaultProfile(name string) error {
+	return loadDefaultProfile(context.Background(), name)
+}
+
+func loadDefaultProfile(ctx context.Context, name string) error {
 	yes, err := isLoaded(name)
 	if err != nil {
 		return err
@@ -66,19 +71,13 @@ func LoadDefaultProfile(name string) error {
 	if err != nil {
 		return err
 	}
-	f, err := os.CreateTemp(os.Getenv("XDG_RUNTIME_DIR"), p.Name)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	path := f.Name()
-	defer os.Remove(path)
 
-	if err := generate(p, f); err != nil {
+	var buf bytes.Buffer
+	if err := generate(p, &buf); err != nil {
 		return err
 	}
-	if err := loadProfile(path); err != nil {
-		return fmt.Errorf("load apparmor profile %s: %w", path, err)
+	if err := loadProfile(ctx, &buf); err != nil {
+		return fmt.Errorf("load AppArmor profile: %w", err)
 	}
 	return nil
 }
@@ -119,12 +118,12 @@ func isLoaded(name string) (bool, error) {
 	return false, nil
 }
 
-// loadProfile runs "apparmor_parser -Kr" on a specified AppArmor profile to
-// replace the profile. The "-K" is necessary to make sure that apparmor_parser
-// doesn't try to write to a read-only filesystem.
-func loadProfile(profilePath string) error {
-	c := exec.Command("apparmor_parser", "-Kr", profilePath) // #nosec G204 G702 -- Ignore "Subprocess launched with variable (gosec)"
-	c.Dir = ""
+// loadProfile runs "apparmor_parser -Kr", providing the AppArmor profile on
+// stdin to replace the profile. The "-K" is necessary to make sure that
+// apparmor_parser doesn't try to write to a read-only filesystem.
+func loadProfile(ctx context.Context, profile io.Reader) error {
+	c := exec.CommandContext(ctx, "apparmor_parser", "-Kr")
+	c.Stdin = profile
 
 	if out, err := c.CombinedOutput(); err != nil {
 		return fmt.Errorf("parser error(%q): %w", strings.TrimSpace(string(out)), err)

--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 
@@ -42,8 +43,8 @@ func WithProfile(profile string) oci.SpecOpts {
 // WithDefaultProfile will generate a default apparmor profile under the provided name
 // for the container.  It is only generated if a profile under that name does not exist.
 func WithDefaultProfile(name string) oci.SpecOpts {
-	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
-		if err := LoadDefaultProfile(name); err != nil {
+	return func(ctx context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		if err := loadDefaultProfile(ctx, name); err != nil {
 			return err
 		}
 		s.Process.ApparmorProfile = name
@@ -54,6 +55,10 @@ func WithDefaultProfile(name string) oci.SpecOpts {
 // LoadDefaultProfile ensures the default profile to be loaded with the given name.
 // Returns nil error if the profile is already loaded.
 func LoadDefaultProfile(name string) error {
+	return loadDefaultProfile(context.Background(), name)
+}
+
+func loadDefaultProfile(ctx context.Context, name string) error {
 	yes, err := isLoaded(name)
 	if err != nil {
 		return err
@@ -65,19 +70,13 @@ func LoadDefaultProfile(name string) error {
 	if err != nil {
 		return err
 	}
-	f, err := os.CreateTemp(os.Getenv("XDG_RUNTIME_DIR"), p.Name)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	path := f.Name()
-	defer os.Remove(path)
 
-	if err := generate(p, f); err != nil {
+	var buf bytes.Buffer
+	if err := generate(p, &buf); err != nil {
 		return err
 	}
-	if err := loadProfile(path); err != nil {
-		return fmt.Errorf("load apparmor profile %s: %w", path, err)
+	if err := loadProfile(ctx, &buf); err != nil {
+		return fmt.Errorf("load AppArmor profile: %w", err)
 	}
 	return nil
 }
@@ -119,12 +118,12 @@ func isLoaded(name string) (bool, error) {
 	return false, nil
 }
 
-// loadProfile runs "apparmor_parser -Kr" on a specified AppArmor profile to
-// replace the profile. The "-K" is necessary to make sure that apparmor_parser
-// doesn't try to write to a read-only filesystem.
-func loadProfile(profilePath string) error {
-	c := exec.Command("apparmor_parser", "-Kr", profilePath) // #nosec G204 G702 -- Ignore "Subprocess launched with variable (gosec)"
-	c.Dir = ""
+// loadProfile runs "apparmor_parser -Kr", providing the AppArmor profile on
+// stdin to replace the profile. The "-K" is necessary to make sure that
+// apparmor_parser doesn't try to write to a read-only filesystem.
+func loadProfile(ctx context.Context, profile io.Reader) error {
+	c := exec.CommandContext(ctx, "apparmor_parser", "-Kr")
+	c.Stdin = profile
 
 	if out, err := c.CombinedOutput(); err != nil {
 		return fmt.Errorf("parser error(%q): %w", string(bytes.TrimSpace(out)), err)

--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -19,10 +19,12 @@
 package apparmor
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
@@ -74,7 +76,7 @@ func LoadDefaultProfile(name string) error {
 	if err := generate(p, f); err != nil {
 		return err
 	}
-	if err := load(path); err != nil {
+	if err := loadProfile(path); err != nil {
 		return fmt.Errorf("load apparmor profile %s: %w", path, err)
 	}
 	return nil
@@ -92,4 +94,41 @@ func DumpDefaultProfile(name string) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func isLoaded(name string) (bool, error) {
+	f, err := os.Open("/sys/kernel/security/apparmor/profiles")
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Entries are of the form "<profile> (<mode>)", e.g. "foo (enforce)".
+		// Profile names may contain spaces (quoted names are supported in AppArmor);
+		// use splitCon to correctly handle profile names containing spaces and/or parentheses.
+		label, _ := splitCon(scanner.Text())
+		if label == name {
+			return true, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+// loadProfile runs "apparmor_parser -Kr" on a specified AppArmor profile to
+// replace the profile. The "-K" is necessary to make sure that apparmor_parser
+// doesn't try to write to a read-only filesystem.
+func loadProfile(profilePath string) error {
+	c := exec.Command("apparmor_parser", "-Kr", profilePath) // #nosec G204 G702 -- Ignore "Subprocess launched with variable (gosec)"
+	c.Dir = ""
+
+	if out, err := c.CombinedOutput(); err != nil {
+		return fmt.Errorf("parser error(%q): %w", string(bytes.TrimSpace(out)), err)
+	}
+
+	return nil
 }

--- a/contrib/apparmor/apparmor_test.go
+++ b/contrib/apparmor/apparmor_test.go
@@ -19,11 +19,12 @@
 package apparmor
 
 import (
+	"os/exec"
 	"testing"
 )
 
 func TestDumpDefaultProfile(t *testing.T) {
-	if _, err := aaParser("--version"); err != nil {
+	if _, err := exec.LookPath("apparmor_parser"); err != nil {
 		t.Skipf("apparmor_parser not available: %+v", err)
 	}
 	name := "test-dump-default-profile"

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -105,9 +105,14 @@ type data struct {
 }
 
 func cleanProfileName(profile string) string {
-	// Normally profiles are suffixed by " (enforce)". AppArmor profiles cannot
-	// contain spaces so this doesn't restrict daemon profile names.
-	profile, _, _ = strings.Cut(profile, " ")
+	// /proc/self/attr/current returns the current label for the process.
+	// Unlike /sys/kernel/security/apparmor/profiles, this value may not
+	// include a " (<mode>)" suffix (e.g. it can be just "unconfined").
+	// If a suffix is present, it is of the form "<profile> (<mode>)".
+	// Profile names may contain spaces, so split on " (" rather than the
+	// first space. Trim whitespace first because the value includes a
+	// trailing newline.
+	profile, _, _ = strings.Cut(strings.TrimSpace(profile), " (")
 	if profile == "" {
 		profile = "unconfined"
 	}
@@ -187,19 +192,19 @@ func isLoaded(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
-	r := bufio.NewReader(f)
-	for {
-		p, err := r.ReadString('\n')
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return false, err
-		}
-		if strings.HasPrefix(p, name+" ") {
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Entries are of the form "<profile> (<mode>)", e.g. "foo (enforce)".
+		// Profile names may contain spaces (quoted names are supported in AppArmor),
+		// so split on " (" rather than the first space.
+		if prefix, _, ok := strings.Cut(scanner.Text(), " ("); ok && prefix == name {
 			return true, nil
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
 	}
 	return false, nil
 }

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -21,8 +21,6 @@
 package apparmor
 
 import (
-	"bufio"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -168,43 +166,8 @@ func generate(p *data, o io.Writer) error {
 	return t.Execute(o, p)
 }
 
-func load(path string) error {
-	out, err := aaParser("-Kr", path)
-	if err != nil {
-		return fmt.Errorf("parser error(%q): %w", strings.TrimSpace(out), err)
-	}
-	return nil
-}
-
 // macroExists checks if the passed macro exists.
 func macroExists(m string) bool {
 	_, err := os.Stat(path.Join(dir, m))
 	return err == nil
-}
-
-func aaParser(args ...string) (string, error) {
-	out, err := exec.Command("apparmor_parser", args...).CombinedOutput()
-	return string(out), err
-}
-
-func isLoaded(name string) (bool, error) {
-	f, err := os.Open("/sys/kernel/security/apparmor/profiles")
-	if err != nil {
-		return false, err
-	}
-	defer func() { _ = f.Close() }()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		// Entries are of the form "<profile> (<mode>)", e.g. "foo (enforce)".
-		// Profile names may contain spaces (quoted names are supported in AppArmor),
-		// so split on " (" rather than the first space.
-		if prefix, _, ok := strings.Cut(scanner.Text(), " ("); ok && prefix == name {
-			return true, nil
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return false, err
-	}
-	return false, nil
 }

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -46,7 +46,7 @@ const defaultTemplate = `
 {{$value}}
 {{end}}
 
-profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
+profile "{{.Name}}" flags=(attach_disconnected,mediate_deleted) {
 {{range $value := .InnerImports}}
   {{$value}}
 {{end}}
@@ -62,12 +62,12 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   # crun may send signals to container processes.
   signal (receive) peer=crun,
   # Manager may send signals to container processes.
-  signal (receive) peer={{.DaemonProfile}},
+  signal (receive) peer="{{.DaemonProfile}}",
   # Container processes may send signals amongst themselves.
-  signal (send,receive) peer={{.Name}},
+  signal (send,receive) peer="{{.Name}}",
 {{if .RootlessKit}}
   # https://github.com/containerd/nerdctl/issues/2730
-  signal (receive) peer={{.RootlessKit}},
+  signal (receive) peer="{{.RootlessKit}}",
 {{end}}
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
@@ -91,7 +91,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 
   # allow processes within the container to trace each other,
   # provided all other LSM and yama setting allow it.
-  ptrace (trace,tracedby,read,readby) peer={{.Name}},
+  ptrace (trace,tracedby,read,readby) peer="{{.Name}}",
 }
 `
 
@@ -104,14 +104,53 @@ type data struct {
 	RootlessKit   string
 }
 
+// cleanProfileName returns the AppArmor profile name from a confinement
+// context as reported by /proc/self/attr/current.
+//
+// The value may be either a bare profile name, "unconfined", or a profile name
+// with a trailing mode suffix of the form " (<mode>)". If profile is empty,
+// cleanProfileName returns "unconfined".
 func cleanProfileName(profile string) string {
-	// Normally profiles are suffixed by " (enforce)". AppArmor profiles cannot
-	// contain spaces so this doesn't restrict daemon profile names.
-	profile, _, _ = strings.Cut(profile, " ")
-	if profile == "" {
-		profile = "unconfined"
+	label, _ := splitCon(profile)
+	if label == "" {
+		return "unconfined"
 	}
-	return profile
+	return label
+}
+
+// splitCon splits an AppArmor confinement context into a label and mode,
+// similar to libapparmor [splitcon]. splitCon follows libapparmor's parsing
+// semantics and does not validate the returned mode.
+//
+// /proc/self/attr/current returns the current confinement context for the
+// process. Unlike /sys/kernel/security/apparmor/profiles, this value may not
+// include a " (<mode>)" suffix.
+//
+// Supported forms:
+//
+//	<profile>
+//	<profile> (<mode>)
+//	unconfined
+//
+// splitCon strips one trailing newline before parsing.
+//
+// [splitcon]: https://gitlab.com/apparmor/apparmor/-/blob/v5.0.1/libraries/libapparmor/src/kernel.c#L562-615
+func splitCon(con string) (label, mode string) {
+	// Value includes a trailing newline.
+	con = strings.TrimSuffix(con, "\n")
+	if con == "" || con == "unconfined" {
+		return con, ""
+	}
+
+	if strings.HasSuffix(con, ")") {
+		// Profile names may contain spaces, so split on the last " (" before
+		// the trailing ")" rather than the first space.
+		if i := strings.LastIndex(con[:len(con)-1], " ("); i >= 0 {
+			return con[:i], con[i+2 : len(con)-1]
+		}
+	}
+
+	return con, ""
 }
 
 func loadData(name string) (*data, error) {
@@ -187,19 +226,20 @@ func isLoaded(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
-	r := bufio.NewReader(f)
-	for {
-		p, err := r.ReadString('\n')
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return false, err
-		}
-		if strings.HasPrefix(p, name+" ") {
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Entries are of the form "<profile> (<mode>)", e.g. "foo (enforce)".
+		// Profile names may contain spaces (quoted names are supported in AppArmor);
+		// use splitCon to correctly handle profile names containing spaces and/or parentheses.
+		label, _ := splitCon(scanner.Text())
+		if label == name {
 			return true, nil
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
 	}
 	return false, nil
 }

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -21,8 +21,6 @@
 package apparmor
 
 import (
-	"bufio"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -202,44 +200,8 @@ func generate(p *data, o io.Writer) error {
 	return t.Execute(o, p)
 }
 
-func load(path string) error {
-	out, err := aaParser("-Kr", path)
-	if err != nil {
-		return fmt.Errorf("parser error(%q): %w", strings.TrimSpace(out), err)
-	}
-	return nil
-}
-
 // macroExists checks if the passed macro exists.
 func macroExists(m string) bool {
 	_, err := os.Stat(path.Join(dir, m))
 	return err == nil
-}
-
-func aaParser(args ...string) (string, error) {
-	out, err := exec.Command("apparmor_parser", args...).CombinedOutput()
-	return string(out), err
-}
-
-func isLoaded(name string) (bool, error) {
-	f, err := os.Open("/sys/kernel/security/apparmor/profiles")
-	if err != nil {
-		return false, err
-	}
-	defer func() { _ = f.Close() }()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		// Entries are of the form "<profile> (<mode>)", e.g. "foo (enforce)".
-		// Profile names may contain spaces (quoted names are supported in AppArmor);
-		// use splitCon to correctly handle profile names containing spaces and/or parentheses.
-		label, _ := splitCon(scanner.Text())
-		if label == name {
-			return true, nil
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return false, err
-	}
-	return false, nil
 }

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestCleanProfileName(t *testing.T) {
-	assert.Equal(t, cleanProfileName(""), "unconfined")
-	assert.Equal(t, cleanProfileName("unconfined"), "unconfined")
-	assert.Equal(t, cleanProfileName("unconfined (enforce)"), "unconfined")
-	assert.Equal(t, cleanProfileName("docker-default"), "docker-default")
-	assert.Equal(t, cleanProfileName("foo"), "foo")
-	assert.Equal(t, cleanProfileName("foo (enforce)"), "foo")
+	assert.Equal(t, "unconfined", cleanProfileName(""))
+	assert.Equal(t, "unconfined", cleanProfileName("unconfined"))
+	assert.Equal(t, "unconfined", cleanProfileName("unconfined (enforce)"))
+	assert.Equal(t, "docker-default", cleanProfileName("docker-default"))
+	assert.Equal(t, "foo", cleanProfileName("foo"))
+	assert.Equal(t, "foo", cleanProfileName("foo (enforce)"))
 }

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -11,8 +11,12 @@ import (
 func TestCleanProfileName(t *testing.T) {
 	assert.Equal(t, "unconfined", cleanProfileName(""))
 	assert.Equal(t, "unconfined", cleanProfileName("unconfined"))
+	assert.Equal(t, "unconfined", cleanProfileName("unconfined\n"))
 	assert.Equal(t, "unconfined", cleanProfileName("unconfined (enforce)"))
+	assert.Equal(t, "unconfined", cleanProfileName("unconfined (enforce)\n"))
 	assert.Equal(t, "docker-default", cleanProfileName("docker-default"))
 	assert.Equal(t, "foo", cleanProfileName("foo"))
 	assert.Equal(t, "foo", cleanProfileName("foo (enforce)"))
+	assert.Equal(t, "with spaces", cleanProfileName("with spaces"))
+	assert.Equal(t, "with spaces", cleanProfileName("with spaces (enforce)"))
 }

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -24,8 +24,18 @@ func TestCleanProfileName(t *testing.T) {
 			want:    "unconfined",
 		},
 		{
+			doc:     "unconfined newline",
+			profile: "unconfined\n",
+			want:    "unconfined",
+		},
+		{
 			doc:     "unconfined enforce",
 			profile: "unconfined (enforce)",
+			want:    "unconfined",
+		},
+		{
+			doc:     "unconfined enforce newline",
+			profile: "unconfined (enforce)\n",
 			want:    "unconfined",
 		},
 		{
@@ -37,6 +47,21 @@ func TestCleanProfileName(t *testing.T) {
 			doc:     "simple enforce",
 			profile: "docker-default (enforce)",
 			want:    "docker-default",
+		},
+		{
+			doc:     "spaces",
+			profile: "with spaces (enforce)",
+			want:    "with spaces",
+		},
+		{
+			doc:     "parentheses in name",
+			profile: "foo (bar) (enforce)",
+			want:    "foo (bar)",
+		},
+		{
+			doc:     "unknown mode",
+			profile: "foo (anything)",
+			want:    "foo",
 		},
 	}
 

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -9,10 +9,40 @@ import (
 )
 
 func TestCleanProfileName(t *testing.T) {
-	assert.Equal(t, cleanProfileName(""), "unconfined")
-	assert.Equal(t, cleanProfileName("unconfined"), "unconfined")
-	assert.Equal(t, cleanProfileName("unconfined (enforce)"), "unconfined")
-	assert.Equal(t, cleanProfileName("docker-default"), "docker-default")
-	assert.Equal(t, cleanProfileName("foo"), "foo")
-	assert.Equal(t, cleanProfileName("foo (enforce)"), "foo")
+	tests := []struct {
+		doc     string
+		profile string
+		want    string
+	}{
+		{
+			doc:  "empty",
+			want: "unconfined",
+		},
+		{
+			doc:     "unconfined",
+			profile: "unconfined",
+			want:    "unconfined",
+		},
+		{
+			doc:     "unconfined enforce",
+			profile: "unconfined (enforce)",
+			want:    "unconfined",
+		},
+		{
+			doc:     "simple",
+			profile: "docker-default",
+			want:    "docker-default",
+		},
+		{
+			doc:     "simple enforce",
+			profile: "docker-default (enforce)",
+			want:    "docker-default",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			assert.Equal(t, tc.want, cleanProfileName(tc.profile))
+		})
+	}
 }


### PR DESCRIPTION
- [ ] depends on / stacked on https://github.com/containerd/containerd/pull/13278

### contrib/apparmor: load profile without using tempfile

This code is currently using a temp-file to load the profile. The temp-file
was introduced as a hardening to prevent the profile from being modified
(see [moby/moby@2f7596a]); before that change, the profile would be persisted
to disk (in `/etc/apparmor.d`).

However, `apparmor_parser` also supports loading a profile from STDIN. From
the [apparmor_parser(8)] man-page:

> ... The profiles may be specified by file name or a directory name containing
>  set of profiles. (...)  The apparmor_parser will fall back to taking input
> rom standard input if a profile or directory is not supplied.

So we can skip the temp-file altogether; the only potential impact is that
includes using a relative path (`# include "something/foo"`) wouldn't resolve,
but this would already be the case when using a temp-file and all our includes
are resolved through the system include paths (`#include <...>`).

[moby/moby@2f7596a]: https://github.com/moby/moby/commit/2f7596aaef3a9f8ec1f2d0937462d9263bee8b6b
[apparmor_parser(8)]: https://manpages.ubuntu.com/manpages/jammy/man8/apparmor_parser.8.html
