### PR TITLE
remotes/docker: scope token requests to the mirror repository path

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -43,9 +43,10 @@ import (
 type UpdateClientFunc func(client *http.Client) error
 
 type hostConfig struct {
-	scheme string
-	host   string
-	path   string
+	scheme           string
+	host             string
+	path             string
+	repositoryPrefix string
 
 	capabilities docker.HostCapabilities
 
@@ -232,6 +233,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 			rhosts[i].Path = host.path
 			rhosts[i].Capabilities = host.capabilities
 			rhosts[i].Header = host.header
+			rhosts[i].RepositoryPrefix = host.repositoryPrefix
 		}
 
 		return rhosts, nil
@@ -370,6 +372,17 @@ type hostFileConfig struct {
 	// API root endpoint.
 	OverridePath bool `toml:"override_path"`
 
+	// RepositoryPrefix, when non-empty, names the mirror-side namespace
+	// prefix and is composed into the host's API path (appended after the
+	// /v2 base when OverridePath is false), token request scopes, and the
+	// from= parameter on cross-repository blob mount requests. Operators
+	// using OverridePath = true must include the prefix in their server
+	// URL explicitly. Intended for mirrors that namespace upstream
+	// repositories under a path prefix and therefore expect the mirror-side
+	// repository name (e.g. "<prefix>/<original-repo>") rather than the
+	// original reference.
+	RepositoryPrefix string `toml:"repository_prefix"`
+
 	// DialTimeout is the maximum amount of time a dial will wait for
 	// a connect to complete.
 	DialTimeout string `toml:"dial_timeout"`
@@ -446,6 +459,15 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 			u.Path = "/v2"
 		}
 		result.path = u.Path
+	}
+	result.repositoryPrefix = strings.Trim(config.RepositoryPrefix, "/")
+
+	// When override_path is false, the repository_prefix is also appended
+	// to host.Path so requests land at <api-base>/<prefix>/<repo>. With
+	// override_path = true the operator is in control of host.Path and
+	// repository_prefix only affects the token scope and mount-from name.
+	if !config.OverridePath && result.repositoryPrefix != "" && result.path != "" {
+		result.path = strings.TrimRight(result.path, "/") + "/" + result.repositoryPrefix
 	}
 
 	result.skipVerify = config.SkipVerify

--- a/core/remotes/docker/config/hosts_test.go
+++ b/core/remotes/docker/config/hosts_test.go
@@ -114,8 +114,16 @@ ca = "/etc/path/default"
 [host."https://noncompliantmirror.registry/v2/namespaceprefix"]
   capabilities = ["pull"]
   override_path = true
+  repository_prefix = "namespaceprefix"
 
 [host."https://noprefixnoncompliant.registry"]
+  override_path = true
+
+[host."https://scopeprefix.registry"]
+  repository_prefix = "/project/upstream/"
+
+[host."https://proxy.registry/v2/proxy"]
+  capabilities = ["pull", "resolve"]
   override_path = true
 
 [host."https://onlyheader.registry".header]
