### PR TITLE
cri: don't drop pod metrics on transient container error

### DIFF
--- a/internal/cri/server/list_pod_sandbox_metrics_linux.go
+++ b/internal/cri/server/list_pod_sandbox_metrics_linux.go
@@ -108,16 +108,16 @@ func (c *criService) ListPodSandboxMetrics(ctx context.Context, r *runtime.ListP
 					switch {
 					case errdefs.IsUnavailable(err), errdefs.IsNotFound(err):
 						log.G(gctx).WithField("podsandboxid", sandbox.ID).WithField("containerid", container.ID).WithError(err).Error("failed to get container metrics, this is likely a transient error")
-						// Don't return error for transient issues, just log and continue
-						return nil
+						// Don't drop the whole pod for one container's transient error; skip this container.
+						continue
 					case errdefs.IsCanceled(err):
 						log.G(gctx).WithField("podsandboxid", sandbox.ID).WithField("containerid", container.ID).WithError(err).Debug("metrics collection cancelled")
 						// Return the cancellation error to stop other goroutines
 						return err
 					default:
 						log.G(gctx).WithField("podsandboxid", sandbox.ID).WithField("containerid", container.ID).WithError(err).Error("failed to collect container metrics")
-						// Don't return error for individual failures, just log and continue
-						return nil
+						// Don't drop the whole pod for one container's failure; skip this container.
+						continue
 					}
 				}
 

