### PR TITLE
overlay: add layer content cache for cross-image layer deduplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,6 +721,46 @@ jobs:
             podman run --rm --privileged cri-in-userns
           fi
 
+  test-overlay-lcc:
+    name: Overlay LCC
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs: [project, linters, protos, man]
+    env:
+      GOTEST: gotestsum --
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: ./.github/actions/install-go
+      - name: Install containerd dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gperf dmsetup
+          script/setup/install-seccomp
+          script/setup/install-runc
+      - name: Install containerd
+        env:
+          CGO_ENABLED: 1
+        run: |
+          make binaries GO_BUILD_FLAGS="-mod=vendor"
+          sudo -E PATH=$PATH make install
+      - name: Build and install pkg2oci
+        run: |
+          go build -o /tmp/pkg2oci ./integration/lcc/cmd/pkg2oci/
+          sudo mv /tmp/pkg2oci /usr/local/bin/pkg2oci
+      - name: Install flox
+        run: script/setup/install-flox
+      - run: script/setup/install-gotestsum
+      - run: script/setup/install-teststat
+      - name: Overlay LCC integration tests
+        env:
+          GOTESTSUM_JUNITFILE: ${{github.workspace}}/test-overlay-lcc-junit.xml
+          GOTESTSUM_JSONFILE: ${{github.workspace}}/test-overlay-lcc-gotest.json
+        run: sudo -E PATH=$PATH make lcc-integration
+      - run: if [ -f *-gotest.json ]; then echo '# Overlay LCC' >> $GITHUB_STEP_SUMMARY; teststat -markdown *-gotest.json >> $GITHUB_STEP_SUMMARY; fi
+        if: always()
+      - run: script/test/test2annotation.sh *-gotest.json
+        if: always()
+
   tests-mac-os:
     name: MacOS unit tests
     runs-on: macos-latest

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ OUTPUTDIR = $(join $(ROOTDIR), _output)
 CRIDIR=$(OUTPUTDIR)/cri
 
 
-.PHONY: clean all AUTHORS build binaries test integration generate protos check-protos coverage ci check help install uninstall vendor release static-release mandir install-man install-doc genman install-cri-deps cri-release cri-cni-release cri-integration install-deps $(CRI_INTEGRATION_TEST_BINARY) cri-integration-coverage integration-coverage all-coverage remove-replace clean-vendor
+.PHONY: clean all AUTHORS build binaries test integration lcc-integration generate protos check-protos coverage ci check help install uninstall vendor release static-release mandir install-man install-doc genman install-cri-deps cri-release cri-cni-release cri-integration install-deps $(CRI_INTEGRATION_TEST_BINARY) cri-integration-coverage integration-coverage all-coverage remove-replace clean-vendor
 .DEFAULT: default
 
 # Forcibly set the default goal to all, in case an include above brought in a rule definition.
@@ -224,6 +224,10 @@ integration: ## run integration tests
 $(CRI_INTEGRATION_TEST_BINARY):
 	@echo "$(WHALE) $@"
 	@$(GO) test -c ./integration -o $(CRI_INTEGRATION_TEST_BINARY)
+
+lcc-integration:
+	@echo "$(WHALE) $@"
+	@$(GOTEST) -tags integration -v ${TESTFLAGS} -count=1 ./integration/lcc/
 
 cri-integration: binaries $(CRI_INTEGRATION_TEST_BINARY) ## run cri integration tests (example: FOCUS=TestContainerListStats make cri-integration)
 	@echo "$(WHALE) $@"

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -16,6 +16,10 @@
 #   docker build -t containerd-test -f Dockerfile.test --target integration ../
 #   docker run --privileged containerd-test
 #
+# "lcc-integration": for running LCC (layer content cache) integration tests:
+#   docker build -t containerd-test -f Dockerfile.test --target lcc-integration ../
+#   docker run --privileged containerd-test
+#
 # "cri-integration": for running cri-integration tests:
 #   docker build -t containerd-test -f Dockerfile.test --target cri-integration ../
 #   docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 containerd-test
