### PR TITLE
pkg/oci: WithUser: remove redundant isErrRange utility

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -625,17 +625,12 @@ func WithUser(userstr string) SpecOpts {
 			return nil
 		}
 
-		isErrRange := func(err error) bool {
-			var numErr *strconv.NumError
-			return errors.As(err, &numErr) && numErr.Err == strconv.ErrRange
-		}
-
 		parts := strings.Split(userstr, ":")
 		switch len(parts) {
 		case 1:
 			v, err := strconv.Atoi(parts[0])
 			if err != nil {
-				if isErrRange(err) {
+				if errors.Is(err, strconv.ErrRange) {
 					return fmt.Errorf("invalid USER value %q: uid out of range", userstr)
 				}
 				// Non-numeric user value; treat it as a username.
@@ -653,7 +648,7 @@ func WithUser(userstr string) SpecOpts {
 			var uid, gid uint32
 			v, err := strconv.Atoi(parts[0])
 			if err != nil {
-				if isErrRange(err) {
+				if errors.Is(err, strconv.ErrRange) {
 					return fmt.Errorf("invalid USER value %q: uid out of range", userstr)
 				}
 				username = parts[0]
@@ -664,7 +659,7 @@ func WithUser(userstr string) SpecOpts {
 			}
 			v, err = strconv.Atoi(parts[1])
 			if err != nil {
-				if isErrRange(err) {
+				if errors.Is(err, strconv.ErrRange) {
 					return fmt.Errorf("invalid USER value %q: gid out of range", userstr)
 				}
 				groupname = parts[1]


### PR DESCRIPTION
- follow-up to https://github.com/containerd/containerd/pull/13446

`strconv.NumError` implements `Unwrap` (see https://go.dev/cl/194563), so there's no need to manually assert the type and unwrap.

Updates 9439355c2bffd12d9e15f1fa57cdd1c6da677cd2