### PR TITLE
[release/2.0] oci: return explicit error for out-of-range USER values

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -622,13 +622,24 @@ func WithUser(userstr string) SpecOpts {
 			return nil
 		}
 
+		isErrRange := func(err error) bool {
+			var numErr *strconv.NumError
+			return errors.As(err, &numErr) && numErr.Err == strconv.ErrRange
+		}
+
 		parts := strings.Split(userstr, ":")
 		switch len(parts) {
 		case 1:
 			v, err := strconv.Atoi(parts[0])
-			if err != nil || v < minUserID || v > maxUserID {
-				// if we cannot parse as an int32 then try to see if it is a username
+			if err != nil {
+				if isErrRange(err) {
+					return fmt.Errorf("invalid USER value %q: uid out of range", userstr)
+				}
+				// Non-numeric user value; treat it as a username.
 				return WithUsername(userstr)(ctx, client, c, s)
+			}
+			if v < minUserID || v > maxUserID {
+				return fmt.Errorf("invalid USER value %q: uid out of range", userstr)
 			}
 			return WithUserID(uint32(v))(ctx, client, c, s)
 		case 2:
@@ -638,14 +649,24 @@ func WithUser(userstr string) SpecOpts {
 			)
 			var uid, gid uint32
 			v, err := strconv.Atoi(parts[0])
-			if err != nil || v < minUserID || v > maxUserID {
+			if err != nil {
+				if isErrRange(err) {
+					return fmt.Errorf("invalid USER value %q: uid out of range", userstr)
+				}
 				username = parts[0]
+			} else if v < minUserID || v > maxUserID {
+				return fmt.Errorf("invalid USER value %q: uid out of range", userstr)
 			} else {
 				uid = uint32(v)
 			}
 			v, err = strconv.Atoi(parts[1])
-			if err != nil || v < minGroupID || v > maxGroupID {
+			if err != nil {
+				if isErrRange(err) {
+					return fmt.Errorf("invalid USER value %q: gid out of range", userstr)
+				}
 				groupname = parts[1]
+			} else if v < minGroupID || v > maxGroupID {
+				return fmt.Errorf("invalid USER value %q: gid out of range", userstr)
 			} else {
 				gid = uint32(v)
 			}

--- a/pkg/oci/spec_opts_linux_test.go
+++ b/pkg/oci/spec_opts_linux_test.go
@@ -93,15 +93,23 @@ guest:x:100:guest
 		},
 		{
 			user: "405:2147483648",
-			err:  "no groups found",
+			err:  "invalid USER value \"405:2147483648\": gid out of range",
 		},
 		{
 			user: "-1000",
-			err:  "no users found",
+			err:  "invalid USER value \"-1000\": uid out of range",
 		},
 		{
 			user: "2147483648",
-			err:  "no users found",
+			err:  "invalid USER value \"2147483648\": uid out of range",
+		},
+		{
+			user: "999999999999999999999999999999999999",
+			err:  "invalid USER value \"999999999999999999999999999999999999\": uid out of range",
+		},
+		{
+			user: "0:999999999999999999999999999999999999",
+			err:  "invalid USER value \"0:999999999999999999999999999999999999\": gid out of range",
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION


```release-note
Fix handling of out-of-range USER values in OCI spec to avoid unexpected username/group lookups
```