### PR TITLE
Allow hosts file configuration for proxies per registry

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -57,6 +57,8 @@ type hostConfig struct {
 
 	header http.Header
 
+	proxy *url.URL
+
 	// TODO: Add credential configuration (domain alias, username)
 }
 
@@ -171,9 +173,9 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil
 			explicitTLS := tlsConfigured || explicitTLSFromHost
 
-			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 {
+			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 || host.proxy != nil {
 				c := *client
-				if explicitTLSFromHost || host.dialTimeout != nil {
+				if explicitTLSFromHost || host.dialTimeout != nil || host.proxy != nil {
 					tr := defaultTransport.Clone()
 
 					if explicitTLSFromHost {
@@ -188,6 +190,10 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 							KeepAlive:     30 * time.Second,
 							FallbackDelay: 300 * time.Millisecond,
 						}).DialContext
+					}
+
+					if host.proxy != nil {
+						tr.Proxy = http.ProxyURL(host.proxy)
 					}
 
 					c.Transport = tr
@@ -374,6 +380,9 @@ type hostFileConfig struct {
 	// a connect to complete.
 	DialTimeout string `toml:"dial_timeout"`
 
+	// Proxy is the address of the proxy server to use for this host.
+	Proxy string `toml:"proxy"`
+
 	// TODO: Credentials: helper? name? username? alternate domain? token?
 }
 
@@ -544,7 +553,40 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 		result.dialTimeout = &dialTimeout
 	}
 
+	if config.Proxy != "" {
+		proxyURL, err := validateProxy(config.Proxy)
+		if err != nil {
+			return hostConfig{}, err
+		}
+		result.proxy = proxyURL
+	}
+
 	return result, nil
+}
+
+func validateProxy(p string) (*url.URL, error) {
+	proxyURL, err := url.Parse(p)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse configured proxy URL: %w", err)
+	}
+	redacted := redactProxyURL(proxyURL)
+	if proxyURL.Host == "" {
+		return nil, fmt.Errorf("invalid proxy URL %q: must have a non-empty host", redacted)
+	}
+	switch proxyURL.Scheme {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("invalid proxy URL %q: unsupported scheme %q", redacted, proxyURL.Scheme)
+	}
+	switch proxyURL.Path {
+	case "", "/":
+	default:
+		return nil, fmt.Errorf("invalid proxy URL %q: path is not allowed", redacted)
+	}
+	if rq, f := proxyURL.RawQuery != "", proxyURL.Fragment != ""; rq || f {
+		return nil, fmt.Errorf("invalid proxy URL %q: query and fragment are not allowed (query=%t, fragment=%t)", redacted, rq, f)
+	}
+	return proxyURL, nil
 }
 
 // getSortedHosts returns the list of hosts in the order are they defined in the file.
@@ -647,4 +689,16 @@ func loadCertFiles(ctx context.Context, certsDir string) ([]hostConfig, error) {
 		}
 	}
 	return hosts, nil
+}
+
+// redactProxyURL removes extra potentially sensitive info not already removed by the std lib.
+// This is used when printing proxy URLs in debug messages.
+func redactProxyURL(proxyURL *url.URL) string {
+	p := *proxyURL
+	p.Opaque = strings.Repeat("*", len(proxyURL.Opaque))
+	p.RawPath = strings.Repeat("*", len(proxyURL.RawPath))
+	p.RawQuery = strings.Repeat("*", len(proxyURL.RawQuery))
+	p.Fragment = strings.Repeat("*", len(proxyURL.Fragment))
+	p.Path = strings.Repeat("*", len(proxyURL.Path))
+	return p.Redacted()
 }

