### PR TITLE
cmd/containerd-stress: fix potential panic in getMaps on empty lines

### DIFF
--- a/cmd/containerd-stress/density.go
+++ b/cmd/containerd-stress/density.go
@@ -155,10 +155,7 @@ func getMaps(pid int) (map[string]int, error) {
 		s     = bufio.NewScanner(f)
 	)
 	for s.Scan() {
-		var (
-			fields = strings.Fields(s.Text())
-			name   = fields[0]
-		)
+		fields := strings.Fields(s.Text())
 		if len(fields) < 2 {
 			continue
 		}
@@ -166,7 +163,7 @@ func getMaps(pid int) (map[string]int, error) {
 		if err != nil {
 			continue
 		}
-		smaps[name] += n
+		smaps[fields[0]] += n
 	}
 	if err := s.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
In `getMaps()`, `fields[0]` was accessed before checking `len(fields) < 2`.
If `strings.Fields` returns an empty slice (e.g. from an empty or
whitespace-only line in `/proc/[pid]/smaps`), this causes an index out
of range panic.

Move the length check before any field access and use `fields[0]`
directly instead of the intermediate `name` variable.
