### PR TITLE
Fix input mutation in mount option helpers

### DIFF
--- a/core/mount/mount.go
+++ b/core/mount/mount.go
@@ -102,9 +102,9 @@ func (m *Mount) Mount(target string) error {
 	return m.mount(target)
 }
 
-// readonlyMounts modifies the received mount options
-// to make them readonly
+// readonlyMounts returns mounts with readonly options applied.
 func readonlyMounts(mounts []Mount) []Mount {
+	mounts = slices.Clone(mounts)
 	for i, m := range mounts {
 		if m.Type == "overlay" {
 			mounts[i].Options = readonlyOverlay(m.Options)

--- a/core/mount/mount.go
+++ b/core/mount/mount.go
@@ -133,9 +133,9 @@ func (m *Mount) Mount(target string) error {
 	return m.mount(target)
 }
 
-// readonlyMounts modifies the received mount options
-// to make them readonly
+// readonlyMounts returns mounts with readonly options applied.
 func readonlyMounts(mounts []Mount) []Mount {
+	mounts = slices.Clone(mounts)
 	for i, m := range mounts {
 		if m.Type == "overlay" {
 			mounts[i].Options = readonlyOverlay(m.Options)

--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -18,6 +18,7 @@ package mount
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	// required for `-test.root` flag not to fail
@@ -295,7 +296,7 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		original := copyMounts(tc.input)
+		original := slices.Clone(tc.input)
 		actual := RemoveVolatileOption(tc.input)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Fatalf("incorrectly modified mounts: %s.\n\n Expected: %v\n\n, Actual: %v", tc.desc, tc.expected, actual)

--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -144,8 +144,13 @@ func TestReadonlyMounts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		if !reflect.DeepEqual(readonlyMounts(tc.input), tc.expected) {
-			t.Fatalf("incorrectly modified mounts: %s", tc.desc)
+		original := slices.Clone(tc.input)
+		actual := readonlyMounts(tc.input)
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Fatalf("incorrectly modified mounts: %s.\n\n Expected: %v\n\n Actual: %v", tc.desc, tc.expected, actual)
+		}
+		if !reflect.DeepEqual(original, tc.input) {
+			t.Fatalf("modified original mounts: %s.\n\n Expected: %v\n\n Actual: %v", tc.desc, original, tc.input)
 		}
 	}
 }

--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -144,7 +144,7 @@ func TestReadonlyMounts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		original := slices.Clone(tc.input)
+		original := clone(tc.input)
 		actual := readonlyMounts(tc.input)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Fatalf("incorrectly modified mounts: %s.\n\n Expected: %v\n\n Actual: %v", tc.desc, tc.expected, actual)
@@ -298,10 +298,35 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "remove multiple volatile options from overlay mounts",
+			input: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"volatile",
+						"fsync=volatile",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
+			},
+			expected: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
-		original := slices.Clone(tc.input)
+		original := clone(tc.input)
 		actual := RemoveVolatileOption(tc.input)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Fatalf("incorrectly modified mounts: %s.\n\n Expected: %v\n\n, Actual: %v", tc.desc, tc.expected, actual)
@@ -310,4 +335,46 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 			t.Fatalf("modified original mounts: %s.\n\n Expected: %v\n\n, Actual: %v", tc.desc, original, tc.input)
 		}
 	}
+}
+
+func TestRemoveIDMapOption(t *testing.T) {
+	input := []Mount{
+		{
+			Type:   "overlay",
+			Source: "overlay",
+			Options: []string{
+				"index=off",
+				"uidmap=0:1000:1",
+				"gidmap=0:1000:1",
+				"lowerdir=/path/to/snapshots/1/fs",
+			},
+		},
+	}
+	expected := []Mount{
+		{
+			Type:   "overlay",
+			Source: "overlay",
+			Options: []string{
+				"index=off",
+				"lowerdir=/path/to/snapshots/1/fs",
+			},
+		},
+	}
+
+	original := clone(input)
+	actual := RemoveIDMapOption(input)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("incorrectly modified mounts.\n\n Expected: %v\n\n Actual: %v", expected, actual)
+	}
+	if !reflect.DeepEqual(original, input) {
+		t.Fatalf("modified original mounts.\n\n Expected: %v\n\n Actual: %v", original, input)
+	}
+}
+
+func clone(mounts []Mount) []Mount {
+	out := slices.Clone(mounts)
+	for i, m := range mounts {
+		out[i].Options = slices.Clone(m.Options)
+	}
+	return out
 }