--- a/core/remotes/docker/config/hosts_resolver_test.go
+++ b/core/remotes/docker/config/hosts_resolver_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -314,5 +315,95 @@ func (m testManifest) OCIManifest() []byte {
 func (m testManifest) RegisterHandler(r *http.ServeMux, name string) {
 	for _, c := range append(m.references, m.config) {
 		r.Handle(fmt.Sprintf("/v2/%s/blobs/%s", name, c.Digest()), c)
+	}
+}
+
+func TestResolverWithConfiguredProxy(t *testing.T) {
+	ctx := t.Context()
+
+	// Start a mock proxy server at a random port that can do basic forwarding of an HTTP request
+	var proxyCalled atomic.Bool
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyCalled.Store(true)
+		if r.Method == http.MethodConnect {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		req, err := http.NewRequest(r.Method, r.RequestURI, r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
+		// avoid any default ProxyFromEnvironment from CI env for mock proxy server
+		tr := http.Transport{Proxy: nil}
+		client := http.Client{Transport: &tr}
+		resp, err := client.Do(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		for k, vv := range resp.Header {
+			for _, v := range vv {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+	}))
+	defer proxy.Close()
+
+	// Start a target server at a different random port
+	var targetCalled atomic.Bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetCalled.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	targetHost := target.URL[len("http://"):]
+
+	// Write a temporary hosts.toml file with the proxy configuration
+	var testtomlTemplate = `
+server = "http://%s"
+
+[host."http://%s"]
+  capabilities = ["pull", "resolve"]
+  proxy = "%s"
+`
+	testtoml := fmt.Sprintf(testtomlTemplate, targetHost, targetHost, proxy.URL)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "hosts.toml"), []byte(testtoml), 0600); err != nil {
+		t.Fatalf("failed to write hosts.toml: %v", err)
+	}
+
+	hostOptions := HostOptions{
+		HostDir: func(host string) (string, error) {
+			return dir, nil
+		},
+	}
+	options := docker.ResolverOptions{}
+	options.Hosts = ConfigureHosts(ctx, hostOptions)
+
+	resolver := docker.NewResolver(options)
+	image := fmt.Sprintf("%s/library/hello-world:latest", targetHost)
+
+	_, _, err := resolver.Resolve(ctx, image)
+
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+
+	if !proxyCalled.Load() {
+		t.Fatalf("Expected request to go through the configured proxy")
+	}
+
+	if !targetCalled.Load() {
+		t.Fatalf("Expected request to reach target server through proxy")
 	}
 }

--- a/core/remotes/docker/config/hosts_test.go
+++ b/core/remotes/docker/config/hosts_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -123,6 +124,9 @@ ca = "/etc/path/default"
 
 [host."https://dial-timeout.registry"]
   dial_timeout = "3s"
+
+[host."https://proxy.registry"]
+  proxy = "http://my-proxy:8080"
 `
 
 	var tb, fb = true, false
@@ -214,6 +218,13 @@ ca = "/etc/path/default"
 			path:         "/v2",
 			capabilities: allCaps,
 			dialTimeout:  &dialTimeout,
+		},
+		{
+			scheme:       "https",
+			host:         "proxy.registry",
+			path:         "/v2",
+			capabilities: allCaps,
+			proxy:        &url.URL{Scheme: "http", Host: "my-proxy:8080"},
 		},
 		{
 			scheme:       "https",
@@ -510,6 +521,117 @@ func TestHTTPFallback(t *testing.T) {
 	}
 }
 
+func TestParseHostsFileWithProxy(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		tomlContent string
+		expectErr   bool
+		expectProxy string
+	}{
+		{
+			name: "valid proxy URL",
+			tomlContent: `
+[host."https://example.com"]
+  proxy = "http://my-proxy:8080"
+`,
+			expectErr:   false,
+			expectProxy: "http://my-proxy:8080",
+		},
+		{
+			name: "valid proxy URL (root config)",
+			tomlContent: `
+	server = "https://example.com"
+	proxy = "http://my-proxy:8080"
+	`,
+			expectErr:   false,
+			expectProxy: "http://my-proxy:8080",
+		},
+		{
+			name: "invalid proxy URL",
+			tomlContent: `
+[host."https://example.com"]
+  proxy = "http://%"
+`,
+			expectErr: true,
+		},
+		{
+			name: "proxy URL with no scheme",
+			tomlContent: `
+[host."https://example.com"]
+  proxy = "my-proxy:8080"
+`,
+			expectErr: true,
+		},
+		{
+			name: "proxy URL with unsupported scheme",
+			tomlContent: `
+[host."https://example.com"]
+  proxy = "socks5://my-proxy:1080"
+`,
+			expectErr: true,
+		},
+		{
+			name: "proxy URL with empty host",
+			tomlContent: `
+[host."https://example.com"]
+  proxy = "http:///path"
+`,
+			expectErr: true,
+		},
+		{
+			name: "proxy URL with path",
+			tomlContent: `
+[host."https://example.com"]
+  proxy = "http://my-proxy:8080/path"
+`,
+			expectErr: true,
+		},
+		{
+			name: "proxy URL with query",
+			tomlContent: `
+[host."https://example.com"]
+  proxy = "http://my-proxy:8080?param=value"
+`,
+			expectErr: true,
+		},
+		{
+			name: "proxy URL with fragment",
+			tomlContent: `
+[host."https://example.com"]
+  proxy = "http://my-proxy:8080#fragment"
+`,
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hosts, err := parseHostsFile("", []byte(tc.tomlContent))
+
+			if tc.expectErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(hosts) < 1 {
+				t.Fatalf("expected at least 1 host, got %d", len(hosts))
+			}
+
+			if hosts[0].proxy == nil {
+				t.Fatal("expected Proxy to be set, but got nil")
+			}
+
+			if hosts[0].proxy.String() != tc.expectProxy {
+				t.Fatalf("expected proxy URL %q, got %q", tc.expectProxy, hosts[0].proxy.String())
+			}
+		})
+	}
+}
+
 func compareRegistryHost(j, k docker.RegistryHost) bool {
 	if j.Scheme != k.Scheme {
 		return false
@@ -540,7 +662,13 @@ func compareHostConfig(j, k hostConfig) bool {
 	if j.capabilities != k.capabilities {
 		return false
 	}
-
+	if j.proxy != nil && k.proxy != nil {
+		if j.proxy.String() != k.proxy.String() {
+			return false
+		}
+	} else if j.proxy != nil || k.proxy != nil {
+		return false
+	}
 	if len(j.caCerts) != len(k.caCerts) {
 		return false
 	}

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -222,6 +222,51 @@ $ cat /etc/containerd/certs.d/_default/hosts.toml
 server = "https://registry.example.com"
 ```
 
+## Route Registry Traffic Through a Proxy Example
+
+To route traffic for a registry at `my-registry.io` through a proxy at
+`http://my-proxy:8080`, create a path and `hosts.toml` text at the path
+`/etc/containerd/certs.d/my-registry.io/hosts.toml` with the following contents:
+
+```toml
+server = "https://my-registry.io"
+proxy = "http://my-proxy:8080"
+```
+
+To route traffic through a proxy only for a specific host, configure the `proxy`
+field within that host's `[host."..."]` section.
+
+In the following example, containerd first attempts to resolve and pull images
+from the mirror at `https://mirror.my-registry.io`, routing those requests
+through the proxy at `http://my-proxy:8080`. If the request to the mirror fails
+for any reason (including a proxy failure), containerd falls back to connecting
+directly to the upstream server (`https://my-registry.io`) without a proxy.
+
+```toml
+server = "https://my-registry.io"
+
+[host."https://mirror.my-registry.io"]
+  capabilities = ["pull", "resolve"]
+  proxy = "http://my-proxy:8080"
+```
+
+If proxies fail, the host will not be tried directly. In the following example,
+both the mirror and server have associated proxies. containerd first attempts
+the mirror, directing the request through the proxy at `http://my-proxy:8080`.
+If this proxy fails, containerd will fallback and attempt the server
+`https://my-registry.io`, in this case routing that request through the proxy
+configured for it at `http://different-proxy:8080`. If _that_ proxy _also_
+fails, containerd will return the relevant network error.
+
+```toml
+server = "https://my-registry.io"
+proxy = "http://different-proxy:8080"
+
+[host."https://mirror.my-registry.io"]
+  capabilities = ["pull", "resolve"]
+  proxy = "http://my-proxy:8080"
+```
+
 ## Bypass TLS Verification Example
 
 To bypass the TLS verification for a private registry at `192.168.31.250:5000`
@@ -371,6 +416,19 @@ A shorter timeout helps reduce delays when falling back to the original registry
 
 ```
 dial_timeout = "1s"
+```
+
+## proxy field
+
+`proxy` specifies the address of the proxy server to use for the registry host.
+It must be an absolute URL with a scheme of either `http` or `https` and a
+non-empty host, and it must not include a path (other than an optional trailing
+`/`), query string, or fragment. This explicit config will override any
+environmental configuration for that registry host, including `NO_PROXY`,
+`HTTP_PROXY`, and `HTTPS_PROXY`.
+
+```toml
+proxy = "http://my-proxy:8080"
 ```
 
 ## host field(s) (in the toml table format)


### PR DESCRIPTION
Fixes #8377

The setup: I have a proxy running that has DNS mapped `local.registry` to `127.0.0.1`, because I have a registry (with a self signed certificate) running locally as well with an image tagged `local.registry/localpython` in it. (Setup directions are [here](https://gist.github.com/lauralorenz/085c7368886ea4f8ab8b9e2419db8841).)

```
docker run -d   --name local-squid-proxy   --net=host   --add-host local.registry:127.0.0.1   ubuntu/squid:latest

docker run -d   --name registry   -p 443:443   -v /tmp/certs:/certs   -e REGISTRY_HTTP_ADDR=0.0.0.0:443   -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt   -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key   registry:3
```

```
lauralorenz@lauralorenz:bin$ curl -k https://local.registry/v2/localpython/tags/list
{"name":"localpython","tags":["latest"]}
```

In both of the following test scenarios (before the feature and after) I have configured the following hosts.toml:

```
lauralorenz@lauralorenz:containerd$ cat /etc/containerd/certs.d/local.registry/hosts.toml 
[host."https://local.registry"]
 capabilities = ["resolve","pull"]
 proxy="http://localhost:3128"
 skip_verify=true
```

Then I ran against a containerd and ctr built on main (1b71eeeae7d537ec94bcd467089aea136256b83e), and then again on a contained and ctr built from this commit.

# Before this PR / on main

Does not care about the proxy setting in hosts.toml and simply can't find the host.

```
lauralorenz@lauralorenz:containerd$ sudo /usr/local/google/home/lauralorenz/go/src/containerd/containerd/bin/ctr images pull --hosts-dir=/etc/containerd/certs.d local.registry/localpython:latest
ctr: failed to resolve image: failed to do request: Head "https://local.registry/v2/localpython/manifests/latest": dial tcp: lookup local.registry on 127.0.0.1:53: no such host
```


# With this PR

Uses proxy setting in hosts.toml to get to the forward proxy at `localhost`, which itself forwards the original hostname request `local.registry` to the registry itself.

```
lauralorenz@lauralorenz:containerd$ sudo /usr/local/google/home/lauralorenz/go/src/containerd/containerd/bin/ctr images pull --hosts-dir=/etc/containerd/certs.d local.registry/localpython:latest
local.registry/localpython:latest               saved
└──manifest (a3f5fd4ce3ad)                      complete        |++++++++++++++++++++++++++++++++++++++|
   ├──config (7c8620a05d35)                     complete        |++++++++++++++++++++++++++++++++++++++|
   ├──layer (fd8e41ac7277)                      extracted       |++++++++++++++++++++++++++++++++++++++|
   ├──layer (ea923c2ed79e)                      extracted       |++++++++++++++++++++++++++++++++++++++|
   ├──layer (5c671a5c7ab3)                      extracted       |++++++++++++++++++++++++++++++++++++++|
   └──layer (6a0ac1617861)                      extracted       |++++++++++++++++++++++++++++++++++++++|
application/vnd.docker.distribution.manifest.v2+json sha256:a3f5fd4ce3adead6336ca2f69f4589b41c7b24317e451e4048116cbd6d761be4
Completed pull from OCI Registry (local.registry/localpython:latest)    elapsed: 2.2 s      total:  19.4 M  (8.9 MiB/s)
```

```
lauralorenz@lauralorenz:containerd$ sudo /usr/local/google/home/lauralorenz/go/src/containerd/containerd/bin/ctr content list
DIGEST                                                                  SIZE    AGE             LABELS
sha256:5c671a5c7ab3e0fe7526f4ff0a233b54727a1f407035f414a73138d2b0886733 455.7kB About a minute  containerd.io/distribution.source.local.registry=localpython,containerd.io/uncompressed=sha256:611cae45bc2cb7ff6a78488ab602a59918fbc0431a0f12281dacf10cbb7ba94f
sha256:6a0ac1617861a677b045b7ff88545213ec31c0ff08763195a70a4a5adda577bb 3.864MB About a minute  containerd.io/distribution.source.local.registry=localpython,containerd.io/uncompressed=sha256:29df493baa13de438d6d2ece3a8333032e0b7b9b9d8cce4ee82194da255f61e1
sha256:7c8620a05d355e188e9c92949198770fd43d150d051f8c3223f506f215a9f12d 5.276kB About a minute  containerd.io/distribution.source.local.registry=localpython,containerd.io/gc.ref.snapshot.overlayfs=sha256:b4f837ae9f4abc0db962ac37b08df79e45a60a17d7e88ffe7aafb537d1e58353
sha256:a3f5fd4ce3adead6336ca2f69f4589b41c7b24317e451e4048116cbd6d761be4 1.157kB About a minute  containerd.io/distribution.source.local.registry=localpython,containerd.io/gc.ref.content.config=sha256:7c8620a05d355e188e9c92949198770fd43d150d051f8c3223f506f215a9f12d,containerd.io/gc.ref.content.l.0=sha256:6a0ac1617861a677b045b7ff88545213ec31c0ff08763195a70a4a5adda577bb,containerd.io/gc.ref.content.l.1=sha256:5c671a5c7ab3e0fe7526f4ff0a233b54727a1f407035f414a73138d2b0886733,containerd.io/gc.ref.content.l.2=sha256:ea923c2ed79ed2d7163aacc54686501cb3339215671be89b50b62814aeffb95c,containerd.io/gc.ref.content.l.3=sha256:fd8e41ac72776720a5ce79d8a0c66e75ae8d3d836cb15cc6ae0682b0b7999a11
sha256:ea923c2ed79ed2d7163aacc54686501cb3339215671be89b50b62814aeffb95c 16.02MB About a minute  containerd.io/distribution.source.local.registry=localpython,containerd.io/uncompressed=sha256:b02b147e872fb22e2550aaaeae713706d551a5321619cf742e89c4144b54c7d4
sha256:fd8e41ac72776720a5ce79d8a0c66e75ae8d3d836cb15cc6ae0682b0b7999a11 248B    About a minute  containerd.io/distribution.source.local.registry=localpython,containerd.io/uncompressed=sha256:6239b5ae5fda090b9f21fcd4bc2b888837f17814c06c0642921cdb35c6a847e5
```
