### PR TITLE
Allow Windows shim to detach to avoid extra fork

### DIFF
--- a/core/runtime/v2/binary.go
+++ b/core/runtime/v2/binary.go
@@ -114,11 +114,11 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 			log.G(ctx).WithError(err).Error("copy shim log")
 		}
 	}()
-	out, err := cmd.CombinedOutput()
+	// Platform-specific: see binary_windows.go and binary_unix.go.
+	response, err := readShimBootstrap(ctx, cmd)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", out, err)
+		return nil, err
 	}
-	response := bytes.TrimSpace(out)
 
 	onCloseWithShimLog := func() {
 		onClose()

--- a/core/runtime/v2/binary_unix.go
+++ b/core/runtime/v2/binary_unix.go
@@ -1,0 +1,39 @@
+//go:build unix
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// readShimBootstrap starts cmd and collects the shim "start" helper's
+// bootstrap response.
+//
+// On Unix the classic double-fork is cheap: the helper always exits promptly
+// after writing its result, so cmd.CombinedOutput suffices.
+func readShimBootstrap(_ context.Context, cmd *exec.Cmd) ([]byte, error) {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", out, err)
+	}
+	return bytes.TrimSpace(out), nil
+}

--- a/core/runtime/v2/binary_windows.go
+++ b/core/runtime/v2/binary_windows.go
@@ -1,0 +1,170 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/containerd/log"
+)
+
+// stderrCapture buffers writes until MirrorTo is called, then flushes the
+// buffered prefix to the mirror writer and forwards all subsequent writes
+// there. The buffered prefix is retained for error messages.
+//
+// This is used for the shim helper's stderr: during startup we need to
+// capture any error output; once we receive a good bootstrap response the
+// helper (if it self-daemonized) will stay alive and produce output
+// indefinitely, so we mirror to os.Stderr rather than buffering forever.
+//
+// Write is safe to call concurrently with MirrorTo because exec's internal
+// stderr-drain goroutine calls Write from a separate goroutine.
+type stderrCapture struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	mirror io.Writer
+}
+
+func (s *stderrCapture) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mirror != nil {
+		return s.mirror.Write(p)
+	}
+	return s.buf.Write(p)
+}
+
+// MirrorTo flushes any buffered bytes to w and forwards all future writes
+// there. After this returns, the buffer is no longer retained.
+func (s *stderrCapture) MirrorTo(w io.Writer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.buf.Len() > 0 {
+		_, _ = w.Write(s.buf.Bytes())
+		s.buf.Reset()
+	}
+	s.mirror = w
+}
+
+func (s *stderrCapture) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// readShimBootstrap starts cmd and collects the shim "start" helper's
+// bootstrap response.
+//
+// On Windows we support self-daemonizing shims (Detachable): the helper
+// writes its result, closes stdout to signal readiness, and stays alive as
+// the long-lived TTRPC server. CombinedOutput would block indefinitely in
+// that case. Instead we race two goroutines — one draining stdout, one
+// waiting on the process — and proceed as soon as either delivers enough
+// information to make a decision.
+//
+// The helper's exit code is not the source of truth for shim health; the
+// TTRPC connection attempted by the caller is.
+//
+// We use os.Pipe rather than cmd.StdoutPipe so that cmd.Wait does not close
+// the read end while ReadAll is still in flight (per Go docs, calling Wait
+// before StdoutPipe reads complete is incorrect).
+func readShimBootstrap(ctx context.Context, cmd *exec.Cmd) ([]byte, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("shim start pipe: %w", err)
+	}
+	cmd.Stdout = w
+	var sc stderrCapture
+	cmd.Stderr = &sc
+	if err := cmd.Start(); err != nil {
+		r.Close()
+		w.Close()
+		return nil, fmt.Errorf("start shim: %w", err)
+	}
+	// Close the parent's write end; the child has its own dup. This ensures
+	// ReadAll sees EOF when the child closes its copy (or exits).
+	w.Close()
+
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	readCh := make(chan readResult, 1)
+	go func() {
+		defer r.Close()
+		data, err := io.ReadAll(r)
+		readCh <- readResult{data, err}
+	}()
+
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+
+	select {
+	case rr := <-readCh:
+		response := bytes.TrimSpace(rr.data)
+		if len(response) == 0 || rr.err != nil {
+			// Empty or broken stdout: pull the exit code to build a useful
+			// error. Bound the wait in case the helper closed stdout but is
+			// still alive (broken self-daemonizing shim).
+			select {
+			case waitErr := <-waitCh:
+				return nil, fmt.Errorf("shim start: %w (read: %v)\nstderr: %s",
+					waitErr, rr.err, sc.String())
+			case <-time.After(5 * time.Second):
+				cmd.Process.Kill() //nolint:errcheck
+				<-waitCh
+				return nil, fmt.Errorf("shim start: empty bootstrap and helper did not exit within 5s"+
+					"\nread err: %v\nstderr: %s", rr.err, sc.String())
+			}
+		}
+		// Good response. If the helper self-daemonized it will keep running
+		// and producing output; mirror its stderr to containerd's own stderr
+		// rather than buffering indefinitely.
+		sc.MirrorTo(os.Stderr)
+		go func() {
+			if waitErr := <-waitCh; waitErr != nil {
+				log.G(ctx).WithError(waitErr).Debug(
+					"shim start helper exited with error after writing bootstrap")
+			}
+		}()
+		return response, nil
+
+	case waitErr := <-waitCh:
+		// Helper exited before stdout finished draining. Collect whatever it
+		// managed to write.
+		rr := <-readCh
+		response := bytes.TrimSpace(rr.data)
+		if len(response) == 0 {
+			return nil, fmt.Errorf("shim start: %w\nstderr: %s",
+				waitErr, sc.String())
+		}
+		if waitErr != nil {
+			return nil, fmt.Errorf("shim start: %w\nstdout: %s\nstderr: %s",
+				waitErr, response, sc.String())
+		}
+		// Clean exit with output: classic shim happy path.
+		return response, nil
+
+	}
+}

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -295,6 +295,18 @@ func run(ctx context.Context, manager Shim, config Config) error {
 			}
 		}
 
