### PR TITLE
snapshots/blockfile: fix mount-options slice aliasing data race

### DIFF
--- a/plugins/snapshots/blockfile/blockfile.go
+++ b/plugins/snapshots/blockfile/blockfile.go
@@ -423,7 +423,11 @@ func (o *snapshotter) getBlockFile(id string) string {
 
 func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
 	var (
-		mountOptions = o.options
+		// Clone so the per-snapshot ro/rw append below cannot write into
+		// o.options' shared backing array: o.options may carry spare capacity
+		// (NewSnapshotter appends "loop"), and mounts() is called concurrently
+		// for different snapshots via Mounts/Prepare/View with no lock.
+		mountOptions = slices.Clone(o.options)
 		source       string
 	)
 

--- a/plugins/snapshots/blockfile/blockfile_mounts_safety_test.go
+++ b/plugins/snapshots/blockfile/blockfile_mounts_safety_test.go
@@ -1,0 +1,150 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package blockfile
+
+// Characterization + faithful-reproduction tests for P2-6.
+//
+// (*snapshotter).mounts aliases o.options and appends the per-snapshot ro/rw
+// flag in place (blockfile.go:426-434). When o.options has spare capacity, that
+// append writes into the backing array shared with o.options, so successive or
+// concurrent mounts() calls clobber each other's returned options — a data race
+// plus ro/rw flag cross-contamination.
+//
+// mounts() is the common funnel of the exported Mounts/Prepare/View handlers,
+// which the snapshots gRPC service drives concurrently with no lock; these tests
+// exercise that real function directly.
+//
+// All tests below MUST stay green after the fix (decouple from o.options via
+// slices.Clone). The two reproduction tests fail on the pre-fix code:
+//   - NoCrossContamination: deterministic, fails in normal mode.
+//   - ConcurrentNoRace:      fails under -race (DATA RACE).
+
+import (
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/storage"
+)
+
+// spareCapOptions reproduces the exact slice shape NewSnapshotter produces when
+// the operator configures e.g. `mount_options = ["discard","nobarrier"]` without
+// "loop": NewSnapshotter appends "loop" (blockfile.go:164-165), growing the slice
+// to len=3,cap=4 — one spare slot at index 3 that mounts()'s append writes into
+// in place. The default config (["loop"], len=1/cap=1) has no spare capacity and
+// is unaffected, which is why this hazard is config-gated.
+func spareCapOptions(t *testing.T) []string {
+	t.Helper()
+	opts := []string{"discard", "nobarrier"}
+	if !slices.Contains(opts, "loop") {
+		opts = append(opts, "loop")
+	}
+	if cap(opts) <= len(opts) {
+		// The runtime did not over-allocate on this build; force the
+		// production-observed len=3/cap=4 shape so the precondition holds.
+		grown := make([]string, len(opts), len(opts)+1)
+		copy(grown, opts)
+		opts = grown
+	}
+	return opts
+}
+
+// TestBlockfileMountsSafety_KindFlagAndBaseOptions locks the observable contract
+// of a single mounts() call: base options are preserved and the trailing flag
+// matches the snapshot kind (View => ro, Active => rw). Holds before and after
+// the fix.
+func TestBlockfileMountsSafety_KindFlagAndBaseOptions(t *testing.T) {
+	cases := []struct {
+		name     string
+		kind     snapshots.Kind
+		wantFlag string
+	}{
+		{"view-is-ro", snapshots.KindView, "ro"},
+		{"active-is-rw", snapshots.KindActive, "rw"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &snapshotter{root: t.TempDir(), fsType: "ext4", options: spareCapOptions(t)}
+			mounts := o.mounts(storage.Snapshot{Kind: tc.kind, ID: "42"})
+			if len(mounts) != 1 {
+				t.Fatalf("expected 1 mount, got %d", len(mounts))
+			}
+			opts := mounts[0].Options
+			for _, base := range []string{"discard", "nobarrier", "loop"} {
+				if !slices.Contains(opts, base) {
+					t.Errorf("base option %q missing from %v", base, opts)
+				}
+			}
+			if got := opts[len(opts)-1]; got != tc.wantFlag {
+				t.Errorf("last option = %q, want %q (opts=%v)", got, tc.wantFlag, opts)
+			}
+			if mounts[0].Type != "ext4" {
+				t.Errorf("mount type = %q, want ext4", mounts[0].Type)
+			}
+		})
+	}
+}
+
+// TestBlockfileMountsSafety_NoCrossContamination is a deterministic reproduction
+// of the ro/rw cross-contamination. A read-only View mount must stay read-only
+// even after a subsequent read-write (Active) mount is built from the same
+// snapshotter. Pre-fix the second append writes the shared backing slot, flipping
+// the already-returned View mount's flag to "rw". Fails in normal mode pre-fix.
+func TestBlockfileMountsSafety_NoCrossContamination(t *testing.T) {
+	o := &snapshotter{root: t.TempDir(), fsType: "ext4", options: spareCapOptions(t)}
+
+	view := o.mounts(storage.Snapshot{Kind: snapshots.KindView, ID: "view"})
+	if got := view[0].Options[len(view[0].Options)-1]; got != "ro" {
+		t.Fatalf("precondition: view mount last option = %q, want ro", got)
+	}
+
+	// A later read-write mount from the same snapshotter must not mutate the
+	// View mount that was already handed out.
+	_ = o.mounts(storage.Snapshot{Kind: snapshots.KindActive, ID: "active"})
+
+	if got := view[0].Options[len(view[0].Options)-1]; got != "ro" {
+		t.Errorf("View mount flag corrupted to %q after a subsequent Active mount; "+
+			"mounts() aliased o.options and appended the flag in place (P2-6)", got)
+	}
+}
+
+// TestBlockfileMountsSafety_ConcurrentNoRace reproduces the data race under
+// -race: many goroutines call mounts() concurrently (mixed kinds), all appending
+// the flag into the spare slot of the shared o.options backing array. The gRPC
+// snapshots service drives Mounts/Prepare/View concurrently with no lock, so this
+// matches the production topology. Fails under -race pre-fix (DATA RACE).
+func TestBlockfileMountsSafety_ConcurrentNoRace(t *testing.T) {
+	o := &snapshotter{root: t.TempDir(), fsType: "ext4", options: spareCapOptions(t)}
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		kind := snapshots.KindView
+		if i%2 == 0 {
+			kind = snapshots.KindActive
+		}
+		go func(k snapshots.Kind, id string) {
+			defer wg.Done()
+			m := o.mounts(storage.Snapshot{Kind: k, ID: id})
+			_ = m[0].Options[len(m[0].Options)-1]
+		}(kind, "snap"+strconv.Itoa(i))
+	}
+	wg.Wait()
+}


