### PR TITLE
fix(cri): prevent severely distorted Pod CPU metrics under high node load

### DIFF
--- a/internal/cri/server/stats_collector.go
+++ b/internal/cri/server/stats_collector.go
@@ -202,7 +202,6 @@ func (c *StatsCollector) collectSandboxStats(ctx context.Context) {
 		return
 	}
 
-	timestamp := time.Now()
 	for _, sb := range sandboxes {
 		// Get the parent cgroup path for the pod
 		cgroupPath := sb.Config.GetLinux().GetCgroupParent()
@@ -214,7 +213,7 @@ func (c *StatsCollector) collectSandboxStats(ctx context.Context) {
 		if !ok {
 			continue
 		}
-		c.addSample(sb.ID, timestamp, usageCoreNanoSeconds)
+		c.addSample(sb.ID, time.Now(), usageCoreNanoSeconds)
 	}
 }
 


### PR DESCRIPTION
Issue Trigger Scenario: 
The issue occurs in Linux environments where the CRI stats collector is enabled and multiple ready pod sandboxes exist. It is
     triggered when there is noticeable latency during cgroup reads or system scheduling. The probability increases on nodes with high loads or a large number of sandboxes.

 Failure Symptom: 
The instantaneous Pod sandbox CPU usage (UsageNanoCores), visible in CRI pod stats or the kubelet summary, becomes inaccurate (abnormally high or low). This can lead to flaky metrics, confusing dashboards, and potentially misfiring monitoring alerts or autoscalers.

Root Cause: 
In collectSandboxStats , a single timestamp (timestamp := time.Now()) was generated outside  the main loop and reused for all sandboxes. If reading cgroups across multiple sandboxes takes time due to I/O or scheduling delays, the shared  timestamp becomes stale for subsequent sandboxes. Since the usage rate relies on the time delta between consecutive samples, attributing delayed data to an early timestamp distorts the time delta, skewing the final CPU usage calculation.

