### PR TITLE
Add PSI metrics

### DIFF
--- a/internal/cri/server/list_metric_descriptors.go
+++ b/internal/cri/server/list_metric_descriptors.go
@@ -29,6 +29,7 @@ const (
 	ProcessMetrics       = "process"
 	MiscellaneousMetrics = "misc"
 	ContainerSpecMetrics = "container_spec"
+	PressureMetrics      = "pressure"
 )
 
 var (
@@ -312,6 +313,40 @@ var (
 	containerSpecMemorySwapLimitBytes = &runtime.MetricDescriptor{
 		Name:      "container_spec_memory_swap_limit_bytes",
 		Help:      "Memory swap limit for the container",
+		LabelKeys: baseLabelKeys,
+	}
+)
+
+// Pressure metrics
+var (
+	containerPressureCPUStalledSecondsTotal = &runtime.MetricDescriptor{
+		Name:      "container_pressure_cpu_stalled_seconds_total",
+		Help:      "Total time duration no tasks in the container could make progress due to CPU congestion",
+		LabelKeys: baseLabelKeys,
+	}
+	containerPressureCPUWaitingSecondsTotal = &runtime.MetricDescriptor{
+		Name:      "container_pressure_cpu_waiting_seconds_total",
+		Help:      "Total time duration tasks in the container have waited due to CPU congestion",
+		LabelKeys: baseLabelKeys,
+	}
+	containerPressureMemoryStalledSecondsTotal = &runtime.MetricDescriptor{
+		Name:      "container_pressure_memory_stalled_seconds_total",
+		Help:      "Total time duration no tasks in the container could make progress due to memory congestion",
+		LabelKeys: baseLabelKeys,
+	}
+	containerPressureMemoryWaitingSecondsTotal = &runtime.MetricDescriptor{
+		Name:      "container_pressure_memory_waiting_seconds_total",
+		Help:      "Total time duration tasks in the container have waited due to memory congestion",
+		LabelKeys: baseLabelKeys,
+	}
+	containerPressureIOStalledSecondsTotal = &runtime.MetricDescriptor{
+		Name:      "container_pressure_io_stalled_seconds_total",
+		Help:      "Total time duration no tasks in the container could make progress due to IO congestion",
+		LabelKeys: baseLabelKeys,
+	}
+	containerPressureIOWaitingSecondsTotal = &runtime.MetricDescriptor{
+		Name:      "container_pressure_io_waiting_seconds_total",
+		Help:      "Total time duration tasks in the container have waited due to IO congestion",
 		LabelKeys: baseLabelKeys,
 	}
 )

--- a/internal/cri/server/list_metric_descriptors_linux.go
+++ b/internal/cri/server/list_metric_descriptors_linux.go
@@ -100,6 +100,14 @@ func (c *criService) getMetricDescriptors() map[string][]*runtime.MetricDescript
 			containerSpecMemoryReservationLimitBytes,
 			containerSpecMemorySwapLimitBytes,
 		},
+		PressureMetrics: {
+			containerPressureCPUStalledSecondsTotal,
+			containerPressureCPUWaitingSecondsTotal,
+			containerPressureMemoryStalledSecondsTotal,
+			containerPressureMemoryWaitingSecondsTotal,
+			containerPressureIOStalledSecondsTotal,
+			containerPressureIOWaitingSecondsTotal,
+		},
 	}
 	return descriptors
 }

--- a/internal/cri/server/list_pod_sandbox_metrics_linux.go
+++ b/internal/cri/server/list_pod_sandbox_metrics_linux.go
@@ -431,6 +431,16 @@ func (c *criService) extractCPUMetrics(stats cgroupMetrics, labels []string, tim
 					Value:       &runtime.UInt64Value{Value: s.CPU.ThrottledUsec * 1000 / uint64(time.Second)},
 				},
 			}...)
+
+			if s.CPU.PSI != nil {
+				metrics = append(metrics, extractPSIMetrics(
+					s.CPU.PSI,
+					containerPressureCPUStalledSecondsTotal,
+					containerPressureCPUWaitingSecondsTotal,
+					labels,
+					timestamp,
+				)...)
+			}
 		}
 	}
 
@@ -666,6 +676,15 @@ func (c *criService) extractMemoryMetrics(stats cgroupMetrics, labels []string, 
 				},
 			}...)
 
+			if s.Memory.PSI != nil {
+				metrics = append(metrics, extractPSIMetrics(
+					s.Memory.PSI,
+					containerPressureMemoryStalledSecondsTotal,
+					containerPressureMemoryWaitingSecondsTotal,
+					labels,
+					timestamp,
+				)...)
+			}
 		}
 
 		if s.MemoryEvents != nil {
@@ -787,10 +806,45 @@ func (c *criService) extractDiskIOMetrics(stats cgroupMetrics, labels []string, 
 				}...)
 
 			}