### PR DESCRIPTION

#### Summary

- Fix a defect where the blockfile snapshotter's `mounts()` aliases `o.options` and appends the `ro`/`rw` flag in place, causing a data race and ro/rw flag cross-contamination under concurrency.
- Change `mountOptions = o.options` to `mountOptions = slices.Clone(o.options)` so each `mounts()` call appends onto its own backing array.
- Add 3 characterization tests (1 contract test + 2 faithful reproductions: one deterministic, one under `-race`).

#### Problem

**Severity**: silent data corruption (data race + read-only/read-write mount flag cross-contamination).

**Trigger conditions**:

| Path | Source | Frequency |
|------|--------|-----------|
| `o.options` has spare capacity | `mount_options` configured without `"loop"` → `NewSnapshotter` appends `"loop"`, growing to len3/cap4 (blockfile.go:164-165) | constant once configured |
| Concurrent `mounts()` | gRPC snapshots service runs one goroutine per request, no lock; parallel `Prepare`/`View`/`Mounts` (≥2 containers/images prepared in parallel) enter `mounts()` simultaneously | medium (parallel starts) |

The default config (`["loop"]`, len1/cap1) reallocates on append (no sharing) and is **unaffected**; the defect is gated behind a non-default `mount_options`.

**Symptoms (production)**: on a blockfile-backed node with `mount_options` configured without `"loop"`, preparing multiple snapshots concurrently: (1) `-race` builds report a DATA RACE; (2) a `View` mount that should be read-only can have its trailing flag overwritten to `rw` by a concurrent `Prepare` — a read-only layer mounted read-write, allowing the shared parent block file to be written through (layer corruption); conversely a `Prepare` may get `ro`, causing container write failures.

