### PR TITLE
ci: skip advisory jobs in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
   #
   integration-windows:
     name: Windows Integration
+    if: github.event_name != 'merge_group'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     needs: [project, linters, protos, man]
@@ -567,6 +568,7 @@ jobs:
 
   integration-vagrant:
     name: Vagrant integration
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [project, linters, protos, man]
@@ -749,6 +751,7 @@ jobs:
 
   node-e2e:
     name: E2E
+    if: github.event_name != 'merge_group'
     uses: ./.github/workflows/node-e2e.yml
 
   # Currently Github actions UI supports no masks to mark matrix jobs as required to pass status checks.


### PR DESCRIPTION
## Summary
- Skip Windows integration, Vagrant integration, and Kubernetes node e2e for `merge_group` events.
- Keep those jobs running on `pull_request` events for advisory coverage.
- Leave the existing aggregate required status check name unchanged.

## Rationale
`merge_group` CI is primarily a final sanity check that queued changes still compose cleanly. These suites are expensive and have recurring flakes, so rerunning them in the merge queue wastes capacity and can delay unrelated merges.