### PR TITLE
fix: synchronize gc plugin stops before metadata plugin closes

### DIFF
--- a/integration/build_local_containerd_helper_test.go
+++ b/integration/build_local_containerd_helper_test.go
@@ -18,6 +18,7 @@ package integration
 
 import (
 	"context"
+	"io"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -134,6 +135,23 @@ func buildLocalContainerdClient(t *testing.T, tmpDir string, tweakInitFn tweakPl
 		containerd.WithInMemoryServices(lastInitContext),
 	)
 	require.NoError(t, err)
+
+	// Tear down the in-memory containerd before the test completes. This stops
+	// background goroutines before the state dir is removed.
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+
+		plugins := initialized.GetAll()
+		for i := len(plugins) - 1; i >= 0; i-- {
+			instance, err := plugins[i].Instance()
+			if err != nil {
+				continue
+			}
+			if closer, ok := instance.(io.Closer); ok {
+				require.NoError(t, closer.Close())
+			}
+		}
+	})
 
 	return client
 }

--- a/plugins/gc/scheduler.go
+++ b/plugins/gc/scheduler.go
@@ -117,7 +117,9 @@ func init() {
 				"ScheduleDelay":     fmt.Sprint(m.scheduleDelay),
 			}
 
-			go m.run(ic.Context)
+			runCtx, cancel := context.WithCancel(ic.Context)
+			m.cancel = cancel
+			go m.run(runCtx)
 
 			return m, nil
 		},
