### PR TITLE
remove log line which says that NRI is experimental

### DIFF
--- a/plugins/cri/cri.go
+++ b/plugins/cri/cri.go
@@ -229,7 +229,6 @@ func getNRIAPI(ic *plugin.InitContext) nriservice.API {
 		return nil
 	}
 
-	log.G(ctx).Info("using experimental NRI integration - disable nri plugin to prevent this")
 	return api
 }
 


### PR DESCRIPTION
This log line was first added as part of commit b27ef6f when NRI was in its nascent stages. Since then, NRI has been enabled by default in commit fe24b91. Given this, I think NRI should no longer be considered "experimental" and we should remove this so that users are not confused by this log.