### PR TITLE
[release/2.1] Prepare release notes for v2.1.8

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -102,6 +102,7 @@ Kohei Tokunaga <ktokunaga.mail@gmail.com>
 Krasi Georgiev <krasi.root@gmail.com> <krasi@vip-consult.solutions>
 Lantao Liu <lantaol@google.com>
 Lantao Liu <lantaol@google.com> <taotaotheripper@gmail.com>
+LEI WANG <ssst0n3@gmail.com>
 lengrongfu <1275177125@qq.com>
 Li Yuxuan <liyuxuan04@baidu.com> <darfux@163.com>
 Lifubang <lifubang@aliyun.com> <lifubang@acmcoder.com>
@@ -174,6 +175,7 @@ Wei Fu <fuweid89@gmail.com>
 Wei Fu <fuweid89@gmail.com> <fhfuwei@163.com>
 wen chen <wen.chen@daocloud.io>
 William Chen <willchen.005@gmail.com> <root@DESKTOP-HIQTJ3R.localdomain>
+William Myers <willmyrs@amazon.com>
 Xiaodong Zhang <a4012017@sina.com>
 Xuean Yan <yan.xuean@zte.com.cn>
 Yang Yang <yang8518296@163.com>

--- a/releases/v2.1.8.toml
+++ b/releases/v2.1.8.toml
@@ -1,0 +1,31 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "v2.1.7"
+
+pre_release = false
+
+preface = """\
+The eighth patch release for containerd 2.1 contains various fixes and updates.
+
+### Security Updates
+
+* [**CVE-2026-46680**](https://github.com/containerd/containerd/security/advisories/GHSA-fqw6-gf59-qr4w)
+"""
+
+postface = """\
+### Which file should I download?
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.35 (Ubuntu 22.04).
+* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on Linux distributions that do not use glibc >= 2.35. Not position-independent.
+
+In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
+and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.
+
+See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.1.7+unknown"
+	Version = "2.1.8+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
containerd 2.1.8

Welcome to the v2.1.8 release of containerd!

The eighth patch release for containerd 2.1 contains various fixes and updates.

### Security Updates

* [**CVE-2026-46680**](https://github.com/containerd/containerd/security/advisories/GHSA-fqw6-gf59-qr4w)

### Highlights

#### Runtime

* Fix handling of out-of-range USER values in OCI spec to avoid unexpected username/group lookups ([#13497](https://github.com/containerd/containerd/pull/13497))
* Fix bugs in sandbox service affecting sandbox creation configuration and event publishing ([#13272](https://github.com/containerd/containerd/pull/13272))
* Set AppArmor abi conditionally to support versions < 3.0 ([#13274](https://github.com/containerd/containerd/pull/13274))

#### Snapshotters

* Support both "volatile" and "fsync=volatile" mount options for volatile snapshotter ([#13297](https://github.com/containerd/containerd/pull/13297))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Wei Fu
* Brian Goff
* Chris Henzie
* Samuel Karp
* LEI WANG
* William Myers

### Changes
<details><summary>11 commits</summary>
<p>

  * [`782280ef0`](https://github.com/containerd/containerd/commit/782280ef011951156ee40778d8efeb82a89a4e7f) Prepare release notes for v2.1.8
* oci: return explicit error for out-of-range USER values ([#13497](https://github.com/containerd/containerd/pull/13497))
  * [`2054cc54c`](https://github.com/containerd/containerd/commit/2054cc54c101831e44c83b4185e1e3d09ff50840) oci: return explicit error for out-of-range USER values
* Support both styles of volatile mount option ([#13297](https://github.com/containerd/containerd/pull/13297))
  * [`677e8f08a`](https://github.com/containerd/containerd/commit/677e8f08a0492ed68144931f37513c8f9d69c411) Support both styles of volatile mount option
* backport: sandbox: forward Create fields, fix event topics ([#13272](https://github.com/containerd/containerd/pull/13272))
  * [`f3b4b35c9`](https://github.com/containerd/containerd/commit/f3b4b35c94cab35c398df89800b198e94984e2f6) sandbox: forward Create fields, fix event topics
* apparmor: Set abi conditionally ([#13274](https://github.com/containerd/containerd/pull/13274))
  * [`eba90da61`](https://github.com/containerd/containerd/commit/eba90da61a53494bacfbe0e97f5f9559000b068f) apparmor: Set abi conditionally
* Add GitHub Action for k8s node e2e tests ([#13249](https://github.com/containerd/containerd/pull/13249))
  * [`b8b110584`](https://github.com/containerd/containerd/commit/b8b1105842ba6df2e956f88448253545be6d8785) Add GitHub Action for k8s node e2e tests
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v2.1.7](https://github.com/containerd/containerd/releases/tag/v2.1.7)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.35 (Ubuntu 22.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on Linux distributions that do not use glibc >= 2.35. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