**Why race detector / regular tests don't catch it**: the default `mount_options` (`["loop"]`) has no spare capacity, so append reallocates → no sharing, `-race` stays green; functional tests do not combine a non-default `mount_options` with concurrent `mounts()`. The defect only manifests when a non-default config produces spare capacity and two `mounts()` calls interleave, and the ro/rw contamination surfaces only further downstream at mount/write time.

#### Root cause

`mounts()` aliases the shared slice and appends in place:

```go
// plugins/snapshots/blockfile/blockfile.go:424-434 (pre-fix)
func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
	var (
		mountOptions = o.options   // alias: shares o.options' backing array
		source       string
	)
	if s.Kind == snapshots.KindView {
		mountOptions = append(mountOptions, "ro")   // cap>len => writes backing[len] in place
	} else {
		mountOptions = append(mountOptions, "rw")   // same slot
	}
	...
}
```

The spare capacity of `o.options` originates at construction:

```go
// plugins/snapshots/blockfile/blockfile.go:164-165
if !slices.Contains(config.mountOptions, "loop") {
	config.mountOptions = append(config.mountOptions, "loop") // len2→len3, cap doubles to 4
}
```

Concurrency topology (the three exported entries funnel into `mounts()`, all called **outside** the bolt transaction, so the single-writer lock does not protect it):

```
SnapshotService gRPC (one goroutine per request, no lock)
 ├─ Mounts(keyA)          blockfile.go:285 → o.mounts(s)  blockfile.go:299  (outside txn)
 └─ View/Prepare(keyB)    blockfile.go:277/273 → createSnapshot → o.mounts(s)  blockfile.go:417  (outside txn)
      ↓ concurrent calls into mounts(): both goroutines append-write o.options' backing[3]
```

#### Fix

Clone before appending, decoupling from `o.options`:

```diff
 func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
 	var (
-		mountOptions = o.options
+		// Clone so the per-snapshot ro/rw append below cannot write into
+		// o.options' shared backing array: o.options may carry spare capacity
+		// (NewSnapshotter appends "loop"), and mounts() is called concurrently
+		// for different snapshots via Mounts/Prepare/View with no lock.
+		mountOptions = slices.Clone(o.options)
 		source       string
 	)
```

**Why this is the minimal, safest fix**:
1. `slices` is already imported (used by NewSnapshotter); zero new dependency, change confined to one line in one function.
2. After cloning, each `mounts()` appends onto its own array, eliminating the shared write at the root; the happy-path return value is unchanged.
3. Does not touch the spare-capacity source (construction-time loop append) or any exported API signature/semantics.

**Why not other approaches**:
| Alternative | Rejection reason |
|-------------|------------------|
| Add a lock guarding `mounts()` | Overkill: `o.options` is read-only after construction; the real issue is the aliased append, not a missing lock — a lock adds needless serialization |
| Change construction so `o.options` has no spare capacity | Fragile: depends on the runtime's growslice heuristic, and any later append re-introduces spare capacity |
| `make([]string,0,len+1)` then copy-append | Equivalent but more verbose; `slices.Clone` is clearer and consistent with existing usage |

#### Reproduction (reviewers can run locally)

No root / no Linux required (the white-box test drives the real `mounts()`):

```bash
# Deterministic reproduction (fails in normal mode)
go test ./plugins/snapshots/blockfile/ -run TestBlockfileMountsSafety_NoCrossContamination -v -count=1 -timeout 60s

# Data-race reproduction (-race)
go test ./plugins/snapshots/blockfile/ -run TestBlockfileMountsSafety_ConcurrentNoRace -race -v -count=1 -timeout 120s
```

Expected (pre-fix, deterministic):

```
--- FAIL: TestBlockfileMountsSafety_NoCrossContamination (0.00s)
    blockfile_mounts_safety_test.go:122: View mount flag corrupted to "rw" after a subsequent Active mount; mounts() aliased o.options and appended the flag in place (P2-6)
```

