### PR TITLE
cri: normalize pinned_images refs before comparison in getLabels

### DIFF
--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -421,7 +421,15 @@ func (c *CRIImageService) createOrUpdateImageReference(ctx context.Context, name
 func (c *CRIImageService) getLabels(ctx context.Context, name string) map[string]string {
 	labels := map[string]string{crilabels.ImageLabelKey: crilabels.ImageLabelValue}
 	for _, pinned := range c.config.PinnedImages {
-		if pinned == name {
+		// Normalize the config value through ParseDockerRef so that a tagless
+		// entry (e.g. "registry.k8s.io/pause") is treated as equivalent to its
+		// normalized form ("registry.k8s.io/pause:latest"), matching the
+		// normalization already applied to `name` at the call site.
+		normalizedPinned, err := distribution.ParseDockerRef(pinned)
+		if err != nil {
+			continue
+		}
+		if normalizedPinned.String() == name {
 			labels[crilabels.PinnedImageLabelKey] = crilabels.PinnedImageLabelValue
 		}
 	}

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -474,9 +474,12 @@ func TestImageGetLabels(t *testing.T) {
 			pullImageName: "registry.k8s.io/pause:3.10.2",
 		},
 		{
+			// Tagless config entry "k8s.gcr.io/pause" must match the normalized
+			// pull ref "k8s.gcr.io/pause:latest". Previously the exact-string
+			// comparison failed and the pinned label was never applied.
 			name:          "pinned image labels should get added on sandbox image without tag",
 			expectedLabel: map[string]string{labels.ImageLabelKey: labels.ImageLabelValue, labels.PinnedImageLabelKey: labels.PinnedImageLabelValue},
-			pinnedImages:  map[string]string{"sandboxnotag": "k8s.gcr.io/pause", "sandbox": "k8s.gcr.io/pause:latest"},
+			pinnedImages:  map[string]string{"sandboxnotag": "k8s.gcr.io/pause"},
 			pullImageName: "k8s.gcr.io/pause:latest",
 		},
 		{


### PR DESCRIPTION
## What this PR does / why we need it

Fixes a regression where the `pinned` label (`io.cri-containerd.pinned=pinned`) is never applied when a `pinned_images` config entry has no explicit tag (e.g. `registry.k8s.io/pause`).

## Root cause

`getLabels` compares each `PinnedImages` config value against `name` using raw string equality:

```go
for _, pinned := range c.config.PinnedImages {
    if pinned == name {   // exact match — no normalization on config side
```

But `name` at the call site has already been normalized through `distribution.ParseDockerRef`, which appends `:latest` to any tagless ref:

```go
namedRef, err := distribution.ParseDockerRef(name)
ref := namedRef.String()        // "registry.k8s.io/pause" → "registry.k8s.io/pause:latest"
labels := c.getLabels(ctx, ref) // comparison always fails for tagless config entry
```

This was a regression introduced in ad4c9f8a9de, which replaced the original `SandboxImage` path (which correctly ran `ParseDockerRef` on the config value before comparing) with the generic `PinnedImages` loop (which omitted the normalization).

The `PinnedImages` config also affects `UpdateImage` (called from `ImageCreate`/`ImageUpdate` events and `CheckImages` at startup), so the label is never applied via any code path for tagless entries.

## Fix

Normalize each `PinnedImages` config value through `ParseDockerRef` before comparing. Errors from `ParseDockerRef` are skipped (the value would never match the already-successfully-parsed `name` anyway).

Also fix the `"without tag"` test case, which masked the regression by listing both the tagless and the already-normalized `:latest` form; the test now uses only the tagless config entry, which is what users actually configure.

## Impact

Without this fix:
1. Image is in the store and used as the sandbox image — everything appears healthy
2. `ImageStatus` returns `Pinned: false`
3. Under disk pressure, kubelet GCs the sandbox/pause image
4. Next pod creation fails silently across the node

Fixes #13314