### PR TITLE
release: add .zip archive for Windows releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-tars-${{env.PLATFORM_CLEAN}}
-          path: src/github.com/containerd/containerd/releases/*.tar.gz*
+          path: |
+            src/github.com/containerd/containerd/releases/*.tar.gz*
+            src/github.com/containerd/containerd/releases/*.zip*
 
   release:
     name: Create containerd Release
@@ -148,7 +150,9 @@ jobs:
         id: attest
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: ./builds/release-tars-**/*.tar.gz
+          subject-path: |
+            ./builds/release-tars-**/*.tar.gz
+            ./builds/release-tars-**/*.zip
       - name: Rename attestation artifact
         run: mv ${{ steps.attest.outputs.bundle-path }} containerd-${{ needs.check.outputs.stringver }}-attestation.intoto.jsonl
       - name: Create Release

--- a/.github/workflows/release/Dockerfile
+++ b/.github/workflows/release/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=xx / /
 SHELL ["/bin/bash", "-xec"]
 ENV DEBIAN_FRONTEND=noninteractive
 RUN	apt-get update && \
-	apt-get install -y dpkg-dev git make pkg-config
+	apt-get install -y dpkg-dev git make pkg-config zip
 ARG TARGETPLATFORM
 # gcc is needed for github.com/containerd/btrfs/v2
 RUN xx-apt-get install -y gcc

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ containerd.test
 _site/
 releases/*.tar.gz
 releases/*.tar.gz.sha256sum
+releases/*.zip
+releases/*.zip.sha256sum
 _output/
 .vagrant/

--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,17 @@ define pack_release
 	@rm -rf releases/$(1)
 endef
 
+# pack_release_zip creates a .zip archive for Windows releases.
+# This enables WinGet and other Windows package managers that do not support
+# .tar.gz to consume containerd releases.
+define pack_release_zip
+	@rm -rf releases/$(1) releases/$(1).zip
+	@$(INSTALL) -d releases/$(1)/bin
+	@$(INSTALL) $(BINARIES) releases/$(1)/bin
+	@cd releases/$(1) && zip -r ../$(1).zip bin
+	@rm -rf releases/$(1)
+endef
+
 
 releases/$(RELEASE).tar.gz: $(BINARIES)
 	@echo "$(WHALE) $@"
@@ -328,6 +339,10 @@ releases/$(RELEASE).tar.gz: $(BINARIES)
 release: releases/$(RELEASE).tar.gz
 	@echo "$(WHALE) $@"
 	@cd releases && sha256sum $(RELEASE).tar.gz >$(RELEASE).tar.gz.sha256sum
+ifeq ($(GOOS),windows)
+	$(call pack_release_zip,$(RELEASE))
+	@cd releases && sha256sum $(RELEASE).zip >$(RELEASE).zip.sha256sum
+endif
 
 releases/$(STATICRELEASE).tar.gz:
 ifeq ($(GOOS),linux)


### PR DESCRIPTION
## release: add .zip archive for Windows releases

Fixes #12315

### What

When `GOOS=windows`, the `release` Makefile target now produces a `.zip` archive alongside the existing `.tar.gz`. The `.zip` has the same content (the `bin/` directory with containerd binaries) and gets its own `.sha256sum`.

### Why

Windows package managers like WinGet do not support `.tar.gz` archives. The lack of a `.zip` release artifact blocks creating a WinGet package for containerd. Having containerd available through `winget install containerd` would reduce friction for Windows container users.

### Changes

- **Makefile**: Added `pack_release_zip` macro that creates a `.zip` using the same staging directory pattern as `pack_release`. The `release` target calls it conditionally when `GOOS=windows` and generates the corresponding `.zip.sha256sum`.
- **release/Dockerfile**: Added `zip` to the `apt-get install` list in the base build stage so the `zip` command is available during cross-compilation.
- **release.yml**: Updated artifact upload to include `*.zip*` globs and added `.zip` to the build provenance attestation subject paths.

### What this looks like in a release

Before:
```
containerd-2.1.0-windows-amd64.tar.gz
containerd-2.1.0-windows-amd64.tar.gz.sha256sum
```

After:
```
containerd-2.1.0-windows-amd64.tar.gz
containerd-2.1.0-windows-amd64.tar.gz.sha256sum
containerd-2.1.0-windows-amd64.zip
containerd-2.1.0-windows-amd64.zip.sha256sum
```

Linux and other platform releases are not affected.