### PR TITLE
fix(cmd/containerd): ignore SIGHUP to prevent accidental daemon restarts

### DIFF
--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -32,6 +32,7 @@ var handledSignals = []os.Signal{
 	unix.SIGINT,
 	unix.SIGUSR1,
 	unix.SIGPIPE,
+	unix.SIGHUP,
 }
 
 func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *server.Server, cancel func()) chan struct{} {
@@ -54,6 +55,8 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 				switch s {
 				case unix.SIGUSR1:
 					dumpStacks(true)
+				case unix.SIGHUP:
+					log.G(ctx).Warn("Warning: SIGHUP received, configuration reloading is not supporting")
 				default:
 					if err := notifyStopping(ctx); err != nil {
 						log.G(ctx).WithError(err).Error("notify stopping failed")


### PR DESCRIPTION
Currently, containerd treats SIGHUP as an unhandled signal, which triggers an abrupt shutdown. This causes the daemon to terminate unexpectedly whenever external tools send SIGHUP expecting a config reload.

This is causing crash-loops for users running containerd under supervisors like RKE2.

This fix adds SIGHUP to the handled signals and explicitly ignores it to keep the daemon stable. I've added a warning log so admins know the signal was received, even though we aren't supporting reloads yet.