### PR TITLE
runc-shim: don't hold the service lock across runc create

### DIFF
--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -221,9 +221,6 @@ func (s *service) preStart(c *runc.Container) (handleStarted func(*runc.Containe
 
 // Create a new initial process and container with the underlying OCI runtime
 func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *taskAPI.CreateTaskResponse, err error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	s.lifecycleMu.Lock()
 	handleStarted, cleanup := s.preStart(nil)
 	s.lifecycleMu.Unlock()
@@ -234,7 +231,9 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 		return nil, err
 	}
 
+	s.mu.Lock()
 	s.containers[r.ID] = container
+	s.mu.Unlock()
 
 	s.send(&eventstypes.TaskCreate{
 		ContainerID: r.ID,


### PR DESCRIPTION
The task service guards its containers map with s.mu, and getContainer() takes it on behalf of effectively every task RPC (State, Connect, Stats, Wait, Pause, Kill, ...). Create() held s.mu for its whole duration, including runc.NewContainer(), which runs the actual `runc create`.

`runc create` can be slow on a loaded host. While it runs, any concurrent task RPC blocks on s.mu. The tasks service applies a 2s timeout to State (io.containerd.timeout.task.state), so a concurrent State waits on s.mu, exceeds the deadline, and the ttrpc call is abandoned -- the late shim reply then shows up as:

    ttrpc: received message on inactive stream stream=3

Since deadline errors are now surfaced to clients, this is treated as a fatal failure and the just-created container is torn down right after start (observed on Lima/vz: nginx -> Exited (1)).

Move runc.NewContainer() out of the s.mu critical section, mirroring the runtime v1 shim lock optimization. s.mu is taken only once the container exists, to guard the map and the remaining (fast) setup, so a slow create no longer blocks concurrent State and other lookups. preStart/handleStarted/cleanup only use s.lifecycleMu, so early-exit handling is unchanged.

See:
- lima-vm/lima#5030.

> The regression is caused by https://github.com/containerd/containerd/commit/f078cebbd
> - https://github.com/containerd/containerd/pull/12821
> 
> - - -
> - `f078cebbd` https://github.com/lima-vm/lima/actions/runs/26487350835/job/77997535035?pr=5049
> ```
> + limactl shell default nerdctl ps -a
> time="2026-05-27T02:56:35Z" level=warning msg="treating lima version \"0c93a37\" from \"/Users/runner/.lima/default/lima-version\" as very latest release"
> CONTAINER ID    IMAGE                                              COMMAND                   CREATED           STATUS                      PORTS                     NAMES
> 3f67f52a5931    ghcr.io/stargz-containers/nginx:1.19-alpine-org    "/docker-entrypoint.…"    10 seconds ago    Exited (1) 5 seconds ago    127.0.0.1:8080->80/tcp    nginx
> + limactl shell default nerdctl logs nginx
> time="2026-05-27T02:56:36Z" level=warning msg="treating lima version \"0c93a37\" from \"/Users/runner/.lima/default/lima-version\" as very latest release"
> + [[ -z '' ]]
> + limactl shell default journalctl --user -u containerd
> [...]
> May 27 02:55:49 lima-default containerd-rootless.sh[1173]: time="2026-05-27T02:55:49.956586096Z" level=info msg="containerd successfully booted in 7.782954s"
> May 27 02:56:25 lima-default containerd-rootless.sh[1173]: time="2026-05-27T02:56:25.445537685Z" level=info msg="connecting to shim 3f67f52a59314ed6fc4e1048b0e2c826ab26df575cec4cbf38619beb754dbebd" address="unix:///run/containerd/s/56dfcbff8ef161f104b965a6f02b0158fca28ed1beba7df4c255935edf3a9122" namespace=default protocol=ttrpc version=3
> May 27 02:56:29 lima-default containerd-rootless.sh[1173]: time="2026-05-27T02:56:29.753250886Z" level=error msg="ttrpc: received message on inactive stream" stream=3
> ```
> - `f078cebbd~1` https://github.com/lima-vm/lima/actions/runs/26487350835/job/77997535032?pr=5049
> 

            
- - -
Note: used Claude