### PR TITLE
feat: support for oci volume sources on windows

### DIFF
--- a/integration/image_volume_windows_test.go
+++ b/integration/image_volume_windows_test.go
@@ -1,0 +1,226 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/go-winio/pkg/bindfilter"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/opencontainers/image-spec/identity"
+	"github.com/stretchr/testify/require"
+)
+
+const windowsTestImage = "ghcr.io/containerd/windows/nanoserver:ltsc2022"
+
+// isBindFilterActive returns true if the given path has an active bind filter
+// mapping in the Windows kernel. This is an independent reimplementation of the same
+// check used by ensureImageVolumeMounted in internal/cri/server/container_image_mount_windows.go.
+func isBindFilterActive(t *testing.T, target string) bool {
+	t.Helper()
+	// Normalize path before comparing against bind filter mount points.
+	target = filepath.Clean(target)
+	volume := filepath.VolumeName(target) + string(filepath.Separator)
+	mappings, err := bindfilter.GetBindMappings(volume)
+	if err != nil {
+		// GetBindMappings can fail if stale bind filter entries reference
+		// VHD disks that are no longer mounted. Treat this as not mounted.
+		t.Logf("GetBindMappings returned error (treating as not mounted): %v", err)
+		return false
+	}
+	// Windows paths are case-insensitive; use EqualFold for comparison.
+	for _, m := range mappings {
+		if strings.EqualFold(filepath.Clean(m.MountPoint), target) {
+			return true
+		}
+	}
+	return false
+}
+
+// criStateDir returns the CRI plugin state directory from the running containerd.
+// The state directory is where the CRI plugin stores pod and container state,
+// including image volume mounts at <stateDir>/image-volumes/<podID>/<imageDigest>.
+//
+// This mirrors criRuntimeInfo in release_upgrade_linux_test.go, which parses
+// the same runtime status JSON to extract configuration values.
+func criStateDir(t *testing.T) string {
+	t.Helper()
+	resp, err := runtimeService.Status()
+	require.NoError(t, err)
+	rawCfg, ok := resp.Info["config"]
+	require.True(t, ok, "could not find config in containerd runtime info")
+	var cfg map[string]any
+	require.NoError(t, json.Unmarshal([]byte(rawCfg), &cfg))
+	stateDir, ok := cfg["stateDir"].(string)
+	require.True(t, ok && stateDir != "", "could not find stateDir in containerd runtime info")
+	return stateDir
+}
+
+// TestImageVolumeBasicWindows verifies that an OCI image can be mounted as a
+// read-only volume and its contents are accessible inside the container.
+func TestImageVolumeBasicWindows(t *testing.T) {
+	EnsureImageExists(t, windowsTestImage)
+
+	// Create a pod sandbox — the container will live inside this.
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "image-volume-windows")
+
+	// Configure a container that mounts windowsTestImage as a read-only volume
+	// at C:\image-mount, then keeps running with a ping loop.
+	cfg := ContainerConfig("test-container", windowsTestImage,
+		WithCommand("cmd", "/c", "ping -t 127.0.0.1"),
+		WithImageVolumeMount(windowsTestImage, "", `C:\image-mount`),
+	)
+	cnID, err := runtimeService.CreateContainer(sb, cfg, sbConfig)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		runtimeService.StopContainer(cnID, 10)
+		runtimeService.RemoveContainer(cnID)
+	})
+	require.NoError(t, runtimeService.StartContainer(cnID))
+
+	// Verify the mount path has content. nanoserver contains License.txt,
+	// Users\, and Windows\ — a non-empty dir listing confirms the mount worked.
+	stdout, stderr, err := runtimeService.ExecSync(cnID,
+		[]string{"cmd", "/c", "dir C:\\image-mount"},
+		30*time.Second)
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+	require.NoError(t, err)
+	require.NotEmpty(t, string(stdout), "expected files at C:\\image-mount, got empty output")
+}
+
+// TestImageVolumeSetupIfContainerdRestartsWindows verifies that ensureImageVolumeMounted
+// correctly handles two scenarios:
+//
+//  1. The image volume directory exists but has no active bind filter (simulates
+//     a containerd restart where the bind filter was removed by the OS but the
+//     directory remains on disk). The volume must be remounted.
+//
+//  2. The image volume directory exists and has an active bind filter (normal
+//     "second container in same pod" case). The volume must not be remounted.
+//
+// This mirrors TestImageVolumeSetupIfContainerdRestarts in image_volume_linux_test.go.
+func TestImageVolumeSetupIfContainerdRestartsWindows(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "k8s.io")
+
+	EnsureImageExists(t, windowsTestImage)
+
+	// Resolve the image's chain ID and digest — these are used to locate the
+	// snapshot and the image volume directory path respectively.
+	img, err := containerdClient.GetImage(ctx, windowsTestImage)
+	require.NoError(t, err)
+
+	diffIDs, err := img.RootFS(ctx)
+	require.NoError(t, err)
+
+	imageChainID := identity.ChainID(diffIDs).String()
+	imageTarget := img.Target().Digest.Encoded()
+
+	snSrv := containerdClient.SnapshotService("windows")
+	stateDir := criStateDir(t)
+
+	t.Run("snapshot and dir exist, no bind filter (restart scenario)", func(t *testing.T) {
+		// Simulates a containerd restart: snapshot exists, directory exists,
+		// but the bind filter is gone. ensureImageVolumeMounted must detect
+		// the missing bind filter and remount.
+		sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "image-volume-restart-windows")
+
+		// target is the path that mutateImageMount would use for this pod and image.
+		target := filepath.Join(stateDir, "image-volumes", sb, imageTarget)
+
+		// Pre-create the snapshot and directory without applying a bind filter.
+		// This replicates the on-disk state after a containerd restart: the
+		// snapshot and directory persist, but the kernel bind filter is gone.
+		_, err := snSrv.Prepare(ctx, target, imageChainID)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			snSrv.Remove(ctx, target)
+			os.RemoveAll(target)
+		})
+		require.NoError(t, os.MkdirAll(target, 0755))
+
+		require.False(t, isBindFilterActive(t, target),
+			"bind filter should not be active before container creation")
+
+		cfg := ContainerConfig(t.Name()+"-restart-cn",
+			windowsTestImage,
+			WithCommand("cmd", "/c", "ping -t 127.0.0.1"),
+			WithImageVolumeMount(windowsTestImage, "", `C:\image-mount`),
+		)
+		cnID, err := runtimeService.CreateContainer(sb, cfg, sbConfig)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			runtimeService.StopContainer(cnID, 10)
+			runtimeService.RemoveContainer(cnID)
+		})
+		require.NoError(t, runtimeService.StartContainer(cnID))
+
+		// After container creation, ensureImageVolumeMounted should have detected
+		// the missing bind filter and triggered a remount.
+		require.True(t, isBindFilterActive(t, target),
+			"bind filter should be active after container creation (remounted)")
+	})
+
+	t.Run("bind filter active after first container (idempotency)", func(t *testing.T) {
+		// Normal case: first container mounts the volume, second container in
+		// the same pod should reuse the existing mount without remounting.
+		sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "image-volume-idempotency-windows")
+		target := filepath.Join(stateDir, "image-volumes", sb, imageTarget)
+
+		// First container — this triggers mutateImageMount which calls
+		// ensureImageVolumeMounted, finds no existing mount, and applies the bind filter.
+		cn1, err := runtimeService.CreateContainer(sb, ContainerConfig("first",
+			windowsTestImage,
+			WithCommand("cmd", "/c", "ping -t 127.0.0.1"),
+			WithImageVolumeMount(windowsTestImage, "", `C:\image-mount`),
+		), sbConfig)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			runtimeService.StopContainer(cn1, 10)
+			runtimeService.RemoveContainer(cn1)
+		})
+		require.NoError(t, runtimeService.StartContainer(cn1))
+
+		require.True(t, isBindFilterActive(t, target),
+			"bind filter should be active after first container creation")
+
+		// Second container in the same pod — ensureImageVolumeMounted should
+		// detect the active bind filter via GetBindMappings and skip remounting.
+		cn2, err := runtimeService.CreateContainer(sb, ContainerConfig("second",
+			windowsTestImage,
+			WithCommand("cmd", "/c", "ping -t 127.0.0.1"),
+			WithImageVolumeMount(windowsTestImage, "", `C:\image-mount`),
+		), sbConfig)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			runtimeService.StopContainer(cn2, 10)
+			runtimeService.RemoveContainer(cn2)
+		})
+		require.NoError(t, runtimeService.StartContainer(cn2))
+
+		require.True(t, isBindFilterActive(t, target),
+			"bind filter should still be active after second container creation (not remounted)")
+	})
+}

