### PR TITLE
cri: skip pause image pull for shim sandboxer

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -294,6 +294,7 @@ version = 3
           cni_max_conf_num = 0
           snapshotter = ''
           sandboxer = 'podsandbox'
+          disable_pause_image_pull = false
           io_type = ''
 
           [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -125,6 +125,12 @@ type Runtime struct {
 	// shim - means use whatever Controller implementation provided by shim (e.g. use RemoteController).
 	// podsandbox - means use Controller implementation from sbserver podsandbox package.
 	Sandboxer string `toml:"sandboxer" json:"sandboxer"`
+	// DisablePauseImagePull disables the automatic pre-pull of the pause container image
+	// in ensurePauseImageExists() during RunPodSandbox. When set to true, the shim controller
+	// implementation is responsible for ensuring the pause image (or its equivalent) is available.
+	// This is useful for sandboxers that do not require the host-level pause image.
+	// Default: false (CRI pre-pulls the pause image for all runtimes).
+	DisablePauseImagePull bool `toml:"disable_pause_image_pull" json:"disablePauseImagePull"`
 	// IOType defines how containerd transfer the io streams of the container
 	// if it is not set, the named pipe will be created for the container
 	// we can also set it to "streaming" to create a stream by streaming api,

--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -292,8 +292,16 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	// containers anyway, the CRI layer will pre-pull the pause container to guarantee
 	// it exists (even though it's counter to the purpose of the sandbox API). This may
 	// be removed/deprecated in the distant future, if we decide to remove pause containers.
-	if err := c.ensurePauseImageExists(ctx, r.GetConfig(), r.GetRuntimeHandler()); err != nil {
-		return nil, err
+	//
+	// Runtimes set disable_pause_image_pull = true to tell the CRI layer that they manage
+	// pause image availability on their own (e.g. shim sandboxers).
+	if !ociRuntime.DisablePauseImagePull {
+		if err := c.ensurePauseImageExists(ctx, r.GetConfig(), r.GetRuntimeHandler()); err != nil {
+			return nil, err
+		}
+	} else {
+		log.G(ctx).Debugf("Skipping pause image pull for runtime handler %q (type=%q, sandboxer=%q, disable_pause_image_pull=true)",
+			r.GetRuntimeHandler(), ociRuntime.Type, ociRuntime.Sandboxer)
 	}
 
 	ctrl, err := c.sandboxService.StartSandbox(ctx, sandbox.Sandboxer, id)

--- a/internal/cri/server/sandbox_run_test.go
+++ b/internal/cri/server/sandbox_run_test.go
@@ -23,7 +23,10 @@ import (
 
 	"github.com/containerd/go-cni"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 )
 
 func TestToCNIPortMappings(t *testing.T) {
@@ -185,6 +188,48 @@ func TestSelectPodIP(t *testing.T) {
 			ip, additionalIPs := selectPodIPs(context.Background(), ipConfigs, test.pref)
 			assert.Equal(t, test.expectedIP, ip)
 			assert.Equal(t, test.expectedAdditionalIPs, additionalIPs)
+		})
+	}
+}
+
+func TestDisablePauseImagePullConfig(t *testing.T) {
+	for _, test := range []struct {
+		desc                  string
+		sandboxer             string
+		DisablePauseImagePull bool
+	}{
+		{
+			desc:                  "Podsandbox sandboxer should pull pause image when DisablePauseImagePull is false",
+			sandboxer:             "podsandbox",
+			DisablePauseImagePull: false,
+		},
+		{
+			desc:                  "Shim sandboxer should skip pause image pull when DisablePauseImagePull is true",
+			sandboxer:             "shim",
+			DisablePauseImagePull: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			cfg := criconfig.Config{
+				RuntimeConfig: criconfig.RuntimeConfig{
+					ContainerdConfig: criconfig.ContainerdConfig{
+						DefaultRuntimeName: "test-runtime",
+						Runtimes: map[string]criconfig.Runtime{
+							"test-runtime": {
+								Type:                  "io.containerd.runc.v2",
+								Sandboxer:             test.sandboxer,
+								DisablePauseImagePull: test.DisablePauseImagePull,
+							},
+						},
+					},
+				},
+			}
+
+			ociRuntime, err := cfg.GetSandboxRuntime(&runtime.PodSandboxConfig{
+				Metadata: &runtime.PodSandboxMetadata{Name: "test", Namespace: "default"},
+			}, "")
+			require.NoError(t, err)
+			assert.Equal(t, test.DisablePauseImagePull, ociRuntime.DisablePauseImagePull)
 		})
 	}
 }


### PR DESCRIPTION
### Background
  
When using the Sandbox API with sandboxer = "shim" (e.g. Kata Containers), ensurePauseImageExists()
  unconditionally pulls the pause image even though the shim controller never uses it. This PR skips the pull for
  non-podsandbox sandboxers.

### Solution

  Gate the ensurePauseImageExists() call on sandbox.Sandboxer == "podsandbox":
```
type Runtime struct {
     ...
     DisablePullPauseImage bool `toml:"disable_pull_pause_image" json:"disablePullPauseImage"`
     ...
}

 if !ociRuntime.DisablePullPauseImage {
     if err := c.ensurePauseImageExists(ctx, r.GetConfig(), r.GetRuntimeHandler()); err != nil {
        return nil, err
      }
}
```

And the containerd config.toml with the disable_pull_pause_image looks like as below:
```toml
      [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes]
        [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.kata]
          runtime_type = 'io.containerd.kata.v2'
          runtime_path = ''
          pod_annotations = []
          container_annotations = []
          privileged_without_host_devices = false
          privileged_without_host_devices_all_devices_allowed = false
          cgroup_writable = false
          base_runtime_spec = ''
          cni_conf_dir = ''
          cni_max_conf_num = 0
          snapshotter = ''
          sandboxer = 'shim'
         disable_pull_pause_image = true
          io_type = ''

        [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
          runtime_type = 'io.containerd.runc.v2'
          runtime_path = ''
          pod_annotations = []
          container_annotations = []
          privileged_without_host_devices = false
          privileged_without_host_devices_all_devices_allowed = false
          cgroup_writable = false
          base_runtime_spec = ''
          cni_conf_dir = ''
          cni_max_conf_num = 0
          snapshotter = ''
          sandboxer = 'podsandbox'
         disable_pull_pause_image = true
          io_type = ''

```