### PR TITLE
snapshots/windows: don't unlock mergeLock when Lock fails

### DIFF
--- a/internal/kmutex/kmutex_misuse_safety_test.go
+++ b/internal/kmutex/kmutex_misuse_safety_test.go
@@ -1,0 +1,119 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kmutex
+
+// Characterization tests for the Lock-error contract that the Windows
+// block-CIM snapshotter (plugins/snapshots/windows/block_cimfs.go) relies on.
+//
+// These run on every platform (kmutex is platform independent) and therefore
+// act as the cross-platform reproduction of finding P1-3: the block-CIM merge
+// path used to call mergeLock.Lock(ctx, parent) while *ignoring* the returned
+// error and then unconditionally `defer mergeLock.Unlock(parent)`. When Lock
+// fails (e.g. the request ctx is cancelled while waiting for a long-running
+// merge) it does NOT hold the lock — Acquire failed — and kmutex deletes the
+// key, so the unconditional Unlock panics with "unlock of unlocked key",
+// crashing the (un-recovered) daemon.
+//
+// The actual call site is Windows-only and cannot run on this host; the
+// matching guard for the real code lives in
+// plugins/snapshots/windows/block_cimfs_safety_test.go. The two helpers below
+// transcribe the pre-fix and post-fix patterns verbatim so the mechanism is
+// proven against the real kmutex primitive.
+//
+// Both tests must pass before and after the fix: they lock kmutex's contract,
+// not the snapshotter's behaviour.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// buggyMergeLockPattern mirrors block_cimfs.go:348-349 BEFORE the fix:
+//
+//	s.mergeLock.Lock(ctx, parent)    // error ignored
+//	defer s.mergeLock.Unlock(parent) // unconditional
+func buggyMergeLockPattern(ctx context.Context, l KeyedLocker, key string) {
+	l.Lock(ctx, key)    //nolint:errcheck // deliberately reproducing the bug
+	defer l.Unlock(key) // unconditional Unlock even when Lock failed
+}
+
+// fixedMergeLockPattern mirrors block_cimfs.go AFTER the fix:
+//
+//	if err := s.mergeLock.Lock(ctx, parent); err != nil {
+//		return err
+//	}
+//	defer s.mergeLock.Unlock(parent)
+func fixedMergeLockPattern(ctx context.Context, l KeyedLocker, key string) error {
+	if err := l.Lock(ctx, key); err != nil {
+		return err
+	}
+	defer l.Unlock(key)
+	return nil
+}
+
+// TestKeyMutexSafety_LockErrIgnoredThenUnlockPanics proves the P1-3 mechanism:
+// when Lock fails on a never-held key, ignoring the error and unconditionally
+// Unlocking panics. This documents WHY the caller must check Lock's error.
+func TestKeyMutexSafety_LockErrIgnoredThenUnlockPanics(t *testing.T) {
+	t.Parallel()
+
+	km := newKeyMutex()
+
+	// Already-cancelled ctx: Acquire returns ctx.Err() with priority even
+	// though the semaphore is free, so the key is never actually held. This
+	// is the single-request production trigger (CreateContainer reaching the
+	// merge with an expired/cancelled request ctx).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic from unconditional Unlock after a failed Lock, got none")
+		}
+		t.Logf("reproduced P1-3 panic: %v", r)
+		// After the panic the key must have been deleted (ref hit 0), i.e.
+		// the lock was never held.
+		assert.Equal(t, 0, len(km.locks))
+	}()
+
+	buggyMergeLockPattern(ctx, km, t.Name())
+}
+
+// TestKeyMutexSafety_LockErrCheckedNoPanic proves the fix: checking Lock's
+// error and returning before registering the Unlock leaves the locker clean
+// and never panics.
+func TestKeyMutexSafety_LockErrCheckedNoPanic(t *testing.T) {
+	t.Parallel()
+
+	km := newKeyMutex()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var err error
+	assert.NotPanics(t, func() {
+		err = fixedMergeLockPattern(ctx, km, t.Name())
+	})
+
+	assert.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got %v", err)
+	// Failed Lock must not leak a klock entry.
+	assert.Equal(t, 0, len(km.locks))
+}

