### PR TITLE
Upload crash artifacts from go test -fuzz when failed

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -43,3 +43,10 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/install-go
       - run: script/go-test-fuzz.sh
+      - name: Upload Crash
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: go-test-fuzz-artifacts
+          path: "**/testdata/fuzz/**"
+          if-no-files-found: ignore


### PR DESCRIPTION
Update the Fuzzing workflow to upload crash artifacts found during the go_test_fuzz job when it fails.

Uses same `actions/upload-artifact` version as elsewhere in the workflows. 

I am not sure if this was avoided in the past for any specific reason (file size? -- and fwiw as far as I can tell file retention can only be handled with one flat value [at the org level](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization)) but if this is a concern we can get some more complicated if statements in here.