### PR TITLE
ci: ensure nat HNS network exists on Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,32 @@ jobs:
           git checkout "${CRITOOLS_VERSION}"
           make critest
 
+      # GitHub Actions windows-2022 runners sometimes come up without the
+      # "nat" HNS network. install-cni-windows reads its gateway and prefix
+      # length via Get-NetIPAddress and produces a broken CNI config if the
+      # interface is missing, which surfaces later as cascading test failures
+      # ("hcnCreateNetwork failed in Win32: Element not found. (0x490)"
+      # from every RunPodSandbox call). Ensure the nat network exists here,
+      # using Docker (already pre-installed on the runner) since it uses HNS
+      # under the hood for the nat driver. Subnet matches windows-periodic.yml.
+      - name: Ensure nat HNS network
+        shell: powershell
+        run: |
+          if (-not (Get-NetIPAddress -InterfaceAlias 'vEthernet (nat)' -AddressFamily IPv4 -ErrorAction SilentlyContinue)) {
+            Write-Host "vEthernet (nat) missing — creating nat HNS network via docker"
+            try { Start-Service docker -ErrorAction Stop } catch { Write-Host $_ }
+            docker network rm nat 2>$null | Out-Null
+            docker network create -d nat --subnet 172.19.208.0/20 --gateway 172.19.208.1 nat
+            for ($i = 0; $i -lt 30; $i++) {
+              if (Get-NetIPAddress -InterfaceAlias 'vEthernet (nat)' -AddressFamily IPv4 -ErrorAction SilentlyContinue) { break }
+              Start-Sleep -Seconds 1
+            }
+            if (-not (Get-NetIPAddress -InterfaceAlias 'vEthernet (nat)' -AddressFamily IPv4 -ErrorAction SilentlyContinue)) {
+              Write-Error "vEthernet (nat) interface did not appear after creating HNS network"
+              exit 1
+            }
+          }
+
       - run: script/setup/install-cni-windows
 
       - env:


### PR DESCRIPTION
GitHub Actions windows-2022 runners sometimes come up without the "nat" HNS network. When that happens, install-cni-windows reads its gateway and prefix length via Get-NetIPAddress — which returns nothing — and silently writes a CNI config with an empty subnet and gateway. PowerShell treats the missing adapter as a non-terminating error, so the setup step still exits 0.

Later, every RunPodSandbox call invokes the nat CNI plugin, which tries to realize the (missing) HNS network and fails with:

  hcnCreateNetwork failed in Win32: Element not found. (0x490)

This cascades into dozens of unrelated integration test failures (TestContainer*, TestPodSandbox*, etc.) that look like flakes on whatever PR happens to be running.

Add a Windows-only CI step, run before install-cni-windows, that creates the nat HNS network via Docker (already pre-installed on the runner — its nat driver is an HNS wrapper) when the adapter is missing, and fails fast with a clear message if the adapter still doesn't appear. The subnet (172.19.208.0/20) matches the one used in windows-periodic.yml to stay consistent with the periodic workflow.

The workaround is kept in the workflow rather than install-cni-windows so the setup script remains environment-agnostic.