### PR TITLE
shim: support to use io.containerd.runc.v2-rs

### DIFF
--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	gruntime "runtime"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/containerd/log"
@@ -798,10 +799,10 @@ func GenerateRuntimeOptions(r Runtime) (any, error) {
 
 // getRuntimeOptionsType gets empty runtime options by the runtime type name.
 func getRuntimeOptionsType(t string) any {
-	switch t {
-	case plugins.RuntimeRuncV2:
+	switch {
+	case strings.HasPrefix(t, plugins.RuntimeRuncV2):
 		return &runcoptions.Options{}
-	case plugins.RuntimeRunhcsV1:
+	case t == plugins.RuntimeRunhcsV1:
 		return &runhcsoptions.Options{}
 	default:
 		return &runtimeoptions.Options{}


### PR DESCRIPTION
@mxpv 