### PR TITLE
Fix CRIU checkpoint failing due to io_uring usage

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/init.go
+++ b/cmd/containerd-shim-runc-v2/process/init.go
@@ -439,6 +439,14 @@ func (p *Init) checkpoint(ctx context.Context, r *CheckpointConfig) error {
 	if !r.Exit {
 		actions = append(actions, runc.LeaveRunning)
 	}
+
+	// Check if the process is using io_uring, which CRIU cannot handle
+	if has, err := hasIoUring(p.pid); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to check for io_uring usage")
+	} else if has {
+		return fmt.Errorf("cannot checkpoint container: process is using io_uring which is not supported by CRIU (see issue #12162)")
+	}
+
 	// keep criu work directory if criu work dir is set
 	work := r.WorkDir
 	if work == "" {

--- a/cmd/containerd-shim-runc-v2/process/utils.go
+++ b/cmd/containerd-shim-runc-v2/process/utils.go
@@ -19,6 +19,7 @@
 package process
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -183,4 +184,25 @@ func stateName(v any) string {
 		return "stopped"
 	}
 	panic(fmt.Errorf("invalid state %v", v))
+}
+
+// hasIoUring checks if the process with the given pid is using io_uring.
+// CRIU cannot checkpoint processes using io_uring (anon_inode:[io_uring]),
+// so we need to detect this before attempting checkpoint.
+func hasIoUring(pid int) (bool, error) {
+	mapsPath := fmt.Sprintf("/proc/%d/maps", pid)
+	file, err := os.Open(mapsPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to open %s: %w", mapsPath, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "[io_uring]") {
+			return true, nil
+		}
+	}
+	return false, scanner.Err()
 }


### PR DESCRIPTION
Fix CRIU checkpoint failing with 'Unknown shit 600 (anon_inode:[io_uring])' error.

Add pre-check to detect io_uring usage before checkpointing. CRIU cannot handle anon_inode:[io_uring] mappings, so we now check /proc/PID/maps for io_uring usage and return a clear error message instead of letting CRIU fail with a cryptic error.

Fixes #12162