### PR TITLE
fix(oci): handle absolute symlinks with folders in rootfs user lookup

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -29,6 +29,7 @@ import (
 	"maps"
 	"math"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -1830,11 +1831,12 @@ func WithWindowsNetworkNamespace(ns string) SpecOpts {
 	}
 }
 
-// readLinker defines the ReadLink method locally.
+// readLinkStater defines the ReadLink/Lstat methods locally.
 // We keep this shim to ensure compatibility with build environments where
 // the standard library's fs.ReadLinkFS interface is not yet available or recognized.
-type readLinker interface {
+type readLinkStater interface {
 	ReadLink(name string) (string, error)
+	Lstat(name string) (os.FileInfo, error)
 }
 
 // openUserFile attempts to open a file within the root fs.
@@ -1849,28 +1851,21 @@ func openUserFile(root fs.FS, name string) (fs.File, error) {
 		return wrapUserFile(f, name)
 	}
 
-	// Check if the FS implements our local ReadLink interface.
-	// We use a local interface instead of fs.ReadLinkFS to avoid strict dependency
-	// issues in some build environments.
-	if lfs, ok := root.(readLinker); ok {
-		if target, lerr := lfs.ReadLink(name); lerr == nil {
-			// Use filepath.IsAbs to handle platform-agnostic absolute path checks
-			if filepath.IsAbs(target) {
-				// Re-anchor the absolute path to the root.
-				// e.g. /nix/store/... becomes nix/store/... (relative to root fs)
-				// We use filepath.Rel to safely strip the leading separator.
-				rel, rerr := filepath.Rel(string(filepath.Separator), target)
-				if rerr == nil {
-					// filepath.Rel might return OS-specific separators (backslashes on Windows).
-					// fs.Open strictly expects forward slashes, so we convert it.
-					f, oerr := root.Open(filepath.ToSlash(rel))
-					if oerr != nil {
-						return nil, oerr
-					}
-					return wrapUserFile(f, name)
-				}
+	// Check if the FS implements our local readLinkStater interface
+	// (providing both ReadLink and Lstat). We use a local interface instead of
+	// fs.ReadLinkFS to avoid strict dependency issues in some build environments.
+	if lfs, ok := root.(readLinkStater); ok {
+		resolved, resolveErr := extractSymlink(lfs, name)
+		if resolveErr == nil {
+			f, oerr := root.Open(resolved)
+			if oerr != nil {
+				return nil, oerr
 			}
+			return wrapUserFile(f, name)
 		}
+		// Preserve the original open error while surfacing the symlink
+		// resolution failure that occurred during fallback handling.
+		return nil, errors.Join(err, resolveErr)
 	}
 
 	// Return the original error if we couldn't resolve it
@@ -1919,4 +1914,56 @@ func (l *limitedFile) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("%q exceeds %d bytes", l.name, maxUserFileBytes)
 	}
 	return n, err
+}
+
+func extractSymlink(root readLinkStater, name string) (string, error) {
+	// maxSymlinkDepth is the maximum number of symlink resolutions to prevent loops.
+	const maxSymlinkDepth = 8
+	resolved := ""
+	remaining := strings.Split(filepath.ToSlash(name), "/")
+	depth := 0
+
+	for len(remaining) > 0 {
+		// Pop the next component.
+		part := remaining[0]
+		remaining = remaining[1:]
+		resolved = path.Join(resolved, part)
+
+		fi, err := root.Lstat(resolved)
+		if err != nil {
+			return "", err
+		}
+
+		if fi.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+
+		depth++
+		if depth > maxSymlinkDepth {
+			return "", errors.New("too many symlink resolutions")
+		}
+
+		target, err := root.ReadLink(resolved)
+		if err != nil {
+			return "", err
+		}
+
+		// Re-anchor absolute symlink targets to the root. Relative targets must
+		// be resolved relative to the directory containing the symlink.
+		if filepath.IsAbs(target) {
+			rel, err := filepath.Rel(string(filepath.Separator), target)
+			if err != nil {
+				return "", err
+			}
+			target = filepath.ToSlash(rel)
+		} else {
+			target = path.Clean(path.Join(path.Dir(resolved), filepath.ToSlash(target)))
+		}
+
+		// Restart resolution from the target with remaining components appended.
+		resolved = ""
+		remaining = append(strings.Split(target, "/"), remaining...)
+	}
+
+	return resolved, nil
 }

--- a/pkg/oci/spec_test.go
+++ b/pkg/oci/spec_test.go
@@ -345,40 +345,136 @@ func TestOpenUserFile_AbsoluteSymlink(t *testing.T) {
 
 	expectedContent := []byte("root:x:0:0:root:/root:/bin/bash" + t.Name())
 
-	root := t.TempDir()
-	// Use 'continuity' library to create a directory structure simulating NixOS
-	if err := fstest.Apply(
-		fstest.CreateDir("/etc", 0o755),
-		fstest.CreateDir("/nix/store/abcd", 0o755),
-		fstest.CreateFile("/nix/store/abcd/passwd", expectedContent, 0o644),
-		// /etc/passwd -> /nix/store/abcd/passwd (absolute symlink)
-		fstest.Symlink("/nix/store/abcd/passwd", "/etc/passwd"),
-	).Apply(root); err != nil {
-		t.Fatal(err)
+	cases := []struct {
+		name          string
+		fsInitializer func(t *testing.T) string
+	}{
+		{
+			name: "absolute symlink", fsInitializer: func(t *testing.T) string {
+				root := t.TempDir()
+				// Use 'continuity' library to create a directory structure simulating NixOS
+				if err := fstest.Apply(
+					fstest.CreateDir("/etc", 0o755),
+					fstest.CreateDir("/nix/store/abcd", 0o755),
+					fstest.CreateFile("/nix/store/abcd/passwd", expectedContent, 0o644),
+					// /etc/passwd -> /nix/store/abcd/passwd (absolute symlink)
+					fstest.Symlink("/nix/store/abcd/passwd", "/etc/passwd"),
+				).Apply(root); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
+		{
+			name: "nested absolute symlink", fsInitializer: func(t *testing.T) string {
+				root := t.TempDir()
+				if err := fstest.Apply(
+					fstest.CreateDir("/etc", 0o755),
+					fstest.CreateDir("/nix/store/abcd", 0o755),
+					fstest.CreateFile("/nix/store/abcd/passwd", expectedContent, 0o644),
+					fstest.Symlink("/nix/store/abcd/passwd", "/nix/store/another"),
+					fstest.Symlink("/nix/store/another", "/etc/passwd"),
+				).Apply(root); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
+		{
+			name: "absolute symlink for folder", fsInitializer: func(t *testing.T) string {
+				// This is a common case for android emulator images where /etc is a symlink to /system/etc
+				root := t.TempDir()
+				if err := fstest.Apply(
+					fstest.CreateDir("/system/etc", 0o755),
+					fstest.CreateFile("/system/etc/passwd", expectedContent, 0o644),
+					// /etc -> /system/etc (absolute symlink)
+					fstest.Symlink("/system/etc", "/etc"),
+				).Apply(root); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
+		{
+			name: "nested absolute symlink for folder", fsInitializer: func(t *testing.T) string {
+				root := t.TempDir()
+				if err := fstest.Apply(
+					fstest.CreateDir("/system/etc", 0o755),
+					fstest.CreateFile("/system/etc/passwd", expectedContent, 0o644),
+					fstest.Symlink("/system/etc", "/system/etc1"),
+					fstest.Symlink("/system/etc1", "/etc"),
+				).Apply(root); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
+		{
+			name: "nested absolute/relative symlink for folder", fsInitializer: func(t *testing.T) string {
+				root := t.TempDir()
+				if err := fstest.Apply(
+					fstest.CreateDir("/system/etc", 0o755),
+					fstest.CreateFile("/system/etc/passwd", expectedContent, 0o644),
+					fstest.Symlink("/system/etc", "/system/etc1"),
+					fstest.Symlink("../system/etc1", "/system/etc2"),
+					fstest.Symlink("system/etc2", "/etc"),
+				).Apply(root); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
+		{
+			name: "nested absolute/relative symlink for folder pointing to the root", fsInitializer: func(t *testing.T) string {
+				root := t.TempDir()
+				if err := fstest.Apply(
+					fstest.CreateDir("/system/etc", 0o755),
+					fstest.CreateFile("/passwd", expectedContent, 0o644),
+					fstest.Symlink("/system/etc/.././..", "/etc"),
+				).Apply(root); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
 	}
 
-	rootFS := os.DirFS(root)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rootPath := tc.fsInitializer(t)
+			root, err := os.OpenRoot(rootPath)
+			if err != nil {
+				t.Fatalf("failed to open test root for subtest %q: %v", tc.name, err)
+			}
+			t.Cleanup(func() {
+				if err := root.Close(); err != nil {
+					t.Errorf("failed to close test root for subtest %q: %v", tc.name, err)
+				}
+			})
+			rootFS := root.FS()
 
-	// Ensure the FS implements the ReadLink interface.
-	// If the native os.DirFS doesn't implement it (depending on Go version),
-	// wrap it in our readLinkFS helper.
-	if _, ok := rootFS.(readLinker); !ok {
-		t.Logf("os.DirFS does not implement ReadLink; wrapping to use ReadLink")
-		rootFS = readLinkFS{root: root, fs: rootFS}
-	}
+			// Ensure the FS implements the readLinkStater interface.
+			// If the native rooted FS doesn't implement it (depending on Go version),
+			// wrap it in our readLinkFS helper.
+			if _, ok := rootFS.(readLinkStater); !ok {
+				t.Logf("rootFS does not implement readLinkStater; wrapping to use ReadLink and Lstat")
+				rootFS = readLinkFS{root: rootPath, fs: rootFS}
+			}
 
-	f, err := openUserFile(rootFS, "etc/passwd")
-	if err != nil {
-		t.Fatalf("openUserFile failed on absolute symlink: %v", err)
-	}
-	defer f.Close()
+			f, err := openUserFile(rootFS, "etc/passwd")
+			if err != nil {
+				t.Fatalf("openUserFile failed for subtest %q: %v", tc.name, err)
+			}
+			defer f.Close()
 
-	content, err := io.ReadAll(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != string(expectedContent) {
-		t.Errorf("expected content %q, got %q", string(expectedContent), string(content))
+			content, err := io.ReadAll(f)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(content) != string(expectedContent) {
+				t.Errorf("expected content %q, got %q", string(expectedContent), string(content))
+			}
+		})
 	}
 }
 
@@ -399,8 +495,14 @@ func TestGroupLookup_AbsoluteSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootFS := os.DirFS(root)
-	if _, ok := rootFS.(readLinker); !ok {
+	openedRoot, err := os.OpenRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer openedRoot.Close()
+
+	rootFS := openedRoot.FS()
+	if _, ok := rootFS.(readLinkStater); !ok {
 		rootFS = readLinkFS{root: root, fs: rootFS}
 	}
 
@@ -438,4 +540,9 @@ func (r readLinkFS) Open(name string) (fs.File, error) {
 func (r readLinkFS) ReadLink(name string) (string, error) {
 	// Force link reading using the actual path on disk
 	return os.Readlink(filepath.Join(r.root, filepath.FromSlash(name)))
+}
+
+func (r readLinkFS) Lstat(name string) (os.FileInfo, error) {
+	// Force lstat using the actual path on disk
+	return os.Lstat(filepath.Join(r.root, filepath.FromSlash(name)))
 }


### PR DESCRIPTION
# What is the problem you're trying to solve

The `openUserFile` function in `pkg/oci/spec_opts.go` fails to resolve absolute symlinks that point to directories rather than files. For example, on Android emulator images, `/etc` is commonly a symlink to `/system/etc`. When containerd tries to open `etc/passwd`, it only handles the case where the final file (`etc/passwd`) is itself a symlink(fixed in https://github.com/containerd/containerd/pull/12732), but not the case where an intermediate directory component (`etc`) is a symlink with absolute path.

This deficiency prevents:

- **Intermediate directory symlink resolution**: Container images with `/etc -> /system/etc` symlink layouts fail to resolve user/group files.
- **Nested symlink resolution**: Any rootfs layout where intermediate path or leaf file are nested absolute symlinks is broken.

# Describe the solution you'd like

The fix introduces an `extractSymlink` function that iteratively walks each path component, uses `Lstat` to check for symlinks (instead of relying on `ReadLink` error semantics), re-anchors absolute targets to the root, and enforces a depth limit of 8 to prevent circular symlink loops which is the same approach as builtin `os/root.go` does. The `readLinker` interface is extended to `readLinkStater` to include the `Lstat` method.

A new test case ("absolute symlink for folder") has been added alongside the existing "absolute symlink" test to verify that directory-level symlinks (e.g., `/etc -> /system/etc`) are correctly resolved when opening `etc/passwd`.

The test case `TestOpenUserFile_AbsoluteSymlink` is extended to include 3 more tests covering:  

1. Absolute symlink for folder (single-level)
2. Multi-level absolute symlinks both for file and folders (nested symlinks)

fixed #13382 