### PR TITLE
cri: normalize PinnedImages config before matching pinned label

### DIFF
--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -434,7 +434,8 @@ func (c *CRIImageService) createOrUpdateImageReference(ctx context.Context, name
 func (c *CRIImageService) getLabels(ctx context.Context, name string) map[string]string {
 	labels := map[string]string{crilabels.ImageLabelKey: crilabels.ImageLabelValue}
 	for _, pinned := range c.config.PinnedImages {
-		if pinned == name {
+		normalizedPinned, err := distribution.ParseDockerRef(pinned)
+		if err == nil && normalizedPinned.String() == name {
 			labels[crilabels.PinnedImageLabelKey] = crilabels.PinnedImageLabelValue
 		}
 	}

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -476,7 +476,7 @@ func TestImageGetLabels(t *testing.T) {
 		{
 			name:          "pinned image labels should get added on sandbox image without tag",
 			expectedLabel: map[string]string{labels.ImageLabelKey: labels.ImageLabelValue, labels.PinnedImageLabelKey: labels.PinnedImageLabelValue},
-			pinnedImages:  map[string]string{"sandboxnotag": "k8s.gcr.io/pause", "sandbox": "k8s.gcr.io/pause:latest"},
+			pinnedImages:  map[string]string{"sandboxnotag": "k8s.gcr.io/pause"},
 			pullImageName: "k8s.gcr.io/pause:latest",
 		},
 		{


### PR DESCRIPTION
## Summary

Closes #13314

When a `pinned_images` entry has no tag (e.g. `localhost/kubernetes/pause`), the `io.cri-containerd.pinned=pinned` label is never set. Kubelet then sees `Pinned: false` and can GC the sandbox image under disk pressure, which breaks pod creation on the node.

`getLabels` does a raw string compare against an image ref that the caller already normalized via `ParseDockerRef`, so `"k8s.gcr.io/pause"` (config) never matches `"k8s.gcr.io/pause:latest"` (normalized ref). This regressed in ad4c9f8a9dea when `SandboxImage` was refactored into `PinnedImages` and the config-side `ParseDockerRef` call was dropped.

This PR runs each `PinnedImages` entry through `ParseDockerRef` before comparing.

The existing "without tag" test passed because the normalized `:latest` form was also listed in `pinnedImages`. Removed that workaround so the test actually covers the tagless path. It fails on main and passes with this fix.

### Test plan
  
- [x] `go test ./internal/cri/server/images/ -run TestImageGetLabels`
- [x] `go test ./internal/cri/server/images/`