### PR TITLE
[release/1.7] Support both styles of volatile mount option

### DIFF
--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -202,6 +202,52 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 			},
 		},
 		{
+			desc: "remove fsync=volatile option from overlay mounts, ignore non overlay",
+			input: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"workdir=/path/to/snapshots/4/work",
+						"upperdir=/path/to/snapshots/4/fs",
+						"lowerdir=/path/to/snapshots/1/fs",
+						"fsync=volatile",
+					},
+				},
+				{
+					Type:   "underlay",
+					Source: "underlay",
+					Options: []string{
+						"index=on",
+						"lowerdir=/another/path/to/snapshots/2/fs",
+						"fsync=volatile",
+					},
+				},
+			},
+			expected: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"workdir=/path/to/snapshots/4/work",
+						"upperdir=/path/to/snapshots/4/fs",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
+				{
+					Type:   "underlay",
+					Source: "underlay",
+					Options: []string{
+						"index=on",
+						"lowerdir=/another/path/to/snapshots/2/fs",
+						"fsync=volatile",
+					},
+				},
+			},
+		},
+		{
 			desc: "return original slice since no volatile options on overlay",
 			input: []Mount{
 				{

--- a/mount/temp.go
+++ b/mount/temp.go
@@ -87,7 +87,7 @@ func RemoveVolatileOption(mounts []Mount) []Mount {
 			continue
 		}
 		for j, opt := range m.Options {
-			if opt == "volatile" {
+			if opt == "volatile" || opt == "fsync=volatile" {
 				if out == nil {
 					out = copyMounts(mounts)
 				}


### PR DESCRIPTION
Manual backport of https://github.com/containerd/containerd/pull/13256.

```release-note
Support both "volatile" and "fsync=volatile" mount options for volatile snapshotter
```