### PR TITLE
Update to current setup-go version

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -10,7 +10,6 @@ runs:
   using: composite
   steps:
     - name: "Setup Go"
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ inputs.go-version }}
-        cache: false # see actions/setup-go#368


### PR DESCRIPTION
Update the setup-go version in our private action yml to:

1) be pinned by hash (with comment to version string)
2) remove cache disable that was fixed 3 years ago

Apparently dependabot doesn't reach into this directory, so we were close to the cutoff date for Node 20 based actions to start to fail intermittently (in a couple weeks)