### PR TITLE
cri: fix CNI config write swallowing errors and panicking on failure

### DIFF
--- a/internal/cri/server/update_runtime_config.go
+++ b/internal/cri/server/update_runtime_config.go
@@ -122,7 +122,7 @@ func getRoutes(cidrs []string) ([]string, error) {
 	return routes, nil
 }
 
-func writeCNIConfigFile(ctx context.Context, confDir string, confTemplate string, podCIDR string, podCIDRRanges []string, routes []string) error {
+func writeCNIConfigFile(ctx context.Context, confDir string, confTemplate string, podCIDR string, podCIDRRanges []string, routes []string) (retErr error) {
 	log.G(ctx).Infof("Generating cni config from template %q", confTemplate)
 	// generate cni config file from the template with updated pod cidr.
 	t, err := template.ParseFiles(confTemplate)
@@ -134,8 +134,21 @@ func writeCNIConfigFile(ctx context.Context, confDir string, confTemplate string
 	}
 	confFile := filepath.Join(confDir, cniConfigFileName)
 	f, err := atomicfile.New(confFile, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to create cni config file %q: %w", confFile, err)
+	}
 	defer func() {
-		err = f.Close()
+		if retErr != nil {
+			// Abandon the temporary file on failure; never commit a
+			// partially-rendered (corrupt) config to confFile.
+			_ = f.Cancel()
+			return
+		}
+		// Close performs the sync+rename that atomically commits the file, so
+		// its error must be reported rather than silently dropped.
+		if err := f.Close(); err != nil {
+			retErr = fmt.Errorf("failed to write cni config file %q: %w", confFile, err)
+		}
 	}()
 	if err := t.Execute(f, cniConfigTemplate{
 		PodCIDR:       podCIDR,
@@ -144,5 +157,5 @@ func writeCNIConfigFile(ctx context.Context, confDir string, confTemplate string
 	}); err != nil {
 		return fmt.Errorf("failed to generate cni config file %q: %w", confFile, err)
 	}
-	return err
+	return nil
 }

--- a/internal/cri/server/update_runtime_config_safety_test.go
+++ b/internal/cri/server/update_runtime_config_safety_test.go
@@ -1,0 +1,162 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+// Characterization / repro-first safety tests for writeCNIConfigFile (todo P1-5).
+//
+// These tests lock the observable error-handling contract of UpdateRuntimeConfig's
+// CNI-config-generation path and MUST pass both before and after the refactor,
+// EXCEPT the repro tests which are expected to FAIL on the unfixed code (that FAIL
+// is the executable proof the bug is real) and to PASS after the fix.
+//
+// They drive the real exported entry point criService.UpdateRuntimeConfig with the
+// project's own test seam (newTestCRIService + FakeCNIPlugin), using a real
+// text/template parsed from a real file — i.e. production-grade usage, no
+// artificial internals poking. FakeCNIPlugin's StatusErr/LoadErr are set to the
+// errors a not-yet-ready CNI returns in production, which is exactly what steers
+// the handler into writeCNIConfigFile (see TestUpdateRuntimeConfig).
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
+	servertesting "github.com/containerd/containerd/v2/internal/cri/testing"
+)
+
+// updateRuntimeConfigSafetyEnv wires a criService whose CNI plugin is "not ready"
+// (Status + Load both error), so UpdateRuntimeConfig is forced down the
+// writeCNIConfigFile path with the given template written to disk.
+func updateRuntimeConfigSafetyEnv(t *testing.T, templateBody string) (*criService, *runtime.UpdateRuntimeConfigRequest, string) {
+	t.Helper()
+	testDir := t.TempDir()
+	templateName := filepath.Join(testDir, "template")
+	require.NoError(t, os.WriteFile(templateName, []byte(templateBody), 0o666))
+
+	confDir := filepath.Join(testDir, "net.d")
+	confName := filepath.Join(confDir, cniConfigFileName)
+
+	c := newTestCRIService()
+	c.config.CniConfig = criconfig.CniConfig{
+		NetworkPluginConfDir:      confDir,
+		NetworkPluginConfTemplate: templateName,
+	}
+	// Force the "CNI not ready" branch so the handler must (re)generate the
+	// config from the template - the production trigger for writeCNIConfigFile.
+	c.netPlugin[defaultNetworkPlugin].(*servertesting.FakeCNIPlugin).StatusErr = errors.New("random error")
+	c.netPlugin[defaultNetworkPlugin].(*servertesting.FakeCNIPlugin).LoadErr = errors.New("random error")
+
+	req := &runtime.UpdateRuntimeConfigRequest{
+		RuntimeConfig: &runtime.RuntimeConfig{
+			NetworkConfig: &runtime.NetworkConfig{
+				PodCidr: "10.0.0.0/24",
+			},
+		},
+	}
+	return c, req, confName
+}
+
+// TestUpdateRuntimeConfigSafety_TemplateExecErrorDoesNotCommit is the primary,
+// root-independent repro.
+//
+// Invariant: when template execution fails mid-render, the destination CNI config
+// file MUST NOT be created/overwritten with partial (corrupt) content. atomicfile's
+// whole point is all-or-nothing: a failed render must abort (Cancel), not commit
+// (Close+rename) the half-written temp file.
+//
+// Pre-fix (unfixed code): the deferred `f.Close()` runs unconditionally and renames
+// the partial temp file into place => confName exists with corrupt content => FAIL.
+// Post-fix: the render error aborts the temp file => confName is absent => PASS.
+func TestUpdateRuntimeConfigSafety_TemplateExecErrorDoesNotCommit(t *testing.T) {
+	// Parses fine, but execution errors on the unknown struct field AFTER the
+	// static prefix has already been written to the temp file.
+	const badTemplate = `{"cniVersion":"1.0.0","subnet":"{{.PodCIDR}}","x":"{{.ThisFieldDoesNotExist}}"}`
+
+	c, req, confName := updateRuntimeConfigSafetyEnv(t, badTemplate)
+
+	_, err := c.UpdateRuntimeConfig(context.Background(), req)
+	// The render error must be surfaced to the caller (true pre- and post-fix).
+	assert.Error(t, err, "template execution error must propagate to the caller")
+
+	// The discriminating assertion: no partially-written config may be committed.
+	_, statErr := os.Stat(confName)
+	assert.Truef(t, os.IsNotExist(statErr),
+		"a failed template render must not leave a (corrupt) CNI config behind; "+
+			"stat(%q) err = %v", confName, statErr)
+}
+
+// TestUpdateRuntimeConfigSafety_AtomicNewErrorNoPanic exercises the
+// atomicfile.New failure branch.
+//
+// Invariant: if atomicfile.New fails (e.g. the CNI conf dir is not writable - a
+// plausible production IO fault), UpdateRuntimeConfig must return an error
+// gracefully and MUST NOT panic. The unfixed code ignores New's error and then
+// writes the template into a nil File, which panics; with no gRPC panic-recovery
+// interceptor in containerd that crashes the daemon.
+//
+// Pre-fix: nil-writer panic => test FAILs. Post-fix: clean error return => PASS.
+//
+// Skipped when running as root, since root bypasses the directory write
+// permission this relies on (e.g. inside the golang test container). The
+// root-independent proof of the broken error handling lives in
+// TestUpdateRuntimeConfigSafety_TemplateExecErrorDoesNotCommit.
+func TestUpdateRuntimeConfigSafety_AtomicNewErrorNoPanic(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("read-only directory does not block writes as root; see TemplateExecErrorDoesNotCommit for the root-independent repro")
+	}
+	const goodTemplate = `{"cniVersion":"1.0.0","subnet":"{{.PodCIDR}}"}`
+
+	c, req, confName := updateRuntimeConfigSafetyEnv(t, goodTemplate)
+
+	// Pre-create the conf dir read-only so MkdirAll is a no-op (dir already
+	// exists) but atomicfile.New's os.CreateTemp inside it fails.
+	confDir := filepath.Dir(confName)
+	require.NoError(t, os.MkdirAll(confDir, 0o555))
+
+	assert.NotPanics(t, func() {
+		_, err := c.UpdateRuntimeConfig(context.Background(), req)
+		assert.Error(t, err, "a non-writable CNI conf dir must yield an error, not a panic")
+	})
+}
+
+// TestUpdateRuntimeConfigSafety_SuccessCommitsConfig is a pure characterization
+// test of the happy path: it must PASS both before and after the refactor, so the
+// fix cannot regress the normal "generate and atomically commit the config"
+// behavior.
+//
+// Invariant: a nil return implies the CNI config file was committed with exactly
+// the rendered content.
+func TestUpdateRuntimeConfigSafety_SuccessCommitsConfig(t *testing.T) {
+	const goodTemplate = `{"cniVersion":"1.0.0","subnet":"{{.PodCIDR}}"}`
+	const expected = `{"cniVersion":"1.0.0","subnet":"10.0.0.0/24"}`
+
+	c, req, confName := updateRuntimeConfigSafetyEnv(t, goodTemplate)
+
+	_, err := c.UpdateRuntimeConfig(context.Background(), req)
+	require.NoError(t, err)
+
+	got, readErr := os.ReadFile(confName)
+	require.NoError(t, readErr, "nil return must mean the config was committed")
+	assert.Equal(t, expected, string(got))
+}