@@ -191,15 +199,36 @@ ca = "/etc/path/default"
 			},
 		},
 		{
-			scheme:       "https",
-			host:         "noncompliantmirror.registry",
-			path:         "/v2/namespaceprefix",
-			capabilities: docker.HostCapabilityPull,
+			scheme:           "https",
+			host:             "noncompliantmirror.registry",
+			path:             "/v2/namespaceprefix",
+			repositoryPrefix: "namespaceprefix",
+			capabilities:     docker.HostCapabilityPull,
 		},
 		{
 			scheme:       "https",
 			host:         "noprefixnoncompliant.registry",
 			capabilities: allCaps,
+		},
+		{
+			// With override_path = false (default), the configured
+			// repository_prefix is also appended to host.Path so requests
+			// land at <api-base>/<prefix>/<repo>.
+			scheme:           "https",
+			host:             "scopeprefix.registry",
+			path:             "/v2/project/upstream",
+			repositoryPrefix: "project/upstream",
+			capabilities:     allCaps,
+		},
+		{
+			// A "/v2/<prefix>" server path with override_path = true does
+			// not, on its own, imply a mirror-side repository prefix; the
+			// mirror may serve unprefixed repositories at that API base.
+			// Absent an explicit repository_prefix, the loader leaves it empty.
+			scheme:       "https",
+			host:         "proxy.registry",
+			path:         "/v2/proxy",
+			capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve,
 		},
 		{
 			scheme:       "https",
@@ -537,6 +566,9 @@ func compareHostConfig(j, k hostConfig) bool {
 	if j.path != k.path {
 		return false
 	}
+	if j.repositoryPrefix != k.repositoryPrefix {
+		return false
+	}
 	if j.capabilities != k.capabilities {
 		return false
 	}
@@ -599,6 +631,7 @@ func printHostConfig(hc []hostConfig) string {
 		fmt.Fprintf(b, "\t[%d]\tscheme: %q\n", i, hc[i].scheme)
 		fmt.Fprintf(b, "\t\thost: %q\n", hc[i].host)
 		fmt.Fprintf(b, "\t\tpath: %q\n", hc[i].path)
+		fmt.Fprintf(b, "\t\trepositoryPrefix: %q\n", hc[i].repositoryPrefix)
 		fmt.Fprintf(b, "\t\tcaps: %03b\n", hc[i].capabilities)
 		fmt.Fprintf(b, "\t\tca: %#v\n", hc[i].caCerts)
 		fmt.Fprintf(b, "\t\tclients: %#v\n", hc[i].clientPairs)

--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -226,11 +226,6 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 		return nil, fmt.Errorf("no pull hosts: %w", errdefs.ErrNotFound)
 	}
 
-	ctx, err := ContextWithRepositoryScope(ctx, r.refspec, false)
-	if err != nil {
-		return nil, err
-	}
-
 	return newHTTPReadSeeker(desc.Size, func(offset int64) (io.ReadCloser, error) {
 		// firstly try fetch via external urls
 		for _, us := range desc.URLs {
@@ -243,7 +238,7 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 				log.G(ctx).Debug("non-http(s) alternative url is unsupported")
 				continue
 			}
-			ctx = log.WithLogger(ctx, log.G(ctx).WithField("url", u))
+			ctx := log.WithLogger(ctx, log.G(ctx).WithField("url", u))
 			log.G(ctx).Info("request")
 
 			// Try this first, parse it
@@ -283,7 +278,14 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 					return nil, err
 				}
 
-				rc, _, err := r.open(ctx, req, desc.MediaType, offset, i == len(r.hosts)-1)
+				// Set the repository scope per-host. See
+				// containerd/containerd#9648.
+				hctx, scopeErr := contextWithRepositoryScopeForHost(ctx, host, r.refspec, false)
+				if scopeErr != nil {
+					return nil, scopeErr
+				}
+
+				rc, _, err := r.open(hctx, req, desc.MediaType, offset, i == len(r.hosts)-1)
 				if err != nil {
 					// Store the error for referencing later
 					if firstErr == nil {
@@ -306,7 +308,13 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 				return nil, err
 			}
 
-			rc, _, err := r.open(ctx, req, desc.MediaType, offset, i == len(r.hosts)-1)
+			// Set the repository scope per-host. See containerd/containerd#9648.
+			hctx, scopeErr := contextWithRepositoryScopeForHost(ctx, host, r.refspec, false)
+			if scopeErr != nil {
+				return nil, scopeErr
+			}
+
+			rc, _, err := r.open(hctx, req, desc.MediaType, offset, i == len(r.hosts)-1)
 			if err != nil {
 				// Store the error for referencing later
 				if firstErr == nil {
@@ -374,20 +382,27 @@ func (r dockerFetcher) FetchByDigest(ctx context.Context, dgst digest.Digest, op
 		return nil, desc, fmt.Errorf("no pull hosts: %w", errdefs.ErrNotFound)
 	}
 
-	ctx, err := ContextWithRepositoryScope(ctx, r.refspec, false)
-	if err != nil {
-		return nil, desc, err
-	}
-
 	var (
 		getReq   *request
 		sz       int64
 		firstErr error
+		// hostCtx tracks the per-host scoped context used to build the chosen
+		// request, so subsequent reads (which may issue retries) reuse the
+		// scope appropriate for the host that succeeded. See
+		// containerd/containerd#9648.
+		hostCtx = ctx
 	)
 
 	for i, host := range r.hosts {
-		getReq, sz, err = r.createGetReq(ctx, host, i == len(r.hosts)-1, config.Mediatype, "blobs", dgst.String())
+		// Set the repository scope per-host. See containerd/containerd#9648.
+		hctx, scopeErr := contextWithRepositoryScopeForHost(ctx, host, r.refspec, false)
+		if scopeErr != nil {
+			return nil, desc, scopeErr
+		}
+		var err error
+		getReq, sz, err = r.createGetReq(hctx, host, i == len(r.hosts)-1, config.Mediatype, "blobs", dgst.String())
 		if err == nil {
+			hostCtx = hctx
 			break
 		}
 		// Store the error for referencing later
@@ -399,8 +414,14 @@ func (r dockerFetcher) FetchByDigest(ctx context.Context, dgst digest.Digest, op
 	if getReq == nil {
 		// Fall back to the "manifests" endpoint
 		for i, host := range r.hosts {
-			getReq, sz, err = r.createGetReq(ctx, host, i == len(r.hosts)-1, config.Mediatype, "manifests", dgst.String())
+			hctx, scopeErr := contextWithRepositoryScopeForHost(ctx, host, r.refspec, false)
+			if scopeErr != nil {
+				return nil, desc, scopeErr
+			}
+			var err error
+			getReq, sz, err = r.createGetReq(hctx, host, i == len(r.hosts)-1, config.Mediatype, "manifests", dgst.String())
 			if err == nil {
+				hostCtx = hctx
 				break
 			}
 			// Store the error for referencing later
@@ -421,7 +442,7 @@ func (r dockerFetcher) FetchByDigest(ctx context.Context, dgst digest.Digest, op
 	}
 
 	seeker, err := newHTTPReadSeeker(sz, func(offset int64) (rc io.ReadCloser, err error) {
-		rc, _, err = r.open(ctx, getReq, config.Mediatype, offset, true)
+		rc, _, err = r.open(hostCtx, getReq, config.Mediatype, offset, true)
 		return
 	})
 	if err != nil {

--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -78,10 +78,6 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 		l.Lock(ref)
 		defer l.Unlock(ref)
 	}
-	ctx, err := ContextWithRepositoryScope(ctx, p.refspec, true)
-	if err != nil {
-		return nil, err
-	}
 	status, err := p.tracker.GetStatus(ref)
 	if err == nil {
 		if status.Committed && status.Offset == status.Total {
@@ -108,6 +104,15 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 		existCheck []string
 		host       = hosts[0]
 	)
+
+	// Set the repository scope based on the selected push host so that mirrors
+	// configured with a path prefix (override_path) receive a token scope that
+	// matches the registry-side repository path. See
+	// containerd/containerd#9648.
+	ctx, err = contextWithRepositoryScopeForHost(ctx, host, p.refspec, true)
+	if err != nil {
+		return nil, err
+	}
 
 	if images.IsManifestType(desc.MediaType) || images.IsIndexType(desc.MediaType) {
 		isManifest = true
@@ -182,8 +187,16 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 		mountedFrom := ""
 		var resp *http.Response
 		if fromRepo := selectRepositoryMountCandidate(p.refspec, desc.Annotations); fromRepo != "" {
-			preq := requestWithMountFrom(req, desc.Digest.String(), fromRepo)
-			pctx := ContextWithAppendPullRepositoryScope(ctx, fromRepo)
+			// For mirrors that namespace upstream repositories under a path
+			// prefix, both the mount-from URL parameter and the pull scope
+			// name the mirror-side repository. RepositoryPrefix is empty for
+			// non-prefixed hosts, leaving the wire-level name unchanged.
+			mountFrom := fromRepo
+			if prefix := strings.Trim(host.RepositoryPrefix, "/"); prefix != "" {
+				mountFrom = prefix + "/" + fromRepo
+			}
+			preq := requestWithMountFrom(req, desc.Digest.String(), mountFrom)
+			pctx := ContextWithAppendPullRepositoryScope(ctx, mountFrom)
 
 			// NOTE: the fromRepo might be private repo and
 			// auth service still can grant token without error.
@@ -194,14 +207,14 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 			resp, err = preq.doWithRetries(pctx, true)
 			if err != nil {
 				if !errors.Is(err, ErrInvalidAuthorization) {
-					return nil, fmt.Errorf("pushing with mount from %s: %w", fromRepo, err)
+					return nil, fmt.Errorf("pushing with mount from %s: %w", mountFrom, err)
 				}
-				log.G(ctx).Debugf("failed to push with mount from repository %s: %v", fromRepo, err)
+				log.G(ctx).Debugf("failed to push with mount from repository %s: %v", mountFrom, err)
 			}
 			if resp != nil {
 				switch resp.StatusCode {
 				case http.StatusUnauthorized:
-					log.G(ctx).Debugf("failed to mount from repository %s, not authorized", fromRepo)
+					log.G(ctx).Debugf("failed to mount from repository %s, not authorized", mountFrom)
 
 					resp.Body.Close()
 					resp = nil
@@ -582,7 +595,8 @@ func requestWithMountFrom(req *request, mount, from string) *request {
 		sep = "&"
 	}
 
-	creq.path = creq.path + sep + "mount=" + mount + "&from=" + from
+	q := url.Values{"mount": {mount}, "from": {from}}
+	creq.path = creq.path + sep + q.Encode()
 
 	return &creq
 }

--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -595,8 +595,7 @@ func requestWithMountFrom(req *request, mount, from string) *request {
 		sep = "&"
 	}
 
-	q := url.Values{"mount": {mount}, "from": {from}}
-	creq.path = creq.path + sep + q.Encode()
+	creq.path = creq.path + sep + "mount=" + mount + "&from=" + from
 
 	return &creq
 }

--- a/core/remotes/docker/pusher_test.go
+++ b/core/remotes/docker/pusher_test.go
@@ -319,6 +319,57 @@ func TestPusherInvalidAuthorizationOnMount(t *testing.T) {
 	}
 }
 
+func TestPusherMountFromWithRepositoryPrefix(t *testing.T) {
+	t.Parallel()
+
+	p, reg, _, done := samplePusher(t)
+	defer done()
+
+	const prefix = "team"
+	p.hosts[0].RepositoryPrefix = prefix
+	reg.uploadable = true
+
+	var (
+		mu             sync.Mutex
+		mountScopes    []string
+		mountFromQuery string
+	)
+	p.hosts[0].Authorizer = &mockAuthorizer{
+		authorize: func(ctx context.Context, r *http.Request) error {
+			if r.URL.Query().Get("mount") != "" {
+				mu.Lock()
+				mountScopes = GetTokenScopes(ctx, nil)
+				mountFromQuery = r.URL.Query().Get("from")
+				mu.Unlock()
+			}
+			return nil
+		},
+	}
+
+	ct := []byte("layer-bytes")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(ct),
+		Size:      int64(len(ct)),
+		Annotations: map[string]string{
+			distributionSourceLabelKey(samplePusherHostname): "always-mount",
+		},
+	}
+
+	w, err := p.push(context.Background(), desc, remotes.MakeRefKey(context.Background(), desc), false)
+	require.NoError(t, err)
+	_, err = w.Write(ct)
+	assert.NoError(t, err)
+	err = w.Commit(context.Background(), desc.Size, desc.Digest)
+	assert.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, prefix+"/always-mount", mountFromQuery, "from= should carry the prefixed repository")
+	assert.Contains(t, mountScopes, "repository:"+prefix+"/always-mount:pull",
+		"mount request scopes should include the prefixed pull scope")
+}
+
 type mockAuthorizer struct {
 	authorize    func(ctx context.Context, r *http.Request) error
 	addResponses func(ctx context.Context, resp []*http.Response) error

--- a/core/remotes/docker/referrers.go
+++ b/core/remotes/docker/referrers.go
@@ -93,11 +93,6 @@ func (r dockerFetcher) openReferrers(ctx context.Context, dgst digest.Digest, co
 		fallbackHosts = hosts
 	}
 
-	ctx, err := ContextWithRepositoryScope(ctx, r.refspec, false)
-	if err != nil {
-		return nil, 0, err
-	}
-
 	var firstErr error
 	for i, host := range hosts {
 		req := r.request(host, http.MethodGet, "referrers", dgst.String())
@@ -117,10 +112,16 @@ func (r dockerFetcher) openReferrers(ctx context.Context, dgst digest.Digest, co
 			return nil, 0, err
 		}
 
-		rc, cl, err := r.open(ctx, req, mediaType, 0, i == len(hosts)-1)
+		// Set the repository scope per-host. See containerd/containerd#9648.
+		hctx, scopeErr := contextWithRepositoryScopeForHost(ctx, host, r.refspec, false)
+		if scopeErr != nil {
+			return nil, 0, scopeErr
+		}
+
+		rc, cl, err := r.open(hctx, req, mediaType, 0, i == len(hosts)-1)
 		if err != nil {
 			if !errdefs.IsNotFound(err) {
-				log.G(ctx).WithError(err).WithField("host", host.Host).Debug("error fetching referrers")
+				log.G(hctx).WithError(err).WithField("host", host.Host).Debug("error fetching referrers")
 				if firstErr == nil {
 					firstErr = err
 				}
@@ -135,14 +136,20 @@ func (r dockerFetcher) openReferrers(ctx context.Context, dgst digest.Digest, co
 		if err := req.addNamespace(r.refspec.Hostname()); err != nil {
 			return nil, 0, err
 		}
-		rc, cl, err := r.open(ctx, req, mediaType, 0, i == len(fallbackHosts)-1)
+
+		// Set the repository scope per-host. See containerd/containerd#9648.
+		hctx, scopeErr := contextWithRepositoryScopeForHost(ctx, host, r.refspec, false)
+		if scopeErr != nil {
+			return nil, 0, scopeErr
+		}
+		rc, cl, err := r.open(hctx, req, mediaType, 0, i == len(fallbackHosts)-1)
 		if err != nil {
 			if errdefs.IsNotFound(err) {
 				// Equivalent to empty referrers list
 				firstErr = err
 				break
 			}
-			log.G(ctx).WithError(err).WithField("host", host.Host).Debug("error fetching referrers via fallback")
+			log.G(hctx).WithError(err).WithField("host", host.Host).Debug("error fetching referrers via fallback")
 			if firstErr == nil {
 				firstErr = err
 			}

--- a/core/remotes/docker/registry.go
+++ b/core/remotes/docker/registry.go
@@ -80,6 +80,14 @@ type RegistryHost struct {
 	Path         string
 	Capabilities HostCapabilities
 	Header       http.Header
+
+	// RepositoryPrefix, when non-empty, is prepended to the repository name in
+	// token request scopes and in cross-repository mount requests for this
+	// host. It is intended for mirrors that namespace upstream repositories
+	// under a path prefix. The config loader populates it from the
+	// repository_prefix key in hosts.toml; no value is inferred from host.Path or
+	// other fields.
+	RepositoryPrefix string
 }
 
 func (h RegistryHost) isProxy(refhost string) bool {

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -272,11 +272,6 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 		return "", ocispec.Descriptor{}, fmt.Errorf("no resolve hosts: %w", errdefs.ErrNotFound)
 	}
 
-	ctx, err = ContextWithRepositoryScope(ctx, refspec, false)
-	if err != nil {
-		return "", ocispec.Descriptor{}, err
-	}
-
 	var (
 		// firstErr is the most relevant error encountered during resolution.
 		// We use this to determine the error to return, making sure that the
@@ -311,13 +306,21 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				req.header[key] = append(req.header[key], value...)
 			}
 
-			ctx := log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
+			// Set the repository scope per-host so that mirrors configured
+			// with a path prefix (override_path) receive a token scope that
+			// matches the registry-side repository path. See
+			// containerd/containerd#9648.
+			hctx, scopeErr := contextWithRepositoryScopeForHost(ctx, host, refspec, false)
+			if scopeErr != nil {
+				return "", ocispec.Descriptor{}, scopeErr
+			}
+			hctx = log.WithLogger(hctx, log.G(hctx).WithFields(log.Fields{
 				"host":   req.host.Host,
 				"method": req.method,
 				"url":    req.sanitizedURL(),
 			}))
-			log.G(ctx).Debug("resolving")
-			resp, err := req.doWithRetries(ctx, i == len(hosts)-1)
+			log.G(hctx).Debug("resolving")
+			resp, err := req.doWithRetries(hctx, i == len(hosts)-1)
 			if err != nil {
 				if errors.Is(err, ErrInvalidAuthorization) {
 					err = fmt.Errorf("pull access denied, repository does not exist or may require authorization: %w", err)
@@ -326,7 +329,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 					firstErr = err
 					firstErrPriority = 1
 				}
-				log.G(ctx).WithError(err).Info(nextHostOrFail(i))
+				log.G(hctx).WithError(err).Info(nextHostOrFail(i))
 				continue // try another host
 			}
 			resp.Body.Close() // don't care about body contents.
@@ -337,7 +340,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 						firstErr = fmt.Errorf("%s: %w", ref, errdefs.ErrNotFound)
 						firstErrPriority = 2
 					}
-					log.G(ctx).Infof("%s after status: %s", nextHostOrFail(i), resp.Status)
+					log.G(hctx).Infof("%s after status: %s", nextHostOrFail(i), resp.Status)
 					continue
 				}
 				if resp.StatusCode > 399 {
@@ -345,7 +348,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 						firstErr = unexpectedResponseErr(resp)
 						firstErrPriority = 3
 					}
-					log.G(ctx).Infof("%s after status: %s", nextHostOrFail(i), resp.Status)
+					log.G(hctx).Infof("%s after status: %s", nextHostOrFail(i), resp.Status)
 					continue // try another host
 				}
 				return "", ocispec.Descriptor{}, unexpectedResponseErr(resp)
@@ -370,7 +373,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				}
 			}
 			if dgst == "" || size == -1 {
-				log.G(ctx).Debug("no Docker-Content-Digest header, fetching manifest instead")
+				log.G(hctx).Debug("no Docker-Content-Digest header, fetching manifest instead")
 
 				req = base.request(host, http.MethodGet, u...)
 				if err := req.addNamespace(base.refspec.Hostname()); err != nil {
@@ -381,7 +384,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 					req.header[key] = append(req.header[key], value...)
 				}
 
-				resp, err := req.doWithRetries(ctx, true)
+				resp, err := req.doWithRetries(hctx, true)
 				if err != nil {
 					return "", ocispec.Descriptor{}, err
 				}
@@ -430,7 +433,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				Size:      size,
 			}
 
-			log.G(ctx).WithField("desc.digest", desc.Digest).Debug("resolved")
+			log.G(hctx).WithField("desc.digest", desc.Digest).Debug("resolved")
 			return ref, desc, nil
 		}
 	}

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -1602,3 +1602,121 @@ func TestResolverErrorStatusCodeOnFetch(t *testing.T) {
 		})
 	}
 }
+
+// TestResolverMirrorScopeWithPathPrefix is a regression test for
+// https://github.com/containerd/containerd/issues/9648.
+//
+// When a registry mirror is configured with a path prefix (typically with
+// override_path), containerd must issue token requests with a scope that
+// matches the mirror-side repository path. Sending an additional scope
+// derived from the original reference causes stricter registries (e.g.
+// ghcr.io, Google Artifact Registry) to reject the entire token request.
+func TestResolverMirrorScopeWithPathPrefix(t *testing.T) {
+	const (
+		// The original reference being resolved is upstream.example/team/app.
+		// The configured host.Path is /v2/mirror, so requests land at
+		// <mirror>/v2/mirror/team/app (the upstream host name is carried
+		// via the ns= query parameter, not in the path). The mirror-side
+		// repository name is therefore mirror/team/app, which is what the
+		// token scope must reflect.
+		mirrorPrefix       = "mirror"
+		originalRepo       = "team/app"
+		expectedMirrorRepo = "mirror/team/app"
+		expectedScope      = "repository:" + expectedMirrorRepo + ":pull"
+	)
+
+	var (
+		tokenScopes  []string
+		manifestSeen bool
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		// Capture all scope query params, in order.
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		tokenScopes = r.Form["scope"]
+		// Reject if any scope other than the expected mirror-side scope is
+		// present — this is what GAR/ghcr.io do in practice.
+		for _, s := range tokenScopes {
+			if s != expectedScope {
+				http.Error(w, "invalid scope: "+s, http.StatusForbidden)
+				return
+			}
+		}
+		_, _ = io.WriteString(w, `{"token":"perfectlyvalidopaquetoken","access_token":"perfectlyvalidopaquetoken"}`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Require bearer auth for everything else; advertise the mirror scope.
+		if r.Header.Get("Authorization") != "Bearer perfectlyvalidopaquetoken" {
+			realm := fmt.Sprintf("http://%s/token", r.Host)
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer realm=%q,service=registry,scope=%q", realm, expectedScope))
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if !strings.Contains(r.URL.Path, "/manifests/") {
+			http.NotFound(w, r)
+			return
+		}
+		manifestSeen = true
+		// Return a minimal but valid manifest so Resolve can complete.
+		manifest := ocispec.Manifest{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			MediaType: ocispec.MediaTypeImageManifest,
+			Config: ocispec.Descriptor{
+				MediaType: ocispec.MediaTypeImageConfig,
+				Digest:    digest.FromString("config"),
+				Size:      6,
+			},
+		}
+		body, _ := json.Marshal(manifest)
+		w.Header().Set("Content-Type", ocispec.MediaTypeImageManifest)
+		w.Header().Set("Docker-Content-Digest", digest.FromBytes(body).String())
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = w.Write(body)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mirrorHostPort := srv.URL[len("http://"):]
+	mirrorPath := "/v2/" + mirrorPrefix
+
+	resolver := NewResolver(ResolverOptions{
+		Hosts: func(string) ([]RegistryHost, error) {
+			return []RegistryHost{
+				{
+					Client:           srv.Client(),
+					Authorizer:       NewDockerAuthorizer(WithAuthClient(srv.Client())),
+					Host:             mirrorHostPort,
+					Scheme:           "http",
+					Path:             mirrorPath,
+					RepositoryPrefix: mirrorPrefix,
+					Capabilities:     HostCapabilityPull | HostCapabilityResolve,
+				},
+			}, nil
+		},
+	})
+
+	ref := "upstream.example/" + originalRepo + ":latest"
+	_, _, err := resolver.Resolve(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if !manifestSeen {
+		t.Fatal("manifest endpoint was not hit; mirror was not exercised")
+	}
+
+	// The token endpoint must have been called with exactly one scope, and
+	// that scope must match the mirror-side repository path. Before the fix,
+	// containerd produced two scopes, including the spurious
+	// original-reference scope "repository:team/app:pull".
+	if len(tokenScopes) != 1 {
+		t.Fatalf("expected exactly one scope, got %d: %v", len(tokenScopes), tokenScopes)
+	}
+	if tokenScopes[0] != expectedScope {
+		t.Fatalf("expected scope %q, got %q", expectedScope, tokenScopes[0])
+	}
+}

--- a/core/remotes/docker/scope.go
+++ b/core/remotes/docker/scope.go
@@ -26,15 +26,45 @@ import (
 	"github.com/containerd/containerd/v2/pkg/reference"
 )
 
-// RepositoryScope returns a repository scope string such as "repository:foo/bar:pull"
-// for "host/foo/bar:baz".
-// When push is true, both pull and push are added to the scope.
-func RepositoryScope(refspec reference.Spec, push bool) (string, error) {
+// repositoryFromRefspec returns the repository name portion of a reference
+// (e.g. "foo/bar" for "host/foo/bar:baz").
+func repositoryFromRefspec(refspec reference.Spec) (string, error) {
 	u, err := url.Parse("dummy://" + refspec.Locator)
 	if err != nil {
 		return "", err
 	}
-	s := "repository:" + strings.TrimPrefix(u.Path, "/") + ":pull"
+	return strings.TrimPrefix(u.Path, "/"), nil
+}
+
+// RepositoryScope returns a repository scope string such as "repository:foo/bar:pull"
+// for "host/foo/bar:baz".
+// When push is true, both pull and push are added to the scope.
+func RepositoryScope(refspec reference.Spec, push bool) (string, error) {
+	repo, err := repositoryFromRefspec(refspec)
+	if err != nil {
+		return "", err
+	}
+	s := "repository:" + repo + ":pull"
+	if push {
+		s += ",push"
+	}
+	return s, nil
+}
+
+// repositoryScopeForHost returns the repository scope appropriate for a
+// token request to a specific host. When host.RepositoryPrefix is non-empty (set
+// by the config loader for mirrors that namespace upstream repositories
+// under a path prefix), the prefix is prepended to the repository name in
+// the scope. Otherwise the result equals RepositoryScope.
+func repositoryScopeForHost(host RegistryHost, refspec reference.Spec, push bool) (string, error) {
+	repo, err := repositoryFromRefspec(refspec)
+	if err != nil {
+		return "", err
+	}
+	if prefix := strings.Trim(host.RepositoryPrefix, "/"); prefix != "" {
+		repo = prefix + "/" + repo
+	}
+	s := "repository:" + repo + ":pull"
 	if push {
 		s += ",push"
 	}
@@ -54,11 +84,24 @@ func ContextWithRepositoryScope(ctx context.Context, refspec reference.Spec, pus
 	return WithScope(ctx, s), nil
 }
 
+// contextWithRepositoryScopeForHost returns a context with tokenScopesKey{}
+// and the repository scope value derived from the given host. See
+// repositoryScopeForHost for details on how mirror path prefixes are handled.
+func contextWithRepositoryScopeForHost(ctx context.Context, host RegistryHost, refspec reference.Spec, push bool) (context.Context, error) {
+	s, err := repositoryScopeForHost(host, refspec, push)
+	if err != nil {
+		return ctx, err
+	}
+	return WithScope(ctx, s), nil
+}
+
 // WithScope appends a custom registry auth scope to the context.
 func WithScope(ctx context.Context, scope string) context.Context {
 	var scopes []string
 	if v := ctx.Value(tokenScopesKey{}); v != nil {
-		scopes = v.([]string)
+		parent := v.([]string)
+		scopes = make([]string, 0, len(parent)+1)
+		scopes = append(scopes, parent...)
 		scopes = append(scopes, scope)
 	} else {
 		scopes = []string{scope}

--- a/core/remotes/docker/scope_test.go
+++ b/core/remotes/docker/scope_test.go
@@ -56,6 +56,72 @@ func TestRepositoryScope(t *testing.T) {
 	}
 }
 
+func TestRepositoryScopeForHost(t *testing.T) {
+	testCases := []struct {
+		name     string
+		host     RegistryHost
+		refspec  reference.Spec
+		push     bool
+		expected string
+	}{
+		{
+			name: "no RepositoryPrefix yields the original repository",
+			host: RegistryHost{Host: "registry-1.docker.io"},
+			refspec: reference.Spec{
+				Locator: "registry-1.docker.io/library/alpine",
+				Object:  "ignored",
+			},
+			expected: "repository:library/alpine:pull",
+		},
+		{
+			// Regression for https://github.com/containerd/containerd/issues/9648.
+			name: "RepositoryPrefix is prepended to the repository name",
+			host: RegistryHost{Host: "ghcr.io", RepositoryPrefix: "stackhpc/docker.io"},
+			refspec: reference.Spec{
+				Locator: "docker.io/calico/node",
+				Object:  "v3.27.0",
+			},
+			expected: "repository:stackhpc/docker.io/calico/node:pull",
+		},
+		{
+			name: "RepositoryPrefix with leading and trailing slashes is normalized",
+			host: RegistryHost{Host: "us-docker.pkg.dev", RepositoryPrefix: "/project/quay-io/"},
+			refspec: reference.Spec{
+				Locator: "quay.io/prometheus/node-exporter",
+				Object:  "v1.7.0",
+			},
+			expected: "repository:project/quay-io/prometheus/node-exporter:pull",
+		},
+		{
+			name: "push action produces pull,push scope",
+			host: RegistryHost{Host: "registry-1.docker.io"},
+			refspec: reference.Spec{
+				Locator: "registry-1.docker.io/library/alpine",
+				Object:  "ignored",
+			},
+			push:     true,
+			expected: "repository:library/alpine:pull,push",
+		},
+		{
+			name: "push action with RepositoryPrefix produces prefixed pull,push scope",
+			host: RegistryHost{Host: "ghcr.io", RepositoryPrefix: "stackhpc/docker.io"},
+			refspec: reference.Spec{
+				Locator: "docker.io/library/alpine",
+				Object:  "ignored",
+			},
+			push:     true,
+			expected: "repository:stackhpc/docker.io/library/alpine:pull,push",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := repositoryScopeForHost(tc.host, tc.refspec, tc.push)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 func TestGetTokenScopes(t *testing.T) {
 	testCases := []struct {
 		scopesInCtx  []string

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -363,6 +363,57 @@ non-compliant OCI registries which are missing the `/v2` prefix.
 override_path = true
 ```
 
+## repository_prefix field
+
+`repository_prefix` is used by mirrors that namespace upstream repositories
+under a path prefix such as `<registry-host>/<repository-prefix>/<upstream-repository-name>`.
+Leading and trailing `/` in the configured value are ignored.
+When set, the value is composed into:
+
+- the host's API path, when `override_path` is false: the prefix is
+  appended after the `/v2` API base, so requests land at
+  `<api-base>/<prefix>/<repo>/...`;
+- token request scopes (`repository:<prefix>/<repo>:...`);
+- the `from=` parameter on cross-repository blob mount requests.
+
+(Defaults to empty.)
+
+For example, a mirror at `https://mirror.example` whose repositories are
+stored as `project/<original-repo>` (so a pull of `docker.io/library/alpine`
+resolves on the mirror as `project/library/alpine`):
+
+```toml
+[host."https://mirror.example"]
+  capabilities = ["pull"]
+  repository_prefix = "project"
+```
+
+containerd computes `host.Path = /v2/project` and sends token requests
+scoped to `repository:project/library/alpine:pull`.
+
+When `override_path = true` the operator is in control of `host.Path` and
+must include the prefix in the server URL explicitly:
+
+```toml
+[host."https://mirror.example/v2/project"]
+  capabilities = ["pull"]
+  override_path = true
+  repository_prefix = "project"
+```
+
+Mirrors whose API base merely lives under a vanity path but expose the
+standard upstream repository names underneath should leave
+`repository_prefix` unset; in that case the token scope and
+`from=` parameter stay as the original reference.
+
+The same prefix is also applied to cross-repository blob mounts when
+pushing through such a host: both the `from=` URL parameter and the
+appended pull scope name the mirror-side repository. For example, a
+mount of a layer from `library/foo` on a host with
+`repository_prefix = "project"` is issued as `from=project/library/foo`,
+keeping token-service scope checks consistent and letting the mirror
+locate the source layer in its prefixed namespace.
+
 ## dial_timeout field
 
 `dial_timeout` specifies the maximum time allowed for a connection attempt to complete.


### PR DESCRIPTION
Fixes #9648.

_See comprehensive test results [below](https://github.com/containerd/containerd/pull/13412#issuecomment-4511308977)._

## The bug

The resolver, fetcher, pusher, and referrers client all set up a preemptive token scope from the **original reference** — wrong for any mirror that namespaces upstream registries under a path prefix. The first request goes out unauthenticated; the mirror returns `401` with a challenge that carries the mirror-side scope; the authorizer then unions the (wrong) preemptive scope with the (correct) challenge scope on the token request:

```
GET /token?service=...&scope=repository:library/alpine:pull
                       &scope=repository:my-project/dockerhub/library/alpine:pull
```

Docker Hub ignores unknown scopes, so the bug is invisible there. Stricter token services (GAR, ghcr.io) reject the whole request and the mirror breaks.

Real configurations affected:

- **Google Artifact Registry remote repositories** — `https://us-docker.pkg.dev/v2/<project>/<remote-repo>` proxying Docker Hub or Quay.
- **Harbor proxy cache projects** — `https://harbor.example/v2/<project>` fronting an upstream registry.
- **Self-hosted mirrors** that namespace upstream registries under a path (the #9648 report used a `ghcr.io` mirror with `/v2/<owner>/<upstream>`).

## The fix

Move scope setup inside the per-host loop and derive the scope per host. A new TOML key `repository_prefix` lets operators state the mirror-side namespace for a host; the resolver/fetcher/pusher/referrers code composes it into the URL path, token request scopes, and cross-repository mount `from=` parameter. With the prefix declared, the preemptive scope matches the challenge and the token request carries one scope (the two sources dedup):

```
GET /token?service=...&scope=repository:my-project/dockerhub/library/alpine:pull
```

Configuration is opt-in: hosts without `repository_prefix` set produce the same preemptive scope as `main`, so existing `hosts.toml` files are unaffected by the upgrade.

With `override_path = false` (the default), the loader appends the declared prefix to the `/v2` API base — the operator writes the prefix once:

```toml
[host."https://mirror.example"]
  capabilities = ["pull"]
  repository_prefix = "project"
# config loader computes host.Path = /v2/project
```

With `override_path = true`, the operator is in control of `host.Path` and must include the prefix in the server URL explicitly:

```toml
[host."https://mirror.example/v2/project"]
  capabilities = ["pull"]
  override_path = true
  repository_prefix = "project"
# host.Path = /v2/project (as configured)
```

Both forms produce the same `host.Path`, the same prefixed token scope (`repository:project/library/alpine:pull`), and the same mirror-side mount-from name.

The same prefix is also applied to cross-repository blob mounts on push: both the `from=` URL parameter and the appended pull scope name the mirror-side repository, so strict token services don't see a mixed prefixed/unprefixed scope set and the mirror can locate the source layer under its prefixed namespace.

### Scope examples

Preemptive scope before and after this PR. The challenge-derived scope is unaffected and matches the "Scope after" column — so on `main` the token endpoint receives both columns when they differ (the bug); after this PR they match and dedup to one. Server URLs are shown with the full endpoint path (i.e. assuming `override_path = true`); the equivalent `override_path = false` shortcut (server URL is just the hostname, prefix declared only via `repository_prefix`) produces identical behavior.

| Server URL | `repository_prefix` | Reference | Scope before (main) | Scope after (this PR) |
|---|---|---|---|---|
| `registry-1.docker.io` | _(unset)_ | `registry-1.docker.io/library/alpine` | `repository:library/alpine:pull` | `repository:library/alpine:pull` |
| `ghcr.io/v2/stackhpc/docker.io` | `stackhpc/docker.io` | `docker.io/calico/node` | `repository:calico/node:pull` | `repository:stackhpc/docker.io/calico/node:pull` |
| `us-docker.pkg.dev/v2/project/quay-io` | `project/quay-io` | `quay.io/prometheus/node-exporter` | `repository:prometheus/node-exporter:pull` | `repository:project/quay-io/prometheus/node-exporter:pull` |
| `harbor.example/v2/project` | `project` | `upstream.example/library/app` | `repository:library/app:pull` | `repository:project/library/app:pull` |
| `dockerhub.example/v2/dockerhub_proxy` | _(unset)_ | `docker.io/library/alpine` | `repository:library/alpine:pull` | `repository:library/alpine:pull` |

The last row covers a mirror whose V2 API lives under a vanity path but whose repositories are *not* namespaced under that prefix (the mirror serves the original upstream repository names directly). With `repository_prefix` unset the preemptive scope is unchanged, matching `main`.

## API and config surface

- **New Go API**: `RegistryHost.RepositoryPrefix string` in `core/remotes/docker`. Additive field on an existing public struct; the zero value (`""`) preserves `main` behavior. Callers constructing `RegistryHost` directly (custom resolvers, third-party host providers) can populate this without going through the TOML loader — a future regex-rewrite strategy along the lines of the k3s fork could be wired in by setting this field.
- **New TOML key**: `repository_prefix = "<prefix>"` under `[host."..."]` entries in `hosts.toml`. Optional, defaults to empty. Leading and trailing `/` are trimmed.
- **Config loader composition**: when `override_path` is false (the default), the loader appends `repository_prefix` to `host.Path` so requests land at `<api-base>/<prefix>/<repo>/...` without operators needing to write the prefix twice. When `override_path = true` the operator's path is authoritative and must include the prefix.

## Why not just drop the preemptive scope?

The challenge scope alone would suffice for any mirror that returns one. But some registries omit `scope=` from their `WWW-Authenticate` header, and the preemptive scope is the only thing keeping those flows working. This fix keeps the safety net and lets operators make it correct for prefixed mirrors.

## Comparison with the k3s fork

The k3s team fixed the same issue in their fork (`brandond/containerd@c18a4212c76eed6d`) as part of a "Mirror repository rewrites" feature. Both fixes move scope setup into the per-host loop; they differ in how the mirror-side repository name is supplied:

| | Source of mirror-side repo | Mechanism | Config surface |
|---|---|---|---|
| k3s fork | `host.Rewrites` regex map | user-supplied regex transform on the original repo | new `RegistryHost.Rewrites` field + new TOML keys + CRI plumbing |
| this PR | `host.RepositoryPrefix` string | operator-supplied fixed prefix | new `RegistryHost.RepositoryPrefix` Go field + new `repository_prefix` TOML key |

A future PR could add the regex mechanism alongside `RepositoryPrefix` (the regex result can populate `RepositoryPrefix` per pull); they're complementary, not competing.

## Files touched

- `registry.go` — adds `RegistryHost.RepositoryPrefix`.
- `scope.go` — adds `repositoryScopeForHost` and `contextWithRepositoryScopeForHost`. Both just read `host.RepositoryPrefix`; `RepositoryScope` / `ContextWithRepositoryScope` unchanged.
- `resolver.go`, `fetcher.go`, `pusher.go`, `referrers.go` — set the scope per-host inside the existing host loops. `FetchByDigest` threads the chosen host's scope through to the lazy seeker. `pusher.go` also prefixes the `from=` parameter and the appended pull scope when issuing a cross-repo blob mount on a prefixed host.
- `config/hosts.go` — adds the `repository_prefix` TOML key and plumbs it through to `RegistryHost.RepositoryPrefix`.
- `scope_test.go`, `config/hosts_test.go` — cover the helper and the loader plumbing.
- `resolver_test.go` — `TestResolverMirrorScopeWithPathPrefix` stands up a fake registry on a `/v2/<prefix>` path and asserts the token endpoint receives exactly one scope.
- `docs/hosts.md` — adds a `repository_prefix field` section documenting the new key.

## Testing

- `go test ./core/remotes/docker/...` passes.
- `TestResolverMirrorScopeWithPathPrefix` fails on `main` (two scopes → request rejected) and passes here.
