### PR TITLE
content: handle sharing violations on Windows

### DIFF
--- a/plugins/content/local/store.go
+++ b/plugins/content/local/store.go
@@ -632,7 +632,7 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 // be cancelled. Any resources associated with the ingest will be cleaned.
 func (s *store) Abort(ctx context.Context, ref string) error {
 	root := s.ingestRoot(ref)
-	if err := os.RemoveAll(root); err != nil {
+	if err := removePath(root); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("ingest ref %q: %w", ref, errdefs.ErrNotFound)
 		}
@@ -684,7 +684,7 @@ func readFileString(path string) (string, error) {
 
 // readFileTimestamp reads a file with just a timestamp present.
 func readFileTimestamp(p string) (time.Time, error) {
-	b, err := os.ReadFile(p)
+	b, err := readFileWithRetry(p)
 	if err != nil {
 		if os.IsNotExist(err) {
 			err = fmt.Errorf("%s: %w", err.Error(), errdefs.ErrNotFound)

--- a/plugins/content/local/store_other.go
+++ b/plugins/content/local/store_other.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import "os"
+
+func removePath(path string) error {
+	return os.RemoveAll(path)
+}
+
+func readFileWithRetry(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/plugins/content/local/store_windows.go
+++ b/plugins/content/local/store_windows.go
@@ -17,10 +17,81 @@
 package local
 
 import (
+	"errors"
 	"os"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 func getATime(fi os.FileInfo) time.Time {
 	return fi.ModTime()
+}
+
+const (
+	// maxFileRetries is the number of attempts for file operations that
+	// may fail due to transient sharing violations on Windows.
+	maxFileRetries = 5
+
+	// fileRetryDelay is the base delay between retries. Each attempt
+	// waits (attempt number) * fileRetryDelay.
+	fileRetryDelay = 100 * time.Millisecond
+)
+
+// isRetryableError returns true for Windows errors that are known to be
+// transient when a file handle has not been fully released by the OS.
+func isRetryableError(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION) ||
+		errors.Is(err, windows.ERROR_DIR_NOT_EMPTY)
+}
+
+// removePath wraps os.RemoveAll with a retry loop for Windows.
+//
+// On Windows, a file that has been closed by the application may
+// still be held briefly by the OS. Unlike Unix, Windows does not
+// allow deleting a file while any handle is open, so os.RemoveAll
+// can fail with a sharing violation if it races with a recent Close.
+// Retrying after a short delay allows the OS to finish releasing the handle.
+func removePath(path string) error {
+	var err error
+	for i := range maxFileRetries {
+		err = os.RemoveAll(path)
+		if err == nil {
+			return nil
+		}
+		if !isRetryableError(err) {
+			return err
+		}
+		if i < maxFileRetries-1 {
+			time.Sleep(time.Duration(i+1) * fileRetryDelay)
+		}
+	}
+	return err
+}
+
+// readFileWithRetry wraps os.ReadFile with a retry loop for Windows.
+//
+// On Windows, a file that has been closed by the application may
+// still be held briefly by the OS. Unlike Unix, Windows does not
+// allow reading a file while an exclusive handle is open, so
+// os.ReadFile can fail with a sharing violation if it races with
+// a recent Close. Retrying after a short delay allows the OS to
+// finish releasing the handle.
+func readFileWithRetry(path string) ([]byte, error) {
+	var err error
+	for i := range maxFileRetries {
+		var b []byte
+		b, err = os.ReadFile(path)
+		if err == nil {
+			return b, nil
+		}
+		if os.IsNotExist(err) || !isRetryableError(err) {
+			return nil, err
+		}
+		if i < maxFileRetries-1 {
+			time.Sleep(time.Duration(i+1) * fileRetryDelay)
+		}
+	}
+	return nil, err
 }


### PR DESCRIPTION
### Problem

Issue #11044 highlights that `TestContentClient/CommitErrorState` flakes on Windows CI with sharing violations during cleanup:
```
Cleanup failed: failed to abort c1-commiterror-state: unlinkat ...\updatedat.tmp:
The process cannot access the file because it is being used by another process.
```
### Root cause

I believe the root cause is a race between the gRPC server-side `defer wr.Close()` (which writes `updatedat.tmp` via `writeToCompletion`) and the client-side cleanup calling `Abort` (which runs `os.RemoveAll` on the ingest directory). On Unix this doesn't matter since you can unlink files with open handles. On Windows, the OS can hold handles briefly after `Close()` returns, so deletes and reads hit a sharing violation.

While investigating, I found the same race also affects `readFileTimestamp` in `status()`, where the `updatedat` file can't be read while the handle is still held. This wasn't called out in the issue, but I ran into it while testing, so I fixed it as well.

### Fix

Adds `removePath` and `readFileWithRetry` as platform-specific helpers in `plugins/content/local/`. On Windows they retry with linear backoff (5 attempts, 100-500ms). On other platforms they pass through directly. Same pattern as `ensureRemoveAll` in `internal/cri/server/helpers_linux.go`, which retries on `EBUSY` for mount races.

### Test results

I ran `TestContentClient/CommitErrorState` 500 times on a Windows Server 2022 EC2 instance (`t3.large`). The race reproduces naturally but infrequently (~11% with mainline containerd v2.3 on this instance type, could vary based on instance) so I used a large number of runs to get a clear signal.

The "before" run uses mainline at `2976f38cc`. The "after" commit hash (`d0911796a`) differs from the final PR commit because I amended after testing for a few edits.

The three failure types are all the same underlying race hitting different operations:
- `abort-unlinkat`: `Abort` calls `os.RemoveAll`, fails to delete a file in the ingest directory (the original error)
- `dir-not-empty`: `Abort` calls `os.RemoveAll`, can't remove the directory because a held file blocks child deletion
- `read-updatedat`: `status()` calls `readFileTimestamp`, can't open `updatedat` while the handle is still held

```
=== BEFORE FIX === (2976f38cc, mainline v2.3.0)
PASS: 444  FAIL: 56  (11.2%)
  abort-unlinkat: 46
  read-updatedat: 10
  dir-not-empty:  8

=== AFTER FIX === (d0911796a)
PASS: 500  FAIL: 0
  abort-unlinkat: 0
  read-updatedat: 0
  dir-not-empty:  0
```

Fixes #11044