### PR TITLE
seccomp: Block AF_ALG in default socket policy

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -426,6 +426,10 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 			Action: specs.ActAllow,
 			Args:   []specs.LinuxSeccompArg{},
 		},
+		// Allow socket(2) for all address families except AF_VSOCK.
+		// NOTE: on 32-bit x86, socket() goes through socketcall(2) which is
+		// allowed unconditionally above; these arg filters only apply to the
+		// direct socket syscall.
 		{
 			Names:  []string{"socket"},
 			Action: specs.ActAllow,

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -426,10 +426,45 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 			Action: specs.ActAllow,
 			Args:   []specs.LinuxSeccompArg{},
 		},
-		// Allow socket(2) for all address families except AF_VSOCK.
-		// NOTE: on 32-bit x86, socket() goes through socketcall(2) which is
-		// allowed unconditionally above; these arg filters only apply to the
-		// direct socket syscall.
+		// Allow socket(2) for all address families except AF_VSOCK and AF_ALG.
+		// NOTE: on socketcall(2)-based ABIs (for example 32-bit x86), socket()
+		// goes through socketcall(2), which is allowed unconditionally above.
+		// These arg filters only apply to the direct socket syscall.
+		//
+		// Do not use one rule with both "arg0 != AF_VSOCK" and "arg0 != AF_ALG".
+		// runc splits repeated argument-index conditions into separate
+		// libseccomp rules, so they behave like OR and allow both blocked
+		// domains.
+		//
+		// Do not combine explicit ERRNO rules with a broad socket ALLOW.
+		// libseccomp can make the ERRNO branch unreachable, collapse an
+		// unconditional ALLOW into a bare syscall allow, or silently reject
+		// repeated not-equal checks.
+		//
+		// These three single-condition ranges make AF_ALG and AF_VSOCK match
+		// none and fall through to the default errno action.
+		{
+			Names:  []string{"socket"},
+			Action: specs.ActAllow,
+			Args: []specs.LinuxSeccompArg{
+				{
+					Index: 0,
+					Value: unix.AF_ALG,
+					Op:    specs.OpLessThan,
+				},
+			},
+		},
+		{
+			Names:  []string{"socket"},
+			Action: specs.ActAllow,
+			Args: []specs.LinuxSeccompArg{
+				{
+					Index: 0,
+					Value: unix.AF_ALG + 1,
+					Op:    specs.OpEqualTo,
+				},
+			},
+		},
 		{
 			Names:  []string{"socket"},
 			Action: specs.ActAllow,
@@ -437,7 +472,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				{
 					Index: 0,
 					Value: unix.AF_VSOCK,
-					Op:    specs.OpNotEqual,
+					Op:    specs.OpGreaterThan,
 				},
 			},
 		},


### PR DESCRIPTION
- port: https://github.com/moby/profiles/pull/20

Addresses `CVE-2026-31431`.

Note: This doesn't block usage via `socketcall`.

AF_ALG (address family 38) exposes the Linux kernel crypto API to userspace via socket(2). Containers have no legitimate need for this interface under the default profile, and leaving it accessible widens the kernel attack surface unnecessarily (see https://copy.fail/).

The previous socket rule used a single "arg0 != AF_VSOCK" condition. Adding a second OpNotEqual for AF_ALG does not work because seccomp evaluates multiple argument conditions within a single rule as a logical AND against the same argument index.

Instead, restructure the socket allowlist into three range-based rules that cover every domain except AF_ALG (38) and AF_VSOCK (40):

1. Allow socket when arg0 < 38   (all families below AF_ALG)
2. Allow socket when arg0 == 39  (the single family between them)
3. Allow socket when arg0 > 40   (all families above AF_VSOCK)

Domains 38 and 40 match none of the three rules and fall through to the default SCMP_ACT_ERRNO action.

Port of https://github.com/moby/profiles/pull/20