--- a/plugins/snapshots/windows/block_cimfs.go
+++ b/plugins/snapshots/windows/block_cimfs.go
@@ -342,14 +342,7 @@ func (s *blockCIMSnapshotter) createSnapshot(ctx context.Context, kind snapshots
 		// the last layer in that merge, which in case of the scratch snapshot is
 		// a direct parent of that scratch snapshot.
 
-		prepareMergedCIMLocked := func() error {
-			// function created to limit the scope of locked code and ensure
-			// that the lock is always released via defer
-			s.mergeLock.Lock(ctx, parent)
-			defer s.mergeLock.Unlock(parent)
-			return s.prepareMergedCIM(ctx, newSnapshot.ParentIDs)
-		}
-		if err = prepareMergedCIMLocked(); err != nil {
+		if err = s.prepareMergedCIMLocked(ctx, parent, newSnapshot.ParentIDs); err != nil {
 			return nil, fmt.Errorf("failed to prepare merged CIM: %w", err)
 		}
 	}
@@ -467,6 +460,24 @@ const (
 	mergedCIMName   = "merged.cim"
 	mergedBlockName = "merged.vhd"
 )
+
+// prepareMergedCIMLocked serializes the parent-CIM merge identified by `parent`
+// under mergeLock and runs prepareMergedCIM while holding it. The merge can take
+// a long time, so concurrent requests for the same parent must serialize here.
+//
+// The lock is released via defer only when it was actually acquired: if Lock
+// fails (e.g. the request ctx is cancelled or its deadline expires while
+// waiting for an in-flight merge) the lock is NOT held, and an unconditional
+// Unlock would panic with "unlock of unlocked key" (see internal/kmutex.Unlock),
+// crashing the daemon. So Lock's error is checked and propagated before the
+// defer is registered.
+func (s *blockCIMSnapshotter) prepareMergedCIMLocked(ctx context.Context, parent string, snapshotIDs []string) error {
+	if err := s.mergeLock.Lock(ctx, parent); err != nil {
+		return err
+	}
+	defer s.mergeLock.Unlock(parent)
+	return s.prepareMergedCIM(ctx, snapshotIDs)
+}
 
 // prepareMergedCIM creates a new merged block CIM from the given snapshots. The order of
 // `snapshotIDs` is important. It is expected that the snapshot ID at the last index is

--- a/plugins/snapshots/windows/block_cimfs_safety_test.go
+++ b/plugins/snapshots/windows/block_cimfs_safety_test.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package windows
+
+// Characterization test for finding P1-3: prepareMergedCIMLocked must not call
+// Unlock when mergeLock.Lock fails. Pre-fix the merge path ignored Lock's error
+// and unconditionally deferred Unlock; when Lock failed (request ctx cancelled
+// while waiting for a long-running merge) the lock was never held, so kmutex
+// panicked with "unlock of unlocked key", crashing the un-recovered daemon.
+//
+// This test drives the real method against a real kmutex. A cancelled ctx makes
+// Lock return immediately (Acquire honours ctx-done with priority), so
+// prepareMergedCIM is never reached and no further snapshotter state is needed.
+//
+// Pre-fix (revert the `if err != nil { return err }` guard inside
+// prepareMergedCIMLocked) this test FAILs with a panic; post-fix it PASSes.
+//
+// Note: this package is Windows-only and cannot be executed on a non-Windows
+// host. The platform-independent reproduction of the same mechanism lives in
+// internal/kmutex/kmutex_misuse_safety_test.go and runs everywhere.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/containerd/containerd/v2/internal/kmutex"
+)
+
+func TestBlockCIMSnapshotterSafety_MergeLockErrorNoPanic(t *testing.T) {
+	s := &blockCIMSnapshotter{mergeLock: kmutex.New()}
+
+	// Already-cancelled ctx: Lock's Acquire returns ctx.Err() with priority,
+	// so the lock is never held — the pre-fix unconditional defer Unlock would
+	// panic here.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("prepareMergedCIMLocked panicked on Lock failure (P1-3 regression): %v", r)
+			}
+		}()
+		err = s.prepareMergedCIMLocked(ctx, "parent-key", []string{"a", "b"})
+	}()
+
+	if err == nil {
+		t.Fatal("expected an error when Lock fails on a cancelled ctx, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled to propagate, got %v", err)
+	}
+}


### PR DESCRIPTION

#### Summary

- Fix a daemon panic: the block-CIM snapshotter ran `defer Unlock` even when `mergeLock.Lock` failed.
- Extract the inline `prepareMergedCIMLocked` closure into a method that checks `Lock`'s error and returns early, registering `defer Unlock` only after the lock is actually held.
- Add two characterization tests: a cross-platform kmutex misuse reproduction (runs everywhere) and a Windows-tagged guard on the real call site.

#### Problem

**Severity**: panic (unrecovered → daemon crash, Windows-only).

**Trigger conditions**:

