### PR TITLE
internal/erofsutils: mark layer.erofs sparse before mkfs.erofs (Windows)

### DIFF
--- a/internal/erofsutils/mount.go
+++ b/internal/erofsutils/mount.go
@@ -39,6 +39,9 @@ func IsErofsMediaType(mt string) bool {
 }
 
 func ConvertTarErofs(ctx context.Context, r io.Reader, layerPath, uuid string, mkfsExtraOpts []string) error {
+	if err := ensureSparseLayerFile(layerPath); err != nil {
+		log.G(ctx).WithError(err).WithField("path", layerPath).Debug("failed to mark layer file sparse (non-fatal)")
+	}
 	args := append([]string{"--tar=f", "--aufs", "--quiet", "-Enoinline_data"}, mkfsExtraOpts...)
 	if uuid != "" {
 		args = append(args, []string{"-U", uuid}...)
@@ -72,6 +75,9 @@ func GenerateTarIndexAndAppendTar(ctx context.Context, r io.Reader, layerPath, u
 	// Use TeeReader to process the input once while saving it to disk
 	teeReader := io.TeeReader(r, tarFile)
 
+	if err := ensureSparseLayerFile(layerPath); err != nil {
+		log.G(ctx).WithError(err).WithField("path", layerPath).Debug("failed to mark layer file sparse (non-fatal)")
+	}
 	// Generate tar index directly to layerPath using --tar=i option
 	args := append([]string{"--tar=i", "--aufs", "--quiet"}, mkfsExtraOpts...)
 	if uuid != "" {
@@ -128,6 +134,9 @@ func AddDefaultMkfsOpts(mkfsExtraOpts []string) []string {
 }
 
 func ConvertErofs(ctx context.Context, layerPath string, srcDir string, mkfsExtraOpts []string) error {
+	if err := ensureSparseLayerFile(layerPath); err != nil {
+		log.G(ctx).WithError(err).WithField("path", layerPath).Debug("failed to mark layer file sparse (non-fatal)")
+	}
 	args := append([]string{"--quiet", "-Enoinline_data"}, mkfsExtraOpts...)
 	args = append(args, layerPath, srcDir)
 	cmd := exec.CommandContext(ctx, "mkfs.erofs", args...)

--- a/internal/erofsutils/sparse_other.go
+++ b/internal/erofsutils/sparse_other.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofsutils
+
+// ensureSparseLayerFile is a no-op; ftruncate-extension is naturally
+// sparse on these platforms.
+func ensureSparseLayerFile(_ string) error { return nil }

--- a/internal/erofsutils/sparse_windows.go
+++ b/internal/erofsutils/sparse_windows.go
@@ -1,0 +1,45 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofsutils
+
+import (
+	"os"
+	"syscall"
+)
+
+const fsctlSetSparse = 0x000900c4 // FSCTL_SET_SPARSE
+
+// ensureSparseLayerFile creates path if missing and marks it sparse so
+// mkfs.erofs's 2 TiB ftruncate of the output file does not zero-fill on
+// NTFS/ReFS. See erofs-utils lib/diskbuf.c::erofs_diskbuf_init.
+func ensureSparseLayerFile(path string) error {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var bytesReturned uint32
+	return syscall.DeviceIoControl(
+		syscall.Handle(f.Fd()),
+		fsctlSetSparse,
+		nil, 0,
+		nil, 0,
+		&bytesReturned,
+		nil,
+	)
+}

--- a/internal/erofsutils/sparse_windows_test.go
+++ b/internal/erofsutils/sparse_windows_test.go
@@ -1,0 +1,62 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofsutils
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const fileAttributeSparseFile = 0x00000200 // FILE_ATTRIBUTE_SPARSE_FILE
+
+// TestEnsureSparseLayerFile creates the file and verifies the sparse
+// attribute is set.
+func TestEnsureSparseLayerFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "layer.erofs")
+
+	require.NoError(t, ensureSparseLayerFile(path))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Zero(t, info.Size())
+
+	require.True(t, fileHasSparseAttr(t, path))
+}
+
+// TestEnsureSparseLayerFile_Idempotent verifies repeated calls don't
+// error and preserve the sparse flag.
+func TestEnsureSparseLayerFile_Idempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "layer.erofs")
+
+	require.NoError(t, ensureSparseLayerFile(path))
+	require.NoError(t, ensureSparseLayerFile(path))
+
+	require.True(t, fileHasSparseAttr(t, path))
+}
+
+func fileHasSparseAttr(t *testing.T, path string) bool {
+	t.Helper()
+	p, err := syscall.UTF16PtrFromString(path)
+	require.NoError(t, err)
+	attrs, err := syscall.GetFileAttributes(p)
+	require.NoError(t, err)
+	return attrs&fileAttributeSparseFile != 0
+}


### PR DESCRIPTION
## Root cause

erofs-utils v1.x [`lib/diskbuf.c::erofs_diskbuf_init`](https://github.com/erofs/erofs-utils/blob/v1.9.1/lib/diskbuf.c) reuses the output erofs file as scratch:

```c
if (strm == dbufstrm && !g_sbi.bdev.ops) {
    strm->devpos = 1ULL << 40;                            // 1 TiB
    if (!ftruncate(g_sbi.bdev.fd, strm->devpos << 1)) {   // 2 TiB
        strm->fd = dup(g_sbi.bdev.fd);
        goto setupone;
    }
}
```

Linux: ftruncate creates a sparse hole. Windows NTFS/ReFS without sparse: zero-fills 2 TiB on disk. On-disk fingerprint is `layer.erofs` files of size 2048.0 GiB = `1ULL << 41`, capable of consuming all free space on the volume.

Trigger: ≥ 2 TiB free on the volume holding the snapshotter state directory.

## Fix

Pre-create `layerPath` and call `FSCTL_SET_SPARSE` before invoking mkfs.erofs in `ConvertTarErofs`, `GenerateTarIndexAndAppendTar`, `ConvertErofs`. mkfs.erofs opens the same path with `O_RDWR|O_CREAT` (no `O_TRUNC`), so the sparse attribute persists through its internal ftruncate calls and the 2 TiB extension stays a sparse hole on disk.

No-op on non-Windows.

Errors from `ensureSparseLayerFile` are logged at Debug and treated as non-fatal — mkfs.erofs still succeeds via its `erofs_tmpfile()` fallback, just without the sparse safeguard.

## Tests

`internal/erofsutils/sparse_windows_test.go`:
- `TestEnsureSparseLayerFile` — verifies a fresh path is created and `FILE_ATTRIBUTE_SPARSE_FILE` is set.
- `TestEnsureSparseLayerFile_Idempotent` — repeated calls preserve the flag.

Manual end-to-end on Windows 11 / NTFS: pulling a 13-layer image after the patch produces every `layer.erofs` with the sparse attribute set; on-disk allocation matches the actual erofs image sizes (≈3.8 GiB) instead of growing without bound.

## Draft

Posting as draft for early review.