### PR TITLE
cri: treat ErrNotFound from LocalResolve as non-checkpoint image in checkIfCheckpointOCIImage

### DIFF
--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -71,6 +71,11 @@ func (c *criService) checkIfCheckpointOCIImage(ctx context.Context, input string
 
 	image, err := c.LocalResolve(input)
 	if err != nil {
+		if errdefs.IsNotFound(err) {
+			// Image not yet in the CRI store (e.g. imported via the containerd
+			// client API rather than PullImage). Treat as a non-checkpoint image.
+			return "", nil
+		}
 		return "", fmt.Errorf("failed to resolve image %q: %w", input, err)
 	}
 	containerdImage, err := c.toContainerdImage(ctx, image)


### PR DESCRIPTION
## Problem

`checkIfCheckpointOCIImage` is called on every `CreateContainer` to detect whether the image is a CRIU checkpoint OCI image. Internally it calls `LocalResolve`, which queries the CRI in-memory store.

The CRI store is populated asynchronously via event handlers. When an image is imported through the containerd client API (rather than via `PullImage`), there is a window where the image exists in the metadata store but has not yet been registered in the CRI store.

During this window, `LocalResolve` returns `errdefs.ErrNotFound`. This was previously propagated as a hard error:

```
failed to check if this is a checkpoint image: failed to resolve image "sha256:...": not found
```

This blocks `CreateContainer` entirely, even though the image is not a checkpoint.

## Fix

Treat `ErrNotFound` from `LocalResolve` as a signal that the image is not a checkpoint image (return `("", nil)`), rather than as a hard error. This matches the function's semantics: it should return an empty string when the image is not a checkpoint, regardless of whether it exists in the CRI store.

Fixes #12980