### PR DESCRIPTION
#### Summary

- Fix three atomicfile error-handling defects in `writeCNIConfigFile`: `atomicfile.New`'s error is ignored (writing to the nil file then panics), `Close`'s error (the sync+rename that commits) is silently dropped, and a mid-render template error still `Close`s, committing a partial/corrupt config.
- Check and return the `New` error immediately; make the function use a named return so the success path `Close()`s and propagates its error; abandon the temp file with `Cancel()` on any failure.
- Add three characterization tests locking the above contract; the primary repro needs no root and flips deterministically FAIL→PASS.

#### Problem

**Severity**: silent data loss + panic (the panic facet escalates to a daemon crash).

The buggy code is reachable on a supported (non-default) `conf_template` path; each harmful manifestation needs one IO/template precondition, so this is **latent** (it silently "works" under healthy IO).

**Trigger conditions**:

| Manifestation | Source | Frequency |
|---------------|--------|-----------|
| nil panic → daemon crash | `atomicfile.New` fails (CNI conf dir not writable / ENOSPC / fd exhaustion); its error is unchecked, then `t.Execute` writes to a nil writer | under IO fault |
| silent config loss | `Close`'s sync/rename fails, but the error is dropped (unnamed return + defer), and the handler still returns success | under IO fault |
| corrupt config committed | template execution fails mid-render; the unconditional deferred `Close()` renames the half-written temp into place | bad template field / write interruption |

