### PR TITLE
do not hide linitng errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,6 @@ jobs:
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - run: script/setup/install-dev-tools
-      - run: make proto-fmt
       - run: make check-protos
 
   man:

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ CRIDIR=$(OUTPUTDIR)/cri
 
 all: binaries
 
-check: proto-fmt ## run all linters
+check: check-protos ## run all linters
 	@echo "$(WHALE) $@"
 	GOGC=75 golangci-lint run
 
@@ -196,7 +196,7 @@ check-protos: ## check if protobufs needs to be generated again
 	@echo "$(WHALE) $@"
 	@(cd api && buf format --diff --exit-code --exclude-path vendor \
 		$(if $(GITHUB_ACTIONS),--error-format github-actions)) || \
-		(echo "$(ONI) please run 'make protos' when making changes to proto files" && false)
+		(echo "$(ONI) please run 'make proto-fmt' to fix formatting or 'make protos' to regenerate proto files" && false)
 
 proto-fmt: ## format proto files
 	@echo "$(WHALE) $@"

--- a/api/runtime/bootstrap/v1/bootstrap.proto
+++ b/api/runtime/bootstrap/v1/bootstrap.proto
@@ -114,10 +114,10 @@ message BootstrapResult {
 // positive, and more verbose levels are negative. This is an open enum;
 // unknown numeric values are preserved on the wire.
 enum LogLevel {
-  LOG_LEVEL_INFO  = 0;
+  LOG_LEVEL_INFO = 0;
   LOG_LEVEL_TRACE = -8;
   LOG_LEVEL_DEBUG = -4;
-  LOG_LEVEL_WARN  = 4;
+  LOG_LEVEL_WARN = 4;
   LOG_LEVEL_ERROR = 8;
   LOG_LEVEL_FATAL = 10;
   LOG_LEVEL_PANIC = 12;

--- a/api/types/transfer/container.proto
+++ b/api/types/transfer/container.proto
@@ -1,20 +1,19 @@
 /*
-	Copyright The containerd Authors.
+   Copyright The containerd Authors.
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 syntax = "proto3";
-
 
 package containerd.types.transfer;
 
@@ -24,16 +23,16 @@ option go_package = "github.com/containerd/containerd/api/types/transfer";
 // filesystem. It acts as either a source or destination in a transfer
 // operation, identifying the container and path for archive operations.
 message ContainerPath {
-	string container_id = 1;
-	string path = 2;
+  string container_id = 1;
+  string path = 2;
 
-	// When true and path is a directory, return only the directory entry
-	// itself without walking into its contents. This is useful for
-	// stat-like operations where only the directory's metadata is needed.
-	bool no_walk = 3;
+  // When true and path is a directory, return only the directory entry
+  // itself without walking into its contents. This is useful for
+  // stat-like operations where only the directory's metadata is needed.
+  bool no_walk = 3;
 
-	// When true, preserve the UID/GID from tar headers when extracting
-	// files. When false, extracted files are owned by the extracting
-	// process.
-	bool preserve_ownership = 4;
+  // When true, preserve the UID/GID from tar headers when extracting
+  // files. When false, extracted files are owned by the extracting
+  // process.
+  bool preserve_ownership = 4;
 }

--- a/api/types/transfer/streaming.proto
+++ b/api/types/transfer/streaming.proto
@@ -32,14 +32,14 @@ message WindowUpdate {
 // direction). The client sends data through the stream and the
 // server reads it.
 message ReadStream {
-	string stream = 1;
-	string media_type = 2;
+  string stream = 1;
+  string media_type = 2;
 }
 
 // WriteStream carries data from the server to the client (export
 // direction). The server writes data into the stream and the
 // client receives it.
 message WriteStream {
-	string stream = 1;
-	string media_type = 2;
+  string stream = 1;
+  string media_type = 2;
 }

--- a/vendor/github.com/containerd/containerd/api/runtime/bootstrap/v1/bootstrap.proto
+++ b/vendor/github.com/containerd/containerd/api/runtime/bootstrap/v1/bootstrap.proto
@@ -114,10 +114,10 @@ message BootstrapResult {
 // positive, and more verbose levels are negative. This is an open enum;
 // unknown numeric values are preserved on the wire.
 enum LogLevel {
-  LOG_LEVEL_INFO  = 0;
+  LOG_LEVEL_INFO = 0;
   LOG_LEVEL_TRACE = -8;
   LOG_LEVEL_DEBUG = -4;
-  LOG_LEVEL_WARN  = 4;
+  LOG_LEVEL_WARN = 4;
   LOG_LEVEL_ERROR = 8;
   LOG_LEVEL_FATAL = 10;
   LOG_LEVEL_PANIC = 12;

--- a/vendor/github.com/containerd/containerd/api/types/transfer/container.proto
+++ b/vendor/github.com/containerd/containerd/api/types/transfer/container.proto
@@ -1,20 +1,19 @@
 /*
-	Copyright The containerd Authors.
+   Copyright The containerd Authors.
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 syntax = "proto3";
-
 
 package containerd.types.transfer;
 
@@ -24,16 +23,16 @@ option go_package = "github.com/containerd/containerd/api/types/transfer";
 // filesystem. It acts as either a source or destination in a transfer
 // operation, identifying the container and path for archive operations.
 message ContainerPath {
-	string container_id = 1;
-	string path = 2;
+  string container_id = 1;
+  string path = 2;
 
-	// When true and path is a directory, return only the directory entry
-	// itself without walking into its contents. This is useful for
-	// stat-like operations where only the directory's metadata is needed.
-	bool no_walk = 3;
+  // When true and path is a directory, return only the directory entry
+  // itself without walking into its contents. This is useful for
+  // stat-like operations where only the directory's metadata is needed.
+  bool no_walk = 3;
 
-	// When true, preserve the UID/GID from tar headers when extracting
-	// files. When false, extracted files are owned by the extracting
-	// process.
-	bool preserve_ownership = 4;
+  // When true, preserve the UID/GID from tar headers when extracting
+  // files. When false, extracted files are owned by the extracting
+  // process.
+  bool preserve_ownership = 4;
 }

--- a/vendor/github.com/containerd/containerd/api/types/transfer/streaming.proto
+++ b/vendor/github.com/containerd/containerd/api/types/transfer/streaming.proto
@@ -32,14 +32,14 @@ message WindowUpdate {
 // direction). The client sends data through the stream and the
 // server reads it.
 message ReadStream {
-	string stream = 1;
-	string media_type = 2;
+  string stream = 1;
+  string media_type = 2;
 }
 
 // WriteStream carries data from the server to the client (export
 // direction). The server writes data into the stream and the
 // client receives it.
 message WriteStream {
-	string stream = 1;
-	string media_type = 2;
+  string stream = 1;
+  string media_type = 2;
 }


### PR DESCRIPTION
This was counterproductive to format files before checking. Now lining errors will actually be checked