### PR TITLE
runtime: invoke shim.Delete when connection is closed

### DIFF
--- a/core/runtime/v2/shim_manager.go
+++ b/core/runtime/v2/shim_manager.go
@@ -257,6 +257,26 @@ func (m *ShimManager) Start(ctx context.Context, id string, bundle *Bundle, opts
 		shouldInvokeShimBinary = true
 	}
 
+	runtimePath, err := m.resolveRuntimePath(opts.Runtime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve runtime path: %w", err)
+	}
+
+	b := shimBinary(bundle, shimBinaryConfig{
+		runtime:      runtimePath,
+		address:      m.containerdAddress,
+		ttrpcAddress: m.containerdTTRPCAddress,
+		env:          m.env,
+	})
+	closefunc := func() {
+		log.G(ctx).WithField("id", id).Info("shim disconnected")
+		cleanupAfterDeadShim(context.WithoutCancel(ctx), id, m.shims, m.events, b)
+		// Remove self from the runtime task list. Even though the cleanupAfterDeadShim()
+		// would publish taskExit event, but the shim.Delete() would always failed with ttrpc
+		// disconnect and there is no chance to remove this dead task from runtime task lists.
+		// Thus it's better to delete it here.
+		m.shims.Delete(ctx, id)
+	}
 	if !shouldInvokeShimBinary {
 		// Write sandbox ID this task belongs to.
 		if err := os.WriteFile(filepath.Join(bundle.Path, "sandbox"), []byte(opts.SandboxID), 0600); err != nil {
@@ -266,8 +286,7 @@ func (m *ShimManager) Start(ctx context.Context, id string, bundle *Bundle, opts
 		if err := writeBootstrapParams(filepath.Join(bundle.Path, "bootstrap.json"), params); err != nil {
 			return nil, fmt.Errorf("failed to write bootstrap.json for bundle %s: %w", bundle.Path, err)
 		}
-
-		shim, err := loadShim(ctx, bundle, func() {})
+		shim, err := loadShim(ctx, bundle, closefunc)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load sandbox task %q: %w", opts.SandboxID, err)
 		}
@@ -279,7 +298,7 @@ func (m *ShimManager) Start(ctx context.Context, id string, bundle *Bundle, opts
 		return shim, nil
 	}
 
-	shim, err := m.startShim(ctx, bundle, id, opts)
+	shim, err := m.startShim(ctx, opts, b, closefunc)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +315,7 @@ func (m *ShimManager) Start(ctx context.Context, id string, bundle *Bundle, opts
 	return shim, nil
 }
 
-func (m *ShimManager) startShim(ctx context.Context, bundle *Bundle, id string, opts runtime.CreateOpts) (*shim, error) {
+func (m *ShimManager) startShim(ctx context.Context, opts runtime.CreateOpts, b *binary, onClose func()) (*shim, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, err
@@ -307,29 +326,7 @@ func (m *ShimManager) startShim(ctx context.Context, bundle *Bundle, id string, 
 	if topts == nil || topts.GetValue() == nil {
 		topts = opts.RuntimeOptions
 	}
-
-	runtimePath, err := m.resolveRuntimePath(opts.Runtime)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve runtime path: %w", err)
-	}
-
-	b := shimBinary(bundle, shimBinaryConfig{
-		runtime:      runtimePath,
-		address:      m.containerdAddress,
-		ttrpcAddress: m.containerdTTRPCAddress,
-		socketDir:    m.socketDir,
-		env:          m.env,
-	})
-	shim, err := b.Start(ctx, typeurl.MarshalProto(topts), func() {
-		log.G(ctx).WithField("id", id).Info("shim disconnected")
-
-		cleanupAfterDeadShim(context.WithoutCancel(ctx), id, m.shims, m.events, b)
-		// Remove self from the runtime task list. Even though the cleanupAfterDeadShim()
-		// would publish taskExit event, but the shim.Delete() would always failed with ttrpc
-		// disconnect and there is no chance to remove this dead task from runtime task lists.
-		// Thus it's better to delete it here.
-		m.shims.Delete(ctx, id)
-	})
+	shim, err := b.Start(ctx, typeurl.MarshalProto(topts), onClose)
 	if err != nil {
 		return nil, fmt.Errorf("start failed: %w", err)
 	}

--- a/core/runtime/v2/shim_manager.go
+++ b/core/runtime/v2/shim_manager.go
@@ -283,7 +283,27 @@ func (m *ShimManager) Start(ctx context.Context, id string, bundle *Bundle, opts
 			return nil, fmt.Errorf("failed to write bootstrap.json for bundle %s: %w", bundle.Path, err)
 		}
 
-		shim, err := loadShim(ctx, bundle, func() {})
+		runtimePath, err := m.resolveRuntimePath(opts.Runtime)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve runtime path: %w", err)
+		}
+		b := shimBinary(bundle, shimBinaryConfig{
+			runtime:      runtimePath,
+			address:      m.containerdAddress,
+			ttrpcAddress: m.containerdTTRPCAddress,
+			socketDir:    m.socketDir,
+			env:          m.env,
+		})
+		shim, err := loadShim(ctx, bundle, func() {
+			log.G(ctx).WithField("id", id).Info("shim disconnected")
+
+			cleanupAfterDeadShim(context.WithoutCancel(ctx), id, m.shims, m.events, b)
+			// Remove self from the runtime task list. Even though the cleanupAfterDeadShim()
+			// would publish taskExit event, but the shim.Delete() would always failed with ttrpc
+			// disconnect and there is no chance to remove this dead task from runtime task lists.
+			// Thus it's better to delete it here.
+			m.shims.Delete(ctx, id)
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to load sandbox task %q: %w", opts.SandboxID, err)
 		}

--- a/integration/container_leak_linux_test.go
+++ b/integration/container_leak_linux_test.go
@@ -1,0 +1,71 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuncLeakWithShimKilled(t *testing.T) {
+	testImage := images.Get(images.BusyBox)
+	cnConfig := ContainerConfig(
+		"test-container-dir-leak",
+		testImage,
+		WithCommand("sh", "-c", "sleep 365d"),
+	)
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "test-container-dir-leak-after-shimkilled")
+	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.NoError(t, err)
+	t.Logf("Start the container %s", cn)
+	require.NoError(t, runtimeService.StartContainer(cn))
+	dir := fmt.Sprintf("/run/containerd/runc/k8s.io/%s", cn)
+	_, err = os.Stat(dir)
+	require.NoError(t, err)
+	pid := getShimPid(t, sb)
+	KillPid(pid)
+	runtimeService.RemoveContainer(cn)
+	// wait the leak dir to be deleted.
+	result := make(chan error)
+	go func() {
+		for {
+			time.Sleep(time.Millisecond * 100)
+			_, err = os.Stat(dir)
+			if err == nil {
+				continue
+			}
+			result <- err
+			break
+		}
+	}()
+	select {
+	case <-time.After(time.Second * 30):
+		t.Fatalf("dir %s should be deleted", dir)
+	case res := <-result:
+		if !errors.Is(res, os.ErrNotExist) {
+			t.Fatalf("err should be %s but got %s", os.ErrNotExist, res.Error())
+		}
+	}
+	//wait the task to be removed
+	time.Sleep(time.Second * 3)
+}

--- a/integration/issue7496_shutdown_linux_test.go
+++ b/integration/issue7496_shutdown_linux_test.go
@@ -117,6 +117,58 @@ func TestKillShimPublishesTaskExitAndDeleteEvents(t *testing.T) {
 	waitForTaskExitDeleteEvents(t, sbID, eventCh, eventErrCh, 10*time.Second)
 }
 
+// Regression test for https://github.com/containerd/containerd/issues/13293 (orphaned shim state after shim SIGKILL).
+// This test asserts that containerd publishes task exit and delete events for a container when the shim disconnects.
+func TestKillShimPublishesTaskExitAndDeleteEventsForContainer(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "k8s.io")
+
+	sbConfig := PodSandboxConfig("sandbox", t.Name(), WithHostNetwork)
+	sbID, err := runtimeService.RunPodSandbox(sbConfig, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, runtimeService.StopPodSandbox(sbID))
+		require.NoError(t, runtimeService.RemovePodSandbox(sbID))
+	})
+	testImage := images.Get(images.BusyBox)
+	EnsureImageExists(t, testImage)
+	t.Log("Create a container - sleep 1d")
+	containerName := "test-container"
+	cnConfig := ContainerConfig(
+		containerName,
+		testImage,
+		WithCommand("sh", "-c", "sleep 1d"),
+		WithPidNamespace(runtime.NamespaceMode_CONTAINER),
+	)
+	cnID, err := runtimeService.CreateContainer(sbID, cnConfig, sbConfig)
+	require.NoError(t, err)
+
+	t.Log("Start the container")
+	require.NoError(t, runtimeService.StartContainer(cnID))
+
+	shimCli := connectToShim(ctx, t, containerdEndpoint, 3, sbID)
+	shimPID := shimPid(ctx, t, shimCli)
+
+	eventCh, eventErrCh := containerdClient.EventService().Subscribe(ctx,
+		fmt.Sprintf(`topic=="%s",event.container_id=="%s"`, ctrdruntime.TaskExitEventTopic, cnID),
+		fmt.Sprintf(`topic=="%s",event.container_id=="%s"`, ctrdruntime.TaskDeleteEventTopic, cnID),
+	)
+
+	require.NoError(t, syscall.Kill(int(shimPID), syscall.SIGKILL))
+	waitForTaskExitDeleteEvents(t, cnID, eventCh, eventErrCh, 10*time.Second)
+
+	// Wait for the container to exit and ensure it is fully cleaned up.
+	require.NoError(t, Eventually(func() (bool, error) {
+		s, err := runtimeService.ContainerStatus(cnID)
+		if err != nil {
+			return false, err
+		}
+		if s.State == runtime.ContainerState_CONTAINER_EXITED {
+			return true, nil
+		}
+		return false, nil
+	}, 1000*time.Millisecond, 30*time.Second))
+}
+
 func waitForTaskExitDeleteEvents(t *testing.T, id string,
 	ch <-chan *events.Envelope, errCh <-chan error, timeout time.Duration,
 ) {


### PR DESCRIPTION
fix https://github.com/containerd/containerd/issues/13293
(ci failed for other reason I find if run github actions many times CI failure is becoming more likely )

ping @fuweid  @mikebrow  can you take a look thanks

```release-note
Invoke shim delete to clean up shim process when connection is closed
```
