### PR TITLE
transfer/registry: always answer credential requests to avoid deadlock

### DIFF
--- a/core/transfer/registry/registry.go
+++ b/core/transfer/registry/registry.go
@@ -259,22 +259,25 @@ func (r *OCIRegistry) MarshalAny(ctx context.Context, sm streaming.StreamCreator
 
 				req, err := stream.Recv()
 				if err != nil {
-					// If not EOF, log error
+					if !errors.Is(err, io.EOF) {
+						log.G(ctx).WithError(err).Error("credential stream receive failed")
+					}
 					return
 				}
+
+				// Every AuthRequest must be answered with exactly one
+				// AuthResponse; otherwise the peer blocks forever in Recv().
+				// On any failure resolving credentials, fall back to "no
+				// credentials" (NONE) so the transfer can proceed anonymously
+				// (and fail cleanly later) rather than hang.
+				resp := &transfertypes.AuthResponse{AuthType: transfertypes.AuthType_NONE}
 
 				var s transfertypes.AuthRequest
 				if err := typeurl.UnmarshalTo(req, &s); err != nil {
 					log.G(ctx).WithError(err).Error("failed to unmarshal credential request")
-					continue
-				}
-				creds, err := r.creds.GetCredentials(ctx, s.Reference, s.Host)
-				if err != nil {
+				} else if creds, err := r.creds.GetCredentials(ctx, s.Reference, s.Host); err != nil {
 					log.G(ctx).WithError(err).Error("failed to get credentials")
-					continue
-				}
-				var resp transfertypes.AuthResponse
-				if creds.Header != "" {
+				} else if creds.Header != "" {
 					resp.AuthType = transfertypes.AuthType_HEADER
 					resp.Secret = creds.Header
 				} else if creds.Username != "" {
@@ -286,10 +289,13 @@ func (r *OCIRegistry) MarshalAny(ctx context.Context, sm streaming.StreamCreator
 					resp.Secret = creds.Secret
 				}
 
-				a, err := typeurl.MarshalAny(&resp)
+				a, err := typeurl.MarshalAny(resp)
 				if err != nil {
+					// Cannot answer this request; close the stream so the
+					// peer's Recv() returns an error instead of blocking.
 					log.G(ctx).WithError(err).Error("failed to marshal credential response")
-					continue
+					_ = stream.Close()
+					return
 				}
 
 				if err := stream.Send(a); err != nil {

--- a/core/transfer/registry/registry_deadlock_test.go
+++ b/core/transfer/registry/registry_deadlock_test.go
@@ -1,0 +1,230 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	transfertypes "github.com/containerd/containerd/api/types/transfer"
+	"github.com/containerd/containerd/v2/core/streaming"
+	"github.com/containerd/typeurl/v2"
+)
+
+// pipeStream is an in-memory streaming.Stream used to connect the client-side
+// credential responder (spawned by OCIRegistry.MarshalAny) to the server-side
+// credCallback within a single process.
+type pipeStream struct {
+	sendCh chan typeurl.Any
+	recvCh chan typeurl.Any
+	closed chan struct{}
+	once   *sync.Once
+}
+
+func (s *pipeStream) Send(a typeurl.Any) error {
+	select {
+	case s.sendCh <- a:
+		return nil
+	case <-s.closed:
+		return io.EOF
+	}
+}
+
+func (s *pipeStream) Recv() (typeurl.Any, error) {
+	select {
+	case a := <-s.recvCh:
+		return a, nil
+	case <-s.closed:
+		return nil, io.EOF
+	}
+}
+
+func (s *pipeStream) Close() error {
+	s.once.Do(func() { close(s.closed) })
+	return nil
+}
+
+// newStreamPipe returns two connected in-memory streams that share one
+// shutdown signal, so closing either endpoint unblocks the peer's Recv with
+// io.EOF -- the teardown behavior of a real bidirectional stream.
+func newStreamPipe() (client, server *pipeStream) {
+	c2s := make(chan typeurl.Any)
+	s2c := make(chan typeurl.Any)
+	closed := make(chan struct{})
+	once := &sync.Once{}
+	client = &pipeStream{sendCh: c2s, recvCh: s2c, closed: closed, once: once}
+	server = &pipeStream{sendCh: s2c, recvCh: c2s, closed: closed, once: once}
+	return client, server
+}
+
+type singleStreamCreator struct{ s streaming.Stream }
+
+func (c singleStreamCreator) Create(context.Context, string) (streaming.Stream, error) {
+	return c.s, nil
+}
+
+type failingCredentialHelper struct{}
+
+func (failingCredentialHelper) GetCredentials(context.Context, string, string) (Credentials, error) {
+	return Credentials{}, errors.New("credential backend unavailable")
+}
+
+type staticCredentialHelper struct{ creds Credentials }
+
+func (h staticCredentialHelper) GetCredentials(context.Context, string, string) (Credentials, error) {
+	return h.creds, nil
+}
+
+// TestCredentialResponderRepliesOnHelperError verifies that when the client-side
+// credential helper returns an error, the responder goroutine started by
+// OCIRegistry.MarshalAny still answers the request, so the server-side
+// credCallback.GetCredentials does not block forever in stream.Recv().
+//
+// Before the fix the responder logged the error and `continue`d without sending
+// a response, so this test deadlocks and fails via the timeout below.
+func TestCredentialResponderRepliesOnHelperError(t *testing.T) {
+	ctx := t.Context()
+	clientStream, serverStream := newStreamPipe()
+	defer clientStream.Close()
+	defer serverStream.Close()
+
+	reg := &OCIRegistry{
+		reference: "docker.io/library/test",
+		creds:     failingCredentialHelper{},
+	}
+	if _, err := reg.MarshalAny(ctx, singleStreamCreator{s: clientStream}); err != nil {
+		t.Fatalf("MarshalAny: %v", err)
+	}
+
+	cc := &credCallback{stream: serverStream}
+	type result struct {
+		creds Credentials
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		creds, err := cc.GetCredentials(ctx, "docker.io/library/test", "registry-1.docker.io")
+		done <- result{creds, err}
+	}()
+
+	select {
+	case got := <-done:
+		// The responder replied, so there is no deadlock. The reply must also be
+		// the anonymous fallback: a helper error resolves to empty credentials
+		// (AuthType_NONE), not an error.
+		if got.err != nil {
+			t.Fatalf("GetCredentials returned an error after a helper failure: %v", got.err)
+		}
+		if got.creds.Username != "" || got.creds.Secret != "" || got.creds.Header != "" {
+			t.Fatalf("expected anonymous (empty) credentials, got %+v", got.creds)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("credCallback.GetCredentials hung: responder did not reply after credential helper error")
+	}
+}
+
+// TestCredentialResponderRepliesOnUnmarshalError verifies that a request the
+// responder cannot unmarshal into an AuthRequest still draws exactly one reply,
+// so the peer is not left blocked in Recv(). The reply is the NONE fallback.
+// The credential helper returns real credentials, so a NONE reply proves the
+// unmarshal-error branch answered rather than the helper being consulted.
+func TestCredentialResponderRepliesOnUnmarshalError(t *testing.T) {
+	clientStream, serverStream := newStreamPipe()
+	defer clientStream.Close()
+	defer serverStream.Close()
+
+	reg := &OCIRegistry{
+		reference: "docker.io/library/test",
+		creds:     staticCredentialHelper{creds: Credentials{Username: "user", Secret: "secret"}},
+	}
+	if _, err := reg.MarshalAny(t.Context(), singleStreamCreator{s: clientStream}); err != nil {
+		t.Fatalf("MarshalAny: %v", err)
+	}
+
+	// An AuthResponse is not an AuthRequest, so the responder's UnmarshalTo fails.
+	bogus, err := typeurl.MarshalAny(&transfertypes.AuthResponse{})
+	if err != nil {
+		t.Fatalf("marshal bogus request: %v", err)
+	}
+
+	type result struct {
+		any typeurl.Any
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		if err := serverStream.Send(bogus); err != nil {
+			done <- result{err: err}
+			return
+		}
+		a, err := serverStream.Recv()
+		done <- result{any: a, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("stream exchange failed: %v", got.err)
+		}
+		var resp transfertypes.AuthResponse
+		if err := typeurl.UnmarshalTo(got.any, &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if resp.AuthType != transfertypes.AuthType_NONE {
+			t.Fatalf("expected AuthType_NONE for an unmarshalable request, got %v", resp.AuthType)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("responder did not reply to an unmarshalable request")
+	}
+}
+
+// TestCredentialResponderRemainsUsableAfterError verifies that the stream stays
+// usable for later credential requests after one request fails to resolve. This
+// is the property that justifies replying NONE rather than closing the stream,
+// which is shared across every credential request in a transfer.
+func TestCredentialResponderRemainsUsableAfterError(t *testing.T) {
+	ctx := t.Context()
+	clientStream, serverStream := newStreamPipe()
+	defer clientStream.Close()
+	defer serverStream.Close()
+
+	reg := &OCIRegistry{
+		reference: "docker.io/library/test",
+		creds:     failingCredentialHelper{},
+	}
+	if _, err := reg.MarshalAny(ctx, singleStreamCreator{s: clientStream}); err != nil {
+		t.Fatalf("MarshalAny: %v", err)
+	}
+
+	cc := &credCallback{stream: serverStream}
+	for i := 1; i <= 2; i++ {
+		done := make(chan error, 1)
+		go func() {
+			_, err := cc.GetCredentials(ctx, "docker.io/library/test", "registry-1.docker.io")
+			done <- err
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("credCallback.GetCredentials hung on request %d after a prior helper error", i)
+		}
+	}
+}


### PR DESCRIPTION
I used Claude Code (Opus 4.8) for the analysis and the fix.

## Impact

Since nerdctl 2.3.0, `nerdctl pull` hangs when `~/.docker/config.json` names a credential helper that is not installed. One way to get there is a config.json copied from a Docker Desktop machine, where `"credsStore": "desktop"` points at a helper only Docker Desktop ships. nerdctl 2.2.1 failed the same pull at once with an error naming the missing helper. Any other helper failure, meaning anything but a clean "credentials not found" reply, hangs the same way. The image does not have to be private; the pull below is `hello-world`.

nerdctl 2.3.0 moved pull and push to the containerd transfer service, where the daemon asks the client for credentials over a stream and blocks in `Recv()` for the answer. The client only answered on success, so a helper error left the daemon waiting for a reply that never came.

## Reproduce

With no `docker-credential-desktop` on `PATH`:

```sh
mkdir -p ~/.docker && echo '{"credsStore":"desktop"}' > ~/.docker/config.json
nerdctl pull docker.io/library/hello-world
```

nerdctl 2.2.1 exits 1 at once:

```
level=fatal msg="failed to resolve reference \"docker.io/library/hello-world:latest\": unable to retrieve credentials\nerror getting credentials - err: exec: \"docker-credential-desktop\": executable file not found in $PATH, out: ``"
```

nerdctl 2.3.5 logs the same cause once as `failed to get credentials`, then hangs until killed. With this patch it logs the error and the pull completes.

## Fix

The client-side responder in `OCIRegistry.MarshalAny` now answers every `AuthRequest` with exactly one `AuthResponse`. On a helper error or an unmarshalable request it falls back to `AuthType_NONE`, so the transfer proceeds anonymously and a private image fails with a registry error instead of a hang. On a marshal failure it closes the stream so the daemon's `Recv()` returns. The daemon already treats `NONE` as empty credentials, so the fix is client-side only. nerdctl 2.2.1 refused the pull; with this patch the helper error stays in the log and a public image still pulls. Three regression tests in `registry_deadlock_test.go` cover the helper-error, unmarshal-error, and stream-reuse paths; each times out without the change.

## Testing

I ran the repro above in a Lima VM against containerd v2.3.3 (nerdctl-full 2.3.5, rootless) with three clients, each pull under `timeout 60`. nerdctl 2.2.1 exited 1 at once with the error above. Stock nerdctl 2.3.5 was still hanging after 60 seconds. nerdctl 2.3.5 rebuilt against containerd v2.3.4 plus this commit completed the pull in 2 seconds. In an earlier run a helper that failed with a message on stderr hung the same way and the patch fixed it, and a helper that reported "credentials not found" pulled fine on both 2.3.5 clients. `go test -race ./core/transfer/registry/...` passes on this branch and on v2.3.4 with the commit cherry-picked.

<details>
<summary>Original description (root cause, alternatives, follow-ups)</summary>

Both analysis and fix have been created with the help of Claude Code/Opus 4.8.

## Summary

An image pull via the containerd transfer service can hang forever (intermittently) when the client's docker `credsStore` credential helper returns a hard error. This patch makes the client-side credential responder goroutine in `core/transfer/registry/registry.go` answer **every** `AuthRequest` with exactly one `AuthResponse`, falling back to `AuthType_NONE` when it cannot resolve credentials. That removes the deadlock and lets the pull proceed anonymously (and fail cleanly later) instead of blocking the daemon forever.

## Root cause

The credential exchange is a bidirectional gRPC stream split across two processes:

- **Client side (the responder):** `OCIRegistry.MarshalAny` spawns a goroutine that loops on `stream.Recv()`, resolves each request through the local credential helper, and `Send`s back an `AuthResponse`. This goroutine runs **inside nerdctl**, which vendors containerd **v2.3.1**.

- **Server side (the requester):** `credCallback.GetCredentials` in the **containerd daemon** does `stream.Send(AuthRequest)` then a blocking `stream.Recv()`. That `Recv()` has **no timeout** and is driven by `context.Background()` (`registry.go:381`), so it ignores the real request/transfer context.

In the unpatched responder, on a credential-helper error (and on an unmarshal error) the goroutine logged the error and `continue`d **without sending any response**, and on any `Recv` error it `return`ed. With no response sent, the daemon's `GetCredentials` blocks in `Recv()` forever — a cross-process client/server deadlock.

This stayed latent until **nerdctl 2.3.0 switched image pull to the transfer service**, which routes credential resolution through this responder goroutine, exposing the bug. A *clean* "credentials not found" (ENOENT) result already worked, because that path returns empty credentials and proceeds anonymously — which is exactly why the hang was **intermittent** and correlated with a misconfigured/broken helper rather than a missing one.

## Reproduction

Deterministic against a stock containerd daemon + nerdctl ≥ 2.3.0 (e.g. inside a Lima VM). The trigger is a `credsStore` credential helper that *hard-fails*, rather than cleanly reporting "no credentials". Per the docker credential-helper protocol, a `get` counts as "no credentials" **only** when the helper writes exactly `credentials not found in native keychain` to **stdout**; any other non-zero exit is a hard error — and it is the hard error that deadlocks.

**A. Reproduce the hang** — a helper that hard-fails:

```sh
cat > /usr/local/bin/docker-credential-boom <<'EOF'
#!/bin/sh
echo "boom: credential backend unavailable" >&2
exit 1
EOF
chmod +x /usr/local/bin/docker-credential-boom

mkdir -p ~/.docker
echo '{"credsStore":"boom"}' > ~/.docker/config.json

nerdctl pull docker.io/library/hello-world   # a PUBLIC image
```

- **Before this patch:** `nerdctl pull` hangs **forever** (the helper error is logged client-side, then nothing).

- **After this patch:** the pull **completes** via an anonymous fetch.

**B. Negative control** — a helper that cleanly reports "not found" (ENOENT). This path returns empty credentials and proceeds anonymously, so it already works on **unpatched** code — which is why the hang was intermittent (it only triggered when the helper *hard*-failed, not when it simply had no entry):

```sh
cat > /usr/local/bin/docker-credential-notfound <<'EOF'
#!/bin/sh
echo "credentials not found in native keychain"
exit 1
EOF
chmod +x /usr/local/bin/docker-credential-notfound

echo '{"credsStore":"notfound"}' > ~/.docker/config.json

nerdctl pull docker.io/library/hello-world   # succeeds before AND after the patch
```

**Optional — confirm *where* it is stuck.** While the pull from (A) is hanging, dump the daemon's goroutines (containerd writes them to a file on `SIGUSR1`) and look for the blocked credential callback:

```sh
kill -USR1 "$(pgrep -x containerd)"          # writes /tmp/containerd.<pid>.stacks.log
grep -A3 'credCallback).GetCredentials' /tmp/containerd.*.stacks.log
# core/transfer/registry/registry.go: credCallback.GetCredentials
#   -> plugins/services/streaming/.../serviceStream.Recv  [select]   <-- blocked forever
```

## What this patch changes

In the responder loop in `OCIRegistry.MarshalAny`:

- Pre-initialize the reply to a safe default: `resp := &AuthResponse{AuthType: AuthType_NONE}`. `AuthType_NONE == 0` is the zero value, so this matches the prior implicit default and is overwritten on the success branches.

- Collapse the unmarshal / `GetCredentials` / branch-selection into one `if / else-if` chain so the **error paths no longer `continue` past the `Send`** — on unmarshal failure or helper failure the loop now falls through and **sends `NONE`** instead of silently skipping the response.

- On `Recv` error, only log when it is not `io.EOF` (EOF is the normal half-close), then return.

- On the (practically impossible) marshal failure of the locally-constructed response, `_ = stream.Close()` then `return`, so the peer's `Recv()` gets `io.EOF` rather than blocking.

`AuthType_NONE` is behaviorally consistent with existing code: the server-side switch in `credCallback.GetCredentials` has no `NONE` case and no `default`, so it falls through to `Credentials{Host: host}` with empty username/secret — i.e. an anonymous pull, the same outcome as the already-working ENOENT path. The fix introduces no new auth semantics; it routes the error case into a pre-existing, tested branch.

## Alternatives considered

- **(a) Answer `AuthType_NONE` on resolution failure (chosen).** Eliminates the hang and degrades **per-request**: public images and multi-host / mirror / cross-repo-mount pulls where a later host would succeed continue to work. The shared bidi stream stays open for subsequent requests.

- **(b) Close the stream so `GetCredentials` returns an error and the pull fails clearly (rejected as the general strategy).** Gives the clearest error message, but the stream is **one bidi stream reused for every credential request in a transfer**. Closing it on the first helper error kills credential resolution for **all subsequent** hosts/requests on that pull, converting a hang into a broader and sometimes-spurious failure. We keep `Close()` only for the marshal-failure branch, where no valid response can be constructed.

- **(c) Add an error/status field to the `AuthResponse` proto (rejected for this fix).** The `AuthResponse` proto has only `AuthType`, `Username`, `Secret`, `ExpireAt` — no error field. Adding one is a generated-API/proto change that must be deployed to **both** the nerdctl client and the containerd daemon; a new client talking to an old daemon would still see `AuthType=0=NONE` and gain nothing. That is a coordinated, cross-version upstream change, not a point-fix.

**Known cost of (a):** because `NONE` is byte-for-byte indistinguishable from "helper legitimately returned no credentials", a hard `credsStore` failure on a **private, bearer-auth** image now surfaces as a generic registry 401/403 rather than a "credential helper failed" diagnostic. (For basic-auth registries the authorizer still errors on empty username/secret, so that failure still surfaces.) The helper error is still logged on the client side; the mitigation is to make that log louder/actionable rather than to change the protocol — see follow-ups.

## Validation

- **Regression tests included** (`core/transfer/registry/registry_deadlock_test.go`): three tests drive the responder goroutine over an in-memory `streaming.Stream` and assert the server-side `credCallback.GetCredentials` returns (rather than hanging) within a timeout — on a credential-helper error (asserting the anonymous `NONE` fallback), on an unmarshalable request, and across two sequential requests on one stream (proving the stream stays usable after a failure). A/B confirmed: all three **fail (time out) on the unpatched code and pass with the fix**.

- `go build`, `go vet`, `go test ./core/transfer/registry/...`, and `go test -race ./core/transfer/registry/...` all pass.

- Confirmed end-to-end against a stock containerd **v2.2.0** daemon: the repro above hangs with the **unpatched** nerdctl and the pull **succeeds** with a nerdctl rebuilt against this patch (sha256-verified binary swap).

## Follow-up / not in this PR (intentionally out of scope)

1. **Bound the server side (defense-in-depth).** `credCallback.GetCredentials` is invoked with `context.Background()` (`registry.go:381`), discarding the real transfer context, and `Stream.Recv()` (`core/streaming/streaming.go`) takes no context at all, so the daemon cannot time out or cancel a non-conforming client. The tree already flags this: `// TODO: Timeout waiting` at `plugins/services/streaming/service.go:73`. A follow-up should thread the real transfer context through and add a `ctx.Done()` select around the server's `Recv()` (or give it a deadline) — protecting the daemon against **any** non-conforming transfer client, not just an old vendored copy. This touches the stream interface / context plumbing and belongs in its own PR.

2. **Louder client log on fallback.** Upgrade the existing "failed to get credentials" log to include the host and reference and to state that the pull is proceeding anonymously, so an operator can correlate a later "access denied" with the helper failure.

3. **Consistency nit.** The marshal-failure branch uses `_ = stream.Close(); return` (strategy b) while the resolution-error branches use `NONE` (strategy a). Since the response is locally constructed and marshal cannot realistically fail, this branch could also fall back to `NONE` for a single "cannot answer" philosophy.

</details>
