### PR TITLE
seccomp: Explicitly block socketcall to prevent AF_ALG filter bypass

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -426,6 +426,10 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 			Action: specs.ActAllow,
 			Args:   []specs.LinuxSeccompArg{},
 		},
+		// Allow socket(2) for all address families except AF_VSOCK.
+		// NOTE: on 32-bit x86, socket() goes through socketcall(2) which is
+		// allowed unconditionally above; these arg filters only apply to the
+		// direct socket syscall.
 		{
 			Names:  []string{"socket"},
 			Action: specs.ActAllow,

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -380,7 +380,6 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"signalfd4",
 				"sigprocmask",
 				"sigreturn",
-				"socketcall",
 				"socketpair",
 				"splice",
 				"stat",
@@ -435,10 +434,25 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 			Action: specs.ActAllow,
 			Args:   []specs.LinuxSeccompArg{},
 		},
+		// socketcall(2) is explicitly denied to prevent bypassing the socket
+		// address family filters below on architectures where socketcall is
+		// supported (i386, s390, MIPS o32).
+		// Seccomp cannot inspect socketcall's pointer argument, so allowing it
+		// would let an attacker open AF_ALG sockets via socketcall(SYS_SOCKET,
+		// ...). Since Linux 4.3 all affected architectures provide direct
+		// socket syscalls, so modern userspace is not impacted.
+		//
+		// ENOSYS (not EPERM) is used because the errno must differ from
+		// DefaultErrnoRet; otherwise both runc and libseccomp treat the rule
+		// as identical to the default action and silently omit it from the
+		// generated BPF, which lets libseccomp's auto-generated
+		// socketcall(SYS_SOCKET) -> ALLOW path survive unchallenged.
+		{
+			Names:    []string{"socketcall"},
+			Action:   specs.ActErrno,
+			ErrnoRet: &nosys,
+		},
 		// Allow socket(2) for all address families except AF_VSOCK and AF_ALG.
-		// NOTE: on socketcall(2)-based ABIs (for example 32-bit x86), socket()
-		// goes through socketcall(2), which is allowed unconditionally above;
-		// these arg filters only apply to the direct socket syscall.
 		{
 			Names:  []string{"socket"},
 			Action: specs.ActAllow,

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -426,10 +426,32 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 			Action: specs.ActAllow,
 			Args:   []specs.LinuxSeccompArg{},
 		},
-		// Allow socket(2) for all address families except AF_VSOCK.
-		// NOTE: on 32-bit x86, socket() goes through socketcall(2) which is
-		// allowed unconditionally above; these arg filters only apply to the
-		// direct socket syscall.
+		// Allow socket(2) for all address families except AF_VSOCK and AF_ALG.
+		// NOTE: on socketcall(2)-based ABIs (for example 32-bit x86), socket()
+		// goes through socketcall(2), which is allowed unconditionally above;
+		// these arg filters only apply to the direct socket syscall.
+		{
+			Names:  []string{"socket"},
+			Action: specs.ActAllow,
+			Args: []specs.LinuxSeccompArg{
+				{
+					Index: 0,
+					Value: unix.AF_ALG,
+					Op:    specs.OpLessThan,
+				},
+			},
+		},
+		{
+			Names:  []string{"socket"},
+			Action: specs.ActAllow,
+			Args: []specs.LinuxSeccompArg{
+				{
+					Index: 0,
+					Value: unix.AF_ALG + 1,
+					Op:    specs.OpEqualTo,
+				},
+			},
+		},
 		{
 			Names:  []string{"socket"},
 			Action: specs.ActAllow,
@@ -437,7 +459,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				{
 					Index: 0,
 					Value: unix.AF_VSOCK,
-					Op:    specs.OpNotEqual,
+					Op:    specs.OpGreaterThan,
 				},
 			},
 		},

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -27,6 +27,15 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// Compile-time assertions: the socket rules in DefaultProfile rely on AF_ALG
+// and AF_VSOCK being exactly two apart (38 and 40), with a single family (39)
+// between them.
+var (
+	_ [38]byte = [unix.AF_ALG]byte{}
+	_ [40]byte = [unix.AF_VSOCK]byte{}
+	_ [1]byte  = [unix.AF_VSOCK - unix.AF_ALG - 1]byte{}
+)
+
 func arches() []specs.Arch {
 	switch runtime.GOARCH {
 	case "amd64":


### PR DESCRIPTION
- Port of https://github.com/moby/profiles/pull/21
- follow up to: https://github.com/containerd/containerd/pull/13327

The socket arg filters that block AF_ALG and AF_VSOCK only apply to the direct socket(2) syscall. On architectures with the legacy socketcall(2) multiplexer (i386, s390, MIPS o32), libseccomp auto-generates a socketcall(SYS_SOCKET) -> ALLOW companion for each socket ALLOW rule. This companion only checks the socketcall sub-command number, not the address family (behind a pointer BPF cannot dereference), bypassing the AF_ALG block for 32-bit binaries.

Move socketcall from the unconditional allow list to an explicit ERRNO(ENOSYS) deny rule placed before the socket allow rules. ENOSYS must be used instead of EPERM because the deny errno must differ from DefaultErrnoRet (EPERM): runc skips calling seccomp_rule_add() when a rule's action matches the default action, so an EPERM deny is never passed to libseccomp and the auto-generated socketcall ALLOW path survives unchallenged.

Since Linux 4.3, all affected architectures provide direct socket syscalls and modern glibc/musl already use them.