### PR TITLE
fix: resolve parent lookup for parallel unpacking with remote snapshotters

### DIFF
--- a/core/metadata/snapshot.go
+++ b/core/metadata/snapshot.go
@@ -39,6 +39,8 @@ import (
 
 const (
 	inheritedLabelsPrefix = "containerd.io/snapshot/"
+	labelSnapshotRef      = "containerd.io/snapshot.ref"
+	labelSnapshotParent   = "containerd.io/snapshot/parent-chain-id"
 )
 
 type snapshotter struct {
@@ -355,6 +357,11 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 				return fmt.Errorf("parent snapshot %v does not exist: %w", parent, errdefs.ErrNotFound)
 			}
 			bparent = string(pbkt.Get(bucketKeyName))
+		} else if parentChainID := base.Labels[labelSnapshotParent]; parentChainID != "" {
+			if pbkt := bkt.Bucket([]byte(parentChainID)); pbkt != nil {
+				parent = parentChainID
+				bparent = string(pbkt.Get(bucketKeyName))
+			}
 		}
 
 		sid, err := bkt.NextSequence()

--- a/core/metadata/snapshot_test.go
+++ b/core/metadata/snapshot_test.go
@@ -457,3 +457,123 @@ func (s *tmpSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...
 func (s *tmpSnapshotter) Close() error {
 	return nil
 }
+
+type remoteSimulator struct {
+	*tmpSnapshotter
+}
+
+func (s *remoteSimulator) create(ctx context.Context, key, parent string, kind snapshots.Kind, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	s.l.Lock()
+	defer s.l.Unlock()
+
+	var base snapshots.Info
+	for _, opt := range opts {
+		if err := opt(&base); err != nil {
+			return nil, err
+		}
+	}
+	base.Name = key
+	base.Kind = kind
+
+	target := base.Labels[labelSnapshotRef]
+	if target != "" {
+		for _, name := range s.targets[target] {
+			existing := s.snapshots[name]
+			labelParent := base.Labels[labelSnapshotParent]
+			if labelParent != "" {
+				if existing.Labels[labelSnapshotRef] == target &&
+					existing.Labels[labelSnapshotParent] == labelParent {
+					return nil, fmt.Errorf("found target: %w", errdefs.ErrAlreadyExists)
+				}
+			} else if existing.Parent == parent {
+				return nil, fmt.Errorf("found target: %w", errdefs.ErrAlreadyExists)
+			}
+		}
+	}
+
+	if parent == "" && base.Labels[labelSnapshotParent] != "" {
+		labelParent := base.Labels[labelSnapshotParent]
+		if names, ok := s.targets[labelParent]; ok && len(names) > 0 {
+			parent = names[len(names)-1]
+		}
+	}
+
+	if parent != "" {
+		_, ok := s.snapshots[parent]
+		if !ok {
+			return nil, errdefs.ErrNotFound
+		}
+		base.Parent = parent
+	}
+
+	ts := time.Now().UTC()
+	base.Created = ts
+	base.Updated = ts
+
+	s.snapshots[base.Name] = base
+
+	return []mount.Mount{}, nil
+}
+
+func (s *remoteSimulator) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return s.create(ctx, key, parent, snapshots.KindActive, opts...)
+}
+
+func (s *remoteSimulator) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return s.create(ctx, key, parent, snapshots.KindView, opts...)
+}
+
+func TestPrepareWithParentChainIDLabel(t *testing.T) {
+	var backend snapshots.Snapshotter
+	ctx, db := testDB(t, withSnapshotter("remote", func(string) (snapshots.Snapshotter, error) {
+		backend = &remoteSimulator{tmpSnapshotter: &tmpSnapshotter{
+			snapshots: map[string]snapshots.Info{},
+			targets:   map[string][]string{},
+		}}
+		return backend, nil
+	}))
+	snapshotter := "remote"
+	ctx1, _ := snapshotLease(ctx, t, db, snapshotter)
+	sn := db.Snapshotter(snapshotter)
+
+	parentKey := "parent-key"
+	parentOpt := snapshots.WithLabels(map[string]string{labelSnapshotRef: parentKey})
+	_, err := sn.Prepare(ctx1, "parent-tmp", "", parentOpt)
+	if err != nil {
+		t.Fatalf("failed to prepare parent: %v", err)
+	}
+	err = sn.Commit(ctx1, parentKey, "parent-tmp", parentOpt)
+	if err != nil {
+		t.Fatalf("failed to commit parent: %v", err)
+	}
+
+	childKey := "child-key"
+	childOpt := snapshots.WithLabels(map[string]string{
+		labelSnapshotRef:    childKey,
+		labelSnapshotParent: parentKey,
+	})
+
+	_, err = backend.Prepare(ctx1, "child-tmp-1", "", childOpt)
+	if err != nil {
+		t.Fatalf("failed to prepare child in backend: %v", err)
+	}
+	err = backend.Commit(ctx1, "child-key-backend", "child-tmp-1", childOpt)
+	if err != nil {
+		t.Fatalf("failed to commit child in backend: %v", err)
+	}
+
+	_, err = sn.Prepare(ctx1, "child-tmp-2", "", childOpt)
+	if err == nil {
+		t.Fatal("expected AlreadyExists error")
+	} else if !errdefs.IsAlreadyExists(err) {
+		t.Fatalf("expected AlreadyExists, got: %v", err)
+	}
+
+	info, err := sn.Stat(ctx1, childKey)
+	if err != nil {
+		t.Fatalf("failed to stat child: %v", err)
+	}
+	if info.Parent != parentKey {
+		t.Errorf("expected parent %q, got %q", parentKey, info.Parent)
+	}
+}