| Path | Source | Frequency |
|------|--------|-----------|
| Single request | `Prepare` (scratch + `ParentIDs>1`) reaches the merge with an already-cancelled/expired request ctx → `Acquire` returns the ctx error with priority; the lock is never held | medium (CreateContainer deadline / client disconnect) |
| Concurrent | A holds the lock during a long merge; B (same parent) blocks in `Acquire`; B's ctx is cancelled → B's Unlock releases A's semaphore and deletes the key → A's later Unlock can't find the key | medium (concurrent container starts from the same image + client cancellation) |

**Symptoms (production)**: on a Windows node, when multi-layer block-CIM images start containers concurrently and a request is cancelled within the merge wait window, `kmutex.Unlock` raises `panic: kmutex: unlock of unlocked key`. The panic is not recovered (neither the snapshot service nor the gRPC server installs a recovery interceptor, and grpc-go does not recover handler panics by default), so it crashes the containerd daemon — a node-wide container-management outage.

**Why race detector / regular tests don't catch it**: this is not a data race (`-race` cannot see it); it is an ignored `Lock` error. It only manifests when the ctx is cancelled within the merge lock-acquisition/wait window, so functional tests and logs stay green and the crash stack points at `kmutex` rather than the caller's omission.

#### Root cause

The `internal/kmutex` contract: `Lock` acquires via `semaphore.Acquire(ctx, 1)`; on failure (ctx cancelled/expired) it decrements `ref` and, when `ref==0`, `delete`s the key before returning the error — **the lock is not held**. A subsequent `Unlock` for that key then panics because `km.locks[key]` is gone:

```go
// internal/kmutex/kmutex.go:86-92
func (km *keyMutex) Unlock(key string) {
	km.mu.Lock()
	defer km.mu.Unlock()
	l, ok := km.locks[key]
	if !ok {
		panic(fmt.Errorf("kmutex: unlock of unlocked key %v", key))
	}
	...
}
```

The pre-fix merge path ignored `Lock`'s error and unconditionally deferred `Unlock`:

```
Prepare(KindActive)                         block_cimfs.go:204
 └─ createSnapshot                           block_cimfs.go:265
    └─ [!UnpackKeyPrefix && ParentIDs>1]      block_cimfs.go:336
       └─ prepareMergedCIMLocked (closure)    block_cimfs.go:345
          ├─ s.mergeLock.Lock(ctx, parent)   // error discarded
          └─ defer s.mergeLock.Unlock(parent) // unconditional → panics when not held  💥
```

#### Fix

Extract the closure into a method; check `Lock`'s error and register `defer Unlock` only on success:

```diff
-		prepareMergedCIMLocked := func() error {
-			// function created to limit the scope of locked code and ensure
-			// that the lock is always released via defer
-			s.mergeLock.Lock(ctx, parent)
-			defer s.mergeLock.Unlock(parent)
-			return s.prepareMergedCIM(ctx, newSnapshot.ParentIDs)
-		}
-		if err = prepareMergedCIMLocked(); err != nil {
+		if err = s.prepareMergedCIMLocked(ctx, parent, newSnapshot.ParentIDs); err != nil {
 			return nil, fmt.Errorf("failed to prepare merged CIM: %w", err)
 		}
```

```diff
+func (s *blockCIMSnapshotter) prepareMergedCIMLocked(ctx context.Context, parent string, snapshotIDs []string) error {
+	if err := s.mergeLock.Lock(ctx, parent); err != nil {
+		return err
+	}
+	defer s.mergeLock.Unlock(parent)
+	return s.prepareMergedCIM(ctx, snapshotIDs)
+}
```

**Why this is the minimal, safest fix**:
1. The defer is registered only after `Lock` succeeds, matching the kmutex contract exactly; the success path is unchanged.
2. Extracting a method makes the critical section unit-testable (a cancelled ctx makes `Lock` return before `prepareMergedCIM`, so no full metastore is needed).
3. Lock acquire/release remain defer-paired — "the critical section is the function body".

**Why not other approaches**:

| Alternative | Rejection reason |
|-------------|------------------|
| Swallow "unlocked key" in kmutex.Unlock instead of panicking | Changes a shared primitive's semantics and masks real bugs in other callers; out of scope |
| Keep the closure, only add the error check | Works, but a closure is not unit-testable; the method costs the same and gives more |

#### Reproduction (reviewers can run locally)

The mechanism reproduces **cross-platform** (no Windows needed): a real `kmutex` + a cancelled ctx drive the pre/post-fix patterns.

```bash
go test ./internal/kmutex/ -run TestKeyMutexSafety_LockErrIgnoredThenUnlockPanics -v -count=1 -timeout 60s
```

Expected (buggy pattern, equivalent to pre-fix):

