### PR TITLE
cri: auto-add prefix for pause image

### DIFF
--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -43,6 +43,7 @@ import (
 	containerdio "github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/deprecation"
 	"github.com/containerd/errdefs"
+	dockerref "github.com/distribution/reference"
 )
 
 func init() {
@@ -78,10 +79,13 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 	)
 
 	sandboxImage := c.getSandboxImageName()
-
-	pauseImage, err := c.client.GetImage(ctx, sandboxImage)
+	normalized, err := dockerref.ParseDockerRef(sandboxImage)
 	if err != nil {
-		return cin, fmt.Errorf("failed to get sandbox image %q: %w", sandboxImage, err)
+		return cin, fmt.Errorf("failed to parse image reference %q: %w", sandboxImage, err)
+	}
+	pauseImage, err := c.client.GetImage(ctx, normalized.String())
+	if err != nil {
+		return cin, fmt.Errorf("failed to get sandbox image %q: %w", normalized.String(), err)
 	}
 
 	// Get the image spec from containerd image


### PR DESCRIPTION
fix if  sandbox_image doesn't have docker.io prefix cause run pod failed.

reproduce :


use config 
```
sandbox_image = "rancher/mirrored-pause:3.6"
```
image is exist 
```
crictl  images
IMAGE                              TAG                 IMAGE ID            SIZE
docker.io/library/busybox          1.28                8c811b4aec35f       1.36MB
docker.io/library/busybox          latest              fa152d3b2cb95       4.49MB
docker.io/rancher/mirrored-pause   3.6                 da86e6ba6ca19       746kB
```


```
crictl  run  --no-pull container.json  pod.json

E0602 15:14:34.707264 2211126 remote_runtime.go:237] "RunPodSandbox from runtime service failed" err="rpc error: code = NotFound desc = failed to start sandbox \"02146ec6af7ad70f5ae2599268b38af5273c52c11a0f4f4f321da2dc133478ed\": failed to get sandbox image \"rancher/mirrored-pause:3.6\": image \"rancher/mirrored-pause:3.6\": not found"
FATA[0000] running container: run pod sandbox: rpc error: code = NotFound desc = failed to start sandbox "02146ec6af7ad70f5ae2599268b38af5273c52c11a0f4f4f321da2dc133478ed": failed to get sandbox image "rancher/mirrored-pause:3.6": image "rancher/mirrored-pause:3.6": not found
```