### PR TITLE
pkg: remove unused nolint annotations

### DIFF
--- a/pkg/oci/utils_unix.go
+++ b/pkg/oci/utils_unix.go
@@ -131,7 +131,7 @@ func getDevices(path, containerPath string) ([]specs.LinuxDevice, error) {
 
 // TODO consider adding these consts to the OCI runtime-spec.
 const (
-	wildcardDevice = "a" //nolint:nolintlint,unused,varcheck // currently unused, but should be included when upstreaming to OCI runtime-spec.
+	wildcardDevice = "a" //nolint:nolintlint,unused // currently unused, but should be included when upstreaming to OCI runtime-spec.
 	blockDevice    = "b"
 	charDevice     = "c" // or "u"
 	fifoDevice     = "p"

--- a/pkg/progress/escape.go
+++ b/pkg/progress/escape.go
@@ -19,6 +19,6 @@ package progress
 const (
 	escape = "\x1b"
 	reset  = escape + "[0m"
-	red    = escape + "[31m" //nolint:nolintlint,unused,varcheck
+	red    = escape + "[31m" //nolint:nolintlint,unused
 	green  = escape + "[32m"
 )


### PR DESCRIPTION
Commit f9c80be1b removed varcheck linter, but some nolint:varcheck annotations
are still there, resulting in golangci-lint warning:

> WARN [runner/nolint_filter] Found unknown linters in //nolint directives: varcheck

Remove those.