### PR TITLE
core/runtime/v2: fix race on Windows deferredPipeConnection.c in Read

### DIFF
--- a/core/runtime/v2/shim_windows.go
+++ b/core/runtime/v2/shim_windows.go
@@ -42,11 +42,9 @@ type deferredPipeConnection struct {
 }
 
 func (dpc *deferredPipeConnection) Read(p []byte) (n int, err error) {
+	dpc.wg.Wait()
 	if dpc.c == nil {
-		dpc.wg.Wait()
-		if dpc.c == nil {
-			return 0, dpc.conerr
-		}
+		return 0, dpc.conerr
 	}
 	return dpc.c.Read(p)
 }


### PR DESCRIPTION
Read short-circuited on `if dpc.c == nil` before calling `dpc.wg.Wait()` which races with the dialer goroutine spawned in openShimLog. The dialer assigns `dpc.c = c` (and may set `dpc.conerr`) outside any lock; the only synchronization is the WaitGroup, and Read skipped it on the fast path.

Redacted stack trace:
```
==================
  WARNING: DATA RACE
  Write at 0x00c00xxxxxxx by goroutine N:
    github.com/containerd/containerd/v2/core/runtime/v2.openShimLog.func1()
        core/runtime/v2/shim_windows.go:84

  Previous read at 0x00c00xxxxxxx by goroutine M:
    github.com/containerd/containerd/v2/core/runtime/v2.(*deferredPipeConnection).Read()
        core/runtime/v2/shim_windows.go:45
    io.copyBuffer()
        io/io.go:429
    io.Copy()
        io/io.go:388
    os.genericReadFrom()
        os/file.go:205
    os.(*File).ReadFrom()
        os/file.go:181
    io.copyBuffer()
        io/io.go:415
    io.Copy()
        io/io.go:388
    github.com/containerd/containerd/v2/core/runtime/v2.(*binary).Start.func3()
        core/runtime/v2/binary.go:106

  Goroutine N (running) created at:
    sync.(*WaitGroup).Go()
        sync/waitgroup.go:238
    github.com/containerd/containerd/v2/core/runtime/v2.(*binary).Start()
        core/runtime/v2/binary.go:92
    github.com/containerd/containerd/v2/core/runtime/v2.(*ShimManager).startShim()
        core/runtime/v2/shim_manager.go:323
    github.com/containerd/containerd/v2/core/runtime/v2.(*ShimManager).Start()
        core/runtime/v2/shim_manager.go:282
    github.com/containerd/containerd/v2/core/runtime/v2.(*TaskManager).Create()
        core/runtime/v2/task_manager.go:213
    go.etcd.io/bbolt.(*Bucket).spill()
        [bbolt internal frames elided]
    github.com/containerd/containerd/v2/core/mount/manager.(*mountManager).Activate()
        core/mount/manager/manager.go:501
    go.etcd.io/bbolt.(*DB).Update()
        [bbolt internal frames elided]
    github.com/containerd/containerd/v2/core/mount/manager.(*mountManager).Activate()
        core/mount/manager/manager.go:246
    github.com/containerd/containerd/v2/core/runtime/v2.(*TaskManager).Create()
        core/runtime/v2/task_manager.go:189
    github.com/containerd/containerd/v2/plugins/services/tasks.(*local).Create()
        plugins/services/tasks/local.go:256
    github.com/containerd/containerd/v2/client.(*container).NewTask()
        client/container.go:295
    [application: container-start handler chain elided]
    net/http.serverHandler.ServeHTTP()
        net/http/server.go:3311
    net/http.(*conn).serve()
        net/http/server.go:2073
    net/http.(*Server).Serve.gowrap3()
        net/http/server.go:3464

  Goroutine M (running) created at:
    github.com/containerd/containerd/v2/core/runtime/v2.(*binary).Start()
        core/runtime/v2/binary.go:104
    [same shim-startup path as Goroutine N above]
  ==================
```