+
+			if s.Io.PSI != nil {
+				metrics = append(metrics, extractPSIMetrics(
+					s.Io.PSI,
+					containerPressureIOStalledSecondsTotal,
+					containerPressureIOWaitingSecondsTotal,
+					labels,
+					timestamp,
+				)...)
+			}
 		}
 	}
 
 	return metrics, nil
+}
+
+// extractPSIMetrics converts cgroupv2 PSI stats into cadvisor-compatible pressure metrics.
+// PSI Total is in microseconds, cadvisor returns seconds.
+func extractPSIMetrics(psi *cg2.PSIStats, stalledDesc, waitingDesc *runtime.MetricDescriptor, labels []string, timestamp int64) []*runtime.Metric {
+	var metrics []*runtime.Metric
+	if psi.Full != nil {
+		metrics = append(metrics, &runtime.Metric{
+			Name:        stalledDesc.Name,
+			Timestamp:   timestamp,
+			MetricType:  runtime.MetricType_COUNTER,
+			LabelValues: labels,
+			Value:       &runtime.UInt64Value{Value: psi.Full.Total * 1000 / uint64(time.Second)},
+		})
+	}
+	if psi.Some != nil {
+		metrics = append(metrics, &runtime.Metric{
+			Name:        waitingDesc.Name,
+			Timestamp:   timestamp,
+			MetricType:  runtime.MetricType_COUNTER,
+			LabelValues: labels,
+			Value:       &runtime.UInt64Value{Value: psi.Some.Total * 1000 / uint64(time.Second)},
+		})
+	}
+	return metrics
 }
 
 func (c *criService) extractProcessMetrics(ctx context.Context, task containerd.Task, stats cgroupMetrics, labels []string, timestamp int64) ([]*runtime.Metric, error) {

--- a/internal/cri/server/list_pod_sandbox_metrics_linux_test.go
+++ b/internal/cri/server/list_pod_sandbox_metrics_linux_test.go
@@ -1,0 +1,174 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
+	"github.com/stretchr/testify/assert"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestExtractCPUPressureMetrics(t *testing.T) {
+	c := newTestCRIService()
+	labels := []string{"pod", "ns", "ctr", "id", "img"}
+	var timestamp int64 = 1000
+
+	stats := cgroupMetrics{v2: &v2.Metrics{
+		CPU: &v2.CPUStat{
+			PSI: &v2.PSIStats{
+				Full: &v2.PSIData{Total: 2000000},
+				Some: &v2.PSIData{Total: 5000000},
+			},
+		},
+	}}
+
+	metrics, err := c.extractCPUMetrics(stats, labels, timestamp)
+	assert.NoError(t, err)
+
+	stalledMetric := findMetricByName(metrics, "container_pressure_cpu_stalled_seconds_total")
+	assert.NotNil(t, stalledMetric, "expected container_pressure_cpu_stalled_seconds_total metric")
+	assert.Equal(t, uint64(2), stalledMetric.Value.GetValue())
+	assert.Equal(t, labels, stalledMetric.LabelValues)
+
+	waitingMetric := findMetricByName(metrics, "container_pressure_cpu_waiting_seconds_total")
+	assert.NotNil(t, waitingMetric, "expected container_pressure_cpu_waiting_seconds_total metric")
+	assert.Equal(t, uint64(5), waitingMetric.Value.GetValue())
+	assert.Equal(t, labels, waitingMetric.LabelValues)
+}
+
+func TestExtractMemoryPressureMetrics(t *testing.T) {
+	c := newTestCRIService()
+	labels := []string{"pod", "ns", "ctr", "id", "img"}
+	var timestamp int64 = 1000
+
+	stats := cgroupMetrics{v2: &v2.Metrics{
+		Memory: &v2.MemoryStat{
+			PSI: &v2.PSIStats{
+				Full: &v2.PSIData{Total: 1000000},
+				Some: &v2.PSIData{Total: 3000000},
+			},
+		},
+	}}
+
+	metrics, err := c.extractMemoryMetrics(stats, labels, timestamp)
+	assert.NoError(t, err)
+
+	stalledMetric := findMetricByName(metrics, "container_pressure_memory_stalled_seconds_total")
+	assert.NotNil(t, stalledMetric, "expected container_pressure_memory_stalled_seconds_total metric")
+	assert.Equal(t, uint64(1), stalledMetric.Value.GetValue())
+	assert.Equal(t, labels, stalledMetric.LabelValues)
+
+	waitingMetric := findMetricByName(metrics, "container_pressure_memory_waiting_seconds_total")
+	assert.NotNil(t, waitingMetric, "expected container_pressure_memory_waiting_seconds_total metric")
+	assert.Equal(t, uint64(3), waitingMetric.Value.GetValue())
+	assert.Equal(t, labels, waitingMetric.LabelValues)
+}
+
+func TestExtractIOPressureMetrics(t *testing.T) {
+	c := newTestCRIService()
+	labels := []string{"pod", "ns", "ctr", "id", "img"}
+	var timestamp int64 = 1000
+
+	stats := cgroupMetrics{v2: &v2.Metrics{
+		Io: &v2.IOStat{
+			PSI: &v2.PSIStats{
+				Full: &v2.PSIData{Total: 4000000},
+				Some: &v2.PSIData{Total: 7000000},
+			},
+		},
+	}}
+
+	metrics, err := c.extractDiskIOMetrics(stats, labels, timestamp)
+	assert.NoError(t, err)
+
+	stalledMetric := findMetricByName(metrics, "container_pressure_io_stalled_seconds_total")
+	assert.NotNil(t, stalledMetric, "expected container_pressure_io_stalled_seconds_total metric")
+	assert.Equal(t, uint64(4), stalledMetric.Value.GetValue())
+	assert.Equal(t, labels, stalledMetric.LabelValues)
+
+	waitingMetric := findMetricByName(metrics, "container_pressure_io_waiting_seconds_total")
+	assert.NotNil(t, waitingMetric, "expected container_pressure_io_waiting_seconds_total metric")
+	assert.Equal(t, uint64(7), waitingMetric.Value.GetValue())
+	assert.Equal(t, labels, waitingMetric.LabelValues)
+}
+
+func TestNoPressureMetricsWithNilPSI(t *testing.T) {
+	c := newTestCRIService()
+	labels := []string{"pod", "ns", "ctr", "id", "img"}
+	var timestamp int64 = 1000
+
+	stats := cgroupMetrics{v2: &v2.Metrics{
+		CPU:    &v2.CPUStat{},
+		Memory: &v2.MemoryStat{},
+		Io:     &v2.IOStat{},
+	}}
+
+	cpuMetrics, err := c.extractCPUMetrics(stats, labels, timestamp)
+	assert.NoError(t, err)
+	assert.Nil(t, findMetricByName(cpuMetrics, "container_pressure_cpu_stalled_seconds_total"))
+	assert.Nil(t, findMetricByName(cpuMetrics, "container_pressure_cpu_waiting_seconds_total"))
+
+	memMetrics, err := c.extractMemoryMetrics(stats, labels, timestamp)
+	assert.NoError(t, err)
+	assert.Nil(t, findMetricByName(memMetrics, "container_pressure_memory_stalled_seconds_total"))
+	assert.Nil(t, findMetricByName(memMetrics, "container_pressure_memory_waiting_seconds_total"))
+
+	ioMetrics, err := c.extractDiskIOMetrics(stats, labels, timestamp)
+	assert.NoError(t, err)
+	assert.Nil(t, findMetricByName(ioMetrics, "container_pressure_io_stalled_seconds_total"))
+	assert.Nil(t, findMetricByName(ioMetrics, "container_pressure_io_waiting_seconds_total"))
+}
+
+func TestPressureMetricDescriptorsRegistered(t *testing.T) {
+	c := newTestCRIService()
+	descriptors := c.getMetricDescriptors()
+
+	pressureDescs, ok := descriptors[PressureMetrics]
+	assert.True(t, ok, "PressureMetrics key should exist in metric descriptors")
+	assert.Len(t, pressureDescs, 6)
+
+	expectedNames := []string{
+		"container_pressure_cpu_stalled_seconds_total",
+		"container_pressure_cpu_waiting_seconds_total",
+		"container_pressure_memory_stalled_seconds_total",
+		"container_pressure_memory_waiting_seconds_total",
+		"container_pressure_io_stalled_seconds_total",
+		"container_pressure_io_waiting_seconds_total",
+	}
+
+	for _, name := range expectedNames {
+		found := false
+		for _, desc := range pressureDescs {
+			if desc.Name == name {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected descriptor %q to be registered", name)
+	}
+}
+
+func findMetricByName(metrics []*runtime.Metric, name string) *runtime.Metric {
+	for _, m := range metrics {
+		if m.Name == name {
+			return m
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
In Kubernetes, PSI metrics were historically implemented by cAdvisor. Now that we are moving away from it, the container-runtime became responsible for exposing these metrics.

The new metrics are:
- container_pressure_cpu_stalled_seconds_total
- container_pressure_cpu_waiting_seconds_total
- container_pressure_memory_stalled_seconds_total
- container_pressure_memory_waiting_seconds_total
- container_pressure_io_stalled_seconds_total
- container_pressure_io_waiting_seconds_total

Conformance is going to be validated by https://github.com/kubernetes-sigs/cri-tools/pull/2017 across containerd and cri-o.

Related to https://github.com/containerd/containerd/issues/13532