### PR TITLE
Register tracing log hook before signal handling

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -163,6 +163,12 @@ can be used and modified as necessary as a custom configuration.`
 			return err
 		}
 
+		// Register the tracing hook as soon as config is available. Later startup
+		// steps may start goroutines that log, so avoid mutating hooks after hook
+		// reads may have begun.
+		tracingHook := tracing.NewLogrusHook(tracing.WithTraceIDField(config.Debug.LogTraceID))
+		logrus.StandardLogger().AddHook(tracingHook)
+
 		// Make sure top-level directories are created early.
 		if err := server.CreateTopLevelDirectories(config); err != nil {
 			return err
@@ -194,10 +200,6 @@ can be used and modified as necessary as a custom configuration.`
 		for _, w := range warnings {
 			log.G(ctx).WithError(w).Warn("cleanup temp mount")
 		}
-
-		// Register logging hook for tracing
-		tracingHook := tracing.NewLogrusHook(tracing.WithTraceIDField(config.Debug.LogTraceID))
-		logrus.StandardLogger().AddHook(tracingHook)
 
 		log.G(ctx).WithFields(log.Fields{
 			"version":  version.Version,


### PR DESCRIPTION
## Description

Move tracing logrus hook registration earlier in daemon startup, immediately after config loading and CLI flags have been applied.

This avoids a startup ordering race where logrus hooks can be mutated after startup goroutines may already be logging.

## Root Cause

This is not a logrus race that "shouldn't be possible". It is a real race that can happen when hook registration is delayed until after startup work begins.

The tracing hook used to be registered from `init()`, before daemon startup spawned goroutines. That ordering was safe because the hook was installed before concurrent startup logging could begin.

That changed when tracing hook registration moved into `cmd/containerd/command/main.go`. The move was needed because the hook now depends on `config.Debug.LogTraceID`, which is only known after config loading and CLI flag application. So the hook can no longer be registered from `init()`.

However, the current placement registers the hook after signal handling setup has started.

On Windows, `handleSignals` calls `setupDumpStacks`. `setupDumpStacks` starts a goroutine whose first action is to log that it is waiting for the stackdump event: `log.L.Debugf("Stackdump - waiting signal at %s", event)`.

That creates this startup ordering:

1. Daemon config is loaded and flags are applied.
2. Signal handling starts.
3. On Windows, stackdump setup starts a goroutine.
4. The stackdump goroutine logs immediately.
5. Logging reads/copies logrus hooks.
6. Main startup continues and adds the tracing hook.
7. Adding the tracing hook mutates logrus hooks.

Normally logrus serializes hook access with its logger mutex. `AddHook` locks while mutating hooks, and the logging path locks while copying hooks before firing them.

However, users may run containerd with logrus locking disabled. One example is the `containerd/log` slog bridge, where `UseSlog()` calls `SetNoLock()`. Once locking is disabled, those `Lock`/`Unlock` calls become no-ops. At that point, logging can read/copy the hook map while `AddHook` mutates it, which can panic with a concurrent map iteration/write.

This is easiest to trigger on Windows because the stackdump goroutine logs immediately during signal handling setup. Unix signal handling does not start the same immediate stackdump logging goroutine, but the broader startup invariant still applies: hooks should be registered before startup goroutines that may log are started.

## Fix

Register the tracing hook immediately after `applyFlags`, which is the earliest point where `config.Debug.LogTraceID` is available.

This preserves the `LogTraceID` configurability while restoring the previous ordering property: known hooks are registered before later startup steps may spawn goroutines that log.

The change is intentionally small: it only moves the existing tracing hook registration earlier in startup and documents why the placement matters.

## Testing

- `go test ./cmd/containerd/command/... -count=1`
- `go test ./cmd/containerd/... -count=1`