### PR TITLE
cmd/containerd: ignore SIGHUP when config reload is unsupported

### DIFF
--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -30,6 +30,7 @@ import (
 var handledSignals = []os.Signal{
 	unix.SIGTERM,
 	unix.SIGINT,
+	unix.SIGHUP,
 	unix.SIGUSR1,
 	unix.SIGPIPE,
 }
@@ -52,6 +53,8 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 
 				log.G(ctx).WithField("signal", s).Debug("received signal")
 				switch s {
+				case unix.SIGHUP:
+					log.G(ctx).Warn("received SIGHUP, but config reload is not supported; ignoring signal")
 				case unix.SIGUSR1:
 					dumpStacks(true)
 				default:

--- a/cmd/containerd/command/main_unix_test.go
+++ b/cmd/containerd/command/main_unix_test.go
@@ -1,0 +1,65 @@
+//go:build linux || darwin || freebsd || solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package command
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/cmd/containerd/server"
+	"golang.org/x/sys/unix"
+)
+
+func TestHandleSignalsIgnoreSIGHUP(t *testing.T) {
+	signals := make(chan os.Signal, 2)
+	serverC := make(chan *server.Server, 1)
+	var cancelCalled atomic.Bool
+	cancel := func() {
+		cancelCalled.Store(true)
+	}
+
+	done := handleSignals(context.Background(), signals, serverC, cancel)
+
+	signals <- unix.SIGHUP
+
+	select {
+	case <-done:
+		t.Fatal("signal handler exited on SIGHUP")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if cancelCalled.Load() {
+		t.Fatal("cancel should not be called for SIGHUP")
+	}
+
+	signals <- unix.SIGTERM
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("signal handler did not exit on SIGTERM")
+	}
+
+	if !cancelCalled.Load() {
+		t.Fatal("cancel should be called for SIGTERM")
+	}
+}

--- a/cmd/containerd/command/main_unix_test.go
+++ b/cmd/containerd/command/main_unix_test.go
@@ -30,6 +30,17 @@ import (
 )
 
 func TestHandleSignalsIgnoreSIGHUP(t *testing.T) {
+	var handlesSIGHUP bool
+	for _, signal := range handledSignals {
+		if signal == unix.SIGHUP {
+			handlesSIGHUP = true
+			break
+		}
+	}
+	if !handlesSIGHUP {
+		t.Fatal("handledSignals should include SIGHUP")
+	}
+
 	signals := make(chan os.Signal, 2)
 	serverC := make(chan *server.Server, 1)
 	var cancelCalled atomic.Bool


### PR DESCRIPTION
Fixes #13285.

### Summary

containerd currently does not support live config reload, but SIGHUP should not
shut down the daemon.

This change:

1. Registers `SIGHUP` in `handledSignals` on Unix.
2. Handles `SIGHUP` explicitly in `handleSignals` as a no-op with a warning.

`SIGTERM`/`SIGINT` shutdown behavior is unchanged.

### Why this is minimal/safe

- No reload implementation is introduced.
- Existing termination paths are untouched.
- The fix only changes SIGHUP behavior from stop/terminate to ignore.

### Tests

Added `TestHandleSignalsIgnoreSIGHUP` in `cmd/containerd/command/main_unix_test.go`:

- verifies SIGHUP does not cancel or exit the signal loop
- verifies SIGTERM still cancels and exits

### Verification

```sh
docker run --rm -v "$PWD":/src -w /src golang:1.26 go test ./cmd/containerd/command -run TestHandleSignalsIgnoreSIGHUP -count=1
```