--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -144,7 +144,7 @@ func TestReadonlyMounts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		original := slices.Clone(tc.input)
+		original := clone(tc.input)
 		actual := readonlyMounts(tc.input)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Fatalf("incorrectly modified mounts: %s.\n\n Expected: %v\n\n Actual: %v", tc.desc, tc.expected, actual)
@@ -363,10 +363,35 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "remove multiple volatile options from overlay mounts",
+			input: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"volatile",
+						"fsync=volatile",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
+			},
+			expected: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
-		original := slices.Clone(tc.input)
+		original := clone(tc.input)
 		actual := RemoveVolatileOption(tc.input)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Fatalf("incorrectly modified mounts: %s.\n\n Expected: %v\n\n, Actual: %v", tc.desc, tc.expected, actual)
@@ -375,4 +400,46 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 			t.Fatalf("modified original mounts: %s.\n\n Expected: %v\n\n, Actual: %v", tc.desc, original, tc.input)
 		}
 	}
+}
+
+func TestRemoveIDMapOption(t *testing.T) {
+	input := []Mount{
+		{
+			Type:   "overlay",
+			Source: "overlay",
+			Options: []string{
+				"index=off",
+				"uidmap=0:1000:1",
+				"gidmap=0:1000:1",
+				"lowerdir=/path/to/snapshots/1/fs",
+			},
+		},
+	}
+	expected := []Mount{
+		{
+			Type:   "overlay",
+			Source: "overlay",
+			Options: []string{
+				"index=off",
+				"lowerdir=/path/to/snapshots/1/fs",
+			},
+		},
+	}
+
+	original := clone(input)
+	actual := RemoveIDMapOption(input)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("incorrectly modified mounts.\n\n Expected: %v\n\n Actual: %v", expected, actual)
+	}
+	if !reflect.DeepEqual(original, input) {
+		t.Fatalf("modified original mounts.\n\n Expected: %v\n\n Actual: %v", original, input)
+	}
+}
+
+func clone(mounts []Mount) []Mount {
+	out := slices.Clone(mounts)
+	for i, m := range mounts {
+		out[i].Options = slices.Clone(m.Options)
+	}
+	return out
 }

--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -152,6 +152,7 @@ func TestReadonlyMounts(t *testing.T) {
 		if !reflect.DeepEqual(original, tc.input) {
 			t.Fatalf("modified original mounts: %s.\n\n Expected: %v\n\n Actual: %v", tc.desc, original, tc.input)
 		}
+		assertNoMountAlias(t, tc.desc, actual, tc.input, original)
 	}
 }
 
