### PR TITLE
Deprecate shim.Command

### DIFF
--- a/core/runtime/v2/binary.go
+++ b/core/runtime/v2/binary.go
@@ -64,7 +64,9 @@ type binary struct {
 }
 
 func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ *shim, err error) {
-	cmd, err := client.Command(
+	// containerd daemon is the intended caller of client.Command; the deprecation
+	// targets external callers.
+	cmd, err := client.Command( //nolint:staticcheck // SA1019
 		ctx,
 		&client.CommandConfig{
 			ID:           b.bundle.ID,
@@ -165,7 +167,9 @@ func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 		bundlePath = b.bundle.Path
 	}
 
-	cmd, err := client.Command(ctx,
+	// containerd daemon is the intended caller of client.Command; the deprecation
+	// targets external callers.
+	cmd, err := client.Command(ctx, //nolint:staticcheck // SA1019
 		&client.CommandConfig{
 			ID:           b.bundle.ID,
 			RuntimePath:  b.runtime,

--- a/pkg/shim/util.go
+++ b/pkg/shim/util.go
@@ -57,11 +57,13 @@ type CommandConfig struct {
 	SocketDir    string
 }
 
-// Command returns the shim command with the provided args and configuration
+// Command returns the shim command with the provided args and configuration.
 //
-// TODO(refactor): move this function to core containerd runtime. This function is only used
-// by the containerd daemon for the initial shim launches (e.g. shim -start) and makes
-// no sense for shim implementations.
+// Deprecated: this function is internal to the containerd daemon, which uses it to
+// invoke the shim binary for "start" and "delete" actions during the shim lifecycle.
+// It encodes daemon-specific launch internals — backwards compatibility with older shim
+// models and the new Bootstrap protocol used by 2.3+ shims — and is not intended for use
+// by external callers. It will be moved into the core containerd runtime package in the future.
 func Command(ctx context.Context, config *CommandConfig) (*exec.Cmd, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {


### PR DESCRIPTION
Deprecate `Command` from `pkg/shim`. This function is used by containerd to launch shims and should not be exposed to external users. This PR updates the comment so Go can recognize it as deprecated. I think it worth doing this in 2.3