### PR TITLE
cleanup the systemd debug notification logging

### DIFF
--- a/cmd/containerd/command/notify_systemd.go
+++ b/cmd/containerd/command/notify_systemd.go
@@ -38,13 +38,17 @@ func notifyStopping(ctx context.Context) error {
 
 func sdNotify(ctx context.Context, state string) error {
 	notified, err := sd.SdNotify(false, state)
-	entry := log.G(ctx)
 	if err != nil {
-		entry = entry.WithError(err)
+		return err
 	}
-	entry.WithField("notified", notified).
-		WithField("state", state).
-		Debug("sd notification")
-
-	return err
+	logger := log.G(ctx).WithFields(log.Fields{
+		"notified": notified,
+		"state":    state,
+	})
+	if notified {
+		logger.Debug("systemd notification successful")
+	} else {
+		logger.Debug("systemd notification is not sent (i.e. NOTIFY_SOCKET is unset)")
+	}
+	return nil
 }


### PR DESCRIPTION
debug log output before PR:
```
DEBU[2026-05-13T12:24:11.459266289-05:00] sd notification                               notified=false state="READY=1"
```
requires insider knowledge to decode.. and it's the next to last log message on startup ...

PR makes it a bit more human readable :-)

after:
```
DEBU[2026-05-13T14:30:43.405952987-05:00] systemd notification is not sent (i.e. NOTIFY_SOCKET is unset)  notified=false state="READY=1"
```

errors continue to be reported back to caller... double logging on error path is corrected