### PR TITLE
[release/2.2] Support both styles of volatile mount option

### DIFF
--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -202,6 +202,52 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 			},
 		},
 		{
+			desc: "remove fsync=volatile option from overlay mounts, ignore non overlay",
+			input: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"workdir=/path/to/snapshots/4/work",
+						"upperdir=/path/to/snapshots/4/fs",
+						"lowerdir=/path/to/snapshots/1/fs",
+						"fsync=volatile",
+					},
+				},
+				{
+					Type:   "underlay",
+					Source: "underlay",
+					Options: []string{
+						"index=on",
+						"lowerdir=/another/path/to/snapshots/2/fs",
+						"fsync=volatile",
+					},
+				},
+			},
+			expected: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"workdir=/path/to/snapshots/4/work",
+						"upperdir=/path/to/snapshots/4/fs",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
+				{
+					Type:   "underlay",
+					Source: "underlay",
+					Options: []string{
+						"index=on",
+						"lowerdir=/another/path/to/snapshots/2/fs",
+						"fsync=volatile",
+					},
+				},
+			},
+		},
+		{
 			desc: "return original slice since no volatile options on overlay",
 			input: []Mount{
 				{

--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -88,7 +88,7 @@ func RemoveVolatileOption(mounts []Mount) []Mount {
 			continue
 		}
 		for j, opt := range m.Options {
-			if opt == "volatile" {
+			if opt == "volatile" || opt == "fsync=volatile" {
 				if out == nil {
 					out = copyMounts(mounts)
 				}

--- a/integration/image_volume_linux_test.go
+++ b/integration/image_volume_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -247,7 +248,8 @@ func TestImageVolumeCheckVolatileOption(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mpInfo.Mountpoint, imageVolumeMount)
 	require.Equal(t, "overlay", mpInfo.FSType)
-	require.Contains(t, strings.Split(mpInfo.VFSOptions, ","), "volatile")
+	vfsOpts := strings.Split(mpInfo.VFSOptions, ",")
+	require.True(t, slices.Contains(vfsOpts, "volatile") || slices.Contains(vfsOpts, "fsync=volatile"), "VFSOptions should contain either 'volatile' or 'fsync=volatile'")
 }
 
 func TestImageVolumeSetupIfContainerdRestarts(t *testing.T) {

--- a/internal/cri/server/container_image_mount_linux.go
+++ b/internal/cri/server/container_image_mount_linux.go
@@ -58,7 +58,7 @@ func addVolatileOptionOnImageVolumeMount(mounts []mount.Mount) []mount.Mount {
 
 		need := true
 		for _, opt := range m.Options {
-			if opt == "volatile" {
+			if opt == "volatile" || opt == "fsync=volatile" {
 				need = false
 				break
 			}


### PR DESCRIPTION
Manual backport of https://github.com/containerd/containerd/pull/13256.

```release-note
Support both "volatile" and "fsync=volatile" mount options for volatile snapshotter
```
