### PR TITLE
content,diff: pick the digest algorithm when producing blobs

### DIFF
--- a/core/content/content.go
+++ b/core/content/content.go
@@ -18,9 +18,11 @@ package content
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -188,8 +190,9 @@ func WithLabels(labels map[string]string) Opt {
 
 // WriterOpts is internally used by WriterOpt.
 type WriterOpts struct {
-	Ref  string
-	Desc ocispec.Descriptor
+	Ref       string
+	Desc      ocispec.Descriptor
+	Algorithm digest.Algorithm
 }
 
 // WriterOpt is used for passing options to Ingester.Writer.
@@ -212,6 +215,29 @@ func WithDescriptor(desc ocispec.Descriptor) WriterOpt {
 func WithRef(ref string) WriterOpt {
 	return func(opts *WriterOpts) error {
 		opts.Ref = ref
+		return nil
+	}
+}
+
+// WithBlobDigestAlgorithm requests that the writer hash incoming data using
+// the given algorithm when no expected digest has been supplied via
+// WithDescriptor. The algorithm must be registered with go-digest; an
+// unregistered algorithm is rejected with ErrInvalidArgument so callers do
+// not silently get a sha256 blob under a non-sha256 commit verification. An
+// empty algorithm is a no-op; implementations fall back to digest.Canonical.
+//
+// An expected digest carried by the descriptor still takes precedence: the
+// writer must honour the algorithm baked into a known target digest so that
+// resumed ingests and verification remain correct.
+func WithBlobDigestAlgorithm(algo digest.Algorithm) WriterOpt {
+	return func(opts *WriterOpts) error {
+		if algo == "" {
+			return nil
+		}
+		if !algo.Available() {
+			return fmt.Errorf("digest algorithm %q is not available: %w", algo, errdefs.ErrInvalidArgument)
+		}
+		opts.Algorithm = algo
 		return nil
 	}
 }

--- a/core/content/proxy/content_store.go
+++ b/core/content/proxy/content_store.go
@@ -193,6 +193,15 @@ func (pcs *proxyContentStore) Writer(ctx context.Context, opts ...content.Writer
 			return nil, err
 		}
 	}
+	// TODO: thread WithBlobDigestAlgorithm through the gRPC write protocol.
+	// The api/services/content/v1 WriteContentRequest does not currently
+	// carry a per-write algorithm hint, so the proxy cannot honour
+	// wOpts.Algorithm. Rather than silently demote to canonical (which
+	// would produce a blob digest in the wrong algorithm), fail so
+	// callers notice that their choice would be ignored.
+	if wOpts.Algorithm != "" {
+		return nil, fmt.Errorf("proxy content store: WithBlobDigestAlgorithm not yet wired through the gRPC write protocol: %w", errdefs.ErrNotImplemented)
+	}
 	wrclient, offset, err := pcs.negotiate(ctx, wOpts.Ref, wOpts.Desc.Size, wOpts.Desc.Digest)
 	if err != nil {
 		return nil, errgrpc.ToNative(err)

--- a/core/diff/apply/apply.go
+++ b/core/diff/apply/apply.go
@@ -105,7 +105,11 @@ func (s *fsApplier) Apply(ctx context.Context, desc ocispec.Descriptor, mounts [
 	}
 	defer processor.Close()
 
-	digester := digest.Canonical.Digester()
+	algo := config.DigestAlgorithm
+	if algo == "" {
+		algo = digest.Canonical
+	}
+	digester := algo.Digester()
 	rc := &readCounter{
 		r: io.TeeReader(processor, digester.Hash()),
 	}

--- a/core/diff/diff.go
+++ b/core/diff/diff.go
@@ -18,12 +18,16 @@ package diff
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 // Config is used to hold parameters needed for a diff operation
@@ -48,6 +52,13 @@ type Config struct {
 
 	// SourceDateEpoch specifies the SOURCE_DATE_EPOCH without touching the env vars.
 	SourceDateEpoch *time.Time
+
+	// DigestAlgorithm is the algorithm used to digest both the uncompressed
+	// diff (the DiffID stored on the LabelUncompressed label) and the
+	// compressed blob committed to the content store. When unset, the
+	// differ falls back to digest.Canonical (sha256), preserving today's
+	// behaviour for callers that do not opt in.
+	DigestAlgorithm digest.Algorithm
 }
 
 // Opt is used to configure a diff operation
@@ -71,6 +82,11 @@ type ApplyConfig struct {
 	SyncFs bool
 	// Progress is a function which reports status of processed read data
 	Progress func(int64)
+	// DigestAlgorithm is the algorithm used to hash the uncompressed stream
+	// while a diff is being applied. The returned descriptor carries this
+	// digest, which a caller compares against the DiffID recorded on the
+	// image config. When unset, digest.Canonical (sha256) is used.
+	DigestAlgorithm digest.Algorithm
 }
 
 // ApplyOpt is used to configure an Apply operation
@@ -157,6 +173,37 @@ func WithProgress(f func(ocispec.Descriptor, int64)) ApplyOpt {
 func WithSourceDateEpoch(tm *time.Time) Opt {
 	return func(c *Config) error {
 		c.SourceDateEpoch = tm
+		return nil
+	}
+}
+
+// WithDigestAlgorithm selects the digest algorithm used when packing a diff.
+// The algorithm must be registered with go-digest. An empty algorithm is a
+// no-op; the differ falls back to digest.Canonical.
+func WithDigestAlgorithm(algo digest.Algorithm) Opt {
+	return func(c *Config) error {
+		if algo == "" {
+			return nil
+		}
+		if !algo.Available() {
+			return fmt.Errorf("digest algorithm %q is not available: %w", algo, errdefs.ErrInvalidArgument)
+		}
+		c.DigestAlgorithm = algo
+		return nil
+	}
+}
+
+// WithApplyDigestAlgorithm selects the digest algorithm used when applying a
+// diff. The same constraints apply as for WithDigestAlgorithm.
+func WithApplyDigestAlgorithm(algo digest.Algorithm) ApplyOpt {
+	return func(_ context.Context, _ ocispec.Descriptor, c *ApplyConfig) error {
+		if algo == "" {
+			return nil
+		}
+		if !algo.Available() {
+			return fmt.Errorf("digest algorithm %q is not available: %w", algo, errdefs.ErrInvalidArgument)
+		}
+		c.DigestAlgorithm = algo
 		return nil
 	}
 }

--- a/core/diff/diff_test.go
+++ b/core/diff/diff_test.go
@@ -1,0 +1,94 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package diff
+
+import (
+	"context"
+	_ "crypto/sha256" // required for digest.Canonical fallback path
+	_ "crypto/sha512" // required for sha384 and sha512 digest support
+	"testing"
+
+	"github.com/containerd/errdefs"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestWithDigestAlgorithm(t *testing.T) {
+	tests := []struct {
+		name    string
+		algo    digest.Algorithm
+		wantErr bool
+		want    digest.Algorithm
+	}{
+		{name: "empty is a no-op", algo: "", wantErr: false, want: ""},
+		{name: "sha256 accepted", algo: digest.SHA256, wantErr: false, want: digest.SHA256},
+		{name: "sha512 accepted", algo: digest.SHA512, wantErr: false, want: digest.SHA512},
+		{name: "sha384 accepted", algo: digest.SHA384, wantErr: false, want: digest.SHA384},
+		{name: "unknown rejected", algo: digest.Algorithm("not-a-real-algorithm"), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Config
+			err := WithDigestAlgorithm(tt.algo)(&cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("WithDigestAlgorithm(%q): err = %v, wantErr %v", tt.algo, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if !errdefs.IsInvalidArgument(err) {
+					t.Fatalf("WithDigestAlgorithm(%q): error does not wrap ErrInvalidArgument: %v", tt.algo, err)
+				}
+				return
+			}
+			if cfg.DigestAlgorithm != tt.want {
+				t.Fatalf("WithDigestAlgorithm(%q): cfg.DigestAlgorithm = %q, want %q", tt.algo, cfg.DigestAlgorithm, tt.want)
+			}
+		})
+	}
+}
+
+func TestWithApplyDigestAlgorithm(t *testing.T) {
+	tests := []struct {
+		name    string
+		algo    digest.Algorithm
+		wantErr bool
+		want    digest.Algorithm
+	}{
+		{name: "empty is a no-op", algo: "", wantErr: false, want: ""},
+		{name: "sha256 accepted", algo: digest.SHA256, wantErr: false, want: digest.SHA256},
+		{name: "sha512 accepted", algo: digest.SHA512, wantErr: false, want: digest.SHA512},
+		{name: "sha384 accepted", algo: digest.SHA384, wantErr: false, want: digest.SHA384},
+		{name: "unknown rejected", algo: digest.Algorithm("not-a-real-algorithm"), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg ApplyConfig
+			err := WithApplyDigestAlgorithm(tt.algo)(context.Background(), ocispec.Descriptor{}, &cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("WithApplyDigestAlgorithm(%q): err = %v, wantErr %v", tt.algo, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if !errdefs.IsInvalidArgument(err) {
+					t.Fatalf("WithApplyDigestAlgorithm(%q): error does not wrap ErrInvalidArgument: %v", tt.algo, err)
+				}
+				return
+			}
+			if cfg.DigestAlgorithm != tt.want {
+				t.Fatalf("WithApplyDigestAlgorithm(%q): cfg.DigestAlgorithm = %q, want %q", tt.algo, cfg.DigestAlgorithm, tt.want)
+			}
+		})
+	}
+}

--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -472,7 +472,10 @@ func (cs *contentStore) Writer(ctx context.Context, opts ...content.WriterOpt) (
 			// available in the current namespace.
 			desc := wOpts.Desc
 			desc.Digest = ""
-			w, err = cs.Store.Writer(ctx, content.WithRef(bref), content.WithDescriptor(desc))
+			w, err = cs.Store.Writer(ctx,
+				content.WithRef(bref),
+				content.WithDescriptor(desc),
+				content.WithBlobDigestAlgorithm(wOpts.Algorithm))
 		}
 		return err
 	}); err != nil {
@@ -493,6 +496,7 @@ func (cs *contentStore) Writer(ctx context.Context, opts ...content.WriterOpt) (
 		bref:      bref,
 		started:   time.Now(),
 		desc:      wOpts.Desc,
+		algorithm: wOpts.Algorithm,
 	}, nil
 }
 
@@ -509,9 +513,10 @@ type namespacedWriter struct {
 
 	w content.Writer
 
-	bref    string
-	started time.Time
-	desc    ocispec.Descriptor
+	bref      string
+	started   time.Time
+	desc      ocispec.Descriptor
+	algorithm digest.Algorithm
 }
 
 func (nw *namespacedWriter) Close() error {
@@ -556,7 +561,10 @@ func (nw *namespacedWriter) Truncate(size int64) error {
 func (nw *namespacedWriter) createAndCopy(ctx context.Context, desc ocispec.Descriptor) error {
 	nwDescWithoutDigest := desc
 	nwDescWithoutDigest.Digest = ""
-	w, err := nw.provider.Writer(ctx, content.WithRef(nw.bref), content.WithDescriptor(nwDescWithoutDigest))
+	w, err := nw.provider.Writer(ctx,
+		content.WithRef(nw.bref),
+		content.WithDescriptor(nwDescWithoutDigest),
+		content.WithBlobDigestAlgorithm(nw.algorithm))
 	if err != nil {
 		return err
 	}

--- a/core/metadata/content_test.go
+++ b/core/metadata/content_test.go
@@ -19,6 +19,8 @@ package metadata
 import (
 	"bytes"
 	"context"
+	_ "crypto/sha256" // required for digest package
+	_ "crypto/sha512" // required for sha384 and sha512 digest support
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -233,4 +235,44 @@ func checkIngestLeased(ctx context.Context, db *DB, ref string) error {
 
 		return nil
 	})
+}
+
+// TestContentWriterDigestAlgorithm verifies that content.WithBlobDigestAlgorithm
+// is forwarded through the metadata content store wrapper on the eager open
+// path that the walking differ uses. Without forwarding, a caller asking for
+// e.g. sha512 receives a writer that silently hashed with sha256, leading to
+// a compressed-blob digest in the wrong algorithm.
+//
+// The deferred (shared-namespace createAndCopy) path also forwards the
+// algorithm, but that is a performance fix only: the re-hash safety net in
+// the local store's Commit already preserves correctness for that flow, so it
+// is not directly exercised here.
+func TestContentWriterDigestAlgorithm(t *testing.T) {
+	ctx, db := testDB(t)
+	cs := db.ContentStore()
+
+	for _, algo := range []digest.Algorithm{digest.SHA256, digest.SHA384, digest.SHA512} {
+		t.Run(algo.String(), func(t *testing.T) {
+			blob := bytes.Repeat([]byte(algo.String()[0:1]), 1024)
+			expected := algo.FromBytes(blob)
+
+			cw, err := cs.Writer(ctx,
+				content.WithRef("alg-"+algo.String()),
+				content.WithBlobDigestAlgorithm(algo),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cw.Close()
+			if _, err := cw.Write(blob); err != nil {
+				t.Fatal(err)
+			}
+			if got := cw.Digest(); got != expected {
+				t.Fatalf("metadata wrapper dropped the algorithm: got %s, want %s", got, expected)
+			}
+			if err := cw.Commit(ctx, int64(len(blob)), ""); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
 }

--- a/plugins/content/local/store.go
+++ b/plugins/content/local/store.go
@@ -489,7 +489,7 @@ func (s *store) Writer(ctx context.Context, opts ...content.WriterOpt) (content.
 		return nil, err
 	}
 
-	w, err := s.writer(ctx, wOpts.Ref, wOpts.Desc.Size, wOpts.Desc.Digest)
+	w, err := s.writer(ctx, wOpts.Ref, wOpts.Desc.Size, wOpts.Desc.Digest, wOpts.Algorithm)
 	if err != nil {
 		s.unlock(wOpts.Ref)
 		return nil, err
@@ -530,7 +530,7 @@ func (s *store) resumeStatus(ref string, total int64, digester digest.Digester) 
 
 // writer provides the main implementation of the Writer method. The caller
 // must hold the lock correctly and release on error if there is a problem.
-func (s *store) writer(ctx context.Context, ref string, total int64, expected digest.Digest) (content.Writer, error) {
+func (s *store) writer(ctx context.Context, ref string, total int64, expected digest.Digest, requested digest.Algorithm) (content.Writer, error) {
 	// TODO(stevvooe): Need to actually store expected here. We have
 	// code in the service that shouldn't be dealing with this.
 	if expected != "" {
@@ -545,10 +545,21 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 
 	path, refp, data := s.ingestPaths(ref)
 
-	// if we get passed an expected digest, we need to use the same algorithm (sha512, etc)
+	// Algorithm precedence:
+	//  1. expected digest's algorithm — the caller already knows the answer
+	//     they want, so honour it (sha512, etc).
+	//  2. caller-requested algorithm via content.WithBlobDigestAlgorithm —
+	//     used when the digest is not yet known (e.g. fresh ingests where
+	//     the caller wants a specific algorithm).
+	//  3. canonical (sha256) for backwards compatibility.
 	digestAlg := digest.Canonical
-	if expected != "" && expected.Algorithm().Available() {
+	switch {
+	case expected != "" && expected.Algorithm().Available():
 		digestAlg = expected.Algorithm()
+	case requested != "" && requested.Available():
+		digestAlg = requested
+	case requested != "":
+		return nil, fmt.Errorf("requested digest algorithm %q is not available: %w", requested, errdefs.ErrInvalidArgument)
 	}
 	var (
 		digester  = digestAlg.Digester()

--- a/plugins/content/local/store_test.go
+++ b/plugins/content/local/store_test.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"crypto/rand"
 	_ "crypto/sha256" // required for digest package
-	_ "crypto/sha512" // required for sha512 digest support
+	_ "crypto/sha512" // required for sha384 and sha512 digest support
 	"fmt"
 	"io"
 	"os"
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -141,7 +142,7 @@ func TestInvalidPermissionRootDir(t *testing.T) {
 }
 
 func TestContentWriter(t *testing.T) {
-	for _, alg := range []digest.Algorithm{digest.SHA256, digest.SHA512} {
+	for _, alg := range []digest.Algorithm{digest.SHA256, digest.SHA384, digest.SHA512} {
 		t.Run(alg.String(), func(t *testing.T) {
 			ctx, tmpdir, cs, cleanup := contentStoreEnv(t)
 			defer cleanup()
@@ -246,6 +247,87 @@ func TestContentWriter(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+// TestContentWriterBlobDigestAlgorithm verifies that
+// content.WithBlobDigestAlgorithm steers the writer to hash with a
+// caller-chosen algorithm when no expected digest is supplied, and that the
+// resulting blob is filed under the requested algorithm's namespace.
+//
+// This exercises the "requested" case in the writer's precedence chain.
+// Cases 1 (expected.Algorithm wins) and 3 (canonical fallback) are already
+// exercised by TestContentWriter above.
+func TestContentWriterBlobDigestAlgorithm(t *testing.T) {
+	for _, alg := range []digest.Algorithm{digest.SHA384, digest.SHA512} {
+		t.Run(alg.String(), func(t *testing.T) {
+			if !alg.Available() {
+				t.Skipf("algorithm %q not registered in this binary", alg)
+			}
+
+			ctx, tmpdir, cs, cleanup := contentStoreEnv(t)
+			defer cleanup()
+			defer testutil.DumpDirOnFailure(t, tmpdir)
+
+			cw, err := cs.Writer(ctx,
+				content.WithRef("alg-"+alg.String()),
+				content.WithBlobDigestAlgorithm(alg),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			payload := make([]byte, 1<<16)
+			if _, err := rand.Read(payload); err != nil {
+				t.Fatal(err)
+			}
+			expected := alg.FromBytes(payload)
+
+			checkCopy(t, int64(len(payload)), cw, bufio.NewReader(io.NopCloser(bytes.NewReader(payload))))
+
+			if got := cw.Digest(); got != expected {
+				t.Fatalf("writer hashed with wrong algorithm: got %s, want %s", got, expected)
+			}
+			// Empty expected — the writer's chosen algorithm decides the
+			// final digest.
+			if err := cw.Commit(ctx, int64(len(payload)), ""); err != nil {
+				t.Fatal(err)
+			}
+			if err := cw.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			path := checkBlobPath(t, cs, expected)
+			// Blobs live at <root>/blobs/<algorithm>/<hex>; check the
+			// algorithm segment specifically so a temp-dir name that
+			// happens to contain the algo string can't false-match.
+			algoDir := string(filepath.Separator) + "blobs" + string(filepath.Separator) + string(alg) + string(filepath.Separator)
+			if !strings.Contains(path, algoDir) {
+				t.Fatalf("blob path %q does not live under %s", path, algoDir)
+			}
+		})
+	}
+}
+
+// TestContentWriterBlobDigestAlgorithmUnavailable verifies that an explicit
+// request for an unregistered algorithm fails fast rather than silently
+// falling back to canonical (which would compute the wrong digest and only
+// fail at commit-time verification, or — worse — not fail at all when no
+// expected digest is supplied).
+func TestContentWriterBlobDigestAlgorithmUnavailable(t *testing.T) {
+	ctx, tmpdir, cs, cleanup := contentStoreEnv(t)
+	defer cleanup()
+	defer testutil.DumpDirOnFailure(t, tmpdir)
+
+	_, err := cs.Writer(ctx,
+		content.WithRef("unavailable-alg"),
+		content.WithBlobDigestAlgorithm(digest.Algorithm("not-a-real-algorithm")),
+	)
+	if err == nil {
+		t.Fatal("expected error for unavailable algorithm, got nil")
+	}
+	if !errdefs.IsInvalidArgument(err) {
+		t.Fatalf("expected ErrInvalidArgument, got: %v", err)
 	}
 }
 

--- a/plugins/diff/walking/algorithm_roundtrip_linux_test.go
+++ b/plugins/diff/walking/algorithm_roundtrip_linux_test.go
@@ -1,0 +1,361 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package walking
+
+import (
+	"bytes"
+	"context"
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sync"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/diff"
+	"github.com/containerd/containerd/v2/core/diff/apply"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/containerd/containerd/v2/pkg/labels"
+	"github.com/containerd/containerd/v2/pkg/reference"
+	"github.com/containerd/containerd/v2/pkg/testutil"
+	"github.com/containerd/containerd/v2/plugins/content/local"
+)
+
+// memoryLabelStore is a minimal label store so the walking differ can write
+// the containerd.io/uncompressed label after committing the blob. The label
+// is what carries the DiffID — without a label store, Compare errors out.
+type memoryLabelStore struct {
+	mu  sync.Mutex
+	all map[digest.Digest]map[string]string
+}
+
+func newMemoryLabelStore() *memoryLabelStore {
+	return &memoryLabelStore{all: map[digest.Digest]map[string]string{}}
+}
+
+func (m *memoryLabelStore) Get(d digest.Digest) (map[string]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.all[d], nil
+}
+
+func (m *memoryLabelStore) Set(d digest.Digest, lbls map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.all[d] = lbls
+	return nil
+}
+
+func (m *memoryLabelStore) Update(d digest.Digest, upd map[string]string) (map[string]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cur, ok := m.all[d]
+	if !ok {
+		cur = map[string]string{}
+	}
+	for k, v := range upd {
+		if v == "" {
+			delete(cur, k)
+		} else {
+			cur[k] = v
+		}
+	}
+	m.all[d] = cur
+	return cur, nil
+}
+
+// algorithmAwareRegistry is a minimal OCI distribution server that hashes each
+// uploaded blob with the algorithm declared in the digest URL query parameter
+// rather than hardcoding sha256. Just enough to support a blob push + blob
+// pull round-trip; no manifest endpoints.
+type algorithmAwareRegistry struct {
+	mu     sync.Mutex
+	blobs  map[string][]byte // digest string -> raw bytes
+	uploads map[string]*bytes.Buffer // upload UUID -> accumulating buffer
+	nextID int
+}
+
+func newAlgorithmAwareRegistry() *algorithmAwareRegistry {
+	return &algorithmAwareRegistry{
+		blobs:   map[string][]byte{},
+		uploads: map[string]*bytes.Buffer{},
+	}
+}
+
+var blobPathRe = regexp.MustCompile(`^/v2/[^/]+(?:/[^/]+)*/blobs/([^/]+)$`)
+var uploadStartRe = regexp.MustCompile(`^/v2/[^/]+(?:/[^/]+)*/blobs/uploads/?$`)
+var uploadCommitRe = regexp.MustCompile(`^/v2/uploads/([^/]+)$`)
+
+func (r *algorithmAwareRegistry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	switch {
+	case req.Method == http.MethodPost && uploadStartRe.MatchString(req.URL.Path):
+		// Start an upload session.
+		r.mu.Lock()
+		r.nextID++
+		id := fmt.Sprintf("upload-%d", r.nextID)
+		r.uploads[id] = &bytes.Buffer{}
+		r.mu.Unlock()
+		w.Header().Set("Location", "/v2/uploads/"+id)
+		w.WriteHeader(http.StatusAccepted)
+
+	case (req.Method == http.MethodPatch || req.Method == http.MethodPut) && uploadCommitRe.MatchString(req.URL.Path):
+		id := uploadCommitRe.FindStringSubmatch(req.URL.Path)[1]
+		r.mu.Lock()
+		buf, ok := r.uploads[id]
+		r.mu.Unlock()
+		if !ok {
+			http.Error(w, "no such upload", http.StatusNotFound)
+			return
+		}
+		if _, err := io.Copy(buf, req.Body); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if req.Method == http.MethodPatch {
+			w.Header().Set("Location", req.URL.Path)
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		// PUT finalises. Honour the digest query parameter's algorithm.
+		dgst := digest.Digest(req.URL.Query().Get("digest"))
+		if err := dgst.Validate(); err != nil {
+			http.Error(w, "bad digest: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		algo := dgst.Algorithm()
+		if !algo.Available() {
+			http.Error(w, "unsupported algorithm: "+string(algo), http.StatusBadRequest)
+			return
+		}
+		got := algo.FromBytes(buf.Bytes())
+		if got != dgst {
+			http.Error(w, fmt.Sprintf("digest mismatch: client claimed %s, server hashed %s", dgst, got), http.StatusBadRequest)
+			return
+		}
+		r.mu.Lock()
+		r.blobs[dgst.String()] = buf.Bytes()
+		delete(r.uploads, id)
+		r.mu.Unlock()
+		w.Header().Set("Docker-Content-Digest", dgst.String())
+		w.WriteHeader(http.StatusCreated)
+
+	case (req.Method == http.MethodHead || req.Method == http.MethodGet) && blobPathRe.MatchString(req.URL.Path):
+		dgst := blobPathRe.FindStringSubmatch(req.URL.Path)[1]
+		r.mu.Lock()
+		blob, ok := r.blobs[dgst]
+		r.mu.Unlock()
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(blob)))
+		w.Header().Set("Docker-Content-Digest", dgst)
+		if req.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(blob)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+
+	default:
+		http.NotFound(w, req)
+	}
+}
+
+// TestAlgorithmRoundtripViaRegistry exercises the full produce → push → pull →
+// consume loop: pack a layer with a non-canonical algorithm, push it to a
+// mock registry that itself honours the algorithm in the digest URL, pull it
+// into a fresh content store, then apply it. The unpacked filesystem must
+// match the original, and every digest along the way must remain in the
+// requested algorithm namespace.
+func TestAlgorithmRoundtripViaRegistry(t *testing.T) {
+	testutil.RequiresRoot(t)
+	for _, algo := range []digest.Algorithm{digest.SHA384, digest.SHA512} {
+		t.Run(algo.String(), func(t *testing.T) {
+			if !algo.Available() {
+				t.Skipf("algorithm %q not registered in this binary", algo)
+			}
+
+			ctx := context.Background()
+			root := t.TempDir()
+
+			// --- Pack ---
+			srcCS, err := local.NewLabeledStore(filepath.Join(root, "src-content"), newMemoryLabelStore())
+			if err != nil {
+				t.Fatalf("src content store: %v", err)
+			}
+
+			upperDir := filepath.Join(root, "upper")
+			if err := os.MkdirAll(filepath.Join(upperDir, "etc"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(upperDir, "etc", "hostname"), []byte("roundtrip\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(upperDir, "README"), []byte("layer body\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			lowerDir := filepath.Join(root, "lower")
+			if err := os.MkdirAll(lowerDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			lowerMounts := []mount.Mount{{Type: "bind", Source: lowerDir, Options: []string{"rbind", "ro"}}}
+			upperMounts := []mount.Mount{{Type: "bind", Source: upperDir, Options: []string{"rbind", "ro"}}}
+
+			differ := NewWalkingDiff(srcCS)
+			desc, err := differ.Compare(ctx, lowerMounts, upperMounts,
+				diff.WithDigestAlgorithm(algo),
+				diff.WithMediaType(ocispec.MediaTypeImageLayerGzip),
+			)
+			if err != nil {
+				t.Fatalf("Compare: %v", err)
+			}
+			if got := desc.Digest.Algorithm(); got != algo {
+				t.Fatalf("packed blob algorithm: got %q, want %q", got, algo)
+			}
+
+			info, err := srcCS.Info(ctx, desc.Digest)
+			if err != nil {
+				t.Fatalf("Info: %v", err)
+			}
+			diffID, err := digest.Parse(info.Labels[labels.LabelUncompressed])
+			if err != nil {
+				t.Fatalf("DiffID parse: %v", err)
+			}
+
+			// --- Registry ---
+			reg := newAlgorithmAwareRegistry()
+			srv := httptest.NewServer(reg)
+			defer srv.Close()
+			u, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resolver := docker.NewResolver(docker.ResolverOptions{
+				Hosts: docker.ConfigureDefaultRegistries(
+					docker.WithPlainHTTP(func(string) (bool, error) { return true, nil }),
+					docker.WithClient(srv.Client()),
+				),
+			})
+
+			repoRef, err := reference.Parse(u.Host + "/test-repo:latest")
+			if err != nil {
+				t.Fatalf("ref parse: %v", err)
+			}
+
+			// --- Push ---
+			pusher, err := resolver.Pusher(ctx, repoRef.String())
+			if err != nil {
+				t.Fatalf("Pusher: %v", err)
+			}
+			cw, err := pusher.Push(ctx, desc)
+			if err != nil {
+				t.Fatalf("Push open: %v", err)
+			}
+			ra, err := srcCS.ReaderAt(ctx, desc)
+			if err != nil {
+				t.Fatalf("ReaderAt: %v", err)
+			}
+			if _, err := io.Copy(cw, content.NewReader(ra)); err != nil {
+				ra.Close()
+				t.Fatalf("Push body: %v", err)
+			}
+			ra.Close()
+			if err := cw.Commit(ctx, desc.Size, desc.Digest); err != nil {
+				t.Fatalf("Push commit: %v", err)
+			}
+
+			// Registry must now hold the blob under the chosen algorithm.
+			reg.mu.Lock()
+			_, stored := reg.blobs[desc.Digest.String()]
+			reg.mu.Unlock()
+			if !stored {
+				t.Fatalf("registry did not receive blob %s", desc.Digest)
+			}
+
+			// --- Pull ---
+			dstCS, err := local.NewLabeledStore(filepath.Join(root, "dst-content"), newMemoryLabelStore())
+			if err != nil {
+				t.Fatalf("dst content store: %v", err)
+			}
+			fetcher, err := resolver.Fetcher(ctx, repoRef.String())
+			if err != nil {
+				t.Fatalf("Fetcher: %v", err)
+			}
+			rc, err := fetcher.Fetch(ctx, desc)
+			if err != nil {
+				t.Fatalf("Fetch: %v", err)
+			}
+			if err := content.WriteBlob(ctx, dstCS, "pulled-"+algo.String(), rc, desc); err != nil {
+				rc.Close()
+				t.Fatalf("WriteBlob: %v", err)
+			}
+			rc.Close()
+
+			// The pulled blob must agree on digest (which means agree on algo).
+			pulledRA, err := dstCS.ReaderAt(ctx, desc)
+			if err != nil {
+				t.Fatalf("pulled ReaderAt: %v", err)
+			}
+			pulledRA.Close()
+
+			// --- Apply ---
+			unpackDir := filepath.Join(root, "unpack")
+			if err := os.MkdirAll(unpackDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			unpackMounts := []mount.Mount{{Type: "bind", Source: unpackDir, Options: []string{"rbind", "rw"}}}
+
+			applier := apply.NewFileSystemApplier(dstCS)
+			applied, err := applier.Apply(ctx, desc, unpackMounts,
+				diff.WithApplyDigestAlgorithm(algo),
+			)
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if applied.Digest != diffID {
+				t.Fatalf("post-pull DiffID mismatch: got %s, want %s", applied.Digest, diffID)
+			}
+
+			// Files round-tripped intact?
+			gotHost, err := os.ReadFile(filepath.Join(unpackDir, "etc", "hostname"))
+			if err != nil || string(gotHost) != "roundtrip\n" {
+				t.Fatalf("etc/hostname: got %q err=%v", gotHost, err)
+			}
+			gotReadme, err := os.ReadFile(filepath.Join(unpackDir, "README"))
+			if err != nil || string(gotReadme) != "layer body\n" {
+				t.Fatalf("README: got %q err=%v", gotReadme, err)
+			}
+		})
+	}
+}

--- a/plugins/diff/walking/differ.go
+++ b/plugins/diff/walking/differ.go
@@ -97,6 +97,11 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 		}
 	}
 
+	algo := config.DigestAlgorithm
+	if algo == "" {
+		algo = digest.Canonical
+	}
+
 	var ocidesc ocispec.Descriptor
 	if err := mount.WithTempMount(ctx, lower, func(lowerRoot string) error {
 		return mount.WithReadonlyTempMount(ctx, upper, func(upperRoot string) error {
@@ -110,7 +115,8 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 				content.WithRef(config.Reference),
 				content.WithDescriptor(ocispec.Descriptor{
 					MediaType: config.MediaType, // most contentstore implementations just ignore this
-				}))
+				}),
+				content.WithBlobDigestAlgorithm(algo))
 			if err != nil {
 				return fmt.Errorf("failed to open writer: %w", err)
 			}
@@ -135,7 +141,7 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 			}
 
 			if compressionType != compression.Uncompressed {
-				dgstr := digest.SHA256.Digester()
+				dgstr := algo.Digester()
 				var compressed io.WriteCloser
 				if config.Compressor != nil {
 					compressed, errOpen = config.Compressor(cw, config.MediaType)


### PR DESCRIPTION
This PR adds opt-in algorithm selection at write time:

- content.WithBlobDigestAlgorithm tells the Writer which algorithm to hash with when no expected digest is set. Errors if the algorithm isn't available.

- diff.WithDigestAlgorithm wires the same choice into the walking differ. It picks the algorithm for the DiffID and forwards it to the content writer so the compressed blob digest matches.

- diff.WithApplyDigestAlgorithm does the equivalent on the apply side, returning a digest in the requested algorithm.

Default unchanged. sha384 and sha512 work out of the box with the vendored go-digest.