@@ -140,6 +142,13 @@ type gcScheduler struct {
 
 	eventC chan mutationEvent
 
+	// cancel stops the background run loop. It is set during plugin
+	// initialization and invoked by Close.
+	cancel context.CancelFunc
+	// doneC is closed by run when the background loop has exited and no
+	// garbage collection is in flight.
+	doneC chan struct{}
+
 	waiterL sync.Mutex
 	waiters []chan gc.Stats
 
@@ -156,6 +165,7 @@ func newScheduler(c collector, cfg *config) *gcScheduler {
 	s := &gcScheduler{
 		c:                 c,
 		eventC:            eventC,
+		doneC:             make(chan struct{}),
 		pauseThreshold:    cfg.PauseThreshold,
 		deletionThreshold: cfg.DeletionThreshold,
 		mutationThreshold: cfg.MutationThreshold,
@@ -188,9 +198,34 @@ func (s *gcScheduler) ScheduleAndWait(ctx context.Context) (gc.Stats, error) {
 	return s.wait(ctx, true)
 }
 
+// Close stops the background garbage collection loop and waits for any
+// in-flight collection to finish before returning.
+func (s *gcScheduler) Close() error {
+	if s.cancel == nil {
+		return nil
+	}
+	s.cancel()
+	<-s.doneC
+	return nil
+}
+
+// errSchedulerClosed is returned to wait callers when the scheduler's run
+// loop has exited and no further collections will be scheduled.
+var errSchedulerClosed = errors.New("gc scheduler closed")
+
 func (s *gcScheduler) wait(ctx context.Context, trigger bool) (gc.Stats, error) {
+	var gcStats gc.Stats
+
 	wc := make(chan gc.Stats, 1)
 	s.waiterL.Lock()
+	// Don't register a waiter once the run loop has exited; nothing would
+	// ever complete or close it.
+	select {
+	case <-s.doneC:
+		s.waiterL.Unlock()
+		return gcStats, errSchedulerClosed
+	default:
+	}
 	s.waiters = append(s.waiters, wc)
 	s.waiterL.Unlock()
 
@@ -198,12 +233,9 @@ func (s *gcScheduler) wait(ctx context.Context, trigger bool) (gc.Stats, error) 
 		e := mutationEvent{
 			ts: time.Now(),
 		}
-		go func() {
-			s.eventC <- e
-		}()
+		go s.sendEvent(e)
 	}
 
-	var gcStats gc.Stats
 	select {
 	case stats, ok := <-wc:
 		if !ok {
@@ -212,6 +244,8 @@ func (s *gcScheduler) wait(ctx context.Context, trigger bool) (gc.Stats, error) 
 		gcStats = stats
 	case <-ctx.Done():
 		return gcStats, ctx.Err()
+	case <-s.doneC:
+		return gcStats, errSchedulerClosed
 	}
 
 	return gcStats, nil
@@ -223,9 +257,17 @@ func (s *gcScheduler) mutationCallback(dirty bool) {
 		mutation: true,
 		dirty:    dirty,
 	}
-	go func() {
-		s.eventC <- e
-	}()
+	go s.sendEvent(e)
+}
+
+// sendEvent delivers an event to the run loop, abandoning the send if the
+// scheduler is closed. This prevents goroutines from leaking on an unbuffered
+// eventC once run has exited and is no longer receiving.
+func (s *gcScheduler) sendEvent(e mutationEvent) {
+	select {
+	case s.eventC <- e:
+	case <-s.doneC:
+	}
 }
 
 func schedule(d time.Duration) (<-chan time.Time, *time.Time) {
@@ -233,7 +275,21 @@ func schedule(d time.Duration) (<-chan time.Time, *time.Time) {
 	return time.After(d), &next
 }
 
+// shutdown marks the scheduler closed and is called when the run loop exits.
+// Closing doneC under waiterL serializes it against waiter registration in
+// wait: a caller either observes doneC before appending (and bails out) or
+// appends first and is then released by the doneC case of its select. Either
+// way no waiter is left stranded in s.waiters after the loop is gone.
+func (s *gcScheduler) shutdown() {
+	s.waiterL.Lock()
+	close(s.doneC)
+	s.waiters = nil
+	s.waiterL.Unlock()
+}
+
 func (s *gcScheduler) run(ctx context.Context) {
+	defer s.shutdown()
+
 	const minimumGCTime = float64(5 * time.Millisecond)
 	var (
 		schedC <-chan time.Time

--- a/plugins/gc/scheduler_test.go
+++ b/plugins/gc/scheduler_test.go
@@ -171,6 +171,154 @@ func TestStartupDelay(t *testing.T) {
 
 }
 
+// TestCloseWaitsForRunLoop verifies that Close() cancels the run loop and
+// blocks until an in-progress GC completes and the loop exits.
+func TestCloseWaitsForRunLoop(t *testing.T) {
+	bc := &blockingCollector{
+		testCollector: &testCollector{},
+		started:       make(chan struct{}),
+		release:       make(chan struct{}),
+		completed:     make(chan struct{}),
+	}
+
+	scheduler := newScheduler(bc, &config{})
+
+	// Wire the cancel func into the scheduler so that Close() is responsible
+	// for stopping the run loop, mirroring how the plugin InitFn starts it.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	scheduler.cancel = cancel
+	go scheduler.run(ctx)
+
+	// Send a trigger event to schedule an immediate GC.
+	go func() {
+		scheduler.eventC <- mutationEvent{ts: time.Now()}
+	}()
+
+	// Wait for GC to start.
+	select {
+	case <-bc.started:
+	case <-t.Context().Done():
+		t.Fatal("timed out waiting for GC to start")
+	}
+
+	// Call Close() while GC is in-flight. Close() is responsible for
+	// cancelling the run loop; the test does not cancel it directly.
+	closeDone := make(chan struct{})
+	go func() {
+		scheduler.Close()
+		close(closeDone)
+	}()
+
+	// Unblock GC; run() will exit on the next select iteration once Close()
+	// has cancelled the context.
+	close(bc.release)
+
+	select {
+	case <-closeDone:
+	case <-t.Context().Done():
+		t.Fatal("Close() did not return after GC finished")
+	}
+
+	// Verify GC completed before Close() returned.
+	select {
+	case <-bc.completed:
+	default:
+		t.Fatal("Close() returned before GC finished")
+	}
+}
+
+// TestSendersDoNotLeakAfterClose verifies that the event senders
+// (mutationCallback and the wait trigger) do not block forever on the
+// unbuffered eventC once the run loop has exited. Before the doneC select was
+// added, each post-shutdown mutation leaked a goroutine blocked on the send.
+func TestSendersDoNotLeakAfterClose(t *testing.T) {
+	scheduler := newScheduler(&testCollector{}, &config{})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	scheduler.cancel = cancel
+	go scheduler.run(ctx)
+
+	assert.NoError(t, scheduler.Close())
+
+	// ScheduleAndWait after close must return promptly rather than register a
+	// waiter that nothing will ever complete.
+	_, err := scheduler.ScheduleAndWait(context.Background())
+	assert.ErrorIs(t, err, errSchedulerClosed)
+
+	// Both mutationCallback and the wait trigger deliver events via
+	// go s.sendEvent(e). Drive sendEvent directly under a WaitGroup so the
+	// assertion tracks the exact senders we spawn. Every send targets the
+	// now-unread eventC; with the doneC select each sender returns, without
+	// it each would block forever on the channel send.
+	const senders = 100
+	var wg sync.WaitGroup
+	for range senders {
+		wg.Go(func() {
+			scheduler.sendEvent(mutationEvent{ts: time.Now(), mutation: true, dirty: true})
+		})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-t.Context().Done():
+		t.Fatal("sender goroutines leaked after Close: blocked on eventC send")
+	}
+}
+
+// TestWaitUnblockedByClose verifies that a pending wait() caller is released
+// when the run loop exits, rather than blocking until its own context is done.
+func TestWaitUnblockedByClose(t *testing.T) {
+	scheduler := newScheduler(&testCollector{}, &config{})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	scheduler.cancel = cancel
+	go scheduler.run(ctx)
+
+	// Register a waiter that no collection will ever satisfy, using a context
+	// independent of the run loop's so that only Close() can release it.
+	errC := make(chan error, 1)
+	go func() {
+		_, err := scheduler.wait(t.Context(), false)
+		errC <- err
+	}()
+
+	assert.NoError(t, scheduler.Close())
+
+	select {
+	case err := <-errC:
+		assert.ErrorIs(t, err, errSchedulerClosed)
+	case <-t.Context().Done():
+		t.Fatal("wait did not unblock after Close")
+	}
+}
+
+// blockingCollector is a test collector that blocks until release is closed, allowing
+// tests to verify that Close() waits for an in-progress GC to complete before returning.
+type blockingCollector struct {
+	*testCollector
+	started   chan struct{}
+	release   chan struct{}
+	completed chan struct{}
+}
+
+func (bc *blockingCollector) GarbageCollect(ctx context.Context) (gc.Stats, error) {
+	close(bc.started)
+	defer close(bc.completed)
+
+	// Block until test releases.
+	<-bc.release
+	return gcStats{}, nil
+}
+
 type testCollector struct {
 	d  time.Duration
 	gc int


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/containerd/containerd/pull/13348

This change synchronizes the gc scheduler completes all collections before metadata plugin is closed during server shutdown.

### Additional context

- > panic: Log in goroutine after TestCRIImagePullTimeout/SlowCommitWriterWithLocalPull has completed: time="2026-06-11T17:36:01.695875750Z" level=error msg="failed to finish collection context" func="metadata.(*gcContext).finish.func1" file="/home/runner/work/containerd/containerd/core/metadata/gc.go:453" error="readdirent /tmp/TestCRIImagePullTimeoutSlowCommitWriterWithLocalPull796840355/001/state/io.containerd.mount-manager.v1.bolt/t/.: no such file or directory" testcase=TestCRIImagePullTimeout/SlowCommitWriterWithLocalPull type=10

From https://github.com/containerd/containerd/actions/runs/27363955475/job/80859027083, commit 449d5cef8b529122f050107f97dac30186e1047b adds synchronization to CRI integration test to close all initialized plugins before the containerd state directory is cleaned up. Additional protection like mount manager no error on directory not found to be considered separately.