### PR TITLE
overlay: disable "rebase" capability when running in UserNS

### DIFF
--- a/plugins/snapshots/overlay/plugin/plugin.go
+++ b/plugins/snapshots/overlay/plugin/plugin.go
@@ -21,6 +21,8 @@ package overlay
 import (
 	"errors"
 
+	"github.com/moby/sys/userns"
+
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
@@ -93,7 +95,12 @@ func init() {
 				ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaOnlyRemapIDs)
 			}
 
-			ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaRebase)
+			if !userns.RunningInUserNS() {
+				// "rebase" capability depends on `mknod c 0 0` via OverlayConvertWhiteout,
+				// so it does not work when running in UserNS.
+				// https://github.com/containerd/containerd/issues/13388
+				ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaRebase)
+			}
 
 			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
 			return overlay.NewSnapshotter(root, oOpts...)


### PR DESCRIPTION
Fix #13388

```
[...]
May 12 16:57:23 kind-control-plane kubelet[257]:         failed to extract layer (application/vnd.docker.image.rootfs
.diff.tar sha256:6f1cdceb6a3146f0ccb986521156bef8a422cdbb0863396f7f751f575ba308f4) to overlayfs as "extract-920875437
-7QPF sha256:31e64620332e54e3e4fb246d8325ed2c9f1c2cc64a95f0bb23b4b7e82834c95a": failed to mount /var/lib/containerd/t
mpmounts/containerd-mount2180142388: mount source: "overlay", target: "/var/lib/containerd/tmpmounts/containerd-mount
2180142388", fstype: overlay, flags: 0, data: "upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/sn
apshots/279/fs", err: invalid argument
[...]
```

This was a regression introduced in PR #13115.