--- a/internal/cri/server/container_image_mount_other.go
+++ b/internal/cri/server/container_image_mount_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !windows
 
 /*
    Copyright The containerd Authors.

--- a/internal/cri/server/container_image_mount_windows.go
+++ b/internal/cri/server/container_image_mount_windows.go
@@ -1,0 +1,83 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/go-winio/pkg/bindfilter"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/log"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// addVolatileOptionOnImageVolumeMount is a no-op on Windows.
+func addVolatileOptionOnImageVolumeMount(mounts []mount.Mount) []mount.Mount {
+	return mounts
+}
+
+// ensureImageVolumeMounted checks whether the target path has an active
+// bind filter mount by querying the kernel for active bind filter mappings
+// on the volume. This correctly handles the case where containerd restarts
+// and the bind filter is removed by the OS while the directory remains on disk.
+func ensureImageVolumeMounted(target string) (bool, error) {
+
+	// Normalize path before comparing against bind filter mount points.
+	target = filepath.Clean(target)
+
+	// Directory must exist, though its existence alone does not confirm the volume is mounted.
+	_, err := os.Stat(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to stat %s: %w", target, err)
+	}
+
+	// Get the volume root for the target path (e.g. "C:\")
+	volume := filepath.VolumeName(target) + string(filepath.Separator)
+
+	// Query the kernel for active bind filter mappings on this volume.
+	mappings, err := bindfilter.GetBindMappings(volume)
+	if err != nil {
+		// GetBindMappings can fail if stale bind filter entries reference
+		// volumes that are no longer mounted (e.g. after a system restart).
+		// Treat this as not mounted so the volume will be remounted.
+		log.L.WithError(err).Debugf("failed to get bind mappings for %s, treating as not mounted", volume)
+		return false, nil
+	}
+
+	// Windows paths are case-insensitive; use EqualFold for comparison.
+	for _, m := range mappings {
+		if strings.EqualFold(filepath.Clean(m.MountPoint), target) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// getImageVolumeSnapshotOpts is a no-op on Windows.
+func (c *criService) getImageVolumeSnapshotOpts(ctx context.Context, m *runtime.Mount) ([]snapshots.Opt, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Issue #11903 requests Windows support for OCI image volume sources ([KEP-4639](https://github.com/kubernetes/enhancements/issues/4639)) to allow mounting an OCI image as a read-only folder inside a container, which is supported on Linux. On Windows, the code compiled but the mount validation was a stub that only checked if a directory existed, which is not actually sufficient to check if something is mounted in Windows.

Note: the original issue mentions writable mounts as the end goal, but writable OCI volume sources are not supported on Linux either, as the KEP explicitly [defers `rw` support to a follow-up enhancement](https://github.com/kubernetes/enhancements/pull/5288#:~:text=The%20plan%20is%20now%20to%20GA%20with%20read%2Donly%20volumes%20and%20extend%20the%20API%20as%20follow%2Dup%20KEP.). This PR brings Windows to parity with the current Linux implementation for read-only mounts.

### What was broken

Windows containerd originally used the `ensureImageVolumeMounted` function in `container_image_mount_other.go`. This function returned `true` whenever the target directory existed, without checking whether a bind filter mount was active. This caused a silent failure after a containerd restart as bind filter is a kernel-level construct that disappears when containerd stops, but the directory remains on disk. On containerd restart, the stub saw the directory and returned `true`, skipping the remount. The container got an empty folder instead of the image contents.

### What changed

**`internal/cri/server/container_image_mount_windows.go`** (new)

On Windows, container layer mounts use bind filters rather than overlayfs. A bind filter is a kernel-level filesystem redirection that disappears when the process that created it stops, unlike a directory which persists on disk. `GetBindMappings` queries the kernel directly for active bind filter mappings, making it the correct way to verify whether a volume is actually mounted.

Therefore, we implement `ensureImageVolumeMounted` for Windows using `bindfilter.GetBindMappings`, which is a kernel API that returns all currently active bind filter mappings on a volume. If the target path appears in the active mappings, the volume is mounted. If not (including after a containerd restart), it returns `false` and the volume is remounted.

The check normalizes paths with `filepath.Clean` and uses case-insensitive comparison since Windows paths are case-insensitive. If `GetBindMappings` fails, it treats the volume as not mounted and remounts as a safe fallback.

**`internal/cri/server/container_image_mount_other.go`**

Build tag updated from `//go:build !linux` to `//go:build !linux && !windows` so Windows uses the new implementation instead of the stub.

**`integration/image_volume_windows_test.go`** (new)

Two integration tests mirroring `image_volume_linux_test.go`:

- `TestImageVolumeBasicWindows` — verifies the basic mount works end-to-end.
- `TestImageVolumeSetupIfContainerdRestartsWindows` — two sub-cases:
  - *Restart scenario*: snapshot and directory exist but no bind filter (simulates post-restart state). Volume must be remounted. **Fails on mainline, passes with this fix.**
  - *Idempotency*: bind filter already active after first container. Second container in the same pod must not remount.

### Test results

Tested on Windows Server 2022 (`t3.xlarge` EC2 instance). Since the test file does not exist on mainline, it was copied from this branch onto the mainline checkout before running, with the mainline containerd binary rebuilt from source. This isolates the test results to the production code difference only.

**Mainline (`2976f38cc`):**
```
--- PASS: TestImageVolumeBasicWindows (80.04s)
--- FAIL: TestImageVolumeSetupIfContainerdRestartsWindows (18.68s)
    --- FAIL: .../snapshot_and_dir_exist,_no_bind_filter_(restart_scenario) (7.48s)
    --- PASS: .../bind_filter_active_after_first_container_(idempotency) (11.18s)
```

**This PR (`4f65e14e6`):**
```
--- PASS: TestImageVolumeBasicWindows (73.97s)
--- PASS: TestImageVolumeSetupIfContainerdRestartsWindows (19.60s)
    --- PASS: .../snapshot_and_dir_exist,_no_bind_filter_(restart_scenario) (7.98s)
    --- PASS: .../bind_filter_active_after_first_container_(idempotency) (11.59s)
```

**Interpretation:**

- `TestImageVolumeBasicWindows` passes on both. On first use with a fresh pod, the stub also works because the directory does not exist yet, so it returns `false` and the mount proceeds normally.

- `snapshot_and_dir_exist,_no_bind_filter` fails on mainline and passes on this PR. This is the discriminating test. The test pre-creates the snapshot and directory without a bind filter, simulating the state after a containerd restart. On mainline, the stub sees the directory and returns `true`, skipping the remount — the bind filter is never applied and the assertion fails. On this PR, `GetBindMappings` finds no active mapping, returns `false`, the remount runs, and the bind filter is applied.

- `bind_filter_active_after_first_container` passes on both. The first container mounts correctly in both cases. The second container in the same pod reuses the existing mount — the stub returns `true` (directory exists) and this PR returns `true` (`GetBindMappings` finds the active mapping). Both skip the remount correctly.

Fixes #11903
