### PR TITLE
Fix flaky e2e test

### DIFF
--- a/internal/cri/server/stats_collector.go
+++ b/internal/cri/server/stats_collector.go
@@ -183,13 +183,12 @@ func (c *StatsCollector) collectContainerStats(ctx context.Context) {
 		return
 	}
 
-	timestamp := time.Now()
 	for _, metric := range resp.Metrics {
 		usageCoreNanoSeconds, ok := extractCPUUsage(metric.Data)
 		if !ok {
 			continue
 		}
-		c.addSample(metric.ID, timestamp, usageCoreNanoSeconds)
+		c.addSample(metric.ID, metric.GetTimestamp().AsTime(), usageCoreNanoSeconds)
 	}
 }
 


### PR DESCRIPTION
Recent CI tests fail with ([1](https://github.com/containerd/containerd/actions/runs/26287530009/job/77378831317?pr=13466), [2](https://github.com/containerd/containerd/actions/runs/26297785405/job/77414856399?pr=13453)):

```
 [FAILED] Failed after 15.072s.
  Expected
      <string>: Summary
  to match fields: {
  .Pods[summary-test-3062::stats-busybox-0].Containers[busybox-container].CPU:
  	Expected
  	    <string>: CPUStats
  	to match fields: {
  	.UsageNanoCores:
  		Expected
  		    <uint64>: 1001557809
  		to be <=
  		    <float64>: 1e+09
  	}
  	
  }
```

This PR removes RPC latency from the equation, which should fix/mitigate flakiness.