### PR TITLE
Prepare release notes for api/v1.11.1

### DIFF
--- a/api/releases/v1.11.1.toml
+++ b/api/releases/v1.11.1.toml
@@ -1,0 +1,17 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+sub_path = "api"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "api/v1.11.0"
+
+pre_release = false
+
+preface = """\
+The first patch release for the containerd 1.11 API includes a fix
+in the task endpoints for non-runc shims.
+"""


### PR DESCRIPTION
Generated notes

----

Welcome to the api/v1.11.1 release of containerd!

The first patch release for the containerd 1.11 API includes a fix
in the task endpoints for non-runc shims.

### Highlights

* Fix sandbox task API endpoints for non-runc runtimes ([#13422](https://github.com/containerd/containerd/pull/13422))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Maksym Pavlenko
* Samuel Karp

### Changes
<details><summary>3 commits</summary>
<p>

  * [`da7aef299`](https://github.com/containerd/containerd/commit/da7aef299c57cc1f290700ade8fa0a5fec69a462) Prepare release notes for api/v1.11.1
* Fix sandbox task API endpoints for non-runc runtimes ([#13422](https://github.com/containerd/containerd/pull/13422))
  * [`e44f5f9ec`](https://github.com/containerd/containerd/commit/e44f5f9ec610d95a712d230e8a19ae516e0a26ac) protos: include task API address to CreateTaskRequest
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [api/v1.11.0](https://github.com/containerd/containerd/releases/tag/api/v1.11.0)
