### PR TITLE
fsverity: close file descriptor leaked by Enable

### DIFF
--- a/internal/fsverity/fsverity_enable_safety_test.go
+++ b/internal/fsverity/fsverity_enable_safety_test.go
@@ -1,0 +1,92 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fsverity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Characterization test for the contract: Enable must close the file descriptor
+// it opens before returning. This test must PASS both before and after any
+// refactor; it currently FAILS on unpatched code, which is the reproduction of
+// the fd-leak bug.
+//
+// Background:
+//   Enable (fsverity_linux.go:97) does `f, err := os.Open(path)` and never closes
+//   f -- neither on the FS_IOC_ENABLE_VERITY error path (line 126) nor on the
+//   success path (line 129). The sibling IsEnabled (lines 76-95) shows the
+//   intended pattern: `f, _ := os.Open(path); defer f.Close()`.
+//
+// Faithful, recommended-usage reproduction (no artificial concurrency, no root,
+// no fsverity-capable filesystem required):
+//   The production content-store hot path calls Enable exactly once per committed
+//   blob -- plugins/content/local/writer.go:165-168 -- and, per its own comment
+//   ("errors should only be logged and not returned"), tolerates a returned error
+//   by logging a warning. On a filesystem without fsverity support the ioctl fails
+//   and Enable returns that error, but the descriptor opened on line 98 has already
+//   leaked. The success path leaks the same descriptor, so observing the error path
+//   is a faithful in-production reproduction of the identical leak.
+//
+// Note on GC: we deliberately do NOT call runtime.GC(). *os.File carries a
+// finalizer that would eventually close a leaked fd, so the leak is not unbounded
+// forever -- but Go's GC is driven by heap growth, not fd pressure, so a daemon
+// committing many blobs accumulates open fds between GC cycles. This test measures
+// that accumulation within a single commit burst, which is the real production
+// failure mode (e.g. a node pulling many multi-layer images at once exhausting
+// RLIMIT_NOFILE).
+
+func openFDCount(t *testing.T) int {
+	t.Helper()
+	ents, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatalf("read /proc/self/fd: %v", err)
+	}
+	return len(ents)
+}
+
+func TestEnableSafety_NoFDLeak(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blob")
+	if err := os.WriteFile(path, []byte("blob-contents"), 0o644); err != nil {
+		t.Fatalf("write test blob: %v", err)
+	}
+
+	// Mirror a content-store commit burst: each committed blob calls Enable once.
+	// The return value is intentionally ignored, exactly like writer.go which only
+	// logs on error.
+	const commits = 64
+
+	before := openFDCount(t)
+	for range commits {
+		_ = Enable(path)
+	}
+	after := openFDCount(t)
+
+	// A correct Enable closes every descriptor it opens, so the open-fd count must
+	// stay flat regardless of how many times it is called. Small slack covers
+	// unrelated runtime descriptors.
+	const slack = 8
+	if grew := after - before; grew > slack {
+		t.Fatalf("fd leak: open fd count grew by %d across %d Enable calls "+
+			"(before=%d after=%d); Enable opens a descriptor per call and never closes it",
+			grew, commits, before, after)
+	}
+}

--- a/internal/fsverity/fsverity_linux.go
+++ b/internal/fsverity/fsverity_linux.go
@@ -99,6 +99,7 @@ func Enable(path string) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	var args = &fsverityEnableArg{}
 	args.version = 1


### PR DESCRIPTION

#### Summary

- Fix a file-descriptor leak: `fsverity.Enable` leaks one fd on every call.
- Add `defer f.Close()` right after `os.Open`, matching the existing `IsEnabled` in the same file.
- Add one characterization test, `TestEnableSafety_NoFDLeak`, locking the contract that `Enable` must not leak fds.

#### Problem

**Severity**: resource leak (file-descriptor exhaustion). The leak itself is **active and deterministic** (one fd per call); the eventual exhaustion is **latent / burst-triggered** — `*os.File` carries a finalizer that closes the fd on GC, but Go's GC is driven by heap growth, not fd pressure, so descriptors accumulate between GC cycles under a commit burst.

**Trigger conditions**:

