### PR TITLE
cri: resolve tag+digest sandbox image refs via digest-only fallback

### DIFF
--- a/internal/cri/server/images/service.go
+++ b/internal/cri/server/images/service.go
@@ -170,10 +170,21 @@ func (c *CRIImageService) LocalResolve(refOrID string) (imagestore.Image, error)
 				return ""
 			}
 			id, err := c.imageStore.Resolve(normalized.String())
-			if err != nil {
-				return ""
+			if err == nil {
+				return id
 			}
-			return id
+			// For tag+digest refs (name:tag@digest), also try the digest-only
+			// canonical form. containerd stores images by their digest-only name
+			// when pulled with a tag+digest reference (the tag is dropped).
+			if _, isTagged := normalized.(docker.Tagged); isTagged {
+				if digested, isDigested := normalized.(docker.Digested); isDigested {
+					digestOnly := normalized.(docker.Named).Name() + "@" + digested.Digest().String()
+					if id, err = c.imageStore.Resolve(digestOnly); err == nil {
+						return id
+					}
+				}
+			}
+			return ""
 		}(refOrID)
 	}
 

--- a/internal/cri/server/images/service.go
+++ b/internal/cri/server/images/service.go
@@ -178,7 +178,7 @@ func (c *CRIImageService) LocalResolve(refOrID string) (imagestore.Image, error)
 			// when pulled with a tag+digest reference (the tag is dropped).
 			if _, isTagged := normalized.(docker.Tagged); isTagged {
 				if digested, isDigested := normalized.(docker.Digested); isDigested {
-					digestOnly := normalized.(docker.Named).Name() + "@" + digested.Digest().String()
+					digestOnly := normalized.Name() + "@" + digested.Digest().String()
 					if id, err = c.imageStore.Resolve(digestOnly); err == nil {
 						return id
 					}

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -361,7 +361,7 @@ func normalizeImageRef(ref string) string {
 	}
 	if _, isTagged := normalized.(docker.Tagged); isTagged {
 		if digested, isDigested := normalized.(docker.Digested); isDigested {
-			return normalized.(docker.Named).Name() + "@" + digested.Digest().String()
+			return normalized.Name() + "@" + digested.Digest().String()
 		}
 	}
 	return normalized.String()

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -29,6 +29,7 @@ import (
 	v1 "github.com/containerd/nri/types/v1"
 	"github.com/containerd/typeurl/v2"
 	"github.com/davecgh/go-spew/spew"
+	docker "github.com/distribution/reference"
 	"github.com/opencontainers/selinux/go-selinux"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -343,8 +344,25 @@ func (c *Controller) getSandboxImageName() string {
 	// returns the name of the sandbox image used to scope pod shared resources used by the pod's containers,
 	// if empty return the default sandbox image.
 	if image, ok := c.imageConfig.PinnedImages["sandbox"]; ok && image != "" {
-		return image
+		return normalizeImageRef(image)
 	}
 
 	return criconfig.DefaultSandboxImage
+}
+
+// normalizeImageRef converts a tag+digest reference (name:tag@digest) to its
+// canonical digest-only form (name@digest). containerd stores images by their
+// digest-only name when they are pulled with a tag+digest reference (tag is
+// dropped), so using the canonical form avoids "image not found" errors.
+func normalizeImageRef(ref string) string {
+	normalized, err := docker.ParseDockerRef(ref)
+	if err != nil {
+		return ref
+	}
+	if _, isTagged := normalized.(docker.Tagged); isTagged {
+		if digested, isDigested := normalized.(docker.Digested); isDigested {
+			return normalized.(docker.Named).Name() + "@" + digested.Digest().String()
+		}
+	}
+	return normalized.String()
 }


### PR DESCRIPTION
## Problem

When `sandbox_image` (or `pinned_images.sandbox`) is configured with a tag+digest
reference like `registry.k8s.io/pause:3.10.1@sha256:278fb9...`, `RunPodSandbox`
fails with `image not found` on containerd 2.3.x (regression from 2.2.x).

**Root cause**: containerd stores images by their canonical **digest-only** name when
pulled with a tag+digest reference (the tag is stripped). Both `LocalResolve` (in
`ensurePauseImageExists`) and `c.client.GetImage` (in `podsandbox.Start`) then fail
because they look up the full `tag@digest` string, which does not match the stored
`digest-only` name.

Example: image pulled as `pause:3.10.1@sha256:abc` is stored as `pause@sha256:abc`,
but the lookup uses `pause:3.10.1@sha256:abc` — a mismatch.

## Fix

Two targeted changes:

**1. `LocalResolve` (`internal/cri/server/images/service.go`)**

After the primary lookup by `normalized.String()` fails, if the reference has both a
tag and a digest, retry with the digest-only canonical form (`name@digest`). This
prevents unnecessary re-pulls on every `RunPodSandbox` call when the image already
exists locally under its canonical name.

**2. `getSandboxImageName` (`internal/cri/server/podsandbox/sandbox_run.go`)**

Normalise the configured sandbox image ref: convert `name:tag@digest` to `name@digest`
before returning. This makes `c.client.GetImage(ctx, sandboxImage)` in `Start()` look
up the image under the name it was actually stored with.

## Testing

Reproducer from issue #13529:
```
containerd -c config.toml &
# config has: sandbox = "registry.k8s.io/pause:3.10.1@sha256:278fb9..."
crictl runp pod.json  # previously: NotFound; after fix: succeeds
```

Fixes #13529