### PR TITLE
Add defer in event of mid-function failures in RunPodSandbox to avoid mount leaks

### DIFF
--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -312,6 +312,16 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, fmt.Errorf("failed to start sandbox %q: %w", id, err)
 	}
 
+	// Shutdown the sandbox if we fail before adding it to store.
+	rollbackSandbox := true
+	defer func() {
+		if retErr != nil && rollbackSandbox {
+			deferCtx, deferCancel := util.DeferContext()
+			defer deferCancel()
+			cleanupErr = c.sandboxService.ShutdownSandbox(deferCtx, sandbox.Sandboxer, id)
+		}
+	}()
+
 	if ctrl.Address != "" {
 		sandbox.Endpoint = sandboxstore.Endpoint{
 			Version: ctrl.Version,
@@ -368,6 +378,8 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err := c.sandboxStore.Add(sandbox); err != nil {
 		return nil, fmt.Errorf("failed to add sandbox %+v into store: %w", sandbox, err)
 	}
+	// We no longer need to stop sandbox with a cleanup defer since it is in the store.
+	rollbackSandbox = false
 
 	// Send CONTAINER_CREATED event with both ContainerId and SandboxId equal to SandboxId.
 	// Note that this has to be done after sandboxStore.Add() because we need to get


### PR DESCRIPTION
- Fixes https://github.com/containerd/containerd/issues/13355
- Fixes https://github.com/containerd/containerd/issues/13609

Add a defer with ~StopSandbox~ ShutdownSandbox in it before we start the RunPodSandbox hooks so if there is a failure in one of them, the mounts are still cleaned up. This rollback defer is active for any failures between the StartSandbox it directly follows and the successful addition of the sandbox to the sandbox store.


# Before this PR / bad
```bash
lauralorenz@lauralorenz:cri-tools$ make critest
# containerd is running locally from main with root /var/lib/containerd-critest and state /var/lib/containerd-critest/state
lauralorenz@lauralorenz:cri-tools$ sudo ./build/bin/linux/$(go env GOARCH)/critest     --runtime-endpoint=unix:///run/containerd/containerd.sock --nri-socket=/var/run/nri/nri.sock    --ginkgo.vv     --ginkgo.focus="should propagate RunPodSandbox plugin error, clean up resources, and allow immediate retry"
```
```bash
lauralorenz@lauralorenz:cri-tools$ sudo rm -rf /var/lib/containerd-critest/state
rm: cannot remove '/var/lib/containerd-critest/state/io.containerd.runtime.v2.task/k8s.io/9e98e9d62868198e2bf07260e25b79a6dc9ed12eec7ddff8183b4f9df681b440/rootfs': Device or resource busy
rm: cannot remove '/var/lib/containerd-critest/state/io.containerd.grpc.v1.cri/sandboxes/9e98e9d62868198e2bf07260e25b79a6dc9ed12eec7ddff8183b4f9df681b440/shm': Device or resource busy
```


# After this PR / good
```bash
# containerd is running locally from this PR with same root/state dirs as above
lauralorenz@lauralorenz:cri-tools$ sudo ./build/bin/linux/$(go env GOARCH)/critest     --runtime-endpoint=unix:///run/containerd/containerd.sock --nri-socket=/var/run/nri/nri.sock    --ginkgo.vv     --ginkgo.focus="should propagate RunPodSandbox plugin error, clean up resources, and allow immediate retry"
```
```bash
lauralorenz@lauralorenz:cri-tools$ sudo rm -rf /var/lib/containerd-critest/state
lauralorenz@lauralorenz:cri-tools$ 
```