+		// Platform-specific: on Windows, if the manager implements
+		// Detachable, tryDetach writes the bootstrap result, closes stdout,
+		// detaches the console, and returns true so we fall through to the
+		// daemon serve loop. On Unix it is always a no-op.
+		// See shim_windows.go and shim_unix.go.
+		if started, err := tryDetach(ctx, manager, &params); err != nil {
+			return err
+		} else if started {
+			break
+		}
+
+		// Classic path: manager spawned a separate daemon subprocess.
 		result, err := manager.Start(ctx, &params)
 		if err != nil {
 			return err

--- a/pkg/shim/shim_unix.go
+++ b/pkg/shim/shim_unix.go
@@ -27,6 +27,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	bootapi "github.com/containerd/containerd/api/runtime/bootstrap/v1"
 	"github.com/containerd/containerd/v2/pkg/sys/reaper"
 	"github.com/containerd/fifo"
 	"github.com/containerd/log"
@@ -116,4 +117,10 @@ func openLog(ctx context.Context, _ string) (io.Writer, error) {
 // shim creating its endpoint and the parent connecting to it.
 func awaitPipeReady(_ string) error {
 	return nil
+}
+
+// tryDetach is a no-op on Unix. The classic double-fork is cheap on Unix so
+// Detachable is never invoked.
+func tryDetach(_ context.Context, _ Shim, _ *bootapi.BootstrapParams) (bool, error) {
+	return false, nil
 }

--- a/pkg/shim/shim_windows.go
+++ b/pkg/shim/shim_windows.go
@@ -22,12 +22,17 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	winio "github.com/Microsoft/go-winio"
+	bootapi "github.com/containerd/containerd/api/runtime/bootstrap/v1"
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
+	"golang.org/x/sys/windows"
 )
 
 func setupSignals(config Config) (chan os.Signal, error) {
@@ -45,8 +50,137 @@ func subreaper() error {
 func setupDumpStacks(dump chan<- os.Signal) {
 }
 
-func serveListener(path string, fd uintptr) (net.Listener, error) {
-	return nil, errdefs.ErrNotImplemented
+var (
+	modkernel32     = windows.NewLazySystemDLL("kernel32.dll")
+	procFreeConsole = modkernel32.NewProc("FreeConsole")
+)
+
+// Detachable is an optional extension of Shim for Windows shims that want to
+// avoid spawning a separate long-lived daemon process.
+//
+// When the Shim passed to RunShim also implements Detachable, the framework
+// calls Detach instead of Start. Detach binds the TTRPC endpoint in the
+// current process and returns the bootstrap result. The framework then writes
+// the result to stdout, closes stdout (so containerd unblocks), calls
+// FreeConsole, and falls through to the serve loop.
+//
+// Implementations should call SetDetachListener with the pre-bound listener so
+// serveListener can reuse it rather than rebinding, preserving any connections
+// containerd queued after reading the result. Any transport is supported.
+type Detachable interface {
+	Shim
+	// Detach binds the TTRPC endpoint in the current process and returns
+	// the bootstrap result. Must not launch a child process.
+	Detach(ctx context.Context, params *bootapi.BootstrapParams) (*bootapi.BootstrapResult, error)
+}
+
+// detachListener holds a net.Listener pre-bound by [Detachable.Detach].
+var detachListener atomic.Pointer[net.Listener]
+
+// SetDetachListener stores a pre-bound listener so that serveListener can
+// reuse it rather than rebinding. The listener must already be bound.
+// Storing it before stdout is closed ensures containerd can connect the
+// instant it reads the bootstrap result, regardless of transport.
+func SetDetachListener(l net.Listener) {
+	detachListener.Store(&l)
+}
+
+// takeDetachListener retrieves and clears the listener stored by
+// SetDetachListener. Returns nil if no listener was pre-bound.
+func takeDetachListener() net.Listener {
+	p := detachListener.Swap(nil)
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+// tryDetach calls Detach if manager implements Detachable, then writes the
+// bootstrap result to stdout, closes stdout so containerd unblocks, and calls
+// FreeConsole. Returns true so the caller falls through to the serve loop.
+// Returns false if manager does not implement Detachable.
+func tryDetach(ctx context.Context, manager Shim, params *bootapi.BootstrapParams) (bool, error) {
+	dm, ok := manager.(Detachable)
+	if !ok {
+		return false, nil
+	}
+
+	result, err := dm.Detach(ctx, params)
+	if err != nil {
+		return false, err
+	}
+
+	data, err := proto.Marshal(result)
+	if err != nil {
+		return false, fmt.Errorf("marshal bootstrap result: %w", err)
+	}
+	if _, err := os.Stdout.Write(data); err != nil {
+		return false, err
+	}
+	// Close stdout: containerd's reader returns at EOF, allowing it to
+	// proceed without waiting for this process to exit.
+	os.Stdout.Close()
+	// Detach from any inherited console so that OS signals (e.g. Ctrl+C)
+	// do not reach the self-daemonized process.
+	if err := detachConsole(); err != nil {
+		log.G(ctx).WithError(err).Debug("detach console (non-fatal)")
+	}
+	return true, nil
+}
+
+// serveListener creates the TTRPC listener for the shim daemon.
+//
+// On Windows two transport modes are supported:
+//
+//   - Named pipe (\\.\pipe\…): the historical default for Windows shims.
+//
+//   - AF_UNIX socket (unix://…): preferred for Detachable shims
+//     because it eliminates the named-pipe polling overhead.
+//     AF_UNIX is available on Windows 10 build 17063+.
+//
+// If Detachable.Detach pre-bound a listener via SetDetachListener, it is
+// returned directly so that connections queued while the "start" process
+// was still running are not lost.
+//
+// Note: Windows does not support inheriting a listener via fd (Unix passes
+// fd 3/4 for this purpose); the fd parameter is unused on Windows.
+func serveListener(path string, _ uintptr) (net.Listener, error) {
+	if path == "" {
+		path = os.Getenv("TTRPC_SOCKET")
+		if path == "" {
+			return nil, fmt.Errorf("no socket path provided and TTRPC_SOCKET env not set")
+		}
+	}
+
+	// If Detach pre-bound a listener, use it regardless of scheme. The shim
+	// is responsible for matching the listener's transport to the address it
+	// returned in BootstrapResult.
+	if l := takeDetachListener(); l != nil {
+		log.L.WithField("address", path).Debug("serving ttrpc on pre-bound listener (Detachable)")
+		return l, nil
+	}
+
+	// AF_UNIX mode.
+	if socketPath, ok := strings.CutPrefix(path, "unix://"); ok {
+		os.Remove(socketPath) //nolint:errcheck,gosec // socketPath is the shim's own socket address
+		l, err := net.Listen("unix", socketPath)
+		if err != nil {
+			return nil, fmt.Errorf("listen unix %s: %w", socketPath, err)
+		}
+		log.L.WithField("socket", socketPath).Debug("serving ttrpc on AF_UNIX socket")
+		return l, nil
+	}
+
+	// Named-pipe mode.
+	if !strings.HasPrefix(path, `\\.\pipe\`) {
+		return nil, fmt.Errorf("unsupported TTRPC_SOCKET address %q (expected unix:// or named pipe)", path)
+	}
+	l, err := winio.ListenPipe(path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listen named pipe %s: %w", path, err)
+	}
+	log.L.WithField("pipe", path).Debug("serving ttrpc on named pipe")
+	return l, nil
 }
 
 func reap(ctx context.Context, logger *log.Entry, signals chan os.Signal) error {
@@ -60,17 +194,39 @@ func openLog(ctx context.Context, _ string) (io.Writer, error) {
 	return nil, errdefs.ErrNotImplemented
 }
 
-// awaitPipeReady polls a named pipe address until it is connectable,
-// retrying for up to 5 seconds with 10ms intervals.
+// detachConsole detaches the current process from its inherited console.
+// After self-daemonizing (Detachable), the "start" process continues
+// running as the shim daemon. Detaching prevents OS signals sent to the
+// parent's console (e.g. Ctrl+C in a terminal) from being delivered to the
+// daemon.
+func detachConsole() error {
+	r, _, err := procFreeConsole.Call()
+	if r == 0 {
+		return fmt.Errorf("FreeConsole: %w", err)
+	}
+	return nil
+}
+
+// awaitPipeReady polls a TTRPC endpoint address until it is connectable.
 //
-// The shim "start" helper returns the pipe address before the long-lived
-// daemon has called winio.ListenPipe(). Unlike Unix domain sockets (which
-// appear atomically on Listen), Windows named pipes may take measurable
-// time to appear — especially under load. See #3659, microsoft/hcsshim.
+// For named pipes the daemon must call winio.ListenPipe before the pipe is
+// visible to clients, so we poll with 10 ms sleep intervals for up to 5 s.
+//
+// For AF_UNIX sockets the socket file appears atomically when net.Listen
+// returns. If the shim used Detachable and pre-bound the socket via
+// SetDetachListener, it exists before stdout was even closed, so no polling
+// is needed.
 func awaitPipeReady(address string) error {
-	if address == "" {
+	if address == "" || strings.HasPrefix(address, "unix://") {
+		// AF_UNIX: either pre-bound by Detach (no wait needed) or bound
+		// atomically by the daemon (containerd's AnonDialer retries).
 		return nil
 	}
+	if !strings.HasPrefix(address, `\\.\pipe\`) {
+		// Unknown scheme — let the caller's dialer deal with it.
+		return nil
+	}
+
 	timer := time.NewTimer(5 * time.Second)
 	defer timer.Stop()
 


### PR DESCRIPTION
On Windows, the classic shim startup requires spawning a second process: the start helper exits after writing the bootstrap address, and the actual long-lived TTRPC server is a separately-launched child. Each spawn costs roughly 10s of ms on Windows. This PR removes that requirement.

No protocol change — containerd identifies self-daemonizing shims by observing that the helper is still alive after stdout closes. After the start has finished sending bootstrap results, there is no need to guarantee it has exited on Windows.