### PR TITLE
integration: skip TestIssue13030 on ppc64le

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -1822,6 +1823,9 @@ func TestIssue10589(t *testing.T) {
 //
 // https://github.com/containerd/containerd/issues/13030
 func TestIssue13030(t *testing.T) {
+	if runtime.GOARCH == "ppc64le" {
+		t.Skip("whiteout-test image not available on ppc64le (https://github.com/containerd/containerd/issues/13351)")
+	}
 	client, err := newClient(t, address)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Description

The `whiteout-test` image (`ghcr.io/containerd/whiteout-test:1.0`) does not have a manifest for `ppc64le`, causing `TestIssue13030` to fail on that architecture with a pull error rather than a meaningful test failure.

This adds a skip guard consistent with the existing pattern used for `s390x` in `import_test.go`.

## Fixes

Fixes #13351

## Testing

The skip is verified by `runtime.GOARCH` — no test infrastructure changes needed. Once the `whiteout-test` image is published for `ppc64le`, the skip can be removed.