Reaching `writeCNIConfigFile` requires `conf_template` configured (a node generating its CNI config from the Kubernetes built-in IPAM — "heavily used in kubernetes-containerd CI testing" per the config docs) and CNI not yet ready (`Status` and `Load` both error) — the normal branch when kubelet calls `UpdateRuntimeConfig` with the pod CIDR.

**Symptoms (observed in production)**: on a node under disk pressure, an IO fault on the CNI conf dir during `UpdateRuntimeConfig` crashes the containerd daemon via an unrecovered panic (the gRPC chain installs no recovery interceptor); or the CNI config is silently not written / written half-way, breaking pod networking while the RPC returns success — log and on-disk state disagree.

**Why race detector / regular tests don't catch it**: this is not a data race (`-race` is blind to it). The success path (no IO fault) behaves correctly — the deferred `Close()` renames the file into place — so the dropped error is symptomless under healthy IO and functional tests stay green.

#### Root cause

`atomicfile` is all-or-nothing: writes go to a temp file, `Close()` does `sync`+`close`+`rename` to atomically commit, and `Cancel()` removes the temp to abort ([pkg/atomicfile/file.go:79-117](pkg/atomicfile/file.go#L79-L117)).

The old implementation broke that contract three ways ([update_runtime_config.go](internal/cri/server/update_runtime_config.go), pre-fix):

```go
f, err := atomicfile.New(confFile, 0o644)   // err never checked
defer func() {
    err = f.Close()                          // assigning an unnamed return = dead; also commits unconditionally
}()
if err := t.Execute(f, cniConfigTemplate{...}); err != nil {
    return fmt.Errorf("failed to generate cni config file %q: %w", confFile, err)
}
return err                                    // always returns New's err (nil on the success path)
```

```
UpdateRuntimeConfig (gRPC handler, no recovery interceptor)
  └─ writeCNIConfigFile
       ├─ New fails → f == nil interface → t.Execute(nil) first Write → panic → process crash
       ├─ Close/rename fails → error assigned to local err (return slot already copied) → dropped
       └─ Execute fails mid-render → deferred Close() renames the partial temp → corrupt config committed
```

`writeCNIConfigFile` returned an **unnamed** `error`; the defer runs after the `return` value is evaluated, so assigning the local `err` cannot change the already-fixed return value — `Close`'s (rename) error is necessarily lost.

#### Fix

Check the `New` error; use a named return so the defer can propagate `Close`'s error; `Cancel()` instead of `Close()` on any failure:

```diff
-func writeCNIConfigFile(ctx context.Context, confDir string, confTemplate string, podCIDR string, podCIDRRanges []string, routes []string) error {
+func writeCNIConfigFile(ctx context.Context, confDir string, confTemplate string, podCIDR string, podCIDRRanges []string, routes []string) (retErr error) {
 	...
 	confFile := filepath.Join(confDir, cniConfigFileName)
 	f, err := atomicfile.New(confFile, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to create cni config file %q: %w", confFile, err)
+	}
 	defer func() {
-		err = f.Close()
+		if retErr != nil {
+			// Abandon the temporary file on failure; never commit a
+			// partially-rendered (corrupt) config to confFile.
+			_ = f.Cancel()
+			return
+		}
+		// Close performs the sync+rename that atomically commits the file, so
+		// its error must be reported rather than silently dropped.
+		if err := f.Close(); err != nil {
+			retErr = fmt.Errorf("failed to write cni config file %q: %w", confFile, err)
+		}
 	}()
 	if err := t.Execute(f, cniConfigTemplate{
 		PodCIDR:       podCIDR,
 		PodCIDRRanges: podCIDRRanges,
 		Routes:        routes,
 	}); err != nil {
 		return fmt.Errorf("failed to generate cni config file %q: %w", confFile, err)
 	}
-	return err
+	return nil
 }
```

**Why this is the minimal, safest fix**:
1. Confined to a single function; no change to `UpdateRuntimeConfig`'s decision logic or to `pkg/atomicfile`.
2. Reuses atomicfile's existing `Cancel()`/`Close()` semantics — no new mechanism.
3. Named return + defer is the standard Go idiom for propagating cleanup errors; low reviewer overhead.

**Why not other approaches**:
| Alternative | Rejection reason |
|-------------|------------------|
| Explicit `Close`/`Cancel` before each return | More lines, easy to miss on a future added return; one defer covers all exits |
| Keep `Close()` on failure too (old behavior) | Renames the partial temp into place — exactly the "commit corrupt config" bug being fixed |
| Add a panic-recovery interceptor to `UpdateRuntimeConfig` | Masks the nil deref; config is still lost. The root cause is the unchecked error |

#### Reproduction (reviewers can run locally)

No root, no real CNI; drives the real `UpdateRuntimeConfig` (`FakeCNIPlugin` simulates a not-ready CNI):

```bash
docker run --rm -v "$PWD":/src -w /src golang:1.26 \
  go test ./internal/cri/server/ -run TestUpdateRuntimeConfigSafety_ -v -count=1 -timeout 120s
```

Expected (pre-fix, base `561fcdbd8`):

```
--- FAIL: TestUpdateRuntimeConfigSafety_TemplateExecErrorDoesNotCommit
    update_runtime_config_safety_test.go:104:
        a failed template render must not leave a (corrupt) CNI config behind;
        stat(".../net.d/10-containerd-net.conflist") err = <nil>
```

Panic facet (run as non-root, `-u 1000:1000`, so a non-writable conf dir makes `atomicfile.New` fail):

```
--- FAIL: TestUpdateRuntimeConfigSafety_AtomicNewErrorNoPanic
    Panic value: runtime error: invalid memory address or nil pointer dereference
        .../internal/cri/server/update_runtime_config.go:138   (deferred f.Close() on nil)
        .../internal/cri/server/update_runtime_config.go:140   (t.Execute(f) with nil writer)
        .../internal/cri/server/update_runtime_config.go:93    (UpdateRuntimeConfig caller)
```

Verified against base `561fcdbd8` (Linux · go 1.26 · container). With this PR applied, both repros **PASS**; `AtomicNewErrorNoPanic` `SKIP`s under root (root bypasses the directory write permission; the non-root run covers that facet).

#### Test plan

| Test | Purpose | pre-fix | post-fix |
|------|---------|---------|----------|
| `TemplateExecErrorDoesNotCommit` | mid-render error commits no corrupt config | FAIL | PASS |
| `AtomicNewErrorNoPanic` | New failure returns an error, no panic | FAIL (panic, non-root) | PASS |
| `SuccessCommitsConfig` | nil return ⇔ config atomically committed | PASS | PASS |
| `TestUpdateRuntimeConfig` (existing) | 4 subcases, generate / skip logic | PASS | PASS |

Regression:

```bash
$ go test ./internal/cri/server/ -count=1
ok   github.com/containerd/containerd/v2/internal/cri/server   (77 PASS / 0 FAIL)

$ go test ./internal/cri/server/ -race -count=1
ok   github.com/containerd/containerd/v2/internal/cri/server   (0 DATA RACE)
```

#### Backwards compatibility / API impact

**None**. `writeCNIConfigFile` is an unexported function in `internal/cri/server`; the CRI `UpdateRuntimeConfig` contract is unchanged — under IO faults / template errors it now returns an error and leaves no corrupt file, instead of panicking / silently losing / committing a partial config.

#### Documentation / comment changes

- Two new source comments in the defer documenting `Cancel()` on failure and that `Close()`'s commit error must be propagated.
- The new test file carries comments documenting the three invariants, the production trigger conditions, and the root-skip rationale.

#### Risk & rollback

| Dimension | Assessment |
|-----------|------------|
| Change surface | one function, +16/-3 source lines |
| Performance impact | none (still one `Close` or one `Cancel`) |
| Data risk | reduced: never commits a partial CNI config; the failure path removes the temp file |
| Rollback | `git revert <sha>` |

#### Reviewer hints

1. The `if err != nil` check sits after `atomicfile.New` ([update_runtime_config.go:137-139](internal/cri/server/update_runtime_config.go#L137-L139)) — `f` is nil when `New` fails, so nothing after it is usable.
2. Confirm the defer branches on the named `retErr`: `Cancel()` on failure, `Close()` + propagate its error on success ([:140-153](internal/cri/server/update_runtime_config.go#L140-L153)).
3. The trailing `return nil` replaces `return err`: the success-path commit error is now reported by the defer via `retErr` ([:161](internal/cri/server/update_runtime_config.go#L161)).

#### Linked issues / discussions

- Novel finding; no matching historical issue/PR located. `git blame internal/cri/server/update_runtime_config.go` pinpoints where this error handling was introduced.

#### Out of scope (kept separate to avoid PR collisions)

- `UpdateRuntimeConfig`'s upstream CIDR parsing / plugin `Status`·`Load` decision logic — untouched.
- The `pkg/atomicfile` package itself — untouched.
- Whether to add a panic-recovery interceptor to the gRPC chain — separate discussion (this PR removes the nil deref directly).

#### Pre-flight checks (passing locally)

- [x] `gofmt -l` clean
- [x] `go vet ./internal/cri/server/` clean
- [x] `GOOS=linux go build ./internal/cri/server/` succeeds
- [x] `internal/cri/server` package `go test`, normal (77 PASS) + `-race` (0 races)
- [x] DCO sign-off applied at commit time (`git commit -s`)

#### Files changed

```
 internal/cri/server/update_runtime_config.go            |  19 ++-
 internal/cri/server/update_runtime_config_safety_test.go | 162 +++++++++++++++++++++
 2 files changed, 178 insertions(+), 3 deletions(-)
```
