### PR TITLE
image: wait the goroutine end

### DIFF
--- a/core/transfer/proxy/transfer.go
+++ b/core/transfer/proxy/transfer.go
@@ -91,6 +91,7 @@ func (p *proxyTransferrer) Transfer(ctx context.Context, src any, dst any, opts 
 		opt(o)
 	}
 	apiOpts := &transferapi.TransferOptions{}
+	done := make(chan struct{})
 	if o.Progress != nil {
 		sid := tstreaming.GenerateID("progress")
 		stream, err := p.streamCreator.Create(ctx, sid)
@@ -105,6 +106,7 @@ func (p *proxyTransferrer) Transfer(ctx context.Context, src any, dst any, opts 
 					if !errors.Is(err, io.EOF) {
 						log.G(ctx).WithError(err).Error("progress stream failed to recv")
 					}
+					close(done)
 					return
 				}
 				i, err := typeurl.UnmarshalAny(a)
@@ -152,6 +154,9 @@ func (p *proxyTransferrer) Transfer(ctx context.Context, src any, dst any, opts 
 		Options: apiOpts,
 	}
 	_, err = p.client.Transfer(ctx, req)
+	if o.Progress != nil {
+		<-done
+	}
 	return errgrpc.ToNative(err)
 }
 func (p *proxyTransferrer) marshalAny(ctx context.Context, i any) (typeurl.Any, error) {


### PR DESCRIPTION
when user use custom Progress  func  can't get all event because main process exited (will break the go routine)
```
	err = client.Transfer(ctx,
		tarchive.NewImageImportStream(options.Stdin, ""),
		transferimage.NewStore("", storeOpts...),
		transfer.WithProgress(func(p transfer.Progress) {
			if p.Event == "saved" {
				if img, err := imageService.Get(ctx, p.Name); err == nil {
					if !beforeSet[img.Name] {
						loadedImages = append(loadedImages, img)
					}
				}
			}
			pf(p)
		}),
	)
```
@mxpv  @mikebrow  can you take a look ?