### PR TITLE
Use intermediate env variables for bash script runners in github workflows

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -28,8 +28,10 @@ jobs:
           path: src/github.com/containerd/containerd
 
       - name: Check signature
+        env:
+          REF: ${{ github.ref }}
         run: |
-          releasever=${{ github.ref }}
+          releasever="$REF"
           releasever="${releasever#refs/tags/}"
           TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||
           echo "${TAGCHECK}" | grep -q "error" && {
@@ -43,8 +45,10 @@ jobs:
 
       - name: Release content
         id: contentrel
+        env:
+          REF: ${{ github.ref }}
         run: |
-          RELEASEVER=${{ github.ref }}
+          RELEASEVER="$REF"
           echo "stringver=${RELEASEVER#refs/tags/api/v}" >> $GITHUB_OUTPUT
           git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
         working-directory: src/github.com/containerd/containerd

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -77,23 +77,29 @@ jobs:
           creds: ${{ secrets.AZURE_CREDS }}
 
       - name: Create Azure Resource Group
+        env:
+          AZURE_LOCATION: ${{github.event.inputs.azure_location }}
         uses: azure/CLI@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlinescript: |
-            az group create -n ${{ env.AZURE_RESOURCE_GROUP }} -l ${{ github.event.inputs.azure_location }} --tags creationTimestamp=$(date +%Y-%m-%dT%T%z)
+            az group create -n ${{ env.AZURE_RESOURCE_GROUP }} -l "$AZURE_LOCATION" --tags creationTimestamp=$(date +%Y-%m-%dT%T%z)
 
       - name: Create Windows Helper VM
+        env:
+          AZURE_WINDOWS_IMAGE_ID: ${{github.event.inputs.azure_windows_image_id}}
+          AZURE_VM_SIZE: ${{github.event.inputs.azure_vm_size}}
         uses: azure/CLI@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlinescript: |
             PASSWORD="$(/usr/bin/tr -dc "a-zA-Z0-9@#$%^&*()_+?><~\`;" < /dev/urandom | /usr/bin/head -c 24; echo '')"
+            echo "::add-mask::$PASSWORD"
             az vm create -n WinDockerHelper \
               --admin-username ${{ env.DEFAULT_ADMIN_USERNAME }} \
               --public-ip-sku Basic \
-              --admin-password "::add-mask::$PASSWORD" \
-              --image ${{ github.event.inputs.azure_windows_image_id }} \
+              --admin-password "$PASSWORD" \
+              --image "$AZURE_WINDOWS_IMAGE_ID" \
               -g ${{ env.AZURE_RESOURCE_GROUP }} \
-              --size ${{ github.event.inputs.azure_vm_size }}
+              --size "$AZURE_VM_SIZE"
             az vm open-port --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name WinDockerHelper --port 22 --priority 101
             az vm open-port --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name WinDockerHelper --port 2376 --priority 102
 
@@ -150,14 +156,16 @@ jobs:
 
       - name: Build and push images
         shell: bash
+        env:
+          PROJECT: ${{ github.event.inputs.push_to_project }}
         run: |
           make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up setup-buildx
 
-          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up build-registry PROJ=${{ github.event.inputs.push_to_project }} REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
-          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up push-manifest PROJ=${{ github.event.inputs.push_to_project }} REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up build-registry PROJ="$PROJECT" REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up push-manifest PROJ="$PROJECT" REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
 
-          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-ownership build-registry PROJ=${{ github.event.inputs.push_to_project }} REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
-          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-ownership push-manifest PROJ=${{ github.event.inputs.push_to_project }} REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-ownership build-registry PROJ="$PROJECT" REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-ownership push-manifest PROJ="$PROJECT" REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
 
       - name: Cleanup resources
         if: always()

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -54,13 +54,16 @@ jobs:
 
       - name: Pull and push image
         shell: bash
+        env:
+          UPSTREAM_IMAGE: ${{ github.event.inputs.upstream }}
+          TARGET_IMAGE: ${{ github.event.inputs.image }}
         run: |
-          sudo containerd -l debug & > /tmp/containerd.out
+          sudo containerd -l debug > /tmp/containerd.out 2>&1 &
           containerd_pid=$!
           sleep 5
 
-          upstream=${{ github.event.inputs.upstream }}
-          target=${{ github.event.inputs.image }}
+          upstream="$UPSTREAM_IMAGE"
+          target="$TARGET_IMAGE"
           if [[ "$target" == "" ]]; then
             mirror="ghcr.io/containerd/${upstream##*/}"
           else


### PR DESCRIPTION
Best practice for interpolation of input variables for bash scripts in Github workflows is to preresolve them during an env step and encapsulate them inline in the bash into a string to avoid script injection. These cases could be injected from either directly in the input step for the workflow (images.yml/build-test-images.yml), or more indirectly by setting a malicious tag (api-release.yml). To be fair, to do so one would still need write access on the repository (for the tag) or the workflows directly (for the input step), but still updating it to sync with the security recommendation in the docs at https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable.