### PR TITLE
Fix pinned label not applied when pinned_images config has no tag

### DIFF
--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -417,12 +417,27 @@ func (c *CRIImageService) createOrUpdateImageReference(ctx context.Context, name
 	return err
 }
 
-// getLabels get image labels to be added on CRI image
 func (c *CRIImageService) getLabels(ctx context.Context, name string) map[string]string {
 	labels := map[string]string{crilabels.ImageLabelKey: crilabels.ImageLabelValue}
 	for _, pinned := range c.config.PinnedImages {
 		if pinned == name {
 			labels[crilabels.PinnedImageLabelKey] = crilabels.PinnedImageLabelValue
+			continue
+		}
+		pinnedNamed, err := distribution.ParseDockerRef(pinned)
+		if err != nil {
+			continue
+		}
+		_, hasTag := pinnedNamed.(distribution.NamedTagged)
+		_, hasDigest := pinnedNamed.(distribution.Canonical)
+		if !hasTag && !hasDigest {
+			named, err := distribution.ParseDockerRef(name)
+			if err == nil {
+				pinnedTagged := distribution.TagNameOnly(pinnedNamed)
+				if pinnedTagged != nil && pinnedTagged.String() == name {
+					labels[crilabels.PinnedImageLabelKey] = crilabels.PinnedImageLabelValue
+				}
+			}
 		}
 	}
 	return labels

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -419,25 +419,19 @@ func (c *CRIImageService) createOrUpdateImageReference(ctx context.Context, name
 
 func (c *CRIImageService) getLabels(ctx context.Context, name string) map[string]string {
 	labels := map[string]string{crilabels.ImageLabelKey: crilabels.ImageLabelValue}
+	named, err := distribution.ParseDockerRef(name)
+	if err != nil {
+		return labels
+	}
+	nameNorm := distribution.TagNameOnly(named).String()
 	for _, pinned := range c.config.PinnedImages {
-		if pinned == name {
-			labels[crilabels.PinnedImageLabelKey] = crilabels.PinnedImageLabelValue
-			continue
-		}
 		pinnedNamed, err := distribution.ParseDockerRef(pinned)
 		if err != nil {
 			continue
 		}
-		_, hasTag := pinnedNamed.(distribution.NamedTagged)
-		_, hasDigest := pinnedNamed.(distribution.Canonical)
-		if !hasTag && !hasDigest {
-			named, err := distribution.ParseDockerRef(name)
-			if err == nil {
-				pinnedTagged := distribution.TagNameOnly(pinnedNamed)
-				if pinnedTagged != nil && pinnedTagged.String() == name {
-					labels[crilabels.PinnedImageLabelKey] = crilabels.PinnedImageLabelValue
-				}
-			}
+		pinnedNorm := distribution.TagNameOnly(pinnedNamed).String()
+		if pinnedNorm == nameNorm {
+			labels[crilabels.PinnedImageLabelKey] = crilabels.PinnedImageLabelValue
 		}
 	}
 	return labels

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -476,7 +476,7 @@ func TestImageGetLabels(t *testing.T) {
 		{
 			name:          "pinned image labels should get added on sandbox image without tag",
 			expectedLabel: map[string]string{labels.ImageLabelKey: labels.ImageLabelValue, labels.PinnedImageLabelKey: labels.PinnedImageLabelValue},
-			pinnedImages:  map[string]string{"sandboxnotag": "k8s.gcr.io/pause", "sandbox": "k8s.gcr.io/pause:latest"},
+			pinnedImages:  map[string]string{"sandbox": "k8s.gcr.io/pause"},
 			pullImageName: "k8s.gcr.io/pause:latest",
 		},
 		{


### PR DESCRIPTION
Normalize pinned image refs before comparing with image name. Restores behavior broken during SandboxImage to PinnedImages refactor.

Fixes #13314