Expected (pre-fix, `-race`):

```
WARNING: DATA RACE
Write at 0x00c0000ade30 by goroutine 14:
  ...blockfile.(*snapshotter).mounts()
      plugins/snapshots/blockfile/blockfile.go:431 +0xac
Previous write at 0x00c0000ade30 by goroutine 11:
  ...blockfile.(*snapshotter).mounts()
      plugins/snapshots/blockfile/blockfile.go:433 +0x134
--- FAIL: TestBlockfileMountsSafety_ConcurrentNoRace (0.00s)
```

Verified against base commit `561fcdbd8` (go 1.26.3, darwin/arm64). With this PR applied, both tests pass in normal and `-race` modes.

#### Test plan

| Test | Purpose | pre-fix | post-fix |
|------|---------|---------|----------|
| `TestBlockfileMountsSafety_KindFlagAndBaseOptions` | lock single-call contract (base opts preserved + View→ro/Active→rw) | PASS | PASS |
| `TestBlockfileMountsSafety_NoCrossContamination` | a View mount must not be contaminated by a later Active mounts() | FAIL | PASS |
| `TestBlockfileMountsSafety_ConcurrentNoRace` | concurrent mounts() free of DATA RACE | FAIL (`-race`) | PASS |

Regression:

```bash
$ go test ./plugins/snapshots/blockfile/... -count=1
ok   github.com/containerd/containerd/v2/plugins/snapshots/blockfile

$ go test ./plugins/snapshots/blockfile/ -race -count=1
ok   github.com/containerd/containerd/v2/plugins/snapshots/blockfile
```

(`TestBlockfile` requires root, SKIPped on darwin; not a regression.)

#### Backwards compatibility / API impact

**None**. The change is confined to internal slice handling in the unexported `mounts()` method; the public signatures and returned contents of `Mounts`/`Prepare`/`View` are unchanged.

#### Documentation / comment changes

- A comment explains why the slice is cloned: `o.options` may carry spare capacity (NewSnapshotter appends `"loop"`), and `mounts()` is called concurrently via Mounts/Prepare/View with no lock.

#### Risk & rollback

| Dimension | Assessment |
|-----------|------------|
| Change surface | one file +5/-1 (alias → clone + comment); one new test file |
| Performance impact | one small slice copy per `mounts()` (length = number of mount_options, typically single digits); negligible |
| Data risk | none; removes a data race and a ro/rw contamination path |
| Rollback | `git revert <sha>` |

#### Reviewer hints

1. Confirm `slices.Clone` sits **before** the two `append(mountOptions, ...)` calls (blockfile.go, `mounts()`).
2. The spare capacity originates at [blockfile.go:164-165](plugins/snapshots/blockfile/blockfile.go#L164): the construction-time `"loop"` append; the default `["loop"]` has no spare capacity, hence safe by default.
3. `NoCrossContamination` needs neither `-race` nor timing; a plain `go test` verifies cause and effect.

#### Linked issues / discussions

- Novel finding; no matching historical issue/PR located. `git blame plugins/snapshots/blockfile/blockfile.go` pinpoints where the alias was introduced.

#### Out of scope (kept separate to avoid PR collisions)

- devmapper `Mounts` swallowing the `GetSnapshot` error and building a malformed mount (P2-5) — follow-up PR / could be batched.
- NewSnapshotter construction-time loop-append producing spare capacity — not changed (not a defect, only the precondition).
- Other blockfile paths — out of scope.

#### Pre-flight checks (passing locally)

- [x] `gofmt -l` clean (2 files)
- [x] `go vet ./plugins/snapshots/blockfile/` clean
- [x] `go build ./plugins/snapshots/blockfile/` succeeds
- [x] package `go test`, normal + `-race`: `ok` (safety tests 5/5 PASS)
- [ ] DCO sign-off applied at commit time (`git commit -s`)

#### Files changed

```
 plugins/snapshots/blockfile/blockfile.go                    |   6 +-
 plugins/snapshots/blockfile/blockfile_mounts_safety_test.go | 150 +++++++++++++++++++++
 2 files changed, 155 insertions(+), 1 deletion(-)
```
