### PR TITLE
contrib/checkpoint: increase timeouts to 30s

### DIFF
--- a/contrib/checkpoint/checkpoint-restore-cri-test.sh
+++ b/contrib/checkpoint/checkpoint-restore-cri-test.sh
@@ -96,7 +96,7 @@ function test_from_archive() {
 	echo -n "--> Create container from checkpoint: "
 	# This requires a larger timeout as we just deleted the image and
 	# pulling can take some time.
-	ctr_id=$(crictl -t 20s create "$pod_id" "$RESTORE_JSON" "$POD_JSON")
+	ctr_id=$(crictl -t 30s create "$pod_id" "$RESTORE_JSON" "$POD_JSON")
 	echo "$ctr_id"
 	rm -f "$RESTORE_JSON" "$POD_JSON"
 	echo -n "--> Start container from checkpoint: "
@@ -175,7 +175,7 @@ function test_from_oci() {
 	../../bin/ctr -n k8s.io images import "$TESTDIR"/oci.tar 2>&1 | sed 's/^/------> \t/'
 	jq ".image.image=\"localhost/checkpoint-image:latest\"" "$TESTDATA"/container_sleep.json >"$RESTORE_JSON"
 	echo -n "--> Create container from checkpoint: "
-	ctr_id=$(crictl -t 10s create "$pod_id" "$RESTORE_JSON" "$RESTORE_POD_JSON")
+	ctr_id=$(crictl -t 30s create "$pod_id" "$RESTORE_JSON" "$RESTORE_POD_JSON")
 	echo "$ctr_id"
 	rm -f "$RESTORE_JSON" "$RESTORE_POD_JSON"
 	echo -n "--> Start container from checkpoint: "


### PR DESCRIPTION
Under slow network conditions (e.g., simulated 2 Mbps ingress bandwidth limits in CI), restoring a container from a checkpoint can fail if it requires pulling the base image again.

During restore, crictl create is called. In test_from_oci, it used a 10-second timeout (crictl -t 10s create). Over a 2 Mbps connection, pulling the 2.8MB Alpine layer takes ~12-13 seconds, causing the operation to exceed the timeout and fail with context canceled.

Increase the timeouts in both test_from_archive and test_from_oci to 30 seconds. This ensures the base image pull can complete successfully even in constrained CI environments.

Tested:
Ran the CRI integration tests on a GCE VM under a simulated 2 Mbps ingress bandwidth limit using traffic control (tc). Verified that both test_from_archive and test_from_oci passed successfully and container restore completed without timeout.

Assisted-by: Antigravity