```
=== RUN   TestKeyMutexSafety_LockErrIgnoredThenUnlockPanics
    kmutex_misuse_safety_test.go:91: reproduced P1-3 panic: kmutex: unlock of unlocked key TestKeyMutexSafety_LockErrIgnoredThenUnlockPanics
--- PASS: TestKeyMutexSafety_LockErrIgnoredThenUnlockPanics (0.00s)
```

(The test recovers and asserts a panic must occur, so PASS means the buggy pattern deterministically panicked.) Verified against base commit `561fcdbd8` (go 1.26).

**Honest disclosure**: the real call site lives in a `//go:build windows` package and **cannot run on a non-Windows host**. The Windows guard test `TestBlockCIMSnapshotterSafety_MergeLockErrorNoPanic` needs Windows CI for its baseline-FAIL/verify-PASS: pre-fix (drop the method's `if err != nil { return err }`) → panic FAIL; post-fix → PASS. Locally only `GOOS=windows go build / vet / test -c` were run.

#### Test plan

| Test | Purpose | pre-fix | post-fix |
|------|---------|---------|----------|
| `TestKeyMutexSafety_LockErrIgnoredThenUnlockPanics` (cross-platform) | ignoring Lock err + unconditional Unlock must panic | PASS (catches panic) | PASS |
| `TestKeyMutexSafety_LockErrCheckedNoPanic` (cross-platform) | checking err: no panic, returns ctx error, clean locker | PASS | PASS |
| `TestBlockCIMSnapshotterSafety_MergeLockErrorNoPanic` (windows) | real method does not panic on Lock failure, propagates ctx error | FAIL (panic)* | PASS* |

\*Windows test requires CI; only compile-verified locally.

Regression:

```bash
$ go test ./internal/kmutex/ -count=1
ok   github.com/containerd/containerd/v2/internal/kmutex   (normal)

$ go test ./internal/kmutex/ -race -count=1
ok   github.com/containerd/containerd/v2/internal/kmutex   (0 DATA RACE)
```

#### Backwards compatibility / API impact

**None**. The change is confined to internal error handling in an unexported method; the public signatures and success-path behaviour of `Prepare`/`View`/`createSnapshot` are unchanged.

#### Documentation / comment changes

- The new `prepareMergedCIMLocked` method carries a doc comment explaining why the lock is released only after `Lock` succeeds (referencing the kmutex panic semantics).
- Incidental: extracting the method had split `prepareMergedCIM`'s doc comment; its adjacency is restored.

#### Risk & rollback

| Dimension | Assessment |
|-----------|------------|
| Change surface | one file +19/-8 (extract method + one error check); two new test files |
| Performance impact | none; only an extra early return when Lock fails |
| Data risk | none; no persistence involved, and the fix removes a crash path |
| Rollback | `git revert <sha>` |

#### Reviewer hints

1. Confirm `defer s.mergeLock.Unlock(parent)` sits **after** the error check (block_cimfs.go, `prepareMergedCIMLocked`).
2. Note that kmutex.Lock's failure path `delete`s the key (internal/kmutex/kmutex.go:78-80), which is exactly why the subsequent Unlock panics.
3. The cross-platform reproduction test is in internal/kmutex and runs locally; the Windows guard test needs CI.

#### Linked issues / discussions

- Novel finding; no matching historical issue/PR located. `git blame plugins/snapshots/windows/block_cimfs.go` pinpoints where the closure was introduced.

#### Out of scope (kept separate to avoid PR collisions)

- kmutex `Unlock` robustness hardening (verify the caller actually holds the lock) — separate finding/PR.
- P1-1 Pod-metrics `return nil` → `continue`; P1-2 DownloadLimiter self-deadlock — follow-up PRs.

#### Pre-flight checks (passing locally)

- [x] `gofmt -l` clean (3 files)
- [x] `go test ./internal/kmutex/` normal + `-race`: `ok`
- [x] `GOOS=windows go build ./plugins/snapshots/windows/` succeeds
- [x] `GOOS=windows go vet ./plugins/snapshots/windows/` clean (only pre-existing `unusedparams` info)
- [x] `GOOS=windows go test -c` links successfully
- [ ] Windows guard test executed → pending CI
- [ ] DCO sign-off applied at commit time (`git commit -s`)

#### Files changed

```
 plugins/snapshots/windows/block_cimfs.go         | 27 +++++++++++++-------
 internal/kmutex/kmutex_misuse_safety_test.go     | 119 +++++++++++++++++++++
 plugins/snapshots/windows/block_cimfs_safety_test.go | 71 ++++++++++++
 3 files changed, 207 insertions(+), 10 deletions(-)
```