@@ -86,6 +90,31 @@ VOLUME /var/lib
 # The entrypoint script is needed for nesting cgroup v2.
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["make", "integration"]
+
+# lcc-integration stage is for running LCC integration tests.
+FROM integration AS lcc-integration
+ARG FLOX_VERSION=1.11.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates sudo xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /nix \
+    && ARCH="$(uname -m)" \
+    && case "$ARCH" in \
+        x86_64|aarch64) ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSLo /tmp/flox.deb \
+       "https://downloads.flox.dev/by-env/stable/deb/flox-${FLOX_VERSION}.${ARCH}-linux.deb" \
+    && curl -fsSLo /tmp/flox.SHA256SUMS \
+       "https://downloads.flox.dev/by-env/stable/flox-${FLOX_VERSION}.SHA256SUMS" \
+    && grep "flox-${FLOX_VERSION}.${ARCH}-linux.deb$" /tmp/flox.SHA256SUMS \
+       | sed "s|flox-${FLOX_VERSION}.${ARCH}-linux.deb|/tmp/flox.deb|" \
+       | sha256sum --check --strict \
+    && apt-get install -y /tmp/flox.deb \
+    && rm -f /tmp/flox.deb /tmp/flox.SHA256SUMS \
+    && rm -rf /var/lib/apt/lists/*
+RUN go build -o /usr/local/bin/pkg2oci ./integration/lcc/cmd/pkg2oci/
+CMD ["make", "lcc-integration"]
 
 # cri-integration stage is for running cri-integration tests.
 FROM integration AS cri-integration

--- a/core/metadata/snapshot.go
+++ b/core/metadata/snapshot.go
@@ -37,11 +37,6 @@ import (
 	errbolt "go.etcd.io/bbolt/errors"
 )
 
-const (
-	inheritedLabelsPrefix = "containerd.io/snapshot/"
-	labelSnapshotRef      = "containerd.io/snapshot.ref"
-)
-
 type snapshotter struct {
 	snapshots.Snapshotter
 	name string
@@ -316,7 +311,7 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 	}
 
 	var (
-		target  = base.Labels[labelSnapshotRef]
+		target  = base.Labels[snapshots.LabelSnapshotRef]
 		bparent string
 		bkey    string
 		bopts   = []snapshots.Opt{
@@ -388,10 +383,10 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 	if errdefs.IsAlreadyExists(err) {
 		if target != "" {
 			var tinfo *snapshots.Info
-			filter := fmt.Sprintf(`labels."containerd.io/snapshot.ref"==%s,parent==%q`, target, bparent)
+			filter := fmt.Sprintf(`labels.%q==%s,parent==%q`, snapshots.LabelSnapshotRef, target, bparent)
 			if err := s.Snapshotter.Walk(ctx, func(ctx context.Context, i snapshots.Info) error {
 				if tinfo == nil && i.Kind == snapshots.KindCommitted {
-					if i.Labels["containerd.io/snapshot.ref"] != target {
+					if i.Labels[snapshots.LabelSnapshotRef] != target {
 						// Walk did not respect filter
 						return nil
 					}

--- a/core/metadata/snapshot_test.go
+++ b/core/metadata/snapshot_test.go
@@ -70,7 +70,7 @@ func TestSnapshotterWithRef(t *testing.T) {
 	key1 := "test1"
 	test1opt := snapshots.WithLabels(
 		map[string]string{
-			labelSnapshotRef: key1,
+			snapshots.LabelSnapshotRef: key1,
 		},
 	)
 
@@ -113,7 +113,7 @@ func TestSnapshotterWithRef(t *testing.T) {
 	key2 := "test2"
 	test2opt := snapshots.WithLabels(
 		map[string]string{
-			labelSnapshotRef: key2,
+			snapshots.LabelSnapshotRef: key2,
 		},
 	)
 
@@ -244,12 +244,12 @@ func TestFilterInheritedLabels(t *testing.T) {
 			map[string]string{},
 		},
 		{
-			map[string]string{inheritedLabelsPrefix + "foo": "bar"},
-			map[string]string{inheritedLabelsPrefix + "foo": "bar"},
+			map[string]string{snapshots.InheritedLabelsPrefix + "foo": "bar"},
+			map[string]string{snapshots.InheritedLabelsPrefix + "foo": "bar"},
 		},
 		{
-			map[string]string{inheritedLabelsPrefix + "foo": "bar", "qux": "qaz"},
-			map[string]string{inheritedLabelsPrefix + "foo": "bar"},
+			map[string]string{snapshots.InheritedLabelsPrefix + "foo": "bar", "qux": "qaz"},
+			map[string]string{snapshots.InheritedLabelsPrefix + "foo": "bar"},
 		},
 	}
 
@@ -340,7 +340,7 @@ func (s *tmpSnapshotter) create(ctx context.Context, key, parent string, kind sn
 	base.Name = key
 	base.Kind = kind
 
-	target := base.Labels[labelSnapshotRef]
+	target := base.Labels[snapshots.LabelSnapshotRef]
 	if target != "" {
 		for _, name := range s.targets[target] {
 			if s.snapshots[name].Parent == parent {
@@ -399,7 +399,7 @@ func (s *tmpSnapshotter) Commit(ctx context.Context, name, key string, opts ...s
 	s.snapshots[name] = base
 	delete(s.snapshots, key)
 
-	if target := base.Labels[labelSnapshotRef]; target != "" {
+	if target := base.Labels[snapshots.LabelSnapshotRef]; target != "" {
 		s.targets[target] = append(s.targets[target], name)
 	}
 

--- a/core/snapshots/benchsuite/benchmark_test.go
+++ b/core/snapshots/benchsuite/benchmark_test.go
@@ -83,7 +83,9 @@ func BenchmarkOverlay(b *testing.B) {
 		b.Skip("overlay root dir must be provided")
 	}
 
-	snapshotter, err := overlay.NewSnapshotter(overlayRootPath)
+	ctx := context.Background()
+
+	snapshotter, err := overlay.NewSnapshotter(ctx, overlayRootPath)
 	assert.Nil(b, err, "failed to create overlay snapshotter")
 
 	defer func() {

--- a/core/snapshots/snapshotter.go
+++ b/core/snapshots/snapshotter.go
@@ -63,6 +63,11 @@ const (
 	// LabelSnapshotParentChainID is set by the unpacker on active snapshots that
 	// have a parent, recording the chainID of the preceding layer.
 	LabelSnapshotParentChainID = "containerd.io/snapshot/parent-chain-id"
+
+	// LabelSkipApply instructs the unpacker to skip calling Apply for this
+	// active snapshot. Set by the snapshotter when the layer content is already
+	// present (e.g. via CAS deduplication) and extraction is unnecessary.
+	LabelSkipApply = "containerd.io/snapshot.skip-apply"
 )
 
 // Kind identifies the kind of snapshot.

--- a/core/snapshots/snapshotter.go
+++ b/core/snapshots/snapshotter.go
@@ -31,9 +31,16 @@ const (
 	// image content unpacked into them.
 	UnpackKeyPrefix = "extract"
 	// UnpackKeyFormat is the format for the snapshotter keys used for extraction
-	UnpackKeyFormat       = UnpackKeyPrefix + "-%s %s"
-	inheritedLabelsPrefix = "containerd.io/snapshot/"
-	labelSnapshotRef      = "containerd.io/snapshot.ref"
+	UnpackKeyFormat = UnpackKeyPrefix + "-%s %s"
+
+	// InheritedLabelsPrefix is the prefix for labels that are propagated from a
+	// descriptor's annotations to a snapshot via Prepare, View, or Commit.
+	InheritedLabelsPrefix = "containerd.io/snapshot/"
+
+	// LabelSnapshotRef is set by the unpacker on every active snapshot to
+	// record the chainID it will be committed under, allowing the metadata
+	// snapshotter to deduplicate already-committed snapshots on re-pull.
+	LabelSnapshotRef = "containerd.io/snapshot.ref"
 
 	// LabelSnapshotUIDMapping is the label used for UID mappings
 	LabelSnapshotUIDMapping = "containerd.io/snapshot/uidmapping"
@@ -48,6 +55,14 @@ const (
 	// Ignoring is not a failure — callers that require enforcement must
 	// pick a snapshotter that supports it.
 	LabelSnapshotMaxSize = "containerd.io/snapshot/max-size"
+
+	// LabelSnapshotDiffID is set by the unpacker on every active snapshot to
+	// record the diffID of the layer being extracted.
+	LabelSnapshotDiffID = "containerd.io/snapshot/diff-id"
+
+	// LabelSnapshotParentChainID is set by the unpacker on active snapshots that
+	// have a parent, recording the chainID of the preceding layer.
+	LabelSnapshotParentChainID = "containerd.io/snapshot/parent-chain-id"
 )
 
 // Kind identifies the kind of snapshot.
@@ -397,7 +412,7 @@ func FilterInheritedLabels(labels map[string]string) map[string]string {
 
 	filtered := make(map[string]string)
 	for k, v := range labels {
-		if k == labelSnapshotRef || strings.HasPrefix(k, inheritedLabelsPrefix) {
+		if k == LabelSnapshotRef || strings.HasPrefix(k, InheritedLabelsPrefix) {
 			filtered[k] = v
 		}
 	}

--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -48,12 +48,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/tracing"
 )
 
-const (
-	labelSnapshotRef    = "containerd.io/snapshot.ref"
-	labelSnapshotParent = "containerd.io/snapshot/parent-chain-id"
-	labelSnapshotDiffID = "containerd.io/snapshot/diff-id"
-	unpackSpanPrefix    = "pkg.unpack.unpacker"
-)
+const unpackSpanPrefix = "pkg.unpack.unpacker"
 
 // Result returns information about the unpacks which were completed.
 type Result struct {
@@ -397,10 +392,10 @@ func (u *Unpacker) unpack(
 		if snapshotLabels == nil {
 			snapshotLabels = make(map[string]string)
 		}
-		snapshotLabels[labelSnapshotRef] = chainID
-		snapshotLabels[labelSnapshotDiffID] = diffIDs[i].String()
+		snapshotLabels[snapshots.LabelSnapshotRef] = chainID
+		snapshotLabels[snapshots.LabelSnapshotDiffID] = diffIDs[i].String()
 		if i > 0 {
-			snapshotLabels[labelSnapshotParent] = chainIDs[i-1].String()
+			snapshotLabels[snapshots.LabelSnapshotParentChainID] = chainIDs[i-1].String()
 		}
 
 		var (

--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -494,8 +494,10 @@ func (u *Unpacker) unpack(
 						return fmt.Errorf("failed to commit snapshot %s: %w", key, err)
 					}
 
-					// Set the uncompressed label after the uncompressed
-					// digest has been verified through apply.
+					// Set the uncompressed label to record the mapping from
+					// compressed digest to diff ID. When extraction ran, the diff
+					// ID was verified at apply time; when LabelSkipApply was set,
+					// the cache content was verified when it was first committed.
 					cinfo := content.Info{
 						Digest: desc.Digest,
 						Labels: map[string]string{
@@ -532,6 +534,24 @@ func (u *Unpacker) unpack(
 			// See: https://github.com/containerd/containerd/issues/13030
 			if i > 0 && parallel && unpack.SnapshotterKey == "overlayfs" {
 				mounts = bindToOverlay(mounts)
+			}
+
+			snInfo, err := sn.Stat(ctx, key)
+			if err != nil {
+				cleanup.Do(ctx, abort)
+				status.err = fmt.Errorf("failed to stat snapshot %q: %w", key, err)
+				resCh <- status
+				return
+			}
+
+			// LabelSkipApply lets the snapshotter signal that extraction is
+			// unnecessary (e.g. content is already present on disk).
+			// NOTE: skipping Apply also skips the diff.Digest verification
+			// below; layer content correctness must be verified externally
+			// (e.g. at the time the content is first committed to the store).
+			if snInfo.Labels[snapshots.LabelSkipApply] == "true" {
+				resCh <- status
+				return
 			}
 
 			diff, err := a.Apply(ctx, desc, mounts, unpack.ApplyOpts...)

--- a/integration/client/snapshot_linux_test.go
+++ b/integration/client/snapshot_linux_test.go
@@ -1,0 +1,51 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/testsuite"
+)
+
+func newOverlaySnapshotterWithLCC(t *testing.T) testsuite.SnapshotterFunc {
+	const configTOML = `version = 3
+[plugins."io.containerd.snapshotter.v1.overlayfs"]
+  layer_content_cache = true
+`
+	_, d, cleanup := newDaemonWithConfig(t, configTOML)
+	t.Cleanup(cleanup)
+
+	return func(_ context.Context, _ string) (snapshots.Snapshotter, func() error, error) {
+		c, err := New(d.addr)
+		if err != nil {
+			return nil, nil, err
+		}
+		return c.SnapshotService("overlayfs"), func() error { return c.Close() }, nil
+	}
+}
+
+func TestOverlaySnapshotterClientWithLCC(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	testsuite.SnapshotterSuite(t, "overlayfs", newOverlaySnapshotterWithLCC(t))
+}

--- a/integration/lcc/cmd/pkg2oci/flox.go
+++ b/integration/lcc/cmd/pkg2oci/flox.go
@@ -1,0 +1,539 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// buildFloxLayers converts a Flox environment into a set of tar.zst blobs and
+// returns their paths (in layer order) plus the base entrypoint for the image
+// config. The caller appends any user-supplied --entrypoint tokens after the
+// base entrypoint and is responsible for cleaning up tmpDir.
+//
+// Layer order: Nix closure store paths (one per path, sorted for determinism),
+// system-utils layer (/bin and /usr/bin symlinks), activation layer (last).
+func buildFloxLayers(floxEnvArg, tmpDir string) (blobPaths []string, baseEntrypoint []string, _ error) {
+	envDir, cleanup, err := resolveFloxEnv(floxEnvArg, tmpDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	if cleanup != "" {
+		defer os.RemoveAll(cleanup)
+	}
+
+	floxEnv, envName, err := readFloxEnv(envDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading flox env: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "pkg2oci: flox env %q → %s\n", envName, floxEnv)
+
+	reqData, err := os.ReadFile(filepath.Join(floxEnv, "requisites.txt"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading requisites.txt in %s: %w", floxEnv, err)
+	}
+	storePaths := parseLines(string(reqData))
+	if len(storePaths) == 0 {
+		return nil, nil, fmt.Errorf("requisites.txt is empty in %s", floxEnv)
+	}
+	fmt.Fprintf(os.Stderr, "pkg2oci: packing %d Nix store paths\n", len(storePaths))
+
+	for _, sp := range storePaths {
+		blobPath := filepath.Join(tmpDir, filepath.Base(sp)+".tar.zst")
+		if err := packNixStorePath(sp, blobPath); err != nil {
+			return nil, nil, fmt.Errorf("packing %s: %w", sp, err)
+		}
+		blobPaths = append(blobPaths, blobPath)
+	}
+
+	sysLayer, err := buildSystemUtilsLayer(tmpDir, storePaths)
+	if err != nil {
+		return nil, nil, fmt.Errorf("building system-utils layer: %w", err)
+	}
+	if sysLayer != "" {
+		blobPaths = append(blobPaths, sysLayer)
+	}
+
+	activationBlob, baseEP, err := buildActivationLayer(tmpDir, floxEnv, envName, storePaths)
+	if err != nil {
+		return nil, nil, fmt.Errorf("building activation layer: %w", err)
+	}
+	blobPaths = append(blobPaths, activationBlob)
+
+	return blobPaths, baseEP, nil
+}
+
+// resolveFloxEnv returns the local env directory for floxEnvArg. If arg is a
+// FloxHub reference (owner/name), it runs "flox pull" into a scratch directory
+// inside tmpDir; cleanup of that directory is the caller's responsibility via
+// tmpDir. For local paths the directory is returned as-is and must not be
+// removed. The cleanup return value is always empty; the signature is kept for
+// future use (e.g. pulling to a location outside tmpDir).
+func resolveFloxEnv(floxEnvArg, tmpDir string) (envDir, cleanup string, _ error) {
+	if isLocalPath(floxEnvArg) {
+		info, err := os.Stat(floxEnvArg)
+		if err != nil || !info.IsDir() {
+			return "", "", fmt.Errorf("--flox-env %q is not a directory", floxEnvArg)
+		}
+		return floxEnvArg, "", nil
+	}
+	if !strings.Contains(floxEnvArg, "/") {
+		return "", "", fmt.Errorf("--flox-env %q is not a local path or a valid FloxHub owner/name reference", floxEnvArg)
+	}
+	floxBin, err := exec.LookPath("flox")
+	if err != nil {
+		return "", "", fmt.Errorf("flox not found in PATH: %w", err)
+	}
+	scratchDir := filepath.Join(tmpDir, "remote-env")
+	if err := os.Mkdir(scratchDir, 0755); err != nil {
+		return "", "", fmt.Errorf("creating scratch dir: %w", err)
+	}
+	var stderr bytes.Buffer
+	pullCmd := exec.Command(floxBin, "pull", "--dir", scratchDir, floxEnvArg)
+	pullCmd.Stderr = &stderr
+	if err := pullCmd.Run(); err != nil {
+		return "", "", fmt.Errorf("flox pull %s: %w\n%s", floxEnvArg, err, stderr.String())
+	}
+	return scratchDir, "", nil
+}
+
+// readFloxEnv returns the Nix store path and name of the built flox environment
+// by reading the pre-built symlink from .flox/run/. No flox invocation needed.
+func readFloxEnv(envDir string) (storePath, name string, _ error) {
+	data, err := os.ReadFile(filepath.Join(envDir, ".flox", "env.json"))
+	if err != nil {
+		return "", "", fmt.Errorf("reading env.json: %w", err)
+	}
+	var envJSON struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(data, &envJSON); err != nil {
+		return "", "", fmt.Errorf("parsing env.json: %w", err)
+	}
+	if envJSON.Name == "" {
+		return "", "", fmt.Errorf("name field missing in env.json")
+	}
+
+	nixArch := runtime.GOARCH
+	switch nixArch {
+	case "amd64":
+		nixArch = "x86_64"
+	case "arm64":
+		nixArch = "aarch64"
+	}
+
+	symlinkPath := filepath.Join(envDir, ".flox", "run", nixArch+"-linux."+envJSON.Name+".dev")
+	resolved, err := filepath.EvalSymlinks(symlinkPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", "", fmt.Errorf("flox environment not built at %s — run 'flox install' in %s first", symlinkPath, envDir)
+		}
+		return "", "", fmt.Errorf("resolving %s: %w", symlinkPath, err)
+	}
+	return resolved, envJSON.Name, nil
+}
+
+// writeTarZst creates outPath, writes a zstd-compressed tar stream by calling
+// fn with the tar.Writer, then flushes and closes everything in order. fn's
+// error takes priority over close errors.
+func writeTarZst(outPath string, fn func(*tar.Writer) error) error {
+	f, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	zw, err := zstd.NewWriter(f, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	if err != nil {
+		f.Close()
+		return err
+	}
+	tw := tar.NewWriter(zw)
+
+	werr := fn(tw)
+
+	cerr := tw.Close()
+	if cerr == nil {
+		cerr = zw.Close()
+	} else {
+		zw.Close()
+	}
+	f.Close()
+
+	if werr != nil {
+		return werr
+	}
+	return cerr
+}
+
+// packNixStorePath creates a deterministic zstd-compressed tar archive of
+// storePath at outPath. Entries are rooted at "/" so they appear as
+// nix/store/<hash>-name/... (no leading slash) in the archive.
+func packNixStorePath(storePath, outPath string) error {
+	return writeTarZst(outPath, func(tw *tar.Writer) error {
+		type entry struct {
+			abs, rel string
+			info     os.FileInfo
+		}
+		var entries []entry
+		if err := filepath.Walk(storePath, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			rel, err := filepath.Rel("/", path)
+			if err != nil {
+				return err
+			}
+			entries = append(entries, entry{path, rel, info})
+			return nil
+		}); err != nil {
+			return fmt.Errorf("walking %s: %w", storePath, err)
+		}
+
+		slices.SortFunc(entries, func(a, b entry) int { return cmp.Compare(a.rel, b.rel) })
+
+		firstSeen := map[uint64]string{}
+		zero := time.Time{}
+
+		for _, e := range entries {
+			mode := e.info.Mode()
+			hdr := &tar.Header{
+				Name:    e.rel,
+				Mode:    int64(mode.Perm()),
+				ModTime: zero,
+			}
+			switch {
+			case e.info.IsDir():
+				hdr.Typeflag = tar.TypeDir
+				if !strings.HasSuffix(hdr.Name, "/") {
+					hdr.Name += "/"
+				}
+				if err := tw.WriteHeader(hdr); err != nil {
+					return err
+				}
+			case mode&os.ModeSymlink != 0:
+				target, err := os.Readlink(e.abs)
+				if err != nil {
+					return err
+				}
+				hdr.Typeflag = tar.TypeSymlink
+				hdr.Linkname = target
+				if err := tw.WriteHeader(hdr); err != nil {
+					return err
+				}
+			case mode.IsRegular():
+				if stat, ok := e.info.Sys().(*syscall.Stat_t); ok && stat.Nlink > 1 {
+					key := stat.Ino
+					if first, ok := firstSeen[key]; ok {
+						hdr.Typeflag = tar.TypeLink
+						hdr.Linkname = first
+						hdr.Size = 0
+						if err := tw.WriteHeader(hdr); err != nil {
+							return err
+						}
+						continue
+					}
+					firstSeen[key] = e.rel
+				}
+				hdr.Typeflag = tar.TypeReg
+				hdr.Size = e.info.Size()
+				if err := tw.WriteHeader(hdr); err != nil {
+					return err
+				}
+				rf, err := os.Open(e.abs)
+				if err != nil {
+					return err
+				}
+				_, copyErr := io.Copy(tw, rf)
+				rf.Close()
+				if copyErr != nil {
+					return copyErr
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// buildSystemUtilsLayer creates a thin tar.zst layer that symlinks /bin and
+// /usr/bin to the coreutils Nix store path, giving hook scripts access to
+// standard utilities. Returns "" if coreutils is not in the closure.
+func buildSystemUtilsLayer(tmpDir string, storePaths []string) (string, error) {
+	coreutilsBin := findCoreutilsBin(storePaths)
+	if coreutilsBin == "" {
+		fmt.Fprintln(os.Stderr, "pkg2oci: coreutils not found in closure; skipping system-utils layer")
+		return "", nil
+	}
+
+	blobPath := filepath.Join(tmpDir, "system-utils.tar.zst")
+	zero := time.Time{}
+	err := writeTarZst(blobPath, func(tw *tar.Writer) error {
+		if err := tw.WriteHeader(&tar.Header{Typeflag: tar.TypeDir, Name: "usr/", Mode: 0755, ModTime: zero}); err != nil {
+			return err
+		}
+		for _, lnk := range []struct{ name, target string }{
+			{"bin", coreutilsBin},
+			{"usr/bin", coreutilsBin},
+		} {
+			if err := tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeSymlink, Name: lnk.name, Linkname: lnk.target, Mode: 0777, ModTime: zero,
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return blobPath, nil
+}
+
+// buildActivationLayer generates the final CAS layer for a Flox OCI image.
+// It contains the ActivateCtx JSON consumed by flox-activations(1) and the
+// minimal filesystem skeleton required at container startup (etc/, run/, tmp/).
+// Always uses root (uid=0, gid=0) and activation mode "run".
+func buildActivationLayer(tmpDir, floxEnv, envName string, storePaths []string) (blobPath string, baseEntrypoint []string, _ error) {
+	activateScript := filepath.Join(floxEnv, "activate")
+
+	bashPath := findBashInteractive(storePaths)
+	if bashPath == "" {
+		var err error
+		bashPath, err = readShebang(activateScript)
+		if err != nil {
+			return "", nil, fmt.Errorf("reading bash path from activate shebang: %w", err)
+		}
+	}
+
+	interpreterPath, err := readInterpreterPath(activateScript)
+	if err != nil {
+		return "", nil, fmt.Errorf("reading interpreter path: %w", err)
+	}
+
+	floxActivationsPath, err := filepath.EvalSymlinks(filepath.Join(floxEnv, "libexec", "flox-activations"))
+	if err != nil {
+		return "", nil, fmt.Errorf("resolving flox-activations: %w", err)
+	}
+
+	const activateDataPath = "etc/cas/activate-data.json"
+	ctx := activateCtx{
+		FloxActivateStorePath: floxEnv,
+		AttachCtx: attachCtx{
+			Env:                    floxEnv,
+			EnvCache:               "/tmp",
+			EnvDescription:         envName,
+			FloxActiveEnvironments: "[]",
+			PromptColor1:           "99",
+			PromptColor2:           "141",
+			FloxPromptEnvironments: "floxenv",
+			SetPrompt:              true,
+			FloxEnvCudaDetection:   "0",
+			InterpreterPath:        interpreterPath,
+		},
+		ActivationStateDir: "/run/flox/container-activations/" + filepath.Base(floxEnv),
+		Mode:               "run",
+		Shell:              shellSpec{Bash: bashPath},
+		RemoveAfterReading: false,
+	}
+	ctxJSON, err := json.MarshalIndent(ctx, "", "  ")
+	if err != nil {
+		return "", nil, fmt.Errorf("marshalling activate context: %w", err)
+	}
+
+	blobPath = filepath.Join(tmpDir, "activation-layer.tar.zst")
+	zero := time.Time{}
+	if err := writeTarZst(blobPath, func(tw *tar.Writer) error {
+		for _, dir := range []struct {
+			name string
+			mode int64
+		}{
+			{"etc/", 0755},
+			{"etc/cas/", 0755},
+			{"run/", 01770},
+			{"run/flox/", 0770},
+			{"tmp/", 01777},
+			{"root/", 0700},
+			{"var/", 0755},
+			{"var/empty/", 0755},
+		} {
+			if err := tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeDir, Name: dir.name, Mode: dir.mode, ModTime: zero,
+			}); err != nil {
+				return err
+			}
+		}
+		for _, nf := range []struct {
+			name, content string
+		}{
+			{"etc/passwd", "root:x:0:0:System administrator:/root:/bin/sh\nnobody:x:65534:65534:Unprivileged user:/var/empty:/bin/sh\n"},
+			{"etc/group", "root:x:0:\nnobody:x:65534:\nnogroup:x:65534:\n"},
+			{"etc/nsswitch.conf", "passwd:  files\ngroup:   files\nshadow:  files\nhosts:   files dns\n"},
+		} {
+			data := []byte(nf.content)
+			if err := tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeReg, Name: nf.name, Size: int64(len(data)), Mode: 0644, ModTime: zero,
+			}); err != nil {
+				return err
+			}
+			if _, err := tw.Write(data); err != nil {
+				return err
+			}
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg, Name: activateDataPath, Size: int64(len(ctxJSON)), Mode: 0644, ModTime: zero,
+		}); err != nil {
+			return err
+		}
+		_, err = tw.Write(ctxJSON)
+		return err
+	}); err != nil {
+		return "", nil, err
+	}
+
+	return blobPath, []string{floxActivationsPath, "activate", "--activate-data", "/" + activateDataPath}, nil
+}
+
+// activateCtx mirrors flox-core's ActivateCtx struct consumed by flox-activations(1).
+type activateCtx struct {
+	FloxActivateStorePath string    `json:"flox_activate_store_path"`
+	AttachCtx             attachCtx `json:"attach_ctx"`
+	ProjectCtx            any       `json:"project_ctx"`
+	ActivationStateDir    string    `json:"activation_state_dir"`
+	Mode                  string    `json:"mode"`
+	Shell                 shellSpec `json:"shell"`
+	InvocationType        any       `json:"invocation_type"`
+	RemoveAfterReading    bool      `json:"remove_after_reading"`
+	MetricsUUID           any       `json:"metrics_uuid"`
+}
+
+type attachCtx struct {
+	Env                    string `json:"env"`
+	EnvCache               string `json:"env_cache"`
+	EnvDescription         string `json:"env_description"`
+	FloxActiveEnvironments string `json:"flox_active_environments"`
+	PromptColor1           string `json:"prompt_color_1"`
+	PromptColor2           string `json:"prompt_color_2"`
+	FloxPromptEnvironments string `json:"flox_prompt_environments"`
+	SetPrompt              bool   `json:"set_prompt"`
+	FloxEnvCudaDetection   string `json:"flox_env_cuda_detection"`
+	InterpreterPath        string `json:"interpreter_path"`
+}
+
+type shellSpec struct {
+	Bash string `json:"bash"`
+}
+
+func findBashInteractive(storePaths []string) string {
+	for _, sp := range storePaths {
+		base := filepath.Base(sp)
+		if len(base) > 33 && base[32] == '-' && strings.Contains(base[33:], "bash-interactive") {
+			bin := filepath.Join(sp, "bin", "bash")
+			if _, err := os.Stat(bin); err == nil {
+				return bin
+			}
+		}
+	}
+	return ""
+}
+
+func findCoreutilsBin(storePaths []string) string {
+	for _, sp := range storePaths {
+		base := filepath.Base(sp)
+		if len(base) > 33 && base[32] == '-' && strings.Contains(base[33:], "coreutils") {
+			binDir := filepath.Join(sp, "bin")
+			if fi, err := os.Stat(binDir); err == nil && fi.IsDir() {
+				return binDir
+			}
+		}
+	}
+	return ""
+}
+
+func readInterpreterPath(activateScript string) (string, error) {
+	data, err := os.ReadFile(activateScript)
+	if err != nil {
+		return "", err
+	}
+	const marker = `_activate_d="`
+	for line := range strings.SplitSeq(string(data), "\n") {
+		_, after, ok := strings.Cut(line, marker)
+		if !ok {
+			continue
+		}
+		val, _, ok := strings.Cut(after, `"`)
+		if !ok {
+			continue
+		}
+		return filepath.Dir(val), nil
+	}
+	return "", fmt.Errorf("could not find _activate_d= in %s", activateScript)
+}
+
+func readShebang(scriptPath string) (string, error) {
+	f, err := os.Open(scriptPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	buf := make([]byte, 256)
+	n, err := f.Read(buf)
+	if err != nil && n == 0 {
+		return "", err
+	}
+	line := strings.SplitN(string(buf[:n]), "\n", 2)[0]
+	if !strings.HasPrefix(line, "#!") {
+		return "", fmt.Errorf("%s: no shebang line", scriptPath)
+	}
+	fields := strings.Fields(strings.TrimPrefix(line, "#!"))
+	if len(fields) == 0 {
+		return "", fmt.Errorf("%s: empty shebang", scriptPath)
+	}
+	return fields[0], nil
+}
+
+func parseLines(s string) []string {
+	var out []string
+	for line := range strings.SplitSeq(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func isLocalPath(arg string) bool {
+	if strings.HasPrefix(arg, "/") || strings.HasPrefix(arg, "./") || strings.HasPrefix(arg, "../") {
+		return true
+	}
+	_, err := os.Stat(arg)
+	return err == nil
+}

--- a/integration/lcc/cmd/pkg2oci/flox_windows.go
+++ b/integration/lcc/cmd/pkg2oci/flox_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import "fmt"
+
+func buildFloxLayers(floxEnvArg, tmpDir string) ([]string, []string, error) {
+	return nil, nil, fmt.Errorf("--flox-env is not supported on Windows")
+}

--- a/integration/lcc/cmd/pkg2oci/main.go
+++ b/integration/lcc/cmd/pkg2oci/main.go
@@ -1,0 +1,316 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// pkg2oci assembles pre-built package blobs (tar+zstd archives) or a Flox
+// environment into an OCI image layout tarball importable with "ctr images import".
+//
+// Usage (pre-built blobs):
+//
+//	pkg2oci --output image.tar \
+//	  --package /path/to/glibc.tar.zst \
+//	  --package /path/to/myapp.tar.zst \
+//	  localhost/myteam/myapp:1.0
+//
+// Usage (Flox environment):
+//
+//	pkg2oci --output image.tar \
+//	  --flox-env ./myproject \
+//	  --entrypoint myapp \
+//	  localhost/myteam/myapp:1.0
+//
+//	pkg2oci --output image.tar \
+//	  --flox-env owner/myenv \
+//	  --entrypoint myapp \
+//	  localhost/myteam/myapp:1.0
+package main
+
+import (
+	"archive/tar"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli/v2"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+func main() {
+	app := &cli.App{
+		Name:      "pkg2oci",
+		Usage:     "assemble package blobs or a Flox environment into an OCI image tarball",
+		ArgsUsage: "<image>",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "output",
+				Aliases:  []string{"o"},
+				Usage:    "output OCI archive tar `path`",
+				Required: true,
+			},
+			&cli.StringSliceFlag{
+				Name:  "package",
+				Usage: "package blob path (tar+zstd); repeatable, base-first",
+			},
+			&cli.StringFlag{
+				Name:  "flox-env",
+				Usage: "Flox environment: local path or FloxHub owner/name",
+			},
+			&cli.StringSliceFlag{
+				Name:  "entrypoint",
+				Usage: "container entrypoint token; repeatable",
+			},
+			&cli.StringSliceFlag{
+				Name:  "cmd",
+				Usage: "container default command token; repeatable",
+			},
+			&cli.StringSliceFlag{
+				Name:  "env",
+				Usage: "environment variable KEY=VALUE; repeatable",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			if c.NArg() != 1 {
+				return fmt.Errorf("expected <image>; got %d arguments", c.NArg())
+			}
+			if len(c.StringSlice("package")) == 0 && c.String("flox-env") == "" {
+				return fmt.Errorf("one of --package or --flox-env is required")
+			}
+			return run(
+				c.Args().Get(0),
+				c.String("flox-env"),
+				c.StringSlice("package"),
+				c.String("output"),
+				c.StringSlice("entrypoint"),
+				c.StringSlice("cmd"),
+				c.StringSlice("env"),
+			)
+		},
+	}
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "pkg2oci:", err)
+		os.Exit(1)
+	}
+}
+
+type layerInfo struct {
+	desc   ocispec.Descriptor
+	diffID digest.Digest
+	path   string
+}
+
+func run(imageRef, floxEnvArg string, packagePaths []string, output string, entrypoint, cmd, envVars []string) error {
+	imageRef = ensureTag(imageRef)
+
+	var layers []layerInfo
+
+	if floxEnvArg != "" {
+		tmpDir, err := os.MkdirTemp("", "pkg2oci-flox-*")
+		if err != nil {
+			return fmt.Errorf("creating temp dir: %w", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		blobPaths, baseEntrypoint, err := buildFloxLayers(floxEnvArg, tmpDir)
+		if err != nil {
+			return fmt.Errorf("building flox layers: %w", err)
+		}
+		entrypoint = append(baseEntrypoint, entrypoint...)
+
+		for _, path := range blobPaths {
+			info, err := hashBlob(path)
+			if err != nil {
+				return fmt.Errorf("hashing flox blob %q: %w", path, err)
+			}
+			layers = append(layers, info)
+		}
+	}
+
+	for _, path := range packagePaths {
+		info, err := hashBlob(path)
+		if err != nil {
+			return fmt.Errorf("hashing %q: %w", path, err)
+		}
+		layers = append(layers, info)
+	}
+
+	diffIDs := make([]digest.Digest, len(layers))
+	descs := make([]ocispec.Descriptor, len(layers))
+	for i, l := range layers {
+		diffIDs[i] = l.diffID
+		descs[i] = l.desc
+	}
+
+	arch := runtime.GOARCH
+	configJSON, err := json.Marshal(ocispec.Image{
+		Platform: ocispec.Platform{Architecture: arch, OS: "linux"},
+		Config: ocispec.ImageConfig{
+			Env:        envVars,
+			Entrypoint: entrypoint,
+			Cmd:        cmd,
+		},
+		RootFS: ocispec.RootFS{Type: "layers", DiffIDs: diffIDs},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	configDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageConfig,
+		Digest:    digest.FromBytes(configJSON),
+		Size:      int64(len(configJSON)),
+	}
+
+	manifestJSON, err := json.MarshalIndent(ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    descs,
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	manifestDesc := ocispec.Descriptor{
+		MediaType:   ocispec.MediaTypeImageManifest,
+		Digest:      digest.FromBytes(manifestJSON),
+		Size:        int64(len(manifestJSON)),
+		Platform:    &ocispec.Platform{OS: "linux", Architecture: arch},
+		Annotations: map[string]string{ocispec.AnnotationRefName: imageRef},
+	}
+
+	indexJSON, err := json.MarshalIndent(ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{manifestDesc},
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal index: %w", err)
+	}
+
+	return writeOCITar(output, layers, configDesc, configJSON, manifestDesc, manifestJSON, indexJSON)
+}
+
+func writeOCITar(output string, layers []layerInfo, configDesc ocispec.Descriptor, configJSON []byte, manifestDesc ocispec.Descriptor, manifestJSON []byte, indexJSON []byte) error {
+	f, err := os.Create(output)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	tw := tar.NewWriter(f)
+	defer tw.Close()
+
+	addBytes := func(name string, data []byte) error {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Size: int64(len(data)), Mode: 0444}); err != nil {
+			return err
+		}
+		_, err := tw.Write(data)
+		return err
+	}
+
+	if err := addBytes("oci-layout", []byte(`{"imageLayoutVersion":"1.0.0"}`)); err != nil {
+		return err
+	}
+
+	for _, l := range layers {
+		lf, err := os.Open(l.path)
+		if err != nil {
+			return err
+		}
+		err = func() error {
+			defer lf.Close()
+			if err := tw.WriteHeader(&tar.Header{
+				Name: "blobs/sha256/" + l.desc.Digest.Hex(),
+				Size: l.desc.Size,
+				Mode: 0444,
+			}); err != nil {
+				return err
+			}
+			_, err := io.Copy(tw, lf)
+			return err
+		}()
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := addBytes("blobs/sha256/"+configDesc.Digest.Hex(), configJSON); err != nil {
+		return err
+	}
+	if err := addBytes("blobs/sha256/"+manifestDesc.Digest.Hex(), manifestJSON); err != nil {
+		return err
+	}
+	return addBytes("index.json", indexJSON)
+}
+
+// hashBlob computes the compressed blob digest (for the layer descriptor) and
+// the uncompressed tar digest (for the image config DiffID) in a single pass.
+func hashBlob(path string) (layerInfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return layerInfo{}, err
+	}
+	defer f.Close()
+
+	compHash := sha256.New()
+	cr := &countingReader{r: io.TeeReader(f, compHash)}
+
+	zr, err := zstd.NewReader(cr)
+	if err != nil {
+		return layerInfo{}, fmt.Errorf("opening zstd stream: %w", err)
+	}
+	defer zr.Close()
+
+	diffHash := sha256.New()
+	if _, err := io.Copy(diffHash, zr); err != nil {
+		return layerInfo{}, fmt.Errorf("hashing: %w", err)
+	}
+
+	blobDigest := digest.NewDigest("sha256", compHash)
+	return layerInfo{
+		desc: ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageLayerZstd,
+			Digest:    blobDigest,
+			Size:      cr.n,
+		},
+		diffID: digest.NewDigest("sha256", diffHash),
+		path:   path,
+	}, nil
+}
+
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
+func ensureTag(ref string) string {
+	last := strings.LastIndex(ref, "/")
+	if !strings.ContainsAny(ref[last+1:], ":@") {
+		return ref + ":latest"
+	}
+	return ref
+}

--- a/integration/lcc/flox_test.go
+++ b/integration/lcc/flox_test.go
@@ -1,0 +1,68 @@
+//go:build linux && integration
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lcc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFloxHelloWorkflow exercises the flox build path end-to-end:
+//
+//  1. Build a LCC OCI image from the flox/hello FloxHub environment using pkg2oci.
+//  2. Import the image via ctr (triggers unpack through the snapshotter).
+//  3. Run the container and verify the GNU hello output.
+//  4. Prune and verify all snapshots and LCC cache dirs are removed.
+func TestFloxHelloWorkflow(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root (overlayfs + containerd)")
+	}
+	checkBinaries(t, "containerd", "ctr", "pkg2oci", "flox")
+
+	env := setupEnv(t)
+	const ref = "localhost/test/flox-hello:v1"
+	tarPath := filepath.Join(env.tmp, "flox-hello.tar")
+
+	runCmd(t, env.ctx, "pkg2oci",
+		"--output", tarPath,
+		"--flox-env", "flox/hello",
+		"--entrypoint", "hello",
+		ref,
+	)
+	t.Logf("pkg2oci: wrote %s", tarPath)
+
+	ctrImport(t, env, tarPath)
+
+	cacheDir := env.cacheDir
+	blobCount := countCachedBlobs(t, cacheDir)
+	if blobCount == 0 {
+		t.Error("expected at least one LCC cache directory")
+	}
+	t.Logf("LCC cache dirs (Nix store paths): %d", blobCount)
+
+	out := ctrRun(t, env, ref, "flox-hello-run")
+	t.Logf("flox/hello output: %q", out)
+	if !strings.Contains(out, "Hello, world!") {
+		t.Errorf("expected 'Hello, world!' in output, got: %q", out)
+	}
+
+	pruneAll(t, env, ref)
+}

--- a/integration/lcc/main_test.go
+++ b/integration/lcc/main_test.go
@@ -1,0 +1,401 @@
+//go:build linux && integration
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package lcc contains end-to-end integration tests for the overlay
+// snapshotter's layer content caching feature.
+//
+// Run as root with:
+//
+//	go test -tags integration -v ./integration/lcc/
+package lcc
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/klauspost/compress/zstd"
+)
+
+// testEnv holds the running test stack: containerd subprocess and a Go client
+// connected to it.
+type testEnv struct {
+	ctx        context.Context
+	tmp        string
+	ctrdRoot   string
+	cacheDir   string
+	ctrdSock   string
+	ctrdClient *client.Client
+}
+
+// setupEnv starts the integration stack and registers t.Cleanup handlers.
+// Each call gets its own isolated tmp directory, registry port, and containerd
+// root, so multiple tests can run without interfering with each other.
+func setupEnv(t *testing.T) *testEnv {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	t.Cleanup(cancel)
+
+	tmp := t.TempDir()
+	ctrdRoot := filepath.Join(tmp, "containerd")
+
+	// Use a fixed short socket path to stay within the 108-byte Unix socket
+	// limit. Tests are serialised so there is no conflict.
+	ctrdSock := fmt.Sprintf("/run/lcc-test-%d.sock", os.Getpid())
+
+	// overlayfs requires upperdir/workdir to live on a non-overlayfs
+	// filesystem. Inside a privileged Docker container /tmp is on Docker's
+	// overlayfs; mount a tmpfs on ctrdRoot so the overlay snapshotter's
+	// snapshots/<id>/fs and cache/ directories land on a real filesystem.
+	if err := os.MkdirAll(ctrdRoot, 0755); err != nil {
+		t.Fatalf("mkdir ctrdRoot: %v", err)
+	}
+	if err := syscall.Mount("tmpfs", ctrdRoot, "tmpfs", 0, ""); err == nil {
+		t.Cleanup(func() { _ = syscall.Unmount(ctrdRoot, syscall.MNT_DETACH) })
+	} else if !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("mount tmpfs on ctrdRoot: %v", err)
+	}
+	// EPERM means /tmp is already on a real FS — safe to continue without tmpfs.
+
+	writeContainerdConfig(t, tmp)
+	startContainerd(t, ctx, tmp, ctrdRoot, ctrdSock)
+	t.Logf("containerd listening on %s", ctrdSock)
+
+	ctrdClient, err := client.New(ctrdSock,
+		client.WithDefaultNamespace("default"),
+	)
+	if err != nil {
+		t.Fatalf("client.New: %v", err)
+	}
+	t.Cleanup(func() { ctrdClient.Close() })
+
+	const overlayPlugin = "io.containerd.snapshotter.v1.overlayfs"
+	return &testEnv{
+		ctx:        ctx,
+		tmp:        tmp,
+		ctrdRoot:   ctrdRoot,
+		cacheDir:   filepath.Join(ctrdRoot, overlayPlugin, "cache"),
+		ctrdSock:   ctrdSock,
+		ctrdClient: ctrdClient,
+	}
+}
+
+// checkBinaries fails the test if any of the named binaries are not in PATH.
+func checkBinaries(t *testing.T, bins ...string) {
+	t.Helper()
+	for _, bin := range bins {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Fatalf("%s not in PATH", bin)
+		}
+	}
+}
+
+// ctrImport imports an OCI image layout tarball into containerd's image store
+// and unpacks it so that overlay snapshots exist before the test inspects them.
+func ctrImport(t *testing.T, env *testEnv, tarPath string) {
+	t.Helper()
+	cmd := exec.CommandContext(env.ctx, "ctr",
+		"--address", env.ctrdSock,
+		"--namespace", "default",
+		"images", "import",
+		"--snapshotter", "overlayfs",
+		tarPath,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ctr images import %s: %v\n%s", tarPath, err, out)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	t.Logf("ctr import %s: %s", filepath.Base(tarPath), lines[len(lines)-1])
+}
+
+// ctrRun starts a container from ref using the overlay snapshotter, waits for
+// it to exit, removes it (--rm), and returns its stdout.
+func ctrRun(t *testing.T, env *testEnv, ref, containerID string, containerCmd ...string) string {
+	t.Helper()
+	args := []string{
+		"--address", env.ctrdSock,
+		"--namespace", "default",
+		"run",
+		"--rm",
+		"--snapshotter", "overlayfs",
+		ref,
+		containerID,
+	}
+	args = append(args, containerCmd...)
+	return runCmdCapture(t, env.ctx, "ctr", args...)
+}
+
+const (
+	pruneMaxAttempts = 10
+	pruneInterval    = 2 * time.Second
+)
+
+// pruneAll removes the image ref and polls until containerd's GC has evicted
+// all snapshots and LCC cache directories. The GC calls Cleanup() on the
+// overlay snapshotter, which removes LCC cache dirs no longer referenced by any
+// remaining snapshot.
+func pruneAll(t *testing.T, env *testEnv, ref string) {
+	t.Helper()
+
+	runCmd(t, env.ctx, "ctr",
+		"--address", env.ctrdSock,
+		"--namespace", "default",
+		"images", "rm", ref,
+	)
+
+	snapSvc := env.ctrdClient.SnapshotService("overlayfs")
+
+	var blobCount int
+	var remaining int
+	for attempt := range pruneMaxAttempts {
+		time.Sleep(pruneInterval)
+
+		blobCount = countCachedBlobs(t, env.cacheDir)
+		remaining = 0
+		_ = snapSvc.Walk(env.ctx, func(_ context.Context, _ snapshots.Info) error {
+			remaining++
+			return nil
+		})
+		if blobCount == 0 && remaining == 0 {
+			break
+		}
+		t.Logf("pruneAll attempt %d/%d: %d blobs, %d snapshots remaining",
+			attempt+1, pruneMaxAttempts, blobCount, remaining)
+	}
+
+	if blobCount != 0 {
+		t.Errorf("want empty LCC cache dir after prune, got %d blobs", blobCount)
+	}
+	if remaining != 0 {
+		t.Errorf("want 0 snapshots after prune, got %d", remaining)
+	}
+	t.Log("prune: LCC cache dir and snapshots empty")
+}
+
+// buildStaticBinary compiles a tiny CGO_ENABLED=0 Go binary that prints msg
+// when executed. Returns the path to the compiled binary.
+func buildStaticBinary(t *testing.T, tmp, name, msg string) string {
+	t.Helper()
+	srcDir := filepath.Join(tmp, "src-"+name)
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", srcDir, err)
+	}
+	src := fmt.Sprintf("package main\nimport \"fmt\"\nfunc main() { fmt.Print(%q) }\n", msg)
+	if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte(src), 0644); err != nil {
+		t.Fatalf("WriteFile main.go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "go.mod"), []byte("module testbin\ngo 1.21\n"), 0644); err != nil {
+		t.Fatalf("WriteFile go.mod: %v", err)
+	}
+	outBin := filepath.Join(tmp, name)
+	cmd := exec.Command("go", "build", "-ldflags=-extldflags=-static", "-o", outBin, ".")
+	cmd.Dir = srcDir
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go build %s: %v", name, err)
+	}
+	return outBin
+}
+
+// makePrintBlob builds a statically-linked binary that prints msg, packs it
+// into a tar+zstd archive at tarPath inside the archive, and returns the path
+// to the archive.
+func makePrintBlob(t *testing.T, dir, outFile, tarPath, msg string) string {
+	t.Helper()
+	binPath := buildStaticBinary(t, dir, outFile+"-bin", msg)
+	binData, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", binPath, err)
+	}
+
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("zstd.NewWriter: %v", err)
+	}
+	tw := tar.NewWriter(zw)
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     tarPath,
+		Size:     int64(len(binData)),
+		Mode:     0755,
+	}); err != nil {
+		t.Fatalf("tar.WriteHeader: %v", err)
+	}
+	if _, err := tw.Write(binData); err != nil {
+		t.Fatalf("tar.Write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar.Close: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zstd.Close: %v", err)
+	}
+	path := filepath.Join(dir, outFile)
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		t.Fatalf("WriteFile blob: %v", err)
+	}
+	return path
+}
+
+// writeContainerdConfig writes a minimal containerd config.toml for testing.
+// Only the overlay snapshotter's LCC option is set here; root, state, address,
+// and disabled plugins are passed as CLI flags by startContainerd.
+func writeContainerdConfig(t *testing.T, tmp string) {
+	t.Helper()
+	const cfg = `version = 3
+disabled_plugins = ["io.containerd.grpc.v1.cri"]
+
+[plugins."io.containerd.snapshotter.v1.overlayfs"]
+  layer_content_cache = true
+`
+	if err := os.WriteFile(filepath.Join(tmp, "containerd.toml"), []byte(cfg), 0644); err != nil {
+		t.Fatalf("WriteFile containerd config: %v", err)
+	}
+}
+
+// startContainerd starts containerd with the config written by
+// writeContainerdConfig and waits for the gRPC socket to appear.
+func startContainerd(t *testing.T, ctx context.Context, tmp, ctrdRoot, ctrdSock string) {
+	t.Helper()
+	// Remove any stale socket left by a previous unclean exit before binding.
+	if err := os.Remove(ctrdSock); err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("remove stale socket %s: %v", ctrdSock, err)
+	}
+	cmd := exec.CommandContext(ctx, "containerd",
+		"--config", filepath.Join(tmp, "containerd.toml"),
+		"--root", ctrdRoot,
+		"--state", filepath.Join(tmp, "containerd-state"),
+		"--address", ctrdSock,
+		"--log-level", "warn",
+	)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start containerd: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+	waitForSocket(t, ctrdSock, 30*time.Second)
+}
+
+// runCmd runs a subprocess, routing its output to the test log.
+// Fails the test on non-zero exit.
+func runCmd(t *testing.T, ctx context.Context, name string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	t.Logf("+ %s %v", name, args)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("%s: %v", name, err)
+	}
+}
+
+// runCmdCapture runs a subprocess and returns its stdout as a string.
+func runCmdCapture(t *testing.T, ctx context.Context, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	t.Logf("+ %s %v", name, args)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("%s: %v", name, err)
+	}
+	return stdout.String()
+}
+
+// waitForSocket polls until the Unix socket at path accepts connections.
+func waitForSocket(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if conn, err := net.DialTimeout("unix", path, time.Second); err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for Unix socket %s", path)
+}
+
+// blobDirInodes returns a map from LCC cache directory path to its inode
+// number. The layout is cache/<algorithm>.<hex>.<uid>.<gid>/; this reads the flat cache dir.
+// ENOENT returns an empty map.
+//
+// Used by TestLCCLayerCacheIndependence to distinguish cache hits (same inode)
+// from registry re-fetches (directory recreated, new inode).
+func blobDirInodes(t *testing.T, cacheDir string) map[string]uint64 {
+	t.Helper()
+	result := make(map[string]uint64)
+	entries, err := os.ReadDir(cacheDir)
+	if os.IsNotExist(err) {
+		return result
+	}
+	if err != nil {
+		t.Fatalf("reading cache dir %s: %v", cacheDir, err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		full := filepath.Join(cacheDir, e.Name())
+		fi, err := os.Stat(full)
+		if err != nil {
+			t.Fatalf("stat %s: %v", full, err)
+		}
+		result[full] = fi.Sys().(*syscall.Stat_t).Ino
+	}
+	return result
+}
+
+// countCachedBlobs returns the number of LCC cache directories under cacheDir.
+// The layout is cache/<algorithm>.<hex>.<uid>.<gid>/; each direct child directory is one blob.
+// ENOENT is treated as zero.
+func countCachedBlobs(t *testing.T, cacheDir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(cacheDir)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("reading cache dir: %v", err)
+	}
+	var count int
+	for _, e := range entries {
+		if e.IsDir() {
+			count++
+		}
+	}
+	return count
+}

--- a/integration/lcc/main_test.go
+++ b/integration/lcc/main_test.go
@@ -350,7 +350,7 @@ func waitForSocket(t *testing.T, path string, timeout time.Duration) {
 }
 
 // blobDirInodes returns a map from LCC cache directory path to its inode
-// number. The layout is cache/<algorithm>.<hex>.<uid>.<gid>/; this reads the flat cache dir.
+// number. The layout is cache/<algorithm>.<hex>.<uid>.<gid>.<seq>/; this reads the flat cache dir.
 // ENOENT returns an empty map.
 //
 // Used by TestLCCLayerCacheIndependence to distinguish cache hits (same inode)
@@ -380,7 +380,7 @@ func blobDirInodes(t *testing.T, cacheDir string) map[string]uint64 {
 }
 
 // countCachedBlobs returns the number of LCC cache directories under cacheDir.
-// The layout is cache/<algorithm>.<hex>.<uid>.<gid>/; each direct child directory is one blob.
+// The layout is cache/<algorithm>.<hex>.<uid>.<gid>.<seq>/; each direct child directory is one blob.
 // ENOENT is treated as zero.
 func countCachedBlobs(t *testing.T, cacheDir string) int {
 	t.Helper()

--- a/integration/lcc/snapshotter_test.go
+++ b/integration/lcc/snapshotter_test.go
@@ -151,6 +151,74 @@ func TestLCCMultiPackageImage(t *testing.T) {
 	pruneAll(t, env, ref)
 }
 
+// TestLCCDuplicateLayer verifies that an image whose layer list contains the
+// same blob at two positions can be imported and run correctly. The sequence
+// number ensures each occurrence of the repeated diffID maps to a distinct cache
+// directory, satisfying the OverlayFS constraint that all lower_dir entries must
+// be distinct.
+//
+// Image layout: [pkgA, pkgB, pkgA] — pkgA appears at positions 0 and 2.
+// Expected outcome: three cache directories (pkgA.seq0, pkgB.seq0, pkgA.seq1),
+// all accessible and distinct, and the container can run both binaries.
+func TestLCCDuplicateLayer(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root (overlayfs + containerd)")
+	}
+	checkBinaries(t, "containerd", "ctr", "pkg2oci")
+
+	env := setupEnv(t)
+	const ref = "localhost/test/dup:v1"
+	tarPath := filepath.Join(env.tmp, "dup.tar")
+
+	blobA := makePrintBlob(t, env.tmp, "pkgA.tar.zst", "usr/bin/pkgA", "pkgA\n")
+	blobB := makePrintBlob(t, env.tmp, "pkgB.tar.zst", "usr/bin/pkgB", "pkgB\n")
+
+	// Pass blobA twice so the image has layers [A, B, A].
+	runCmd(t, env.ctx, "pkg2oci",
+		"--output", tarPath,
+		"--package", blobA,
+		"--package", blobB,
+		"--package", blobA,
+		ref,
+	)
+
+	ctrImport(t, env, tarPath)
+
+	// Three layers → three cache dirs: pkgA.seq=0, pkgB.seq=0, pkgA.seq=1.
+	cacheDir := env.cacheDir
+	blobCount := countCachedBlobs(t, cacheDir)
+	if blobCount != 3 {
+		t.Errorf("want 3 LCC cache dirs (pkgA.seq0, pkgB.seq0, pkgA.seq1), got %d", blobCount)
+	}
+
+	// Verify all three cache dirs are distinct (OverlayFS correctness).
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatalf("ReadDir cache: %v", err)
+	}
+	seen := map[string]struct{}{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, dup := seen[e.Name()]; dup {
+			t.Errorf("duplicate cache dir name: %s", e.Name())
+		}
+		seen[e.Name()] = struct{}{}
+	}
+
+	outA := ctrRun(t, env, ref, "dup-run-a", "/usr/bin/pkgA")
+	if strings.TrimSpace(outA) != "pkgA" {
+		t.Errorf("pkgA: want %q, got %q", "pkgA", strings.TrimSpace(outA))
+	}
+	outB := ctrRun(t, env, ref, "dup-run-b", "/usr/bin/pkgB")
+	if strings.TrimSpace(outB) != "pkgB" {
+		t.Errorf("pkgB: want %q, got %q", "pkgB", strings.TrimSpace(outB))
+	}
+
+	pruneAll(t, env, ref)
+}
+
 // TestLCCLayerCacheIndependence demonstrates the core CAS property: each layer
 // blob is cached independently by content digest. Evicting a single blob does
 // not invalidate cache entries for any other layer. On the next import, only the

--- a/integration/lcc/snapshotter_test.go
+++ b/integration/lcc/snapshotter_test.go
@@ -1,0 +1,285 @@
+//go:build linux && integration
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lcc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+)
+
+// TestLCCImageLifecycle is the primary end-to-end test. It exercises the full
+// pipeline:
+//
+//  1. Create a minimal package blob (static binary that prints "hello").
+//  2. Build an OCI image tarball with pkg2oci.
+//  3. Start containerd with the built-in overlay snapshotter.
+//  4. Import the image via ctr (triggers unpack through the snapshotter).
+//  5. Verify committed snapshots and a populated LCC cache directory.
+//  6. Run a container and verify the binary output.
+//  7. Prune and verify all snapshots and LCC cache dirs are removed.
+func TestLCCImageLifecycle(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root (overlayfs + containerd)")
+	}
+	checkBinaries(t, "containerd", "ctr", "pkg2oci")
+
+	env := setupEnv(t)
+	const ref = "localhost/test/myapp:v1"
+	tarPath := filepath.Join(env.tmp, "myapp.tar")
+
+	blobPath := makePrintBlob(t, env.tmp, "hello-1.0.tar.zst", "usr/bin/hello", "hello\n")
+
+	runCmd(t, env.ctx, "pkg2oci",
+		"--output", tarPath,
+		"--package", blobPath,
+		ref,
+	)
+	t.Logf("pkg2oci: wrote %s", tarPath)
+
+	ctrImport(t, env, tarPath)
+
+	snapSvc := env.ctrdClient.SnapshotService("overlayfs")
+	var committed int
+	if err := snapSvc.Walk(env.ctx, func(ctx context.Context, info snapshots.Info) error {
+		t.Logf("snapshot: name=%s kind=%v", info.Name, info.Kind)
+		if info.Kind == snapshots.KindCommitted {
+			committed++
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk snapshots: %v", err)
+	}
+	if committed == 0 {
+		t.Error("expected at least one committed snapshot after unpack")
+	}
+
+	cacheDir := env.cacheDir
+	blobCount := countCachedBlobs(t, cacheDir)
+	if blobCount == 0 {
+		t.Error("expected at least one LCC cache directory")
+	}
+	t.Logf("committed snapshots: %d  LCC cache dirs: %d", committed, blobCount)
+
+	out := ctrRun(t, env, ref, "hello-run", "/usr/bin/hello")
+	t.Logf("container output: %q", out)
+	if strings.TrimSpace(out) != "hello" {
+		t.Errorf("want %q, got %q", "hello", strings.TrimSpace(out))
+	}
+
+	pruneAll(t, env, ref)
+}
+
+// TestLCCMultiPackageImage verifies that a LCC image containing two packages
+// produces two LCC cache directories and two committed snapshots, that both
+// binaries run correctly, and that pruning leaves a clean state.
+func TestLCCMultiPackageImage(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root (overlayfs + containerd)")
+	}
+	checkBinaries(t, "containerd", "ctr", "pkg2oci")
+
+	env := setupEnv(t)
+	const ref = "localhost/test/multi:v1"
+	tarPath := filepath.Join(env.tmp, "multi.tar")
+
+	blob1 := makePrintBlob(t, env.tmp, "hello-1.0.tar.zst", "usr/bin/hello", "hello\n")
+	blob2 := makePrintBlob(t, env.tmp, "world-1.0.tar.zst", "usr/bin/world", "world\n")
+
+	runCmd(t, env.ctx, "pkg2oci",
+		"--output", tarPath,
+		"--package", blob1,
+		"--package", blob2,
+		ref,
+	)
+	t.Logf("pkg2oci: wrote %s", tarPath)
+
+	ctrImport(t, env, tarPath)
+
+	cacheDir := env.cacheDir
+	blobCount := countCachedBlobs(t, cacheDir)
+	if blobCount != 2 {
+		t.Errorf("want 2 LCC cache dirs, got %d", blobCount)
+	}
+
+	snapSvc := env.ctrdClient.SnapshotService("overlayfs")
+	var committed int
+	if err := snapSvc.Walk(env.ctx, func(ctx context.Context, info snapshots.Info) error {
+		t.Logf("snapshot: name=%s kind=%v parent=%s", info.Name, info.Kind, info.Parent)
+		if info.Kind == snapshots.KindCommitted {
+			committed++
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if committed != 2 {
+		t.Errorf("want 2 committed snapshots, got %d", committed)
+	}
+	t.Logf("LCC cache dirs: %d  committed snapshots: %d", blobCount, committed)
+
+	out1 := ctrRun(t, env, ref, "hello-run", "/usr/bin/hello")
+	if strings.TrimSpace(out1) != "hello" {
+		t.Errorf("hello: want %q, got %q", "hello", strings.TrimSpace(out1))
+	}
+	out2 := ctrRun(t, env, ref, "world-run", "/usr/bin/world")
+	if strings.TrimSpace(out2) != "world" {
+		t.Errorf("world: want %q, got %q", "world", strings.TrimSpace(out2))
+	}
+
+	pruneAll(t, env, ref)
+}
+
+// TestLCCLayerCacheIndependence demonstrates the core CAS property: each layer
+// blob is cached independently by content digest. Evicting a single blob does
+// not invalidate cache entries for any other layer. On the next import, only the
+// missing blob is re-extracted; layers above and below it are served from the
+// local cache.
+//
+// Test setup:
+//
+//	Image A: [pkg1, pkg2, pkg3, pkg4]   — four layers
+//	Image B: [pkg1, pkg3, pkg4]          — same packages except pkg2
+//
+// Import B first to seed pkg1, pkg3, pkg4. Import A — only pkg2 is extracted.
+// Remove A — GC evicts pkg2 (referenced only by A's snapshots); pkg1, pkg3,
+// pkg4 survive because B's snapshots still reference them. Re-import A — only
+// pkg2 is re-extracted.
+func TestLCCLayerCacheIndependence(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root (overlayfs + containerd)")
+	}
+	checkBinaries(t, "containerd", "ctr", "pkg2oci")
+
+	env := setupEnv(t)
+	const refA = "localhost/test/a:v1"
+	const refB = "localhost/test/b:v1"
+	tarA := filepath.Join(env.tmp, "a.tar")
+	tarB := filepath.Join(env.tmp, "b.tar")
+	cacheDir := env.cacheDir
+	snapSvc := env.ctrdClient.SnapshotService("overlayfs")
+
+	blob1 := makePrintBlob(t, env.tmp, "pkg1.tar.zst", "usr/bin/pkg1", "pkg1\n")
+	blob2 := makePrintBlob(t, env.tmp, "pkg2.tar.zst", "usr/bin/pkg2", "pkg2\n")
+	blob3 := makePrintBlob(t, env.tmp, "pkg3.tar.zst", "usr/bin/pkg3", "pkg3\n")
+	blob4 := makePrintBlob(t, env.tmp, "pkg4.tar.zst", "usr/bin/pkg4", "pkg4\n")
+
+	runCmd(t, env.ctx, "pkg2oci", "--output", tarA,
+		"--package", blob1,
+		"--package", blob2,
+		"--package", blob3,
+		"--package", blob4,
+		refA,
+	)
+	runCmd(t, env.ctx, "pkg2oci", "--output", tarB,
+		"--package", blob1,
+		"--package", blob3,
+		"--package", blob4,
+		refB,
+	)
+
+	// Import B: seeds pkg1, pkg3, pkg4.
+	ctrImport(t, env, tarB)
+	if countCachedBlobs(t, cacheDir) != 3 {
+		t.Fatalf("want 3 LCC cache dirs after importing B, got %d", countCachedBlobs(t, cacheDir))
+	}
+
+	bSnapshotCount := 0
+	_ = snapSvc.Walk(env.ctx, func(_ context.Context, _ snapshots.Info) error {
+		bSnapshotCount++
+		return nil
+	})
+
+	// Import A: only pkg2 is extracted; pkg1, pkg3, pkg4 served from cache.
+	ctrImport(t, env, tarA)
+	if countCachedBlobs(t, cacheDir) != 4 {
+		t.Fatalf("want 4 LCC cache dirs after importing A, got %d", countCachedBlobs(t, cacheDir))
+	}
+
+	// Record inodes of all four LCC cache dirs.
+	inodesBefore := blobDirInodes(t, cacheDir)
+
+	// Remove image A. GC removes A's snapshots, then Cleanup() evicts pkg2
+	// (no longer referenced). pkg1, pkg3, pkg4 survive (still in B's chain).
+	runCmd(t, env.ctx, "ctr",
+		"--address", env.ctrdSock, "--namespace", "default",
+		"images", "rm", refA,
+	)
+
+	var blobCount, snapCount int
+	for attempt := range pruneMaxAttempts {
+		time.Sleep(pruneInterval)
+		blobCount = countCachedBlobs(t, cacheDir)
+		snapCount = 0
+		_ = snapSvc.Walk(env.ctx, func(_ context.Context, _ snapshots.Info) error {
+			snapCount++
+			return nil
+		})
+		if blobCount == 3 && snapCount == bSnapshotCount {
+			break
+		}
+		t.Logf("attempt %d/%d: %d LCC cache dirs, %d snapshots (want 3 dirs, %d snapshots)",
+			attempt+1, pruneMaxAttempts, blobCount, snapCount, bSnapshotCount)
+	}
+	if blobCount != 3 {
+		t.Fatalf("want 3 LCC cache dirs after removing A (pkg2 evicted), got %d", blobCount)
+	}
+	if snapCount != bSnapshotCount {
+		t.Fatalf("want %d snapshots after removing A, got %d", bSnapshotCount, snapCount)
+	}
+	t.Logf("after removing A: %d LCC cache dirs (pkg1, pkg3, pkg4); pkg2 evicted", blobCount)
+
+	// Re-import A. The snapshotter finds pkg1, pkg3, pkg4 in the local cache
+	// and sets LabelSkipApply; only pkg2 triggers a fresh extraction.
+	ctrImport(t, env, tarA)
+
+	if countCachedBlobs(t, cacheDir) != 4 {
+		t.Errorf("want 4 LCC cache dirs after re-importing A, got %d", countCachedBlobs(t, cacheDir))
+	}
+
+	inodesAfter := blobDirInodes(t, cacheDir)
+
+	var refetched, cached int
+	for path, ino := range inodesAfter {
+		if prev, ok := inodesBefore[path]; ok && ino == prev {
+			cached++
+			t.Logf("cache hit:  %s", filepath.Base(filepath.Dir(filepath.Dir(path))))
+		} else {
+			refetched++
+			t.Logf("re-extracted: %s", filepath.Base(filepath.Dir(filepath.Dir(path))))
+		}
+	}
+
+	if refetched != 1 {
+		t.Errorf("want 1 re-extracted blob (pkg2), got %d (cached=%d)", refetched, cached)
+	}
+	if cached != 3 {
+		t.Errorf("want 3 cache hits (pkg1, pkg3, pkg4), got %d (re-extracted=%d)", cached, refetched)
+	}
+
+	out := ctrRun(t, env, refA, "independence-test", "/usr/bin/pkg3")
+	if strings.TrimSpace(out) != "pkg3" {
+		t.Errorf("container: want %q, got %q", "pkg3", strings.TrimSpace(out))
+	}
+}

--- a/pkg/rootfs/apply.go
+++ b/pkg/rootfs/apply.go
@@ -121,11 +121,16 @@ func applyLayers(ctx context.Context, layers []Layer, chain []digest.Digest, sn 
 		err     error
 	)
 
+	// Inject the diff ID so snapshotters can act on it (e.g. layer content caching).
+	prepareOpts := append(opts, snapshots.WithLabels(map[string]string{
+		snapshots.LabelSnapshotDiffID: layer.Diff.Digest.String(),
+	}))
+
 	for {
 		key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
 
 		// Prepare snapshot with from parent, label as root
-		mounts, err = sn.Prepare(ctx, key, parent.String(), opts...)
+		mounts, err = sn.Prepare(ctx, key, parent.String(), prepareOpts...)
 		if err != nil {
 			if errdefs.IsNotFound(err) && len(layers) > 1 {
 				if err := applyLayers(ctx, layers[:len(layers)-1], chain[:len(chain)-1], sn, a, opts, applyOpts); err != nil {
@@ -159,14 +164,23 @@ func applyLayers(ctx context.Context, layers []Layer, chain []digest.Digest, sn 
 		}
 	}()
 
-	diff, err = a.Apply(ctx, layer.Blob, mounts, applyOpts...)
+	// LabelSkipApply lets the snapshotter signal that extraction is unnecessary;
+	// note that this also skips the diff.Digest verification below.
+	snInfo, err := sn.Stat(ctx, key)
 	if err != nil {
-		err = fmt.Errorf("failed to extract layer %s: %w", layer.Diff.Digest, err)
+		err = fmt.Errorf("failed to stat snapshot %q: %w", key, err)
 		return err
 	}
-	if diff.Digest != layer.Diff.Digest {
-		err = fmt.Errorf("wrong diff id calculated on extraction %q", diff.Digest)
-		return err
+	if snInfo.Labels[snapshots.LabelSkipApply] != "true" {
+		diff, err = a.Apply(ctx, layer.Blob, mounts, applyOpts...)
+		if err != nil {
+			err = fmt.Errorf("failed to extract layer %s: %w", layer.Diff.Digest, err)
+			return err
+		}
+		if diff.Digest != layer.Diff.Digest {
+			err = fmt.Errorf("wrong diff id calculated on extraction %q", diff.Digest)
+			return err
+		}
 	}
 
 	if err = sn.Commit(ctx, chainID.String(), key, opts...); err != nil {

--- a/plugins/snapshots/overlay/lcc.go
+++ b/plugins/snapshots/overlay/lcc.go
@@ -1,0 +1,294 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package overlay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/storage"
+	"github.com/containerd/log"
+	digest "github.com/opencontainers/go-digest"
+)
+
+const (
+	// When LCC is enabled, labelSnapshotUID and labelSnapshotGID record the uid/gid used to
+	// select the per-ownership cache content directory for this snapshot.
+	labelSnapshotUID = "containerd.io/snapshot.uid"
+	labelSnapshotGID = "containerd.io/snapshot.gid"
+)
+
+// layerContentCache holds per-snapshotter LCC configuration and runtime state.
+type layerContentCache struct {
+	root    string
+	enabled bool
+}
+
+// WithLayerContentCache enables layer content caching on the snapshotter.
+func WithLayerContentCache(config *SnapshotterConfig) error {
+	config.lccEnabled = true
+	return nil
+}
+
+// hasDiffID reports whether info carries a layer diff-ID label, which is set by
+// the unpacker on layer-unpack Prepare calls but absent on container-start
+// Prepare calls. Only snapshots with a diff-ID should go through the LCC path.
+func hasDiffID(info snapshots.Info) bool {
+	return info.Labels[snapshots.LabelSnapshotDiffID] != ""
+}
+
+// hasCacheDir reports whether a snapshot participates in LCC and its shared
+// cache content path can be derived from it. labelSnapshotUID is the authoritative
+// marker: it is set by lcc.computeLabels at CreateSnapshot time (for both cache
+// hits and misses) and re-injected by lcc.commitOpts at CommitActive.
+// Checking all labels that lcc.contentPath needs would be wrong: if labelSnapshotUID
+// is present but another label is missing, that is a data-consistency bug that
+// should surface as an error, not be silently skipped.
+func hasCacheDir(info snapshots.Info) bool {
+	return info.Labels[labelSnapshotUID] != ""
+}
+
+// contentPathFromParts computes the shared content directory path from the
+// raw diffID string and string-form uid/gid. The layout is:
+// <root>/cache/<algorithm>.<hex>.<uid>.<gid>/
+func (lcc *layerContentCache) contentPathFromParts(diffID string, uid, gid int) (string, error) {
+	d, err := digest.Parse(diffID)
+	if err != nil {
+		return "", fmt.Errorf("invalid lcc diffID %q: %w", diffID, err)
+	}
+	name := fmt.Sprintf("%s.%s.%d.%d", d.Algorithm(), d.Encoded(), uid, gid)
+	return filepath.Join(lcc.root, "cache", name), nil
+}
+
+// contentPath returns the shared content directory for the snapshot. The
+// layout is: <root>/cache/<algorithm>.<hex>.<uid>.<gid>/, e.g.
+// <root>/cache/sha256.abc123....0.0 for diffID "sha256:abc123..." owned by root.
+func (lcc *layerContentCache) contentPath(info snapshots.Info) (string, error) {
+	diffID := info.Labels[snapshots.LabelSnapshotDiffID]
+	uidStr := info.Labels[labelSnapshotUID]
+	gidStr := info.Labels[labelSnapshotGID]
+	if diffID == "" || uidStr == "" || gidStr == "" {
+		return "", fmt.Errorf("missing lcc labels for snapshot %q", info.Name)
+	}
+	uid, err := strconv.Atoi(uidStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid lcc uid label %q: %w", uidStr, err)
+	}
+	gid, err := strconv.Atoi(gidStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid lcc gid label %q: %w", gidStr, err)
+	}
+	return lcc.contentPathFromParts(diffID, uid, gid)
+}
+
+// orphanedContentPath returns a staging path derived from the given cache
+// content path by appending a nanosecond epoch timestamp and the ".orphaned"
+// suffix. Two concurrent losers in the same nanosecond would collide, but
+// os.Rename in that case would simply fail and be detected by the caller.
+func (lcc *layerContentCache) orphanedContentPath(path string) string {
+	return fmt.Sprintf("%s.%d.orphaned", path, time.Now().UnixNano())
+}
+
+// computeLabels returns the labels to inject at CreateSnapshot time: uid/gid
+// ownership labels and, if the shared content directory already exists,
+// LabelSkipApply. Labels are returned as a map so the caller can fold them into
+// the opts passed to storage.CreateSnapshot, preserving the Created == Updated
+// invariant (no storage.UpdateInfo call needed after creation).
+func (lcc *layerContentCache) computeLabels(diffID string, uid, gid int) (map[string]string, error) {
+	if uid == -1 || gid == -1 {
+		uid, gid = os.Getuid(), os.Getgid()
+	}
+
+	contentPath, err := lcc.contentPathFromParts(diffID, uid, gid)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := map[string]string{
+		labelSnapshotUID: strconv.Itoa(uid),
+		labelSnapshotGID: strconv.Itoa(gid),
+	}
+
+	f, err := os.Stat(contentPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("stat lcc content path %q: %w", contentPath, err)
+	}
+	if err == nil && !f.IsDir() {
+		return nil, fmt.Errorf("lcc content path %q exists but is not a directory", contentPath)
+	}
+	if err == nil {
+		labels[snapshots.LabelSkipApply] = "true"
+	}
+
+	return labels, nil
+}
+
+// commitOpts returns opts that carry the labels needed by lcc.contentPath
+// into CommitActive. Both the diff-ID and the uid/gid ownership labels are
+// re-injected from the active snapshot's info because CommitActive replaces
+// labels entirely with whatever opts supply; callers (e.g. pkg/rootfs/apply.go)
+// may not forward the diff-ID to Commit, so we preserve it here explicitly.
+func (lcc *layerContentCache) commitOpts(info snapshots.Info) []snapshots.Opt {
+	return []snapshots.Opt{snapshots.WithLabels(map[string]string{
+		snapshots.LabelSnapshotDiffID: info.Labels[snapshots.LabelSnapshotDiffID],
+		labelSnapshotUID:              info.Labels[labelSnapshotUID],
+		labelSnapshotGID:              info.Labels[labelSnapshotGID],
+	})}
+}
+
+// prepareFSDir sets up the fs/ subdirectory within td. If LabelSkipApply is
+// set, fs/ is created as a relative symlink to the shared cache content path;
+// the symlink is relative so the snapshot tree remains valid if the containerd
+// root is relocated. Otherwise fs/ is created as a regular directory for extraction.
+func (lcc *layerContentCache) prepareFSDir(info snapshots.Info, td string) error {
+	contentPath, err := lcc.contentPath(info)
+	if err != nil {
+		return err
+	}
+	if info.Labels[snapshots.LabelSkipApply] == "true" {
+		relPath, err := filepath.Rel(td, contentPath)
+		if err != nil {
+			return fmt.Errorf("failed to compute relative lcc cache path: %w", err)
+		}
+		return os.Symlink(relPath, filepath.Join(td, "fs"))
+	}
+	return os.Mkdir(filepath.Join(td, "fs"), 0755)
+}
+
+// commitFSDir ensures the snapshot's fs/ directory is a symlink to the shared
+// cache content path. If fs/ is already a symlink (skip-apply path), there is
+// nothing to do. If fs/ holds extracted content, it is atomically renamed to
+// the cache path; if another extractor won the race, our copy is renamed to an
+// .orphaned staging path — an O(1) operation that avoids a potentially expensive
+// os.RemoveAll inside the bolt transaction. The next Cleanup call removes any
+// .orphaned entries. The symlink is relative so the snapshot tree remains valid
+// if the containerd root is relocated. Must be called before CommitActive so
+// that fs/ is still in place.
+func (lcc *layerContentCache) commitFSDir(id string, info snapshots.Info) error {
+	upperFSPath := filepath.Join(lcc.root, "snapshots", id, "fs")
+	if f, err := os.Lstat(upperFSPath); err == nil && f.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+
+	contentPath, err := lcc.contentPath(info)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(contentPath), 0700); err != nil {
+		return err
+	}
+
+	// Linux rename(2) returns ENOTEMPTY or EEXIST when the destination is a
+	// non-empty directory. Either means a concurrent extractor won the race.
+	if err := os.Rename(upperFSPath, contentPath); err != nil {
+		if !errors.Is(err, syscall.ENOTEMPTY) && !errors.Is(err, syscall.EEXIST) {
+			return fmt.Errorf("failed to promote layer content to lcc cache %s: %w", contentPath, err)
+		}
+		if err := os.Rename(upperFSPath, lcc.orphanedContentPath(contentPath)); err != nil {
+			return fmt.Errorf("failed to stage orphaned lcc layer content: %w", err)
+		}
+	}
+
+	relPath, err := filepath.Rel(filepath.Dir(upperFSPath), contentPath)
+	if err != nil {
+		return fmt.Errorf("failed to compute relative lcc cache path: %w", err)
+	}
+
+	// If Symlink fails, this function returns an error, which causes Commit's
+	// transaction to roll back — the snapshot is never committed. The renamed
+	// cache directory becomes an unreferenced entry that the next Cleanup call
+	// removes via orphanedPaths. No additional rollback is needed.
+	return os.Symlink(relPath, upperFSPath)
+}
+
+// orphanedPaths identifies cache directories no longer referenced by any
+// snapshot, renames each one to an .orphaned staging path within the transaction,
+// and returns the renamed paths for deletion by the caller. Renaming within the
+// transaction closes the race where a concurrent Prepare could observe the directory
+// still present, create a symlink to it, and then have the symlink broken when the
+// caller removes the directory outside the transaction; after the rename, os.Stat
+// on the original path fails and Prepare takes a cache miss instead. Any *.orphaned
+// entries left by a previous call are also returned so they are retried; referenced
+// *.orphaned entries (a bug, but defensive) are skipped. Must be called within a
+// bolt write transaction.
+func (lcc *layerContentCache) orphanedPaths(ctx context.Context) ([]string, error) {
+	referenced := map[string]struct{}{}
+	if err := storage.WalkInfo(ctx, func(_ context.Context, info snapshots.Info) error {
+		if !hasCacheDir(info) {
+			return nil
+		}
+		path, err := lcc.contentPath(info)
+		if err != nil {
+			return err
+		}
+		referenced[path] = struct{}{}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to walk snapshots for lcc cleanup: %w", err)
+	}
+
+	cacheRoot := filepath.Join(lcc.root, "cache")
+	entries, err := os.ReadDir(cacheRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var orphaned []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			log.G(ctx).WithField("path", filepath.Join(cacheRoot, e.Name())).Warn("unexpected non-directory entry in lcc cache root; skipping")
+			continue
+		}
+		name := e.Name()
+		path := filepath.Join(cacheRoot, name)
+
+		if _, ok := referenced[path]; ok {
+			continue
+		}
+
+		// Already staged for removal by a prior orphanedPaths or commitFSDir
+		// call — collect it for removal.
+		if strings.HasSuffix(name, ".orphaned") {
+			orphaned = append(orphaned, path)
+			continue
+		}
+
+		// Rename within the transaction so that any Prepare starting after
+		// this transaction commits will see the path absent and take a cache miss.
+		staged := lcc.orphanedContentPath(path)
+		if err := os.Rename(path, staged); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("failed to stage orphaned lcc cache dir %s: %w", path, err)
+		}
+		orphaned = append(orphaned, staged)
+	}
+
+	return orphaned, nil
+}

--- a/plugins/snapshots/overlay/lcc.go
+++ b/plugins/snapshots/overlay/lcc.go
@@ -26,26 +26,70 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
 )
 
 const (
-	// When LCC is enabled, labelSnapshotUID and labelSnapshotGID record the uid/gid used to
-	// select the per-ownership cache content directory for this snapshot.
-	labelSnapshotUID = "containerd.io/snapshot.uid"
-	labelSnapshotGID = "containerd.io/snapshot.gid"
+	// When LCC is enabled, these labels are set on every LCC snapshot to fully
+	// identify its cache content directory without requiring a chain walk.
+	labelSnapshotUID       = "containerd.io/snapshot.uid"
+	labelSnapshotGID       = "containerd.io/snapshot.gid"
+	labelSnapshotDiffIDSeq = "containerd.io/snapshot.diffID.seq"
 )
 
 // layerContentCache holds per-snapshotter LCC configuration and runtime state.
 type layerContentCache struct {
-	root    string
-	enabled bool
+	sync.RWMutex
+	root     string
+	enabled  bool
+	snapInfo map[string]lccSnapshotInfo
+}
+
+type lccSnapshotInfo struct {
+	name   string
+	parent string
+	diffID string
+}
+
+// newLayerContentCache constructs a layerContentCache and, when enabled, pre-populates
+// snapInfo by walking all committed snapshots so that diffIDSeqInChain is ready before
+// the first Prepare call.
+func newLayerContentCache(ctx context.Context, ms MetaStore, root string, enabled bool) (*layerContentCache, error) {
+	lcc := &layerContentCache{
+		root:    root,
+		enabled: enabled,
+	}
+	if !enabled {
+		return lcc, nil
+	}
+
+	// IsNotFound means the storage bucket doesn't exist yet (fresh database) — treat as empty.
+	lcc.snapInfo = make(map[string]lccSnapshotInfo)
+	if err := ms.WithTransaction(ctx, false, func(ctx context.Context) error {
+		return storage.WalkInfo(ctx, func(_ context.Context, info snapshots.Info) error {
+			if info.Kind != snapshots.KindCommitted {
+				return nil
+			}
+			lcc.snapInfo[info.Name] = lccSnapshotInfo{
+				info.Name,
+				info.Parent,
+				info.Labels[snapshots.LabelSnapshotDiffID],
+			}
+			return nil
+		})
+	}); err != nil && !errdefs.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to walk snapshots for lcc cache: %w", err)
+	}
+
+	return lcc, nil
 }
 
 // WithLayerContentCache enables layer content caching on the snapshotter.
@@ -73,26 +117,28 @@ func hasCacheDir(info snapshots.Info) bool {
 }
 
 // contentPathFromParts computes the shared content directory path from the
-// raw diffID string and string-form uid/gid. The layout is:
-// <root>/cache/<algorithm>.<hex>.<uid>.<gid>/
-func (lcc *layerContentCache) contentPathFromParts(diffID string, uid, gid int) (string, error) {
+// raw diffID string, uid/gid, and sequence number. The layout is:
+// <root>/cache/<algorithm>.<hex>.<uid>.<gid>.<seq>/
+func (lcc *layerContentCache) contentPathFromParts(diffID string, uid, gid, seq int) (string, error) {
 	d, err := digest.Parse(diffID)
 	if err != nil {
 		return "", fmt.Errorf("invalid lcc diffID %q: %w", diffID, err)
 	}
-	name := fmt.Sprintf("%s.%s.%d.%d", d.Algorithm(), d.Encoded(), uid, gid)
+	name := fmt.Sprintf("%s.%s.%d.%d.%d", d.Algorithm(), d.Encoded(), uid, gid, seq)
 	return filepath.Join(lcc.root, "cache", name), nil
 }
 
 // contentPath returns the shared content directory for the snapshot. The
-// layout is: <root>/cache/<algorithm>.<hex>.<uid>.<gid>/, e.g.
-// <root>/cache/sha256.abc123....0.0 for diffID "sha256:abc123..." owned by root.
+// layout is: <root>/cache/<algorithm>.<hex>.<uid>.<gid>.<seq>/, e.g.
+// <root>/cache/sha256.abc123....0.0.0 for diffID "sha256:abc123..." owned by
+// root appearing for the first time in the layer chain.
 func (lcc *layerContentCache) contentPath(info snapshots.Info) (string, error) {
 	diffID := info.Labels[snapshots.LabelSnapshotDiffID]
 	uidStr := info.Labels[labelSnapshotUID]
 	gidStr := info.Labels[labelSnapshotGID]
-	if diffID == "" || uidStr == "" || gidStr == "" {
-		return "", fmt.Errorf("missing lcc labels for snapshot %q", info.Name)
+	seqStr := info.Labels[labelSnapshotDiffIDSeq]
+	if diffID == "" || uidStr == "" || gidStr == "" || seqStr == "" {
+		return "", fmt.Errorf("snapshot %q missing lcc labels (got %v)", info.Name, info.Labels)
 	}
 	uid, err := strconv.Atoi(uidStr)
 	if err != nil {
@@ -102,7 +148,64 @@ func (lcc *layerContentCache) contentPath(info snapshots.Info) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid lcc gid label %q: %w", gidStr, err)
 	}
-	return lcc.contentPathFromParts(diffID, uid, gid)
+	seq, err := strconv.Atoi(seqStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid lcc seq label %q: %w", seqStr, err)
+	}
+	return lcc.contentPathFromParts(diffID, uid, gid, seq)
+}
+
+// diffIDSeqInChain returns the number of times diffID appears in the snapshot
+// chain leading up to and including parent. For a new snapshot being prepared on
+// top of parent, this is the sequence number that makes its cache path unique when
+// the same diffID recurs in the layer chain. Returns 0 for an empty parent.
+func (lcc *layerContentCache) diffIDSeqInChain(parent, diffID string) int {
+	lcc.RLock()
+	defer lcc.RUnlock()
+	count := 0
+	for cur := parent; cur != ""; cur = lcc.snapInfo[cur].parent {
+		if lcc.snapInfo[cur].diffID == diffID {
+			count++
+		}
+	}
+	return count
+}
+
+// addSnapInfo adds a newly committed snapshot to snapInfo so that future
+// diffIDSeqInChain calls using name as parent return correct results. It
+// returns a rollback closure that restores the prior state of snapInfo[name];
+// the caller uses this in a deferred error handler so that a failed Commit
+// undoes the in-memory write. When name already had an entry (e.g. a parallel
+// committer raced to commit the same chainID first, causing CommitActive to
+// return AlreadyExists), rollback restores that prior entry instead of deleting
+// it.
+func (lcc *layerContentCache) addSnapInfo(name, parent, diffID string) func() {
+	lcc.Lock()
+	defer lcc.Unlock()
+	prev, existed := lcc.snapInfo[name]
+	si := lccSnapshotInfo{
+		name:   name,
+		parent: parent,
+		diffID: diffID,
+	}
+	lcc.snapInfo[name] = si
+	return func() {
+		lcc.Lock()
+		defer lcc.Unlock()
+		if existed {
+			lcc.snapInfo[name] = prev
+		} else {
+			delete(lcc.snapInfo, name)
+		}
+	}
+}
+
+// deleteSnapInfo removes a snapshot from snapInfo when it is removed from the
+// snapshotter so that stale entries do not accumulate.
+func (lcc *layerContentCache) deleteSnapInfo(name string) {
+	lcc.Lock()
+	defer lcc.Unlock()
+	delete(lcc.snapInfo, name)
 }
 
 // orphanedContentPath returns a staging path derived from the given cache
@@ -118,19 +221,22 @@ func (lcc *layerContentCache) orphanedContentPath(path string) string {
 // LabelSkipApply. Labels are returned as a map so the caller can fold them into
 // the opts passed to storage.CreateSnapshot, preserving the Created == Updated
 // invariant (no storage.UpdateInfo call needed after creation).
-func (lcc *layerContentCache) computeLabels(diffID string, uid, gid int) (map[string]string, error) {
+func (lcc *layerContentCache) computeLabels(parent, diffID string, uid, gid int) (map[string]string, error) {
+	seq := lcc.diffIDSeqInChain(parent, diffID)
+
 	if uid == -1 || gid == -1 {
 		uid, gid = os.Getuid(), os.Getgid()
 	}
 
-	contentPath, err := lcc.contentPathFromParts(diffID, uid, gid)
+	contentPath, err := lcc.contentPathFromParts(diffID, uid, gid, seq)
 	if err != nil {
 		return nil, err
 	}
 
 	labels := map[string]string{
-		labelSnapshotUID: strconv.Itoa(uid),
-		labelSnapshotGID: strconv.Itoa(gid),
+		labelSnapshotUID:       strconv.Itoa(uid),
+		labelSnapshotGID:       strconv.Itoa(gid),
+		labelSnapshotDiffIDSeq: strconv.Itoa(seq),
 	}
 
 	f, err := os.Stat(contentPath)
@@ -148,7 +254,7 @@ func (lcc *layerContentCache) computeLabels(diffID string, uid, gid int) (map[st
 }
 
 // commitOpts returns opts that carry the labels needed by lcc.contentPath
-// into CommitActive. Both the diff-ID and the uid/gid ownership labels are
+// into CommitActive. The diff-ID, uid/gid ownership, and sequence number are all
 // re-injected from the active snapshot's info because CommitActive replaces
 // labels entirely with whatever opts supply; callers (e.g. pkg/rootfs/apply.go)
 // may not forward the diff-ID to Commit, so we preserve it here explicitly.
@@ -157,6 +263,7 @@ func (lcc *layerContentCache) commitOpts(info snapshots.Info) []snapshots.Opt {
 		snapshots.LabelSnapshotDiffID: info.Labels[snapshots.LabelSnapshotDiffID],
 		labelSnapshotUID:              info.Labels[labelSnapshotUID],
 		labelSnapshotGID:              info.Labels[labelSnapshotGID],
+		labelSnapshotDiffIDSeq:        info.Labels[labelSnapshotDiffIDSeq],
 	})}
 }
 

--- a/plugins/snapshots/overlay/lcc_test.go
+++ b/plugins/snapshots/overlay/lcc_test.go
@@ -94,6 +94,15 @@ func TestOverlayLCC(t *testing.T) {
 			t.Run("OrphanedStagingPreventsStaleHit", func(t *testing.T) {
 				testLCCOrphanedStagingPreventsStaleHit(t, newSnapshotter)
 			})
+			t.Run("DuplicateLayer", func(t *testing.T) {
+				testLCCDuplicateLayer(t, newSnapshotter)
+			})
+			t.Run("DuplicateLayer_CacheHit", func(t *testing.T) {
+				testLCCDuplicateLayerCacheHit(t, newSnapshotter)
+			})
+			t.Run("CountDiffIDInChain", func(t *testing.T) {
+				testLCCCountDiffIDInChain(t, newSnapshotter)
+			})
 		})
 	}
 }
@@ -134,7 +143,7 @@ func getCommittedBasePath(ctx context.Context, sn *testSnapshotter, root, key st
 }
 
 // testLCCContentPath verifies the cache path layout:
-// <root>/cache/<algo>.<hex>.<uid>.<gid>
+// <root>/cache/<algo>.<hex>.<uid>.<gid>.<seq>
 func testLCCContentPath(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	ctx := context.TODO()
 	root := t.TempDir()
@@ -148,12 +157,13 @@ func testLCCContentPath(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) 
 		snapshots.LabelSnapshotDiffID: "sha256:abcdef1234abcdef1234abcdef1234abcdef1234abcdef1234abcdef12345678",
 		labelSnapshotUID:              "0",
 		labelSnapshotGID:              "0",
+		labelSnapshotDiffIDSeq:        "0",
 	}}
 	got, err := sn.lcc.contentPath(info)
 	if err != nil {
 		t.Fatalf("lcc.contentPath: %v", err)
 	}
-	want := filepath.Join(root, "cache", "sha256.abcdef1234abcdef1234abcdef1234abcdef1234abcdef1234abcdef12345678.0.0")
+	want := filepath.Join(root, "cache", "sha256.abcdef1234abcdef1234abcdef1234abcdef1234abcdef1234abcdef12345678.0.0.0")
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -240,7 +250,7 @@ func testLCCCacheMiss(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 		t.Fatal(err)
 	}
 
-	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0.0")
 
 	// The extracted file must be accessible from the cache directory.
 	if _, err := os.Stat(filepath.Join(cacheDir, "file")); err != nil {
@@ -310,7 +320,7 @@ func testLCCCacheHit_Commit(t *testing.T, newSnapshotter testsuite.SnapshotterFu
 	const diffID = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
 
 	prepareAndCommitLCC(t, ctx, sn, root, "active-miss", "committed-miss", "", diffID)
-	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0.0")
 
 	// Cache-hit Prepare: fs/ is already a symlink.
 	labels := snapshots.WithLabels(map[string]string{snapshots.LabelSnapshotDiffID: diffID})
@@ -354,7 +364,7 @@ func testLCCConcurrentExtraction(t *testing.T, newSnapshotter testsuite.Snapshot
 
 	// Simulate the winning extractor: pre-populate the cache entry so that
 	// os.Rename inside Commit fails with ENOTEMPTY.
-	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000002.0.0")
+	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000002.0.0.0")
 	if err := os.Mkdir(cacheDir, 0755); err != nil {
 		t.Fatalf("Mkdir cache: %v", err)
 	}
@@ -396,8 +406,8 @@ func testLCCCleanup(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	prepareAndCommitLCC(t, ctx, sn, root, "active-1", "snap-1", "", diffID1)
 	prepareAndCommitLCC(t, ctx, sn, root, "active-2", "snap-2", "", diffID2)
 
-	cache1 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
-	cache2 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000002.0.0")
+	cache1 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0.0")
+	cache2 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000002.0.0.0")
 
 	for _, p := range []string{cache1, cache2} {
 		if _, err := os.Stat(p); err != nil {
@@ -458,7 +468,7 @@ func testLCCCleanup_SharedEntry(t *testing.T, newSnapshotter testsuite.Snapshott
 		t.Fatalf("Commit snap-b: %v", err)
 	}
 
-	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0.0")
 
 	// Remove snap-a: snap-b still references the cache entry, so it must survive.
 	if err := sn.Remove(ctx, "snap-a"); err != nil {
@@ -499,7 +509,7 @@ func testLCCOwnershipIsolation(t *testing.T, newSnapshotter testsuite.Snapshotte
 	// Snapshot with root ownership (uid=0, gid=0) — no remap labels.
 	prepareAndCommitLCC(t, ctx, sn, root, "active-root", "snap-root", "", diffID)
 
-	cache0 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+	cache0 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0.0")
 	if _, err := os.Stat(cache0); err != nil {
 		t.Fatalf("root-owned cache dir missing: %v", err)
 	}
@@ -512,6 +522,7 @@ func testLCCOwnershipIsolation(t *testing.T, newSnapshotter testsuite.Snapshotte
 		snapshots.LabelSnapshotDiffID: diffID,
 		labelSnapshotUID:              "1000",
 		labelSnapshotGID:              "1000",
+		labelSnapshotDiffIDSeq:        "0",
 	}}
 	pathRemapped, err := sn.lcc.contentPath(infoRemapped)
 	if err != nil {
@@ -668,7 +679,7 @@ func testLCCOrphanedStagingPreventsStaleHit(t *testing.T, newSnapshotter testsui
 
 	prepareAndCommitLCC(t, ctx, sn, root, "active-1", "snap-1", "", diffID)
 
-	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0.0")
 	if _, err := os.Stat(cacheDir); err != nil {
 		t.Fatalf("cache dir missing before test: %v", err)
 	}
@@ -721,6 +732,149 @@ func testLCCOrphanedStagingPreventsStaleHit(t *testing.T, newSnapshotter testsui
 	}
 	if err := sn.Remove(ctx, "active-race"); err != nil {
 		t.Fatalf("Remove active-race: %v", err)
+	}
+}
+
+// testLCCDuplicateLayer verifies that when the same diffID appears more than
+// once in a snapshot's parent chain, each occurrence gets a distinct seq number
+// and therefore a distinct cache directory. This is required because OverlayFS
+// rejects lower_dir sequences containing duplicate paths.
+//
+// The test builds the chain: root → X(seq=0) → Y(seq=0) → X(seq=1).
+// Both X snapshots must succeed, and their fs/ symlinks must point to distinct
+// cache directories.
+func testLCCDuplicateLayer(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffIDX = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+	const diffIDY = "sha256:0000000000000000000000000000000000000000000000000000000000000002"
+
+	// First occurrence of X: seq=0.
+	prepareAndCommitLCC(t, ctx, sn, root, "active-x0", "snap-x0", "", diffIDX)
+	// Y in between: seq=0 for Y.
+	prepareAndCommitLCC(t, ctx, sn, root, "active-y", "snap-y", "snap-x0", diffIDY)
+	// Second occurrence of X, parent chain contains one prior X → seq=1.
+	prepareAndCommitLCC(t, ctx, sn, root, "active-x1", "snap-x1", "snap-y", diffIDX)
+
+	cacheX0 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0.0")
+	cacheX1 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0.1")
+
+	if _, err := os.Stat(cacheX0); err != nil {
+		t.Errorf("cache dir for X seq=0 missing: %v", err)
+	}
+	if _, err := os.Stat(cacheX1); err != nil {
+		t.Errorf("cache dir for X seq=1 missing: %v", err)
+	}
+	if cacheX0 == cacheX1 {
+		t.Error("both X occurrences share a cache path — OverlayFS would reject duplicate lower_dir entries")
+	}
+
+	// snap-x0's fs/ must point to the seq=0 cache dir.
+	fsX0 := filepath.Join(getCommittedBasePath(ctx, sn, root, "snap-x0"), "fs")
+	checkSymlink(t, fsX0, cacheX0)
+
+	// snap-x1's fs/ must point to the seq=1 cache dir.
+	fsX1 := filepath.Join(getCommittedBasePath(ctx, sn, root, "snap-x1"), "fs")
+	checkSymlink(t, fsX1, cacheX1)
+}
+
+// testLCCDuplicateLayerCacheHit verifies that a snapshot whose parent chain
+// contains exactly one prior occurrence of the same diffID (seq=1) gets a cache
+// hit when the seq=1 directory already exists — i.e. seq is included in the
+// cache key for skip-apply decisions.
+func testLCCDuplicateLayerCacheHit(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffIDX = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+	const diffIDY = "sha256:0000000000000000000000000000000000000000000000000000000000000002"
+
+	// Build chain root → X(seq=0) → Y(seq=0) → X(seq=1), seeding both cache dirs.
+	prepareAndCommitLCC(t, ctx, sn, root, "active-x0", "snap-x0", "", diffIDX)
+	prepareAndCommitLCC(t, ctx, sn, root, "active-y", "snap-y", "snap-x0", diffIDY)
+	prepareAndCommitLCC(t, ctx, sn, root, "active-x1", "snap-x1", "snap-y", diffIDX)
+
+	// Now prepare another snapshot whose parent chain also contains exactly one
+	// prior X (snap-x0 via snap-y) → seq=1. The seq=1 cache dir already exists
+	// from snap-x1, so this must be a cache hit.
+	labels := snapshots.WithLabels(map[string]string{snapshots.LabelSnapshotDiffID: diffIDX})
+	if _, err := sn.Prepare(ctx, "active-x1-hit", "snap-y", labels); err != nil {
+		t.Fatalf("Prepare (seq=1 hit): %v", err)
+	}
+
+	info, err := sn.Stat(ctx, "active-x1-hit")
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Labels[snapshots.LabelSkipApply] != "true" {
+		t.Errorf("LabelSkipApply: got %q, want %q — seq=1 cache dir should trigger skip-apply", info.Labels[snapshots.LabelSkipApply], "true")
+	}
+
+	fsPath := filepath.Join(getBasePath(ctx, sn, root, "active-x1-hit"), "fs")
+	fi, err := os.Lstat(fsPath)
+	if err != nil {
+		t.Fatalf("Lstat fs: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("fs/ should be a symlink on seq=1 cache hit, got real dir")
+	}
+}
+
+// testLCCCountDiffIDInChain directly tests lccState.diffIDSeqInChain by building
+// committed snapshots and verifying the count at each point in the chain.
+func testLCCCountDiffIDInChain(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffIDX = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+	const diffIDY = "sha256:0000000000000000000000000000000000000000000000000000000000000002"
+
+	// Build chain: root → X → Y → X.
+	prepareAndCommitLCC(t, ctx, sn, root, "a-x0", "snap-x0", "", diffIDX)
+	prepareAndCommitLCC(t, ctx, sn, root, "a-y", "snap-y", "snap-x0", diffIDY)
+	prepareAndCommitLCC(t, ctx, sn, root, "a-x1", "snap-x1", "snap-y", diffIDX)
+
+	for _, tc := range []struct {
+		name   string
+		diffID string
+		parent string
+		want   int
+	}{
+		// No parent: count is always 0.
+		{"X at root", diffIDX, "", 0},
+		{"Y at root", diffIDY, "", 0},
+		// After snap-x0 (one X): X count is 1, Y count is 0.
+		{"X after snap-x0", diffIDX, "snap-x0", 1},
+		{"Y after snap-x0", diffIDY, "snap-x0", 0},
+		// After snap-y (one X, one Y): X count is still 1, Y count is 1.
+		{"X after snap-y", diffIDX, "snap-y", 1},
+		{"Y after snap-y", diffIDY, "snap-y", 1},
+		// After snap-x1 (two X, one Y): X count is 2, Y count is 1.
+		{"X after snap-x1", diffIDX, "snap-x1", 2},
+		{"Y after snap-x1", diffIDY, "snap-x1", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sn.lcc.diffIDSeqInChain(tc.parent, tc.diffID)
+			if got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/plugins/snapshots/overlay/lcc_test.go
+++ b/plugins/snapshots/overlay/lcc_test.go
@@ -1,0 +1,745 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package overlay
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/diff"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/storage"
+	"github.com/containerd/containerd/v2/core/snapshots/testsuite"
+	"github.com/containerd/containerd/v2/pkg/rootfs"
+	"github.com/containerd/containerd/v2/pkg/testutil"
+)
+
+// mockApplier is a diff.Applier for tests. fn is called each time Apply is
+// invoked. fn must not be nil; use a function that calls t.Fatal if Apply
+// should never be called in a particular test.
+type mockApplier struct {
+	fn func()
+}
+
+func (m *mockApplier) Apply(_ context.Context, desc ocispec.Descriptor, _ []mount.Mount, _ ...diff.ApplyOpt) (ocispec.Descriptor, error) {
+	m.fn()
+	return desc, nil
+}
+
+func TestOverlayLCC(t *testing.T) {
+	testutil.RequiresRoot(t)
+	optTestCases := map[string][]Opt{
+		"WithLayerContentCache":                    {WithLayerContentCache},
+		"WithLayerContentCache/AsynchronousRemove": {WithLayerContentCache, AsynchronousRemove},
+		"WithLayerContentCache/WithRemapIDs":       {WithLayerContentCache, WithRemapIDs},
+	}
+	for optsName, opts := range optTestCases {
+		t.Run(optsName, func(t *testing.T) {
+			newSnapshotter := newSnapshotterWithOpts(opts...)
+			t.Run("ContentPath", func(t *testing.T) {
+				testLCCContentPath(t, newSnapshotter)
+			})
+			t.Run("ContentPath_InvalidDiffID", func(t *testing.T) {
+				testLCCContentPath_InvalidDiffID(t, newSnapshotter)
+			})
+			t.Run("CacheMiss", func(t *testing.T) {
+				testLCCCacheMiss(t, newSnapshotter)
+			})
+			t.Run("CacheHit", func(t *testing.T) {
+				testLCCCacheHit(t, newSnapshotter)
+			})
+			t.Run("CacheHit_Commit", func(t *testing.T) {
+				testLCCCacheHit_Commit(t, newSnapshotter)
+			})
+			t.Run("ConcurrentExtraction", func(t *testing.T) {
+				testLCCConcurrentExtraction(t, newSnapshotter)
+			})
+			t.Run("Cleanup", func(t *testing.T) {
+				testLCCCleanup(t, newSnapshotter)
+			})
+			t.Run("Cleanup_SharedEntry", func(t *testing.T) {
+				testLCCCleanup_SharedEntry(t, newSnapshotter)
+			})
+			t.Run("OwnershipIsolation", func(t *testing.T) {
+				testLCCOwnershipIsolation(t, newSnapshotter)
+			})
+			t.Run("NoOpWithoutDiffID", func(t *testing.T) {
+				testLCCNoOpWithoutDiffID(t, newSnapshotter)
+			})
+			t.Run("ApplyLayerSkipsOnCacheHit", func(t *testing.T) {
+				testLCCApplyLayerSkipsOnCacheHit(t, newSnapshotter)
+			})
+			t.Run("OrphanedStagingPreventsStaleHit", func(t *testing.T) {
+				testLCCOrphanedStagingPreventsStaleHit(t, newSnapshotter)
+			})
+		})
+	}
+}
+
+// prepareAndCommitLCC runs the minimal Prepare → write file → Commit cycle for
+// a layer-unpack snapshot (one that carries LabelSnapshotDiffID). parent is the
+// name of the parent committed snapshot, or "" for a root snapshot. The diffID
+// label is passed to both Prepare and Commit, mirroring the real unpacker.
+func prepareAndCommitLCC(t *testing.T, ctx context.Context, sn *testSnapshotter, root, activeKey, committedName, parent, diffID string) {
+	t.Helper()
+	labels := snapshots.WithLabels(map[string]string{snapshots.LabelSnapshotDiffID: diffID})
+	if _, err := sn.Prepare(ctx, activeKey, parent, labels); err != nil {
+		t.Fatalf("Prepare %q: %v", activeKey, err)
+	}
+	fsDir := filepath.Join(getBasePath(ctx, sn, root, activeKey), "fs")
+	if err := os.WriteFile(filepath.Join(fsDir, "file"), []byte("content"), 0644); err != nil {
+		t.Fatalf("write into fs: %v", err)
+	}
+	if err := sn.Commit(ctx, committedName, activeKey, labels); err != nil {
+		t.Fatalf("Commit %q: %v", committedName, err)
+	}
+}
+
+// getCommittedBasePath returns the on-disk base directory for a committed
+// snapshot. storage.GetSnapshot only works for active/view snapshots;
+// storage.GetInfo works for all kinds.
+func getCommittedBasePath(ctx context.Context, sn *testSnapshotter, root, key string) string {
+	ctx, t, err := sn.ms.TransactionContext(ctx, false)
+	if err != nil {
+		panic(err)
+	}
+	defer t.Rollback()
+	id, _, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(root, "snapshots", id)
+}
+
+// testLCCContentPath verifies the cache path layout:
+// <root>/cache/<algo>.<hex>.<uid>.<gid>
+func testLCCContentPath(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	info := snapshots.Info{Labels: map[string]string{
+		snapshots.LabelSnapshotDiffID: "sha256:abcdef1234abcdef1234abcdef1234abcdef1234abcdef1234abcdef12345678",
+		labelSnapshotUID:              "0",
+		labelSnapshotGID:              "0",
+	}}
+	got, err := sn.lcc.contentPath(info)
+	if err != nil {
+		t.Fatalf("lcc.contentPath: %v", err)
+	}
+	want := filepath.Join(root, "cache", "sha256.abcdef1234abcdef1234abcdef1234abcdef1234abcdef1234abcdef12345678.0.0")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func testLCCContentPath_InvalidDiffID(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	for _, tc := range []struct {
+		name   string
+		diffID string
+	}{
+		{"no colon", "nodice"},
+		{"empty", ""},
+		{"no algorithm", ":hex"},
+		{"no hex", "algo:"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			info := snapshots.Info{Labels: map[string]string{
+				snapshots.LabelSnapshotDiffID: tc.diffID,
+				labelSnapshotUID:              "0",
+				labelSnapshotGID:              "0",
+			}}
+			if _, err := sn.lcc.contentPath(info); err == nil {
+				t.Errorf("expected error for diffID %q, got nil", tc.diffID)
+			}
+		})
+	}
+}
+
+// testLCCCacheMiss verifies the first-extraction path: fs/ is a real directory
+// before commit (so the unpacker can write into it), LabelSkipApply is not set,
+// and after commit the content is promoted to the cache and fs/ becomes a
+// symlink to the cache entry.
+func testLCCCacheMiss(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffID = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+	const activeKey = "active-1"
+	const name = "committed-1"
+
+	labels := snapshots.WithLabels(map[string]string{snapshots.LabelSnapshotDiffID: diffID})
+	if _, err := sn.Prepare(ctx, activeKey, "", labels); err != nil {
+		t.Fatal(err)
+	}
+
+	// On a cache miss fs/ must be a real directory so the unpacker can extract into it.
+	fsPath := filepath.Join(getBasePath(ctx, sn, root, activeKey), "fs")
+	fi, err := os.Lstat(fsPath)
+	if err != nil {
+		t.Fatalf("Lstat fs: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("fs/ should be a real directory on cache miss, got symlink")
+	}
+
+	// LabelSkipApply must not be set — the unpacker needs to extract.
+	info, err := sn.Stat(ctx, activeKey)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Labels[snapshots.LabelSkipApply] != "" {
+		t.Errorf("LabelSkipApply should not be set on cache miss, got %q", info.Labels[snapshots.LabelSkipApply])
+	}
+
+	// Simulate extraction.
+	if err := os.WriteFile(filepath.Join(fsPath, "file"), []byte("content"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := sn.Commit(ctx, name, activeKey, labels); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+
+	// The extracted file must be accessible from the cache directory.
+	if _, err := os.Stat(filepath.Join(cacheDir, "file")); err != nil {
+		t.Errorf("extracted file not in cache: %v", err)
+	}
+
+	// The committed snapshot's fs/ must be a symlink pointing at the cache entry.
+	checkSymlink(t, filepath.Join(getCommittedBasePath(ctx, sn, root, name), "fs"), cacheDir)
+}
+
+// testLCCCacheHit verifies the skip-apply path: when cached content already
+// exists, Prepare sets LabelSkipApply and creates fs/ as a symlink directly
+// without waiting for extraction.
+func testLCCCacheHit(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffID = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+
+	// Seed the cache via a first extraction.
+	prepareAndCommitLCC(t, ctx, sn, root, "active-miss", "committed-miss", "", diffID)
+
+	// Second Prepare for the same diffID → cache hit.
+	const hitKey = "active-hit"
+	labels := snapshots.WithLabels(map[string]string{snapshots.LabelSnapshotDiffID: diffID})
+	if _, err := sn.Prepare(ctx, hitKey, "", labels); err != nil {
+		t.Fatalf("Prepare (hit): %v", err)
+	}
+
+	// LabelSkipApply must be set so the unpacker skips extraction.
+	info, err := sn.Stat(ctx, hitKey)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Labels[snapshots.LabelSkipApply] != "true" {
+		t.Errorf("LabelSkipApply: got %q, want %q", info.Labels[snapshots.LabelSkipApply], "true")
+	}
+
+	// fs/ must already be a symlink — no extraction needed.
+	fsPath := filepath.Join(getBasePath(ctx, sn, root, hitKey), "fs")
+	fi, err := os.Lstat(fsPath)
+	if err != nil {
+		t.Fatalf("Lstat fs: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("fs/ should be a symlink on cache hit, got real dir")
+	}
+}
+
+// testLCCCacheHit_Commit verifies that committing a cache-hit snapshot — whose
+// fs/ is already a symlink — preserves the symlink and correctly records the
+// cache reference on the committed snapshot.
+func testLCCCacheHit_Commit(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffID = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+
+	prepareAndCommitLCC(t, ctx, sn, root, "active-miss", "committed-miss", "", diffID)
+	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+
+	// Cache-hit Prepare: fs/ is already a symlink.
+	labels := snapshots.WithLabels(map[string]string{snapshots.LabelSnapshotDiffID: diffID})
+	if _, err := sn.Prepare(ctx, "active-hit", "", labels); err != nil {
+		t.Fatalf("Prepare (hit): %v", err)
+	}
+
+	// Commit without writing anything — the unpacker skipped apply.
+	if err := sn.Commit(ctx, "committed-hit", "active-hit", labels); err != nil {
+		t.Fatalf("Commit (hit): %v", err)
+	}
+
+	// The committed snapshot's fs/ must still be a symlink to the same cache entry.
+	checkSymlink(t, filepath.Join(getCommittedBasePath(ctx, sn, root, "committed-hit"), "fs"), cacheDir)
+}
+
+// testLCCConcurrentExtraction verifies the race-loser path in
+// commitLCCSnapshotFSDirectory: when a concurrent extractor wins and the cache
+// entry already exists, the loser discards its local copy and symlinks to the
+// winner's content.
+func testLCCConcurrentExtraction(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffID = "sha256:0000000000000000000000000000000000000000000000000000000000000002"
+	labels := snapshots.WithLabels(map[string]string{snapshots.LabelSnapshotDiffID: diffID})
+	if _, err := sn.Prepare(ctx, "active-loser", "", labels); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write content into the active snapshot's fs/ (simulating extraction).
+	fsPath := filepath.Join(getBasePath(ctx, sn, root, "active-loser"), "fs")
+	if err := os.WriteFile(filepath.Join(fsPath, "loser-file"), []byte("loser"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Simulate the winning extractor: pre-populate the cache entry so that
+	// os.Rename inside Commit fails with ENOTEMPTY.
+	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000002.0.0")
+	if err := os.Mkdir(cacheDir, 0755); err != nil {
+		t.Fatalf("Mkdir cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "winner-file"), []byte("winner"), 0644); err != nil {
+		t.Fatalf("write winner: %v", err)
+	}
+
+	if err := sn.Commit(ctx, "committed-loser", "active-loser", labels); err != nil {
+		t.Fatalf("Commit (race loser): %v", err)
+	}
+
+	// The committed snapshot's fs/ must be a symlink to the winner's cache entry.
+	checkSymlink(t, filepath.Join(getCommittedBasePath(ctx, sn, root, "committed-loser"), "fs"), cacheDir)
+
+	// The winner's content must be intact; the loser's must have been discarded.
+	if _, err := os.Stat(filepath.Join(cacheDir, "winner-file")); err != nil {
+		t.Errorf("winner-file should survive in cache: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "loser-file")); err == nil {
+		t.Error("loser-file should have been discarded, but it exists in cache")
+	}
+}
+
+// testLCCCleanup verifies that orphaned cache entries are removed by Cleanup
+// and that live entries survive. The second half of the test removes the last
+// remaining reference and confirms the entry is collected on the next Cleanup.
+func testLCCCleanup(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffID1 = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+	const diffID2 = "sha256:0000000000000000000000000000000000000000000000000000000000000002"
+
+	prepareAndCommitLCC(t, ctx, sn, root, "active-1", "snap-1", "", diffID1)
+	prepareAndCommitLCC(t, ctx, sn, root, "active-2", "snap-2", "", diffID2)
+
+	cache1 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+	cache2 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000002.0.0")
+
+	for _, p := range []string{cache1, cache2} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("cache dir missing before remove: %v", err)
+		}
+	}
+
+	// Remove snap-1; its cache entry becomes orphaned.
+	if err := sn.Remove(ctx, "snap-1"); err != nil {
+		t.Fatalf("Remove snap-1: %v", err)
+	}
+	if err := sn.Cleanup(ctx); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if _, err := os.Stat(cache1); !os.IsNotExist(err) {
+		t.Error("orphaned cache1 should have been removed by Cleanup")
+	}
+	if _, err := os.Stat(cache2); err != nil {
+		t.Errorf("live cache2 should not have been removed: %v", err)
+	}
+
+	// Remove snap-2; cache2 now has no references and must be collected next.
+	if err := sn.Remove(ctx, "snap-2"); err != nil {
+		t.Fatalf("Remove snap-2: %v", err)
+	}
+	if err := sn.Cleanup(ctx); err != nil {
+		t.Fatalf("Cleanup (second): %v", err)
+	}
+
+	if _, err := os.Stat(cache2); !os.IsNotExist(err) {
+		t.Error("orphaned cache2 should have been removed by second Cleanup")
+	}
+}
+
+// testLCCCleanup_SharedEntry verifies that a cache entry shared by multiple
+// snapshots is not removed until the last referencing snapshot is gone.
+func testLCCCleanup_SharedEntry(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffID = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+
+	// First snapshot: seeds the cache.
+	prepareAndCommitLCC(t, ctx, sn, root, "active-a", "snap-a", "", diffID)
+
+	// Second snapshot for the same diffID: cache hit, fs/ is a symlink.
+	labels := snapshots.WithLabels(map[string]string{snapshots.LabelSnapshotDiffID: diffID})
+	if _, err := sn.Prepare(ctx, "active-b", "", labels); err != nil {
+		t.Fatalf("Prepare snap-b: %v", err)
+	}
+	if err := sn.Commit(ctx, "snap-b", "active-b", labels); err != nil {
+		t.Fatalf("Commit snap-b: %v", err)
+	}
+
+	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+
+	// Remove snap-a: snap-b still references the cache entry, so it must survive.
+	if err := sn.Remove(ctx, "snap-a"); err != nil {
+		t.Fatalf("Remove snap-a: %v", err)
+	}
+	if err := sn.Cleanup(ctx); err != nil {
+		t.Fatalf("Cleanup after snap-a: %v", err)
+	}
+	if _, err := os.Stat(cacheDir); err != nil {
+		t.Errorf("cache dir removed early while snap-b still holds a reference: %v", err)
+	}
+
+	// Remove snap-b: now orphaned.
+	if err := sn.Remove(ctx, "snap-b"); err != nil {
+		t.Fatalf("Remove snap-b: %v", err)
+	}
+	if err := sn.Cleanup(ctx); err != nil {
+		t.Fatalf("Cleanup after snap-b: %v", err)
+	}
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Error("cache dir should be removed after the last reference is gone")
+	}
+}
+
+// testLCCOwnershipIsolation verifies that two snapshots with the same diffID
+// but different uid/gid mappings get separate cache entries.
+func testLCCOwnershipIsolation(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffID = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+
+	// Snapshot with root ownership (uid=0, gid=0) — no remap labels.
+	prepareAndCommitLCC(t, ctx, sn, root, "active-root", "snap-root", "", diffID)
+
+	cache0 := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+	if _, err := os.Stat(cache0); err != nil {
+		t.Fatalf("root-owned cache dir missing: %v", err)
+	}
+
+	// Verify that a different uid/gid produces a distinct cache path.
+	// uid/gid are normally derived from the host process or idmap labels; here we
+	// test the path computation directly, since creating genuinely remapped
+	// snapshots requires kernel id-mapping support.
+	infoRemapped := snapshots.Info{Labels: map[string]string{
+		snapshots.LabelSnapshotDiffID: diffID,
+		labelSnapshotUID:              "1000",
+		labelSnapshotGID:              "1000",
+	}}
+	pathRemapped, err := sn.lcc.contentPath(infoRemapped)
+	if err != nil {
+		t.Fatalf("lcc.contentPath remapped: %v", err)
+	}
+	if pathRemapped == cache0 {
+		t.Error("remapped and root-owned snapshots share a cache path — isolation broken")
+	}
+}
+
+// testLCCNoOpWithoutDiffID verifies that LCC is fully transparent for snapshots
+// that do not carry LabelSnapshotDiffID (e.g. container-start Prepare calls).
+func testLCCNoOpWithoutDiffID(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	// Bypass testSnapshotter.Prepare to omit LabelSnapshotDiffID, simulating a
+	// container-start Prepare that carries no diff-ID.
+	if _, err := sn.snapshotter.Prepare(ctx, "no-diffid", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// No cache entries should be created — the cache dir itself is pre-created
+	// by NewSnapshotter but must remain empty for non-LCC snapshots.
+	cacheDir := filepath.Join(root, "cache")
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatalf("ReadDir cache: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("cache dir should be empty for non-LCC snapshot, got %d entries", len(entries))
+	}
+
+	// fs/ must be a real directory.
+	fsPath := filepath.Join(getBasePath(ctx, sn, root, "no-diffid"), "fs")
+	fi, err := os.Lstat(fsPath)
+	if err != nil {
+		t.Fatalf("Lstat fs: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Error("fs/ should be a real directory for non-LCC snapshot, got symlink")
+	}
+
+	if err := sn.Commit(ctx, "committed-no-lcc", "no-diffid"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cache dir must still be empty after commit.
+	entries, err = os.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatalf("ReadDir cache after commit: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("cache dir should be empty after non-LCC commit, got %d entries", len(entries))
+	}
+
+	// The committed snapshot's fs/ must also be a real directory, not a symlink.
+	committedFS := filepath.Join(getCommittedBasePath(ctx, sn, root, "committed-no-lcc"), "fs")
+	fi, err = os.Lstat(committedFS)
+	if err != nil {
+		t.Fatalf("Lstat committed fs: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Error("committed non-LCC snapshot fs/ should be a real directory, got symlink")
+	}
+}
+
+// testLCCApplyLayerSkipsOnCacheHit verifies that pkg/rootfs.ApplyLayerWithOpts
+// honours LabelSkipApply when the LCC cache is already populated: the diff.Applier
+// must not be called, and the committed snapshot's fs/ must be a symlink.
+//
+// This exercises the pkg/rootfs path (used by client.(*image).Unpack), which is
+// distinct from the core/unpack path exercised by ctr images import.
+func testLCCApplyLayerSkipsOnCacheHit(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	const diffID = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+
+	// Seed the LCC cache under a non-chainID name so the chain snapshot does not
+	// exist when ApplyLayerWithOpts is called below; it will enter applyLayers and
+	// find the cache already populated.
+	prepareAndCommitLCC(t, ctx, sn, root, "active-seed", "snap-seed", "", diffID)
+
+	// Apply must not be called on a cache hit.
+	var applyCalls int
+	a := &mockApplier{fn: func() {
+		applyCalls++
+		t.Error("Apply called on cache hit; extraction should be skipped by LabelSkipApply")
+	}}
+
+	layer := rootfs.Layer{
+		Diff: ocispec.Descriptor{Digest: digest.Digest(diffID)},
+		Blob: ocispec.Descriptor{},
+	}
+
+	// For a single layer with no parent chain, identity.ChainID equals the diff ID.
+	// ApplyLayerWithOpts stats that name first; it is absent, so applyLayers runs.
+	applied, err := rootfs.ApplyLayerWithOpts(ctx, layer, nil, sn, a, nil, nil)
+	if err != nil {
+		t.Fatalf("ApplyLayerWithOpts: %v", err)
+	}
+	if !applied {
+		t.Error("expected applied=true for a new chain snapshot")
+	}
+	if applyCalls != 0 {
+		t.Errorf("Apply called %d time(s) on cache hit; want 0", applyCalls)
+	}
+
+	// The committed snapshot's fs/ must be a symlink to the cache entry.
+	committedFS := filepath.Join(getCommittedBasePath(ctx, sn, root, diffID), "fs")
+	fi, err := os.Lstat(committedFS)
+	if err != nil {
+		t.Fatalf("Lstat committed fs: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error("committed snapshot fs/ should be a symlink on cache hit, got real dir")
+	}
+}
+
+// testLCCOrphanedStagingPreventsStaleHit verifies the race-prevention property
+// of the .orphaned staging mechanism: once lcc.orphanedPaths renames a cache
+// directory within the bolt transaction, a subsequent Prepare for the same diff
+// ID sees the path absent and takes a cache miss rather than creating a symlink
+// to the soon-to-be-deleted staging path.
+func testLCCOrphanedStagingPreventsStaleHit(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	ctx := context.TODO()
+	root := t.TempDir()
+	o, _, err := newSnapshotter(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sn := o.(*testSnapshotter)
+
+	// AsynchronousRemove defers disk cleanup to Cleanup(), so Remove() only
+	// touches bolt. This keeps the cache directory on disk after Remove so we
+	// can manually call lcc.orphanedPaths to simulate the rename-before-delete
+	// portion of Cleanup and verify Prepare then takes a cache miss.
+	if !sn.asyncRemove {
+		t.Skip("test requires AsynchronousRemove")
+	}
+
+	const diffID = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+
+	prepareAndCommitLCC(t, ctx, sn, root, "active-1", "snap-1", "", diffID)
+
+	cacheDir := filepath.Join(root, "cache", "sha256.0000000000000000000000000000000000000000000000000000000000000001.0.0")
+	if _, err := os.Stat(cacheDir); err != nil {
+		t.Fatalf("cache dir missing before test: %v", err)
+	}
+
+	// With async remove, Remove() only marks the snapshot deleted in bolt;
+	// the cache directory remains on disk until Cleanup() is called.
+	if err := sn.Remove(ctx, "snap-1"); err != nil {
+		t.Fatalf("Remove snap-1: %v", err)
+	}
+
+	// Simulate the bolt-transaction portion of Cleanup: rename the orphaned cache
+	// dir to a staging path. After this transaction commits, os.Stat(cacheDir)
+	// returns ENOENT even though the content still exists at the staging path.
+	var staged []string
+	if err := sn.ms.WithTransaction(ctx, true, func(ctx context.Context) error {
+		var err error
+		staged, err = sn.lcc.orphanedPaths(ctx)
+		return err
+	}); err != nil {
+		t.Fatalf("lcc.orphanedPaths: %v", err)
+	}
+	if len(staged) == 0 {
+		t.Fatal("expected at least one staged orphaned path")
+	}
+
+	// Original path must be absent — a concurrent Prepare after this point must
+	// not find it and create a symlink that would break when the staged dir is removed.
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Errorf("cache dir should be absent after staging, got: %v", err)
+	}
+
+	// Prepare for the same diffID must see a cache miss.
+	labels := snapshots.WithLabels(map[string]string{snapshots.LabelSnapshotDiffID: diffID})
+	if _, err := sn.Prepare(ctx, "active-race", "", labels); err != nil {
+		t.Fatalf("Prepare after staging: %v", err)
+	}
+	info, err := sn.Stat(ctx, "active-race")
+	if err != nil {
+		t.Fatalf("Stat active-race: %v", err)
+	}
+	if info.Labels[snapshots.LabelSkipApply] == "true" {
+		t.Error("Prepare set LabelSkipApply after cache staging: would create a dangling symlink")
+	}
+
+	// Cleanup: remove staged paths and the pending active snapshot.
+	for _, p := range staged {
+		if err := os.RemoveAll(p); err != nil {
+			t.Logf("RemoveAll %s: %v", p, err)
+		}
+	}
+	if err := sn.Remove(ctx, "active-race"); err != nil {
+		t.Fatalf("Remove active-race: %v", err)
+	}
+}
+
+// checkSymlink asserts that path is a symlink whose resolved target equals want.
+func checkSymlink(t *testing.T, path, want string) {
+	t.Helper()
+	fi, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat %q: %v", path, err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%q should be a symlink, got regular file/dir", path)
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		t.Fatalf("Readlink %q: %v", path, err)
+	}
+	abs := filepath.Join(filepath.Dir(path), target)
+	if abs != want {
+		t.Errorf("symlink %q → %q, want %q", path, abs, want)
+	}
+}

--- a/plugins/snapshots/overlay/overlay.go
+++ b/plugins/snapshots/overlay/overlay.go
@@ -48,6 +48,7 @@ type SnapshotterConfig struct {
 	mountOptions  []string
 	remapIDs      bool
 	slowChown     bool
+	lccEnabled    bool
 }
 
 // Opt is an option to configure the overlay snapshotter
@@ -113,6 +114,7 @@ type snapshotter struct {
 	options       []string
 	remapIDs      bool
 	slowChown     bool
+	lcc           *layerContentCache
 }
 
 // NewSnapshotter returns a Snapshotter which uses overlayfs. The overlayfs
@@ -146,6 +148,16 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
+	if config.lccEnabled {
+		if err := os.Mkdir(filepath.Join(root, "cache"), 0700); err != nil && !os.IsExist(err) {
+			return nil, err
+		}
+	}
+
+	lcc := &layerContentCache{
+		root:    root,
+		enabled: config.lccEnabled,
+	}
 
 	if !hasOption(config.mountOptions, "userxattr", false) {
 		// figure out whether "userxattr" option is recognized by the kernel && needed
@@ -170,6 +182,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		options:       config.mountOptions,
 		remapIDs:      config.remapIDs,
 		slowChown:     config.slowChown,
+		lcc:           lcc,
 	}, nil
 }
 
@@ -296,12 +309,21 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) (_ []mount.Mount, 
 
 func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
 	return o.ms.WithTransaction(ctx, true, func(ctx context.Context) error {
-		// grab the existing id
-		id, _, _, err := storage.GetInfo(ctx, key)
+		id, info, _, err := storage.GetInfo(ctx, key)
 		if err != nil {
 			return err
 		}
 
+		if o.lcc.enabled && hasDiffID(info) {
+			opts = append(opts, o.lcc.commitOpts(info)...)
+			if err := o.lcc.commitFSDir(id, info); err != nil {
+				return err
+			}
+		}
+
+		// TODO(klueska): Reevaluate disk usage for LCC layers; all snapshots
+		// sharing the same diffID point to the same backing content, so the
+		// reported usage will be over-counted across them.
 		usage, err := fs.DiskUsage(ctx, o.upperPath(id))
 		if err != nil {
 			return err
@@ -397,6 +419,14 @@ func (o *snapshotter) cleanupDirectories(ctx context.Context) (_ []string, err e
 }
 
 func (o *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, error) {
+	// Always collect orphaned LCC cache directories regardless of whether LCC
+	// is currently enabled, so that cache entries left behind by a previous
+	// enabled configuration are cleaned up even after the feature is disabled.
+	cleanup, err := o.lcc.orphanedPaths(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	ids, err := storage.IDMap(ctx)
 	if err != nil {
 		return nil, err
@@ -414,7 +444,6 @@ func (o *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, erro
 		return nil, err
 	}
 
-	cleanup := []string{}
 	for _, d := range dirs {
 		if _, ok := ids[d]; ok {
 			continue
@@ -448,23 +477,17 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		}
 	}()
 
+	// Extract labels from opts so uid/gid and LCC labels can be computed and
+	// folded into CreateSnapshot, preserving the Created == Updated invariant.
+	optLabels, err := labelsFromOpts(opts)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := o.ms.WithTransaction(ctx, true, func(ctx context.Context) (err error) {
-		snapshotDir := filepath.Join(o.root, "snapshots")
-		td, err = o.prepareDirectory(ctx, snapshotDir, kind)
-		if err != nil {
-			return fmt.Errorf("failed to create prepare snapshot dir: %w", err)
-		}
-
-		s, err = storage.CreateSnapshot(ctx, kind, key, parent, opts...)
-		if err != nil {
-			return fmt.Errorf("failed to create snapshot: %w", err)
-		}
-
-		_, info, _, err = storage.GetInfo(ctx, key)
-		if err != nil {
-			return fmt.Errorf("failed to get snapshot info: %w", err)
-		}
-
+		// Resolve the uid/gid that will own the snapshot's fs/ directory. This
+		// must happen before the LCC cache path is computed so that snapshots
+		// with different ownership are stored under distinct paths.
 		var (
 			mappedUID, mappedGID     = -1, -1
 			uidmapLabel, gidmapLabel string
@@ -475,11 +498,11 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		// will use bind mount. To be able to create file objects inside the
 		// rootfs -- just chown this only bound directory according to provided
 		// {uid,gid}map. In case of one/multiple parents -- chown upperdir.
-		if v, ok := info.Labels[snapshots.LabelSnapshotUIDMapping]; ok {
+		if v, ok := optLabels[snapshots.LabelSnapshotUIDMapping]; ok {
 			uidmapLabel = v
 			needsRemap = true
 		}
-		if v, ok := info.Labels[snapshots.LabelSnapshotGIDMapping]; ok {
+		if v, ok := optLabels[snapshots.LabelSnapshotGIDMapping]; ok {
 			gidmapLabel = v
 			needsRemap = true
 		}
@@ -496,19 +519,49 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 			mappedUID, mappedGID = int(root.Uid), int(root.Gid)
 		}
 
-		if mappedUID == -1 || mappedGID == -1 {
-			if len(s.ParentIDs) > 0 {
-				st, err := os.Stat(o.upperPath(s.ParentIDs[0]))
-				if err != nil {
-					return fmt.Errorf("failed to stat parent: %w", err)
-				}
-				stat, ok := st.Sys().(*syscall.Stat_t)
-				if !ok {
-					return fmt.Errorf("incompatible types after stat call: *syscall.Stat_t expected")
-				}
-				mappedUID = int(stat.Uid)
-				mappedGID = int(stat.Gid)
+		if (mappedUID == -1 || mappedGID == -1) && parent != "" {
+			parentID, _, _, err := storage.GetInfo(ctx, parent)
+			if err != nil {
+				return fmt.Errorf("failed to get parent snapshot info: %w", err)
 			}
+			st, err := os.Stat(o.upperPath(parentID))
+			if err != nil {
+				return fmt.Errorf("failed to stat parent: %w", err)
+			}
+			stat, ok := st.Sys().(*syscall.Stat_t)
+			if !ok {
+				return fmt.Errorf("incompatible types after stat call: *syscall.Stat_t expected")
+			}
+			mappedUID, mappedGID = int(stat.Uid), int(stat.Gid)
+		}
+
+		// With uid/gid resolved, fold in LCC labels if this is a layer-unpack Prepare.
+		// computeLabels stats the cache path to detect a hit; this must stay inside
+		// the write transaction so that a concurrent Cleanup cannot delete the cache
+		// directory between the stat and the prepareFSDir symlink that follows.
+		diffID := optLabels[snapshots.LabelSnapshotDiffID]
+		if o.lcc.enabled && diffID != "" {
+			lccLabels, err := o.lcc.computeLabels(diffID, mappedUID, mappedGID)
+			if err != nil {
+				return err
+			}
+			opts = append(opts, snapshots.WithLabels(lccLabels))
+		}
+
+		s, err = storage.CreateSnapshot(ctx, kind, key, parent, opts...)
+		if err != nil {
+			return fmt.Errorf("failed to create snapshot: %w", err)
+		}
+
+		_, info, _, err = storage.GetInfo(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to get snapshot info: %w", err)
+		}
+
+		snapshotDir := filepath.Join(o.root, "snapshots")
+		td, err = o.prepareDirectory(ctx, snapshotDir, info)
+		if err != nil {
+			return fmt.Errorf("failed to create prepare snapshot dir: %w", err)
 		}
 
 		if mappedUID != -1 && mappedGID != -1 {
@@ -530,23 +583,37 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 	return o.mounts(s, info), nil
 }
 
-func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
+func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, info snapshots.Info) (string, error) {
 	td, err := os.MkdirTemp(snapshotDir, "new-")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
-	if err := os.Mkdir(filepath.Join(td, "fs"), 0755); err != nil {
+	if o.lcc.enabled && hasDiffID(info) {
+		if err := o.lcc.prepareFSDir(info, td); err != nil {
+			return td, err
+		}
+	} else if err := os.Mkdir(filepath.Join(td, "fs"), 0755); err != nil {
 		return td, err
 	}
 
-	if kind == snapshots.KindActive {
+	if info.Kind == snapshots.KindActive {
 		if err := os.Mkdir(filepath.Join(td, "work"), 0711); err != nil {
 			return td, err
 		}
 	}
 
 	return td, nil
+}
+
+func labelsFromOpts(opts []snapshots.Opt) (map[string]string, error) {
+	var info snapshots.Info
+	for _, opt := range opts {
+		if err := opt(&info); err != nil {
+			return nil, err
+		}
+	}
+	return info.Labels, nil
 }
 
 func (o *snapshotter) mounts(s storage.Snapshot, info snapshots.Info) []mount.Mount {

--- a/plugins/snapshots/overlay/overlay.go
+++ b/plugins/snapshots/overlay/overlay.go
@@ -120,7 +120,7 @@ type snapshotter struct {
 // NewSnapshotter returns a Snapshotter which uses overlayfs. The overlayfs
 // diffs are stored under the provided root. A metadata file is stored under
 // the root.
-func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
+func NewSnapshotter(ctx context.Context, root string, opts ...Opt) (snapshots.Snapshotter, error) {
 	var config SnapshotterConfig
 	for _, opt := range opts {
 		if err := opt(&config); err != nil {
@@ -154,11 +154,6 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		}
 	}
 
-	lcc := &layerContentCache{
-		root:    root,
-		enabled: config.lccEnabled,
-	}
-
 	if !hasOption(config.mountOptions, "userxattr", false) {
 		// figure out whether "userxattr" option is recognized by the kernel && needed
 		userxattr, err := overlayutils.NeedsUserXAttr(root)
@@ -172,6 +167,11 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 
 	if !hasOption(config.mountOptions, "index", false) && supportsIndex() {
 		config.mountOptions = append(config.mountOptions, "index=off")
+	}
+
+	lcc, err := newLayerContentCache(ctx, config.ms, root, config.lccEnabled)
+	if err != nil {
+		return nil, err
 	}
 
 	return &snapshotter{
@@ -307,7 +307,19 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) (_ []mount.Mount, 
 	return o.mounts(s, info), nil
 }
 
-func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
+func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) (err error) {
+	// addSnapInfo is called optimistically inside the transaction so that bolt's
+	// write serialisation prevents any concurrent Prepare from observing a missing
+	// entry. If the transaction or its disk commit fails, the defer rolls it back
+	// via the closure returned by addSnapInfo, which restores any prior entry
+	// rather than blindly deleting (CommitActive can fail with AlreadyExists when
+	// a parallel committer wins the race for the same chainID).
+	var rollbackSnapInfo func()
+	defer func() {
+		if err != nil && rollbackSnapInfo != nil {
+			rollbackSnapInfo()
+		}
+	}()
 	return o.ms.WithTransaction(ctx, true, func(ctx context.Context) error {
 		id, info, _, err := storage.GetInfo(ctx, key)
 		if err != nil {
@@ -319,6 +331,9 @@ func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 			if err := o.lcc.commitFSDir(id, info); err != nil {
 				return err
 			}
+			parent := info.Parent
+			diffID := info.Labels[snapshots.LabelSnapshotDiffID]
+			rollbackSnapInfo = o.lcc.addSnapInfo(name, parent, diffID)
 		}
 
 		// TODO(klueska): Reevaluate disk usage for LCC layers; all snapshots
@@ -332,6 +347,7 @@ func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 		if _, err = storage.CommitActive(ctx, key, name, snapshots.Usage(usage), opts...); err != nil {
 			return fmt.Errorf("failed to commit snapshot %s: %w", key, err)
 		}
+
 		return nil
 	})
 }
@@ -350,6 +366,9 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 				if err := os.RemoveAll(dir); err != nil {
 					log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
 				}
+			}
+			if o.lcc.enabled {
+				o.lcc.deleteSnapInfo(key)
 			}
 		}
 	}()
@@ -483,7 +502,6 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 	if err != nil {
 		return nil, err
 	}
-
 	if err := o.ms.WithTransaction(ctx, true, func(ctx context.Context) (err error) {
 		// Resolve the uid/gid that will own the snapshot's fs/ directory. This
 		// must happen before the LCC cache path is computed so that snapshots
@@ -541,13 +559,14 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		// directory between the stat and the prepareFSDir symlink that follows.
 		diffID := optLabels[snapshots.LabelSnapshotDiffID]
 		if o.lcc.enabled && diffID != "" {
-			lccLabels, err := o.lcc.computeLabels(diffID, mappedUID, mappedGID)
+			lccLabels, err := o.lcc.computeLabels(parent, diffID, mappedUID, mappedGID)
 			if err != nil {
 				return err
 			}
 			opts = append(opts, snapshots.WithLabels(lccLabels))
 		}
 
+		// All opts are assembled; create the snapshot.
 		s, err = storage.CreateSnapshot(ctx, kind, key, parent, opts...)
 		if err != nil {
 			return fmt.Errorf("failed to create snapshot: %w", err)

--- a/plugins/snapshots/overlay/overlay_test.go
+++ b/plugins/snapshots/overlay/overlay_test.go
@@ -60,7 +60,7 @@ func (s *testSnapshotter) Prepare(ctx context.Context, key, parent string, opts 
 
 func newSnapshotterWithOpts(opts ...Opt) testsuite.SnapshotterFunc {
 	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
-		s, err := NewSnapshotter(root, opts...)
+		s, err := NewSnapshotter(ctx, root, opts...)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/plugins/snapshots/overlay/overlay_test.go
+++ b/plugins/snapshots/overlay/overlay_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"syscall"
 	"testing"
 
@@ -34,28 +35,49 @@ import (
 	"github.com/containerd/containerd/v2/internal/userns"
 	"github.com/containerd/containerd/v2/pkg/testutil"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// testSnapshotter embeds a *snapshotter and injects a unique LabelSnapshotDiffID
+// on every Prepare call, simulating the label the unpacker sets during image
+// unpack. Each call receives a distinct diffID derived from a per-instance
+// counter so that the LCC code path is exercised without creating spurious
+// cache hits when the testsuite reuses the same key across separate operations.
+// Cache-hit paths are covered by the dedicated lcc_test.go tests.
+type testSnapshotter struct {
+	*snapshotter
+	seq atomic.Int64
+}
+
+func (s *testSnapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	diffID := digest.FromString(fmt.Sprintf("prepare-%d", s.seq.Add(1))).String()
+	opts = append([]snapshots.Opt{snapshots.WithLabels(map[string]string{
+		snapshots.LabelSnapshotDiffID: diffID,
+	})}, opts...)
+	return s.snapshotter.Prepare(ctx, key, parent, opts...)
+}
+
 func newSnapshotterWithOpts(opts ...Opt) testsuite.SnapshotterFunc {
 	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
-		snapshotter, err := NewSnapshotter(root, opts...)
+		s, err := NewSnapshotter(root, opts...)
 		if err != nil {
 			return nil, nil, err
 		}
-
-		return snapshotter, func() error { return snapshotter.Close() }, nil
+		return &testSnapshotter{s.(*snapshotter), atomic.Int64{}}, func() error { return s.Close() }, nil
 	}
 }
 
 func TestOverlay(t *testing.T) {
 	testutil.RequiresRoot(t)
 	optTestCases := map[string][]Opt{
-		"no opt": nil,
-		// default in init()
-		"AsynchronousRemove": {AsynchronousRemove},
+		"no opt":                nil,
+		"WithLayerContentCache": {WithLayerContentCache},
+		"AsynchronousRemove":    {AsynchronousRemove},
+		"WithLayerContentCache/AsynchronousRemove": {WithLayerContentCache, AsynchronousRemove},
 		// idmapped mounts enabled
-		"WithRemapIDs": {WithRemapIDs},
+		"WithRemapIDs":                       {WithRemapIDs},
+		"WithLayerContentCache/WithRemapIDs": {WithLayerContentCache, WithRemapIDs},
 	}
 
 	for optsName, opts := range optTestCases {
@@ -344,7 +366,7 @@ func testOverlayRemappedBind(t *testing.T, newSnapshotter testsuite.SnapshotterF
 			t.Fatal(err)
 		}
 
-		if sn, ok := o.(*snapshotter); !ok || !sn.remapIDs {
+		if sn, ok := o.(*testSnapshotter); !ok || !sn.remapIDs {
 			t.Skip("overlayfs doesn't support idmapped mounts")
 		}
 
@@ -500,7 +522,7 @@ func testOverlayRemappedActive(t *testing.T, newSnapshotter testsuite.Snapshotte
 			t.Fatal(err)
 		}
 
-		if sn, ok := o.(*snapshotter); !ok || !sn.remapIDs {
+		if sn, ok := o.(*testSnapshotter); !ok || !sn.remapIDs {
 			t.Skip("overlayfs doesn't support idmapped mounts")
 		}
 
@@ -556,7 +578,7 @@ func testOverlayRemappedInvalidMapping(t *testing.T, newSnapshotter testsuite.Sn
 		t.Fatal(err)
 	}
 
-	if sn, ok := o.(*snapshotter); !ok || !sn.remapIDs {
+	if sn, ok := o.(*testSnapshotter); !ok || !sn.remapIDs {
 		t.Skip("overlayfs doesn't support idmapped mounts")
 	}
 
@@ -636,7 +658,7 @@ func testOverlayRemappedInvalidMapping(t *testing.T, newSnapshotter testsuite.Sn
 }
 
 func getBasePath(ctx context.Context, sn snapshots.Snapshotter, root, key string) string {
-	o := sn.(*snapshotter)
+	o := sn.(*testSnapshotter)
 	ctx, t, err := o.ms.TransactionContext(ctx, false)
 	if err != nil {
 		panic(err)
@@ -652,7 +674,7 @@ func getBasePath(ctx context.Context, sn snapshots.Snapshotter, root, key string
 }
 
 func getParents(ctx context.Context, sn snapshots.Snapshotter, root, key string) []string {
-	o := sn.(*snapshotter)
+	o := sn.(*testSnapshotter)
 	ctx, t, err := o.ms.TransactionContext(ctx, false)
 	if err != nil {
 		panic(err)

--- a/plugins/snapshots/overlay/plugin/plugin.go
+++ b/plugins/snapshots/overlay/plugin/plugin.go
@@ -121,7 +121,7 @@ func init() {
 			}
 
 			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
-			return overlay.NewSnapshotter(root, oOpts...)
+			return overlay.NewSnapshotter(ic.Context, root, oOpts...)
 		},
 	})
 }

--- a/plugins/snapshots/overlay/plugin/plugin.go
+++ b/plugins/snapshots/overlay/plugin/plugin.go
@@ -51,6 +51,21 @@ type Config struct {
 
 	// MountOptions are options used for the overlay mount (not used on bind mounts)
 	MountOptions []string `toml:"mount_options"`
+
+	// LayerContentCache enables layer content caching and deduplication.
+	// When true, identical layers shared across images are stored once in a
+	// cache directory and referenced via symlinks from each snapshot.
+	//
+	// Disabling this option while remaining on a version that supports it
+	// is safe: cache directories are still cleaned up during GC as
+	// snapshots that reference them are removed.
+	//
+	// However, cache directories will not be cleaned up during GC when
+	// downgrading to a version of containerd that does not support this feature
+	// (since the older version has no knowledge of them). Cache directories
+	// can be manually deleted in this case, but only after ensuring no
+	// snapshot fs/ directory holds a symlink into them.
+	LayerContentCache bool `toml:"layer_content_cache"`
 }
 
 func init() {
@@ -81,6 +96,9 @@ func init() {
 
 			if len(config.MountOptions) > 0 {
 				oOpts = append(oOpts, overlay.WithMountOptions(config.MountOptions))
+			}
+			if config.LayerContentCache {
+				oOpts = append(oOpts, overlay.WithLayerContentCache)
 			}
 			if ok, err := overlayutils.SupportsIDMappedMounts(); err == nil && ok {
 				oOpts = append(oOpts, overlay.WithRemapIDs)

--- a/script/setup/install-flox
+++ b/script/setup/install-flox
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eu -o pipefail
+
+SUDO=''
+if (( $EUID != 0 )); then
+    SUDO='sudo'
+fi
+
+: "${FLOX_VERSION:=1.11.4}"
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64|aarch64) ;;
+    *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+$SUDO apt-get update
+$SUDO apt-get install -y --no-install-recommends curl ca-certificates xz-utils
+$SUDO mkdir -p /nix
+
+curl -fsSLo /tmp/flox.deb \
+    "https://downloads.flox.dev/by-env/stable/deb/flox-${FLOX_VERSION}.${ARCH}-linux.deb"
+curl -fsSLo /tmp/flox.SHA256SUMS \
+    "https://downloads.flox.dev/by-env/stable/flox-${FLOX_VERSION}.SHA256SUMS"
+grep "flox-${FLOX_VERSION}.${ARCH}-linux.deb$" /tmp/flox.SHA256SUMS \
+    | sed "s|flox-${FLOX_VERSION}.${ARCH}-linux.deb|/tmp/flox.deb|" \
+    | sha256sum --check --strict
+$SUDO apt-get install -y --no-install-recommends /tmp/flox.deb
+$SUDO rm -rf /var/lib/apt/lists/*
+rm -f /tmp/flox.deb /tmp/flox.SHA256SUMS


### PR DESCRIPTION
Adds a `layer_content_cache` option to the overlayfs snapshotter that deduplicates extracted layer content across images at the snapshotter level.

overlayfs follows symlinks when resolving lowerdir paths, so a snapshot's `fs/` directory does not need to privately own its content. This PR extracts each layer once into a shared cache at `<root>/cache/<algo>.<hex>.<uid>.<gid>/` and replaces `fs/` with a symlink. On a cache hit, `Prepare` sets `LabelSkipApply` and the unpacker skips extraction.

Concurrent first-time extractors race via `os.Rename`; losers symlink to the winner. Cache entries are garbage-collected when the last referencing snapshot is removed. Cleanup runs unconditionally even when the feature is disabled, so cache directories left over from a previously-enabled configuration are cleaned up. Chain IDs, snapshot keys, and all other snapshotter semantics are unchanged.

Two label constants previously package-private in `core/unpack` are exported from `core/snapshots` so the snapshotter can use them without an import cycle. The `pkg/rootfs.applyLayers` path (used by `ctr images pull`) is also fixed to forward `LabelSnapshotDiffID` on `Prepare` and honour `LabelSkipApply`; without this, LCC would be silently bypassed on that path and a cache hit would corrupt the cache directory by extracting on top of it.

The existing overlay unit and snapshotter contract tests are re-run with LCC enabled to confirm transparency. A new `lcc_test.go` covers the LCC-specific code paths directly, and an end-to-end test package under `integration/lcc/` exercises the full stack — image import, container execution, cross-image deduplication, and GC — including a test against a real flox environment to validate behaviour with Nix store path layers. A non-blocking `test-overlay-lcc` CI job runs the integration suite on every PR.

## Open questions

- `fs.DiskUsage` follows the `fs/` symlink to the shared cache directory, so every snapshot sharing a layer reports the full layer size. Should shared cache entries be excluded from per-snapshot usage accounting?

- When `LabelSkipApply` is set, the unpacker skips `Apply` and therefore skips digest verification. Correctness relies on the content having been verified at first-commit time. Is that guarantee sufficient, or should a re-verification step be added?

Closes #13307
