### PR TITLE
monitor:  fix monitor sometimes will kill the container

### DIFF
--- a/plugins/restart/monitor.go
+++ b/plugins/restart/monitor.go
@@ -147,7 +147,7 @@ func (m *monitor) monitor(ctx context.Context) ([]change, error) {
 		desiredStatus := containerd.ProcessStatus(labels[restart.StatusLabel])
 		if task, err = c.Task(ctx, nil); err == nil {
 			if status, err = task.Status(ctx); err == nil {
-				if desiredStatus == status.Status {
+				if desiredStatus == status.Status || status.Status == containerd.Created {
 					continue
 				}
 			}


### PR DESCRIPTION
nerdctl  run -d --restart=always busybox sleep 1000
then nerdctl exec container sometimes  find 

```
time="2026-05-06T15:20:41+08:00" level=fatal msg="task 4075488b92a0b8c0c6e74c3b609e3cd74aec2e9845d84c28fdebbe6a5fa1a3ff not found: not found"
```
because task is killed and deleted by  monitor (task status is created the monitor will delete and recreate it)
@AkihiroSuda   can you take a look thanks ?