@@ -319,7 +320,7 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 			},
 		},
 		{
-			desc: "return original slice since no volatile options on overlay",
+			desc: "return copy when no volatile options on overlay",
 			input: []Mount{
 				{
 					Type:   "overlay",
@@ -399,40 +400,115 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 		if !reflect.DeepEqual(original, tc.input) {
 			t.Fatalf("modified original mounts: %s.\n\n Expected: %v\n\n, Actual: %v", tc.desc, original, tc.input)
 		}
+		assertNoMountAlias(t, tc.desc, actual, tc.input, original)
 	}
 }
 
 func TestRemoveIDMapOption(t *testing.T) {
-	input := []Mount{
+	testCases := []struct {
+		desc     string
+		input    []Mount
+		expected []Mount
+	}{
 		{
-			Type:   "overlay",
-			Source: "overlay",
-			Options: []string{
-				"index=off",
-				"uidmap=0:1000:1",
-				"gidmap=0:1000:1",
-				"lowerdir=/path/to/snapshots/1/fs",
+			desc: "remove idmap options",
+			input: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"uidmap=0:1000:1",
+						"gidmap=0:1000:1",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
+			},
+			expected: []Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
 			},
 		},
-	}
-	expected := []Mount{
 		{
-			Type:   "overlay",
-			Source: "overlay",
-			Options: []string{
-				"index=off",
-				"lowerdir=/path/to/snapshots/1/fs",
+			desc: "remove idmapping options",
+			input: []Mount{
+				{
+					Type:   "fuse-overlayfs",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"uidmapping=0:1000:1",
+						"gidmapping=0:1000:1",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
+			},
+			expected: []Mount{
+				{
+					Type:   "fuse-overlayfs",
+					Source: "overlay",
+					Options: []string{
+						"index=off",
+						"lowerdir=/path/to/snapshots/1/fs",
+					},
+				},
+			},
+		},
+		{
+			desc: "return copy when no idmap options",
+			input: []Mount{
+				{
+					Type:   "bind",
+					Source: "/path/to/source",
+					Options: []string{
+						"rbind",
+						"ro",
+					},
+				},
+			},
+			expected: []Mount{
+				{
+					Type:   "bind",
+					Source: "/path/to/source",
+					Options: []string{
+						"rbind",
+						"ro",
+					},
+				},
 			},
 		},
 	}
 
-	original := clone(input)
-	actual := RemoveIDMapOption(input)
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("incorrectly modified mounts.\n\n Expected: %v\n\n Actual: %v", expected, actual)
+	for _, tc := range testCases {
+		original := clone(tc.input)
+		actual := RemoveIDMapOption(tc.input)
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Fatalf("incorrectly modified mounts: %s.\n\n Expected: %v\n\n Actual: %v", tc.desc, tc.expected, actual)
+		}
+		if !reflect.DeepEqual(original, tc.input) {
+			t.Fatalf("modified original mounts: %s.\n\n Expected: %v\n\n Actual: %v", tc.desc, original, tc.input)
+		}
+		assertNoMountAlias(t, tc.desc, actual, tc.input, original)
+	}
+}
+
+func assertNoMountAlias(t *testing.T, desc string, actual, input, original []Mount) {
+	t.Helper()
+	if len(actual) == 0 {
+		return
+	}
+	actual[0].Source = "changed"
+	if len(actual[0].Options) > 0 {
+		actual[0].Options[0] = "changed"
 	}
 	if !reflect.DeepEqual(original, input) {
-		t.Fatalf("modified original mounts.\n\n Expected: %v\n\n Actual: %v", original, input)
+		t.Fatalf("returned mounts alias original mounts: %s.\n\n Expected: %v\n\n Actual: %v", desc, original, input)
 	}
 }
 

--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -18,6 +18,7 @@ package mount
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	// required for `-test.root` flag not to fail
@@ -360,7 +361,7 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		original := copyMounts(tc.input)
+		original := slices.Clone(tc.input)
 		actual := RemoveVolatileOption(tc.input)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Fatalf("incorrectly modified mounts: %s.\n\n Expected: %v\n\n, Actual: %v", tc.desc, tc.expected, actual)

--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -320,7 +320,7 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 			},
 		},
 		{
-			desc: "return copy when no volatile options on overlay",
+			desc: "return input when no volatile options on overlay",
 			input: []Mount{
 				{
 					Type:   "overlay",
@@ -400,7 +400,9 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 		if !reflect.DeepEqual(original, tc.input) {
 			t.Fatalf("modified original mounts: %s.\n\n Expected: %v\n\n, Actual: %v", tc.desc, original, tc.input)
 		}
-		assertNoMountAlias(t, tc.desc, actual, tc.input, original)
+		if !reflect.DeepEqual(actual, original) {
+			assertNoMountAlias(t, tc.desc, actual, tc.input, original)
+		}
 	}
 }
 
@@ -461,7 +463,7 @@ func TestRemoveIDMapOption(t *testing.T) {
 			},
 		},
 		{
-			desc: "return copy when no idmap options",
+			desc: "return input when no idmap options",
 			input: []Mount{
 				{
 					Type:   "bind",
@@ -494,7 +496,9 @@ func TestRemoveIDMapOption(t *testing.T) {
 		if !reflect.DeepEqual(original, tc.input) {
 			t.Fatalf("modified original mounts: %s.\n\n Expected: %v\n\n Actual: %v", tc.desc, original, tc.input)
 		}
-		assertNoMountAlias(t, tc.desc, actual, tc.input, original)
+		if !reflect.DeepEqual(actual, original) {
+			assertNoMountAlias(t, tc.desc, actual, tc.input, original)
+		}
 	}
 }
 

--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -88,14 +88,24 @@ func RemoveVolatileOption(mounts []Mount) []Mount {
 		if m.Type != "overlay" {
 			continue
 		}
+		var newOpts []string
 		for j, opt := range m.Options {
 			if opt == "volatile" || opt == "fsync=volatile" {
 				if out == nil {
 					out = slices.Clone(mounts)
 				}
-				out[i].Options = append(out[i].Options[:j], out[i].Options[j+1:]...)
-				break
+				if newOpts == nil {
+					// Clone up until this opt.
+					newOpts = slices.Clone(m.Options[:j])
+				}
+				continue
 			}
+			if newOpts != nil {
+				newOpts = append(newOpts, opt)
+			}
+		}
+		if newOpts != nil {
+			out[i].Options = newOpts
 		}
 	}
 
@@ -110,13 +120,24 @@ func RemoveVolatileOption(mounts []Mount) []Mount {
 func RemoveIDMapOption(mounts []Mount) []Mount {
 	var out []Mount
 	for i, m := range mounts {
+		var newOpts []string
 		for j, opt := range m.Options {
 			if strings.HasPrefix(opt, "uidmap") || strings.HasPrefix(opt, "gidmap") {
 				if out == nil {
 					out = slices.Clone(mounts)
 				}
-				out[i].Options = append(out[i].Options[:j], out[i].Options[j+1:]...)
+				if newOpts == nil {
+					// Clone up until this opt.
+					newOpts = slices.Clone(m.Options[:j])
+				}
+				continue
 			}
+			if newOpts != nil {
+				newOpts = append(newOpts, opt)
+			}
+		}
+		if newOpts != nil {
+			out[i].Options = newOpts
 		}
 	}
 	if out != nil {

--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/containerd/log"
@@ -90,7 +91,7 @@ func RemoveVolatileOption(mounts []Mount) []Mount {
 		for j, opt := range m.Options {
 			if opt == "volatile" || opt == "fsync=volatile" {
 				if out == nil {
-					out = copyMounts(mounts)
+					out = slices.Clone(mounts)
 				}
 				out[i].Options = append(out[i].Options[:j], out[i].Options[j+1:]...)
 				break
@@ -112,7 +113,7 @@ func RemoveIDMapOption(mounts []Mount) []Mount {
 		for j, opt := range m.Options {
 			if strings.HasPrefix(opt, "uidmap") || strings.HasPrefix(opt, "gidmap") {
 				if out == nil {
-					out = copyMounts(mounts)
+					out = slices.Clone(mounts)
 				}
 				out[i].Options = append(out[i].Options[:j], out[i].Options[j+1:]...)
 			}
@@ -122,13 +123,6 @@ func RemoveIDMapOption(mounts []Mount) []Mount {
 		return out
 	}
 	return mounts
-}
-
-// copyMounts creates a copy of the original slice to allow for modification and not altering the original
-func copyMounts(in []Mount) []Mount {
-	out := make([]Mount, len(in))
-	copy(out, in)
-	return out
 }
 
 // WithReadonlyTempMount mounts the provided mounts to a temp dir as readonly,

--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -83,51 +83,38 @@ func WithTempMount(ctx context.Context, mounts []Mount, f func(root string) erro
 // TODO: Make this logic conditional once the kernel supports reusing
 // overlayfs volatile mounts.
 func RemoveVolatileOption(mounts []Mount) []Mount {
-	var out []Mount
-	for i, m := range mounts {
-		if m.Type != "overlay" {
-			continue
-		}
-		var newOpts []string
-		for j, opt := range m.Options {
-			if opt == "volatile" || opt == "fsync=volatile" {
-				if out == nil {
-					out = slices.Clone(mounts)
-				}
-				if newOpts == nil {
-					// Clone up until this opt.
-					newOpts = slices.Clone(m.Options[:j])
-				}
-				continue
-			}
-			if newOpts != nil {
-				newOpts = append(newOpts, opt)
+	return filterMountOptions(mounts, func(m Mount, opt string) bool {
+		if m.Type == "overlay" {
+			switch opt {
+			case "volatile", "fsync=volatile":
+				return false
 			}
 		}
-		if newOpts != nil {
-			out[i].Options = newOpts
-		}
-	}
-
-	if out != nil {
-		return out
-	}
-
-	return mounts
+		return true
+	})
 }
 
 // RemoveIDMapOption copies and removes the uidmap/gidmap options on any of the mounts using it.
 func RemoveIDMapOption(mounts []Mount) []Mount {
+	return filterMountOptions(mounts, func(_ Mount, opt string) bool {
+		return !strings.HasPrefix(opt, "uidmap") && !strings.HasPrefix(opt, "gidmap")
+	})
+}
+
+// filterMountOptions returns mounts filtering out options not matching the
+// [keep] predicate.
+// Does not mutate the input and clones only when a removal is needed.
+func filterMountOptions(mounts []Mount, keep func(Mount, string) bool) []Mount {
 	var out []Mount
 	for i, m := range mounts {
 		var newOpts []string
 		for j, opt := range m.Options {
-			if strings.HasPrefix(opt, "uidmap") || strings.HasPrefix(opt, "gidmap") {
+			if !keep(m, opt) {
 				if out == nil {
 					out = slices.Clone(mounts)
 				}
 				if newOpts == nil {
-					// Clone up until this opt.
+					// Clone until this opt.
 					newOpts = slices.Clone(m.Options[:j])
 				}
 				continue

--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -103,24 +103,36 @@ func RemoveIDMapOption(mounts []Mount) []Mount {
 	})
 }
 
-// filterMountOptions returns a copy of mounts filtering out options not
-// matching the [keep] predicate.
-// It does not mutate or alias the input.
+// filterMountOptions returns mounts filtering out options not matching the
+// [keep] predicate.
+// It does not mutate the input, and returns the input unchanged when no options
+// are filtered out.
 func filterMountOptions(mounts []Mount, keep func(Mount, string) bool) []Mount {
-	out := slices.Clone(mounts)
+	var out []Mount
 	for i, m := range mounts {
 		var options []string
-		if m.Options != nil {
-			options = make([]string, 0, len(m.Options))
-		}
-		for _, opt := range m.Options {
-			if keep(m, opt) {
+		for j, opt := range m.Options {
+			if !keep(m, opt) {
+				if out == nil {
+					out = slices.Clone(mounts)
+				}
+				if options == nil {
+					options = slices.Clone(m.Options[:j])
+				}
+				continue
+			}
+			if options != nil {
 				options = append(options, opt)
 			}
 		}
-		out[i].Options = options
+		if options != nil {
+			out[i].Options = options
+		}
 	}
-	return out
+	if out != nil {
+		return out
+	}
+	return mounts
 }
 
 // WithReadonlyTempMount mounts the provided mounts to a temp dir as readonly,

--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -83,51 +83,40 @@ func WithTempMount(ctx context.Context, mounts []Mount, f func(root string) erro
 // TODO: Make this logic conditional once the kernel supports reusing
 // overlayfs volatile mounts.
 func RemoveVolatileOption(mounts []Mount) []Mount {
-	var out []Mount
-	for i, m := range mounts {
-		if m.Type != "overlay" {
-			continue
-		}
-		var newOpts []string
-		for j, opt := range m.Options {
-			if opt == "volatile" || opt == "fsync=volatile" {
-				if out == nil {
-					out = slices.Clone(mounts)
-				}
-				if newOpts == nil {
-					// Clone up until this opt.
-					newOpts = slices.Clone(m.Options[:j])
-				}
-				continue
-			}
-			if newOpts != nil {
-				newOpts = append(newOpts, opt)
+	return filterMountOptions(mounts, func(m Mount, opt string) bool {
+		if m.Type == "overlay" {
+			switch opt {
+			case "volatile", "fsync=volatile":
+				return false
 			}
 		}
-		if newOpts != nil {
-			out[i].Options = newOpts
-		}
-	}
-
-	if out != nil {
-		return out
-	}
-
-	return mounts
+		return true
+	})
 }
 
 // RemoveIDMapOption copies and removes the uidmap/gidmap options on any of the mounts using it.
 func RemoveIDMapOption(mounts []Mount) []Mount {
+	return filterMountOptions(mounts, func(_ Mount, opt string) bool {
+		// Match all uidmap/gidmap prefixes because fuse-overlayfs also uses
+		// related options such as uidmapping and gidmapping.
+		return !strings.HasPrefix(opt, "uidmap") && !strings.HasPrefix(opt, "gidmap")
+	})
+}
+
+// filterMountOptions returns mounts filtering out options not matching the
+// [keep] predicate.
+// Does not mutate the input and clones only when a removal is needed.
+func filterMountOptions(mounts []Mount, keep func(Mount, string) bool) []Mount {
 	var out []Mount
 	for i, m := range mounts {
 		var newOpts []string
 		for j, opt := range m.Options {
-			if strings.HasPrefix(opt, "uidmap") || strings.HasPrefix(opt, "gidmap") {
+			if !keep(m, opt) {
 				if out == nil {
 					out = slices.Clone(mounts)
 				}
 				if newOpts == nil {
-					// Clone up until this opt.
+					// Clone until this opt.
 					newOpts = slices.Clone(m.Options[:j])
 				}
 				continue

--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -103,36 +103,24 @@ func RemoveIDMapOption(mounts []Mount) []Mount {
 	})
 }
 
-// filterMountOptions returns mounts filtering out options not matching the
-// [keep] predicate.
-// Does not mutate the input and clones only when a removal is needed.
+// filterMountOptions returns a copy of mounts filtering out options not
+// matching the [keep] predicate.
+// It does not mutate or alias the input.
 func filterMountOptions(mounts []Mount, keep func(Mount, string) bool) []Mount {
-	var out []Mount
+	out := slices.Clone(mounts)
 	for i, m := range mounts {
-		var newOpts []string
-		for j, opt := range m.Options {
-			if !keep(m, opt) {
-				if out == nil {
-					out = slices.Clone(mounts)
-				}
-				if newOpts == nil {
-					// Clone until this opt.
-					newOpts = slices.Clone(m.Options[:j])
-				}
-				continue
-			}
-			if newOpts != nil {
-				newOpts = append(newOpts, opt)
+		var options []string
+		if m.Options != nil {
+			options = make([]string, 0, len(m.Options))
+		}
+		for _, opt := range m.Options {
+			if keep(m, opt) {
+				options = append(options, opt)
 			}
 		}
-		if newOpts != nil {
-			out[i].Options = newOpts
-		}
+		out[i].Options = options
 	}
-	if out != nil {
-		return out
-	}
-	return mounts
+	return out
 }
 
 // WithReadonlyTempMount mounts the provided mounts to a temp dir as readonly,


### PR DESCRIPTION
`readonlyMounts`, `RemoveVolatileOption`, `RemoveIDMapOption` helpers operated on their input slices directly, unexpectedly mutating the caller's data.

The existing no-mutation test assertions also suffered from the same shallow-copy problem, so they could not detect the corruption.