### PR TITLE
config: preserve legacy grpc address across sparse imports

### DIFF
--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -249,24 +249,52 @@ func serviceMigrate(ctx context.Context, c *Config) error {
 	grpcMaxSend := c.GRPC.MaxSendMsgSize
 	grpcHasLegacy := grpcAddress != "" || grpcUID != 0 || grpcGID != 0 || grpcMaxRecv != 0 || grpcMaxSend != 0
 	if grpcHasLegacy && c.Plugins["io.containerd.server.v1.grpc"] == nil {
-		c.Plugins["io.containerd.server.v1.grpc"] = map[string]any{
-			"address":               grpcAddress,
-			"uid":                   grpcUID,
-			"gid":                   grpcGID,
-			"max_recv_message_size": grpcMaxRecv,
-			"max_send_message_size": grpcMaxSend,
+		grpcConfig := map[string]any{}
+		if grpcAddress != "" {
+			grpcConfig["address"] = grpcAddress
+			// Preserve legacy socket ownership semantics. In v3 configs, uid/gid
+			// default to 0 and cannot be distinguished from an explicit 0.
+			grpcConfig["uid"] = grpcUID
+			grpcConfig["gid"] = grpcGID
+		} else {
+			if grpcUID != 0 {
+				grpcConfig["uid"] = grpcUID
+			}
+			if grpcGID != 0 {
+				grpcConfig["gid"] = grpcGID
+			}
 		}
+		if grpcMaxRecv != 0 {
+			grpcConfig["max_recv_message_size"] = grpcMaxRecv
+		}
+		if grpcMaxSend != 0 {
+			grpcConfig["max_send_message_size"] = grpcMaxSend
+		}
+		c.Plugins["io.containerd.server.v1.grpc"] = grpcConfig
 	}
 	if c.GRPC.TCPAddress != "" && c.Plugins["io.containerd.server.v1.grpc-tcp"] == nil {
-		c.Plugins["io.containerd.server.v1.grpc-tcp"] = map[string]any{
-			"address":               c.GRPC.TCPAddress,
-			"tls_ca":                c.GRPC.TCPTLSCA,
-			"tls_cert":              c.GRPC.TCPTLSCert,
-			"tls_key":               c.GRPC.TCPTLSKey,
-			"tls_common_name":       c.GRPC.TCPTLSCName,
-			"max_recv_message_size": grpcMaxRecv,
-			"max_send_message_size": grpcMaxSend,
+		grpcTCPConfig := map[string]any{
+			"address": c.GRPC.TCPAddress,
 		}
+		if c.GRPC.TCPTLSCA != "" {
+			grpcTCPConfig["tls_ca"] = c.GRPC.TCPTLSCA
+		}
+		if c.GRPC.TCPTLSCert != "" {
+			grpcTCPConfig["tls_cert"] = c.GRPC.TCPTLSCert
+		}
+		if c.GRPC.TCPTLSKey != "" {
+			grpcTCPConfig["tls_key"] = c.GRPC.TCPTLSKey
+		}
+		if c.GRPC.TCPTLSCName != "" {
+			grpcTCPConfig["tls_common_name"] = c.GRPC.TCPTLSCName
+		}
+		if grpcMaxRecv != 0 {
+			grpcTCPConfig["max_recv_message_size"] = grpcMaxRecv
+		}
+		if grpcMaxSend != 0 {
+			grpcTCPConfig["max_send_message_size"] = grpcMaxSend
+		}
+		c.Plugins["io.containerd.server.v1.grpc-tcp"] = grpcTCPConfig
 	}
 	if grpcHasLegacy || c.GRPC.TCPAddress != "" {
 		c.GRPC = GRPCConfig{}

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -29,7 +29,9 @@ import (
 	"github.com/pelletier/go-toml/v2"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/log/logtest"
 )
@@ -178,6 +180,144 @@ disabled_plugins = ["io.containerd.v1.xyz"]
 	assert.Equal(t, 2, out.Version)
 	assert.Equal(t, "/var/lib/containerd", out.Root)
 	assert.Equal(t, []string{"io.containerd.v1.xyz"}, out.DisabledPlugins)
+}
+
+func TestLoadConfigWithV3GRPCImportsMergeSparseKeys(t *testing.T) {
+	const (
+		rootAddress   = "/tmp/root-containerd.sock"
+		importAddress = "/tmp/import-containerd.sock"
+		maxRecvSize   = 67108864
+		maxSendSize   = 33554432
+	)
+
+	var (
+		rootAddressConfig = fmt.Sprintf(`
+version = 3
+imports = ["data2.toml"]
+
+[grpc]
+  address = %q
+`, rootAddress)
+
+		rootMaxSendConfig = fmt.Sprintf(`
+version = 3
+imports = ["data2.toml"]
+
+[grpc]
+  max_send_message_size = %d
+`, maxSendSize)
+
+		rootAddressMaxSendConfig = fmt.Sprintf(`
+version = 3
+imports = ["data2.toml"]
+
+[grpc]
+  address = %q
+  max_send_message_size = %d
+`, rootAddress, maxSendSize)
+
+		importAddressConfig = fmt.Sprintf(`
+version = 3
+
+[grpc]
+  address = %q
+`, importAddress)
+
+		importMaxRecvConfig = fmt.Sprintf(`
+version = 3
+
+[grpc]
+  max_recv_message_size = %d
+`, maxRecvSize)
+
+		importMaxSendConfig = fmt.Sprintf(`
+version = 3
+
+[grpc]
+  max_send_message_size = %d
+`, maxSendSize)
+	)
+
+	tests := []struct {
+		name             string
+		rootConfig       string
+		importConfig     string
+		wantAddress      string
+		wantMaxRecvSize  int
+		wantMaxSendSize  int
+		wantTTRPCAddress string
+	}{
+		{
+			name:             "import without address key does not overwrite root address",
+			rootConfig:       rootAddressConfig,
+			importConfig:     importMaxSendConfig,
+			wantAddress:      rootAddress,
+			wantMaxRecvSize:  defaults.DefaultMaxRecvMsgSize,
+			wantMaxSendSize:  maxSendSize,
+			wantTTRPCAddress: rootAddress + ".ttrpc",
+		},
+		{
+			name:             "import address key is merged into root grpc config",
+			rootConfig:       rootMaxSendConfig,
+			importConfig:     importAddressConfig,
+			wantAddress:      importAddress,
+			wantMaxRecvSize:  defaults.DefaultMaxRecvMsgSize,
+			wantMaxSendSize:  maxSendSize,
+			wantTTRPCAddress: importAddress + ".ttrpc",
+		},
+		{
+			name:             "import address key overwrites root address",
+			rootConfig:       rootAddressMaxSendConfig,
+			importConfig:     importAddressConfig,
+			wantAddress:      importAddress,
+			wantMaxRecvSize:  defaults.DefaultMaxRecvMsgSize,
+			wantMaxSendSize:  maxSendSize,
+			wantTTRPCAddress: importAddress + ".ttrpc",
+		},
+		{
+			name:            "default address is kept when root and import omit address key",
+			rootConfig:      rootMaxSendConfig,
+			importConfig:    importMaxRecvConfig,
+			wantAddress:     defaults.DefaultAddress,
+			wantMaxRecvSize: maxRecvSize,
+			wantMaxSendSize: maxSendSize,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(tc.rootConfig), 0o600)
+			require.NoError(t, err)
+
+			err = os.WriteFile(filepath.Join(tempDir, "data2.toml"), []byte(tc.importConfig), 0o600)
+			require.NoError(t, err)
+
+			out := Config{
+				Version: version.ConfigVersion,
+				Plugins: map[string]any{
+					"io.containerd.server.v1.grpc": map[string]any{
+						"address":               defaults.DefaultAddress,
+						"max_recv_message_size": defaults.DefaultMaxRecvMsgSize,
+						"max_send_message_size": defaults.DefaultMaxSendMsgSize,
+					},
+				},
+			}
+			err = LoadConfig(context.Background(), filepath.Join(tempDir, "data1.toml"), &out)
+			require.NoError(t, err)
+
+			grpcPlugin := out.Plugins["io.containerd.server.v1.grpc"].(map[string]any)
+			require.Equal(t, tc.wantAddress, grpcPlugin["address"])
+			require.Equal(t, tc.wantMaxRecvSize, grpcPlugin["max_recv_message_size"])
+			require.Equal(t, tc.wantMaxSendSize, grpcPlugin["max_send_message_size"])
+
+			if tc.wantTTRPCAddress != "" {
+				ttrpcPlugin := out.Plugins["io.containerd.server.v1.ttrpc"].(map[string]any)
+				require.Equal(t, tc.wantTTRPCAddress, ttrpcPlugin["address"])
+			}
+		})
+	}
 }
 
 func TestLoadConfigWithCircularImports(t *testing.T) {


### PR DESCRIPTION
When migrating v3 [grpc] config to the v4 server plugin config, only emit fields that were actually set in the legacy config. This prevents a sparse imported [grpc] section, such as one only setting max_send_message_size, from generating address = "" and overwriting the address migrated from the root config.

Add table-driven coverage for sparse legacy grpc imports, including address preservation, imported address override, and default address retention when no imported config specifies address.

Fixes: #13316 

@dmcgowan @berkayoz