### PR TITLE
blockcim config and plugin initialization changes

### DIFF
--- a/plugins/diff/windows/cimfs.go
+++ b/plugins/diff/windows/cimfs.go
@@ -72,8 +72,8 @@ func init() {
 			plugins.MetadataPlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (any, error) {
-			if !cimfs.IsBlockCimSupported() {
-				return nil, fmt.Errorf("host OS version doesn't support block CIMs: %w", plugin.ErrSkipPlugin)
+			if !cimfs.IsBlockCimWriteSupported() {
+				return nil, fmt.Errorf("host OS doesn't support writable block CIMs: %w", plugin.ErrSkipPlugin)
 			}
 
 			md, err := ic.GetSingle(plugins.MetadataPlugin)

--- a/plugins/snapshots/windows/block_cimfs.go
+++ b/plugins/snapshots/windows/block_cimfs.go
@@ -96,8 +96,8 @@ func init() {
 }
 
 func NewBlockCIMSnapshotter(root string, config *BlockCIMSnapshotterConfig) (snapshots.Snapshotter, error) {
-	if !cimfs.IsBlockCimSupported() {
-		return nil, fmt.Errorf("host windows version doesn't support block CIMs: %w", plugin.ErrSkipPlugin)
+	if !cimfs.IsBlockCimWriteSupported() {
+		return nil, fmt.Errorf("host OS doesn't support writable block CIMs: %w", plugin.ErrSkipPlugin)
 	}
 
 	baseSn, err := newBaseSnapshotter(root)

--- a/plugins/snapshots/windows/cimfs.go
+++ b/plugins/snapshots/windows/cimfs.go
@@ -83,7 +83,7 @@ func WithSize(size uint64) scratchCreationOpt {
 // defaultScratchCreationOptions returns the default options for scratch VHD creation
 func defaultScratchCreationOptions() *scratchCreationOptions {
 	return &scratchCreationOptions{
-		ntfsFormat:  true,
+		ntfsFormat:  false,
 		sizeInBytes: defaultScratchVHDSizeInBytes,
 	}
 }
@@ -420,7 +420,7 @@ func createDifferencingScratchVHDs(ctx context.Context, path string) (err error)
 	}()
 
 	if !baseVHDExists {
-		if err = createScratchVHD(ctx, baseVHDPath); err != nil {
+		if err = createScratchVHD(ctx, baseVHDPath, WithNTFSFormat()); err != nil {
 			return fmt.Errorf("failed to create base vhd: %w", err)
 		}
 	}


### PR DESCRIPTION
This change updates an incorrect default config value for the block CIM
snapshotter. The `ntfsFormat` should always be false for the block CIM
snapshotter. If the scratch needs to be formatted with NTFS, a format
option named `WithNTFSFormat` can be provided.

Original PR: https://github.com/containerd/containerd/pull/12439

Switch block CIM snapshotter and diff plugin init checks from
IsBlockCimSupported() to IsBlockCimWriteSupported() to allow plugins
to load when the CimWriter.dll is available, even on OS builds
without native block CIM support.