| Path | Source | Frequency |
|------|--------|-----------|
| content blob commit ([writer.go:166](plugins/content/local/writer.go#L166)) | every blob committed while `integritySupported` is true; the flag is **auto-detected** at store init via `IsSupported()` ([store.go:97-104](plugins/content/local/store.go#L97-L104)) — on kernel ≥5.4 + a verity-capable fs it is on by default, not config-gated | high (once per image layer / config / manifest) |
| EROFS layer commit ([erofs.go:668](plugins/snapshots/erofs/erofs.go#L668)) | every layer committed when `enable_fsverity = true` | once per layer when configured |

**Symptoms (production)**: the containerd process's open-fd count grows monotonically with image pulls; a node pulling many multi-layer images at once spikes toward `RLIMIT_NOFILE`, after which any operation needing a new fd (writing a blob, opening bolt, creating a shim socket, starting a container) fails with `too many open files` — a node-wide container-management outage. Restarting the daemon clears the fds and the symptom temporarily disappears.

**Why regular tests / the race detector don't catch it**: this is not a data race (`-race` cannot see it); it is a missing `Close`. There is no functional failure signal either — on a non-verity fs `Enable` returns the ioctl error, and its only production caller ([writer.go:165-168](plugins/content/local/writer.go#L165-L168)) only logs it ("errors should only be logged"), so the leak accumulates silently while functional tests stay green.

#### Root cause

`IsEnabled` in the same file shows the intended pattern (`fsverity_linux.go:76-95`):

```go
func IsEnabled(path string) (bool, error) {
	f, err := os.Open(path)
	if err != nil {
		return false, err
	}
	defer f.Close()   // correct: register close on open
	...
}
```

`Enable` (`fsverity_linux.go:97-130`) opens the file but never closes it; **both the success and the error return paths leak the same fd**:

```
Enable(path)
  ├─ f, _ := os.Open(path)      // line 98: open fd
  ├─ (no defer f.Close())
  ├─ ioctl FS_IOC_ENABLE_VERITY
  │     └─ errno != 0 → return fmt.Errorf(...)   // line 126: leaks f
  └─ return nil                                   // line 129: leaks f
```

#### Fix

Defer the close immediately after a successful `os.Open`:

```diff
 func Enable(path string) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	var args = &fsverityEnableArg{}
```

**Why this is the minimal, safest fix**:
1. Byte-for-byte consistent with the existing `IsEnabled` in the same file — zero cognitive overhead.
2. A single `defer` covers both the success and the ioctl-error return paths; nothing is missed.
3. No observable change to `Enable` (return values and ioctl semantics are unchanged); only the fd lifetime is corrected.

**Why not other approaches**:
| Alternative | Rejection reason |
|-------------|------------------|
| Explicit `f.Close()` before each return | More lines and easy to miss on a future added return; inconsistent with `IsEnabled` |
| Check and return the `Close` error | The fd is read-only; a close error has no recoverable meaning, and `IsEnabled` ignores it too — keep them consistent |

#### Reproduction (reviewers can run locally)

No root and no fsverity-capable filesystem required (it exercises the ioctl-error path that writer.go already tolerates, which leaks the same fd as the success path):

```bash
docker run --rm -v "$PWD":/src -w /src golang:1.26 \
  go test ./internal/fsverity/ -run TestEnableSafety_NoFDLeak -v -count=1 -timeout 60s
```

Expected (pre-fix):

```
=== RUN   TestEnableSafety_NoFDLeak
    fsverity_enable_safety_test.go:88: fd leak: open fd count grew by 64 across 64
        Enable calls (before=7 after=71); Enable opens a descriptor per call and
        never closes it
--- FAIL: TestEnableSafety_NoFDLeak (0.00s)
FAIL	github.com/containerd/containerd/v2/internal/fsverity	0.006s
```

Verified against base commit `561fcdbd8` (Linux/arm64 · go 1.26). With this PR applied, the same test **PASSes (0.00s, both normal and `-race`)**.

#### Test plan

| Test | Purpose | pre-fix | post-fix |
|------|---------|---------|----------|
| `TestEnableSafety_NoFDLeak` | Enable leaks no fd (flat open-fd count over 64 calls) | FAIL (+64) | PASS |
| `TestEnable` (existing) | Enable errors on non-verity fs / succeeds on verity fs | SKIP* | SKIP* |
| `TestIsEnabled` (existing) | IsEnabled contract | SKIP* | SKIP* |

*`TestEnable`/`TestIsEnabled` require root + a verity-capable ext4 and `SKIP` in the container (not a regression).

Regression:

```bash
$ go test ./internal/fsverity/... -count=1
ok   github.com/containerd/containerd/v2/internal/fsverity   (1 PASS / 2 SKIP / 0 FAIL)

$ go test ./internal/fsverity/ -race -count=1
ok   github.com/containerd/containerd/v2/internal/fsverity   (0 DATA RACE)
```

#### Backwards compatibility / API impact

**None**. `internal/fsverity` is an internal package; `Enable`'s signature, return values and ioctl semantics are unchanged — only its internal fd lifetime is corrected.

#### Documentation / comment changes

- No source comment changes. The new test file carries explanatory comments documenting the leak mechanism, the production call sites, and the deliberate choice not to force GC.

#### Risk & rollback

| Dimension | Assessment |
|-----------|------------|
| Change surface | 1 line (a `defer` within a single function) |
| Performance impact | one extra `close(2)` per `Enable`; identical to what `IsEnabled` already does — negligible |
| Data risk | none; read-only fd, no writes/persistence involved |
| Rollback | `git revert <sha>` |

#### Reviewer hints

1. `defer f.Close()` sits **after** the nil check (line 102) — `f` is nil when `os.Open` fails, so the close must not be registered earlier.
2. Confirm the single `defer` covers both the ioctl-error return (line 126) and the success return (line 129).
3. The reproduction takes the ioctl-error path (the container fs has no verity); the success path leaks the same fd and can be cross-checked on root + verity-ext4 via the existing `TestEnable`.

#### Linked issues / discussions

- Novel finding; no matching historical issue/PR located. `git blame internal/fsverity/fsverity_linux.go` pinpoints where `Enable` was introduced, confirming the omission.

#### Out of scope (kept separate to avoid PR collisions)

- P1-5 CNI config write swallows error + nil panic ([update_runtime_config.go:136](internal/cri/server/update_runtime_config.go#L136)) — follow-up PR.
- P1-1 Pod-metrics `return nil` → `continue` ([list_pod_sandbox_metrics_linux.go:112](internal/cri/server/list_pod_sandbox_metrics_linux.go#L112)) — follow-up PR.
- The caller's error-handling policy (writer.go only logs) — not in this PR.

#### Pre-flight checks (passing locally)

- [x] `gofmt -l` clean
- [x] `go vet ./internal/fsverity/` clean (linux container)
- [x] `GOOS=linux go build ./internal/fsverity/` succeeds
- [x] package `go test`, normal (1 PASS / 2 SKIP) + `-race` (0 races)
- [x] DCO sign-off applied at commit time (`git commit -s`)

#### Files changed

```
 internal/fsverity/fsverity_enable_safety_test.go | 92 ++++++++++++++++++++++++
 internal/fsverity/fsverity_linux.go              |  1 +
 2 files changed, 93 insertions(+)
```