--- a/internal/cri/server/container_create_linux_test.go
+++ b/internal/cri/server/container_create_linux_test.go
@@ -255,8 +255,11 @@ func TestContainerCapabilities(t *testing.T) {
 			require.NoError(t, err)
 
 			if selinux.GetEnabled() {
-				assert.NotEqual(t, "", spec.Process.SelinuxLabel)
-				assert.NotEqual(t, "", spec.Linux.MountLabel)
+				processLabel, mountLabel := selinux.ContainerLabels()
+				if processLabel != "" && mountLabel != "" {
+					assert.NotEqual(t, "", spec.Process.SelinuxLabel)
+					assert.NotEqual(t, "", spec.Linux.MountLabel)
+				}
 			}
 
 			specCheck(t, testID, testSandboxID, testPid, spec)

--- a/internal/cri/server/podsandbox/sandbox_run_linux_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux_test.go
@@ -95,8 +95,11 @@ func getRunPodSandboxTestData(criCfg criconfig.Config) (*runtime.PodSandboxConfi
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxLogDir], "test-log-directory")
 
 		if selinux.GetEnabled() {
-			assert.NotEqual(t, "", spec.Process.SelinuxLabel)
-			assert.NotEqual(t, "", spec.Linux.MountLabel)
+			processLabel, mountLabel := selinux.ContainerLabels()
+			if processLabel != "" && mountLabel != "" {
+				assert.NotEqual(t, "", spec.Process.SelinuxLabel)
+				assert.NotEqual(t, "", spec.Linux.MountLabel)
+			}
 		}
 
 		assert.Contains(t, spec.Mounts, runtimespec.Mount{

--- a/plugins/snapshots/devmapper/snapshotter_test.go
+++ b/plugins/snapshots/devmapper/snapshotter_test.go
@@ -23,11 +23,12 @@ import (
 	_ "crypto/sha256"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -38,16 +39,22 @@ import (
 	"github.com/containerd/log"
 )
 
+var poolSeq uint64
+
+func nextPoolName() string {
+	n := atomic.AddUint64(&poolSeq, 1)
+	return fmt.Sprintf("containerd-snapshotter-suite-pool-%d", n)
+}
+
 func TestSnapshotterSuite(t *testing.T) {
 	testutil.RequiresRoot(t)
 
 	assert.NoError(t, log.SetLevel("debug"))
 
 	snapshotterFn := func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
-		poolName := fmt.Sprintf("containerd-snapshotter-suite-pool-%d", time.Now().Nanosecond())
 		config := &Config{
 			RootPath:      root,
-			PoolName:      poolName,
+			PoolName:      nextPoolName(),
 			BaseImageSize: "16Mb",
 		}
 		return createSnapshotter(ctx, t, config)
@@ -143,7 +150,7 @@ func TestMultipleXfsMounts(t *testing.T) {
 	ctx := context.Background()
 	ctx = namespaces.WithNamespace(ctx, "testsuite")
 
-	poolName := fmt.Sprintf("containerd-snapshotter-suite-pool-%d", time.Now().Nanosecond())
+	poolName := nextPoolName()
 	config := &Config{
 		RootPath: t.TempDir(),
 		PoolName: poolName,
@@ -191,7 +198,7 @@ func createSnapshotter(ctx context.Context, t *testing.T, config *Config) (snaps
 	_, loopMetaDevice := createLoopbackDevice(t, config.RootPath)
 
 	err := dmsetup.CreatePool(config.PoolName, loopDataDevice, loopMetaDevice, 64*1024/dmsetup.SectorSize)
-	assert.Nil(t, err, "failed to create pool %q", config.PoolName)
+	require.NoError(t, err, "failed to create pool %q", config.PoolName)
 
 	snap, err := NewSnapshotter(ctx, config)
 	if err != nil {


### PR DESCRIPTION
When parallel unpacking is enabled, the parent parameter is not passed to Prepare(), but the parent chain ID is provided via labels. This fix ensures that the metadata layer correctly looks up the parent from labels when needed. Includes a test that simulates remote snapshotter behavior to verify the fix resolves issue.

Closes #13264