### PR TITLE
cri: uniformly sanitize errors before gRPC return for all CRI RPCs

### DIFF
--- a/internal/cri/instrument/instrumented_service.go
+++ b/internal/cri/instrument/instrumented_service.go
@@ -164,6 +164,10 @@ func (in *instrumentedService) PortForward(ctx context.Context, r *runtime.PortF
 		}
 	}()
 	res, err = in.c.PortForward(ctrdutil.WithNamespace(ctx), r)
+	// Sanitize error to remove sensitive information from both logs and returned gRPC error
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
 	return res, errgrpc.ToGRPC(err)
 }
 
@@ -290,6 +294,10 @@ func (in *instrumentedService) ExecSync(ctx context.Context, r *runtime.ExecSync
 		span.RecordError(err)
 	}()
 	res, err = in.c.ExecSync(ctrdutil.WithNamespace(ctx), r)
+	// Sanitize error to remove sensitive information from both logs and returned gRPC error
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
 	return res, errgrpc.ToGRPC(err)
 }
 
@@ -309,6 +317,10 @@ func (in *instrumentedService) Exec(ctx context.Context, r *runtime.ExecRequest)
 		span.RecordError(err)
 	}()
 	res, err = in.c.Exec(ctrdutil.WithNamespace(ctx), r)
+	// Sanitize error to remove sensitive information from both logs and returned gRPC error
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
 	return res, errgrpc.ToGRPC(err)
 }
 
@@ -327,6 +339,10 @@ func (in *instrumentedService) Attach(ctx context.Context, r *runtime.AttachRequ
 		span.RecordError(err)
 	}()
 	res, err = in.c.Attach(ctrdutil.WithNamespace(ctx), r)
+	// Sanitize error to remove sensitive information from both logs and returned gRPC error
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
 	return res, errgrpc.ToGRPC(err)
 }
 
@@ -343,6 +359,10 @@ func (in *instrumentedService) UpdateContainerResources(ctx context.Context, r *
 		}
 	}()
 	res, err = in.c.UpdateContainerResources(ctrdutil.WithNamespace(ctx), r)
+	// Sanitize error to remove sensitive information from both logs and returned gRPC error
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
 	return res, errgrpc.ToGRPC(err)
 }
 
@@ -574,6 +594,10 @@ func (in *instrumentedService) ReopenContainerLog(ctx context.Context, r *runtim
 		}
 	}()
 	res, err = in.c.ReopenContainerLog(ctrdutil.WithNamespace(ctx), r)
+	// Sanitize error to remove sensitive information from both logs and returned gRPC error
+	if err != nil {
+		err = ctrdutil.SanitizeError(err)
+	}
 	return res, errgrpc.ToGRPC(err)
 }
 


### PR DESCRIPTION
## Summary

`SanitizeError` (`internal/cri/util/sanitize.go`) redacts query-parameter content from `*url.Error` values before they are returned to gRPC callers and written to logs. It was introduced and applied to the four image RPCs (`PullImage`, `ListImages`, `ImageStatus`, `RemoveImage`) in `internal/cri/instrument/instrumented_service.go` so that pre-signed URLs and similar URL-bearing tokens surfaced by registry interactions do not leak verbatim.

This PR extends the same sanitization to the remaining instrumented CRI RPC handlers that propagate errors back to the client, so the behaviour is symmetric across handlers. `SanitizeError` is a no-op for errors that do not wrap a `*url.Error`, so for the vast majority of non-image RPCs this is purely defense-in-depth — but it removes a foot-gun where a future change inside one of these handlers (e.g. an HTTP fetch to a side service, a registry-aware exec hook, etc.) would silently start leaking URLs through gRPC return values and error logs.

## Handlers covered

The following handlers now apply `SanitizeError` using the exact same defer/return pattern as the existing image RPCs:

- `PortForward`
- `ExecSync`
- `Exec`
- `Attach`
- `UpdateContainerResources`
- `ReopenContainerLog`

I picked a conservative set of handlers that either (a) wrap interactive transports likely to surface URL-bearing errors or (b) cover container lifecycle/log endpoints where a runtime backend might end up reaching out over HTTP. Bulk list/status RPCs (`ListContainers`, `ContainerStatus`, `PodSandboxStatus`, etc.) and pure stats RPCs are deliberately not included in this PR to keep the diff small and reviewable.

## Behaviour for non-URL errors

`SanitizeError` returns the original error unchanged unless `errors.As(err, &urlErr)` matches, so for all non-URL errors the wrapping is a no-op and the gRPC status returned through `errgrpc.ToGRPC` is unchanged.

## Test plan

- `go vet ./internal/cri/instrument/... ./internal/cri/util/...`
- `go build ./...`
- `go test ./internal/cri/instrument/... ./internal/cri/util/...` — `internal/cri/util` tests pass; `internal/cri/instrument` has no test files in tree.

No new tests are added because the wrapped helper (`SanitizeError`) already has unit coverage in `internal/cri/util` and the change at each call site is the same idempotent wrapping pattern used by the existing image RPCs.

## Notes

- Diff is +24 / -0 (six 4-line blocks).
- Mirrors the structure introduced for image RPCs in #12801.
- Signed off per DCO.