--- a/internal/cri/server/list_pod_sandbox_metrics_safety_linux_test.go
+++ b/internal/cri/server/list_pod_sandbox_metrics_safety_linux_test.go
@@ -1,0 +1,106 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/errdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+	"github.com/containerd/containerd/v2/pkg/cio"
+)
+
+// Characterization test for the contract: a transient per-container metric error
+// must not erase the rest of the pod's metrics from ListPodSandboxMetrics. This
+// test must PASS both before and after any refactor; it currently FAILS on the
+// unpatched code, which is the reproduction of the dropped-pod-metrics bug.
+//
+// Background:
+//   In ListPodSandboxMetrics (list_pod_sandbox_metrics_linux.go) each sandbox is
+//   processed in its own goroutine: it first collects pod-level metrics into
+//   sandboxMetrics, then loops over the sandbox's containers, and only at the end
+//   appends sandboxMetrics to the response. When collectContainerMetrics returns a
+//   transient error (Unavailable/NotFound) the code does `return nil` (lines 112
+//   and 120) instead of `continue`, despite the comment "just log and continue".
+//   `return nil` ends the whole goroutine before the final append, so the entire
+//   pod -- its pod-level metrics and any already-collected sibling containers --
+//   is silently dropped from the response.
+//
+// Faithful, recommended-usage reproduction (no running runtime, no root, no real
+// network namespace):
+//   - Drives the real exported ListPodSandboxMetrics via the project's own
+//     newTestCRIService/NewSandbox/NewContainer test seams.
+//   - The only test double is Container.Task() returning errdefs.ErrNotFound,
+//     which is exactly what containerd returns when a container's task has just
+//     exited between the container-store snapshot and metric collection -- the
+//     normal, high-frequency churn this code path is meant to tolerate.
+//   - The sandbox has no NetNSPath, so collectPodSandboxMetrics succeeds and
+//     returns a non-nil PodSandboxMetrics carrying PodSandboxId (no netns needed).
+
+// fakeNoTaskContainer is a containerd.Container whose task has disappeared.
+// collectContainerMetrics only calls Task() on the stored container; every other
+// method is left to the embedded (nil) interface and must not be called.
+type fakeNoTaskContainer struct {
+	containerd.Container
+}
+
+func (fakeNoTaskContainer) Task(context.Context, cio.Attach) (containerd.Task, error) {
+	return nil, errdefs.ErrNotFound
+}
+
+func TestListPodSandboxMetricsSafety_TransientContainerErrorKeepsPod(t *testing.T) {
+	const sandboxID = "sandbox-1"
+
+	c := newTestCRIService()
+
+	sb := sandboxstore.NewSandbox(
+		sandboxstore.Metadata{
+			ID:     sandboxID,
+			Name:   "sandbox-name-1",
+			Config: &runtime.PodSandboxConfig{Metadata: &runtime.PodSandboxMetadata{Name: "pod-1"}},
+		},
+		sandboxstore.Status{State: sandboxstore.StateReady},
+	)
+	require.NoError(t, c.sandboxStore.Add(sb))
+
+	cntr, err := containerstore.NewContainer(
+		containerstore.Metadata{ID: "container-1", SandboxID: sandboxID},
+		containerstore.WithContainer(fakeNoTaskContainer{}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, c.containerStore.Add(cntr))
+
+	resp, err := c.ListPodSandboxMetrics(context.Background(), &runtime.ListPodSandboxMetricsRequest{})
+	require.NoError(t, err)
+
+	var gotPods []string
+	for _, pm := range resp.GetPodMetrics() {
+		gotPods = append(gotPods, pm.GetPodSandboxId())
+	}
+
+	assert.Contains(t, gotPods, sandboxID,
+		"pod %q was dropped from ListPodSandboxMetrics because one container returned a "+
+			"transient NotFound; the per-container error path returns nil instead of continue, "+
+			"discarding the whole pod's metrics (got pods: %v)", sandboxID, gotPods)
+}


### PR DESCRIPTION

#### Summary

- Fix `ListPodSandboxMetrics`: a transient per-container metric error silently drops the entire pod's metrics.
- Change two `return nil` in the container loop to `continue`, skipping that container instead of aborting the whole sandbox goroutine.
- Add one characterization test, `TestListPodSandboxMetricsSafety_TransientContainerErrorKeepsPod`.

#### Problem

**Severity**: silent data loss. **active** — default Linux CRI path, no special configuration required.

**Trigger conditions**:
| Path | Source | Frequency |
|------|--------|-----------|
| `ListPodSandboxMetrics` container loop | between the `containerStore.List()` snapshot (:65) and per-container `collectContainerMetrics` (:105), a container exits → `Task()`/`Metrics()` returns `NotFound` | high (container exit/restart is normal K8s node churn) |

**Symptoms (production)**: during kubelet's periodic collection, if any container in a pod has just exited, that pod's **entire** metric set (pod-level network + already-collected sibling containers) vanishes from the response. kubelet Summary / `/metrics/resource` show intermittent gaps that mislead HPA, alerting and dashboards. The more containers a pod has and the later the failing one is iterated, the more data is lost.

**Why regular tools don't catch it**: not a data race (`-race` cannot see it); it is control flow. Logs show only a per-container transient warning that does not point at "the whole pod was dropped"; the symptom is intermittent and load-correlated.

#### Root cause

The container-loop error handling is commented "log and continue" but does `return nil`, which returns from the sandbox goroutine and skips the post-loop `append(podSandboxMetrics, sandboxMetrics)` at line 134:

```
g.Go(func() error {
    sandboxMetrics = collectPodSandboxMetrics(...)        // :87 pod-level network metrics collected
    for container := range sandbox {                       // :105
        m, err := collectContainerMetrics(...)             // :106 → Task()/Metrics() returns NotFound
        if err != nil { switch {
            case NotFound/Unavailable: return nil          // :112 ends the whole goroutine
            case Canceled:             return err          // :116
            default:                   return nil }}        // :120
        append(sandboxMetrics.ContainerMetrics, m)
    }
    append(podSandboxMetrics, sandboxMetrics)              // :134 ← unreachable after return nil
})
```

Error source: `Task()`/`Metrics()` in [collectContainerMetrics:232/237](internal/cri/server/list_pod_sandbox_metrics_linux.go#L232-L239) return `errdefs.ErrNotFound` (preserved via `%w`) when a container's task is gone.

#### Fix

Change the two container-level `return nil` to `continue`:

```diff
 					case errdefs.IsUnavailable(err), errdefs.IsNotFound(err):
 						log.G(gctx)...Error("failed to get container metrics, this is likely a transient error")
-						// Don't return error for transient issues, just log and continue
-						return nil
+						// Don't drop the whole pod for one container's transient error; skip this container.
+						continue
 					case errdefs.IsCanceled(err):
 						...
 						return err
 					default:
 						log.G(gctx)...Error("failed to collect container metrics")
-						// Don't return error for individual failures, just log and continue
-						return nil
+						// Don't drop the whole pod for one container's failure; skip this container.
+						continue
```

**Why this is the minimal, safest fix**:
1. `continue` makes the code match its own comment ("log and continue"); the `return nil` was the mistake.
2. Only the two container-level cases change; `IsCanceled → return err` is preserved (request cancellation still aborts the other goroutines).
3. Go semantics: a `continue` inside a `switch` targets the enclosing `for`, which is exactly what is needed.

**Why not other approaches**:
| Alternative | Rejection reason |
|-------------|------------------|
| Collect per-container errors and return them together | Larger change, and CRI metrics are best-effort (partial collection) by design — unnecessary |
| Also change pod-level :93/:101 | When pod metrics themselves fail, `sandboxMetrics` is not yet formed, so dropping it has limited impact; kept as a separate PR to keep this one's scope clear |

#### Reproduction (reviewers can run locally)

No root, no real netns, no runtime required (exercises the container-exit NotFound path, as in production):

```bash
docker run --rm -v "$PWD":/src -w /src golang:1.26 \
  go test ./internal/cri/server/ -run TestListPodSandboxMetricsSafety_ -v -count=1 -timeout 120s
```

Expected (pre-fix):

```
=== RUN   TestListPodSandboxMetricsSafety_TransientContainerErrorKeepsPod
    pod "sandbox-1" was dropped from ListPodSandboxMetrics because one container
    returned a transient NotFound; the per-container error path returns nil instead
    of continue, discarding the whole pod's metrics (got pods: [])
--- FAIL: TestListPodSandboxMetricsSafety_TransientContainerErrorKeepsPod (0.00s)
```

Verified against base commit `561fcdbd8` (Linux/arm64 · go 1.26). With this PR applied, the same test **PASSes (normal and `-race`)**.

#### Test plan

| Test | Purpose | pre-fix | post-fix |
|------|---------|---------|----------|
| `TestListPodSandboxMetricsSafety_TransientContainerErrorKeepsPod` | one container's transient error must not drop the pod | FAIL | PASS |

Regression:

```bash
$ go test ./internal/cri/server/ -count=1
ok   github.com/containerd/containerd/v2/internal/cri/server   5.4s

$ go test ./internal/cri/server/ -race -count=1
ok   github.com/containerd/containerd/v2/internal/cri/server   6.5s   (0 DATA RACE)
```

#### Backwards compatibility / API impact

**None**. Response shape is unchanged; on partial collection failure it now **returns** the pod-level and healthy-container metrics that were previously dropped (strictly more complete), with no field changes.

#### Documentation / comment changes

- The two error-handling comments are updated from "just log and continue" (which contradicted `return nil`) to accurately describe "skip this container".

#### Risk & rollback

| Dimension | Assessment |
|-----------|------------|
| Change surface | 2 lines (`return nil`→`continue`) |
| Performance impact | none (`continue` adds no work) |
| Data risk | strictly more complete: only returns previously dropped metrics, removes nothing |
| Rollback | `git revert <sha>` |

#### Reviewer hints

1. Go semantics: `continue` inside the `switch` targets the enclosing `for` (:105), not the `switch` — intended.
2. `IsCanceled → return err` (:116) is unchanged; request-cancellation semantics preserved.
3. pod-level :93/:101 `return nil` is intentionally left as-is (lower harm, `sandboxMetrics` not yet formed) — see Out of scope.

#### Linked issues / discussions

- Novel finding; no matching historical issue/PR located. `git blame internal/cri/server/list_pod_sandbox_metrics_linux.go` pinpoints this relatively recent local addition (carries a TODO marker).

#### Out of scope (kept separate to avoid PR collisions)

- pod-level :93/:101 `return nil` (same shape, lower harm) — follow-up PR if desired.
- P1-2 DownloadLimiter self-deadlock, P1-3 kmutex panic, etc. — separate PRs.

#### Pre-flight checks (passing locally)

- [x] `gofmt -l` clean
- [x] `go vet ./internal/cri/server/` clean (linux container)
- [x] `GOOS=linux go build ./internal/cri/server/` succeeds
- [x] package `go test`, normal (5.4s) + `-race` (6.5s, 0 races): all PASS
- [x] DCO sign-off applied at commit time (`git commit -s`)

#### Files changed

```
 internal/cri/server/list_pod_sandbox_metrics_linux.go        |   8 +-
 internal/cri/server/list_pod_sandbox_metrics_safety_linux_test.go | 106 +++++++++++++
 2 files changed, 110 insertions(+), 4 deletions(-)
```
