### PR TITLE
fix(shim): prevent exit event loss from SIGCHLD coalescing

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/init.go
+++ b/cmd/containerd-shim-runc-v2/process/init.go
@@ -41,6 +41,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// unknownExitStatus is used when the process exit status cannot be determined,
+// for example when the exit event was lost due to SIGCHLD coalescing.
+const unknownExitStatus = 255
+
 // Init represents an initial process for a container
 type Init struct {
 	wg        sync.WaitGroup
@@ -52,7 +56,8 @@ type Init struct {
 	// the reaper interface.
 	mu sync.Mutex
 
-	waitBlock chan struct{}
+	waitBlock         chan struct{}
+	liveCheckInterval time.Duration // interval for process liveness fallback check; 0 uses default (30s)
 
 	WorkDir string
 
@@ -215,11 +220,28 @@ func (p *Init) createCheckpointedState(r *CreateConfig, pidFile *pidFile) error 
 
 // Wait for the process to exit
 func (p *Init) Wait(ctx context.Context) error {
-	select {
-	case <-p.waitBlock:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	interval := p.liveCheckInterval
+	if interval == 0 {
+		interval = 30 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.waitBlock:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			// Fallback liveness check: if the process no longer exists but
+			// the exit event was lost (e.g. due to SIGCHLD coalescing),
+			// force the exit to unblock waiters.
+			if err := unix.Kill(p.pid, 0); err == unix.ESRCH {
+				log.L.Warnf("process %d no longer exists but exit event was not received, forcing exit", p.pid)
+				p.SetExited(unknownExitStatus)
+				return nil
+			}
+		}
 	}
 }
 

--- a/cmd/containerd-shim-runc-v2/process/init_wait_test.go
+++ b/cmd/containerd-shim-runc-v2/process/init_wait_test.go
@@ -1,0 +1,119 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestInitWaitLivenessCheck verifies that Init.Wait() detects a dead process
+// via kill(pid, 0) and forces exit even if the exit event was never received.
+// This is the fallback mechanism for containerd/containerd#12678.
+func TestInitWaitLivenessCheck(t *testing.T) {
+	// Use a very large PID that is overwhelmingly unlikely to exist.
+	// Skip the test if it unexpectedly does.
+	const deadPID = 4194305
+
+	// Verify the PID does not exist before proceeding.
+	if err := unix.Kill(deadPID, 0); err != unix.ESRCH {
+		t.Skipf("pid %d unexpectedly exists or kill returned %v", deadPID, err)
+	}
+
+	// Create a minimal Init with the dead PID and an open waitBlock.
+	p := &Init{
+		pid:               deadPID,
+		waitBlock:         make(chan struct{}),
+		initState:         &stoppedState{}, // SetExited on stoppedState is a no-op
+		liveCheckInterval: 500 * time.Millisecond,
+	}
+
+	// Wait should detect the dead process and return within the check interval.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Wait(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Wait() returned error: %v", err)
+		}
+		// Success: Wait detected dead process and returned.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait() did not return within expected time; liveness check failed")
+	}
+}
+
+// TestInitWaitNormalExit verifies that Init.Wait() returns immediately when
+// waitBlock is closed (normal exit path), without waiting for the ticker.
+func TestInitWaitNormalExit(t *testing.T) {
+	p := &Init{
+		pid:       1, // PID 1 always exists, but shouldn't matter
+		waitBlock: make(chan struct{}),
+		initState: &stoppedState{},
+	}
+
+	// Simulate normal exit: close waitBlock.
+	close(p.waitBlock)
+
+	ctx := context.Background()
+	start := time.Now()
+	if err := p.Wait(ctx); err != nil {
+		t.Fatalf("Wait() returned error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Fatalf("Wait() took too long (%v); should return immediately on closed waitBlock", elapsed)
+	}
+}
+
+// TestInitWaitContextCancel verifies that Init.Wait() respects context cancellation.
+func TestInitWaitContextCancel(t *testing.T) {
+	p := &Init{
+		pid:       1,
+		waitBlock: make(chan struct{}), // never closed
+		initState: &stoppedState{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Wait(ctx)
+	}()
+
+	// Cancel context after a short delay.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait() did not return after context cancellation")
+	}
+}

--- a/pkg/sys/reaper/reaper_unix.go
+++ b/pkg/sys/reaper/reaper_unix.go
@@ -65,6 +65,10 @@ func (s *subscriber) do(fn func()) {
 func Reap() error {
 	now := time.Now()
 	exits, err := reap(false)
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
 	for _, e := range exits {
 		done := Default.notify(runc.Exit{
 			Timestamp: now,
@@ -72,10 +76,42 @@ func Reap() error {
 			Status:    e.Status,
 		})
 
+		timer.Reset(1 * time.Second)
 		select {
 		case <-done:
-		case <-time.After(1 * time.Second):
+			if !timer.Stop() {
+				<-timer.C
+			}
+		case <-timer.C:
 		}
+	}
+	// Perform a second reap scan to catch any processes that exited while
+	// we were processing the first batch. This handles the case where
+	// SIGCHLD signals are coalesced by the kernel during the notify loop
+	// above, causing subsequent exits to be missed.
+	if extra, err2 := reap(false); len(extra) > 0 {
+		now = time.Now()
+		for _, e := range extra {
+			done := Default.notify(runc.Exit{
+				Timestamp: now,
+				Pid:       e.Pid,
+				Status:    e.Status,
+			})
+
+			timer.Reset(1 * time.Second)
+			select {
+			case <-done:
+				if !timer.Stop() {
+					<-timer.C
+				}
+			case <-timer.C:
+			}
+		}
+		if err == nil {
+			err = err2
+		}
+	} else if err == nil {
+		err = err2
 	}
 	return err
 }

--- a/pkg/sys/reaper/reaper_unix_test.go
+++ b/pkg/sys/reaper/reaper_unix_test.go
@@ -1,0 +1,208 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package reaper
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	runc "github.com/containerd/go-runc"
+	"golang.org/x/sys/unix"
+)
+
+// TestHelperProcess is a helper process used by tests to avoid depending on
+// external binaries like "true" or "sleep". It is not a test itself.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER_PROCESS") != "1" {
+		return
+	}
+	// If SLEEP is set, sleep for that duration before exiting.
+	if d := os.Getenv("GO_TEST_HELPER_SLEEP"); d != "" {
+		dur, _ := time.ParseDuration(d)
+		time.Sleep(dur)
+	}
+	os.Exit(0)
+}
+
+// helperCmd returns an exec.Cmd that runs the test binary as a helper process.
+// The helper exits immediately unless sleep duration is specified.
+func helperCmd(t *testing.T, sleep ...time.Duration) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperProcess$")
+	cmd.Env = append(os.Environ(), "GO_TEST_HELPER_PROCESS=1")
+	if len(sleep) > 0 {
+		cmd.Env = append(cmd.Env, "GO_TEST_HELPER_SLEEP="+sleep[0].String())
+	}
+	return cmd
+}
+
+// TestReapSecondScanCatchesLateExits verifies that Reap() performs a second
+// wait4 scan to catch processes that exit during the notify phase, addressing
+// the SIGCHLD coalescing race condition described in containerd/containerd#12678.
+func TestReapSecondScanCatchesLateExits(t *testing.T) {
+	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0); err != nil {
+		t.Skipf("cannot set subreaper: %v", err)
+	}
+	defer unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 0, 0, 0, 0)
+
+	ch := Default.Subscribe()
+	defer Default.Unsubscribe(ch)
+
+	// Start two processes without calling cmd.Wait() — let Reap() collect them.
+	cmd1 := helperCmd(t)
+	if err := cmd1.Start(); err != nil {
+		t.Fatalf("failed to start process 1: %v", err)
+	}
+	pid1 := cmd1.Process.Pid
+
+	cmd2 := helperCmd(t)
+	if err := cmd2.Start(); err != nil {
+		t.Fatalf("failed to start process 2: %v", err)
+	}
+	pid2 := cmd2.Process.Pid
+
+	// Give processes time to exit.
+	time.Sleep(200 * time.Millisecond)
+
+	// Call Reap() — should collect both exits.
+	if err := Reap(); err != nil {
+		t.Fatalf("Reap() failed: %v", err)
+	}
+
+	// Collect exit events.
+	received := make(map[int]bool)
+	deadline := time.After(5 * time.Second)
+	for len(received) < 2 {
+		select {
+		case e := <-ch:
+			if e.Pid == pid1 || e.Pid == pid2 {
+				received[e.Pid] = true
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for exit events: got pids %v, want %d and %d", received, pid1, pid2)
+		}
+	}
+}
+
+// TestReapSecondScanNoFalsePositives verifies that the second scan does not
+// produce spurious exit events when no additional processes have exited.
+func TestReapSecondScanNoFalsePositives(t *testing.T) {
+	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0); err != nil {
+		t.Skipf("cannot set subreaper: %v", err)
+	}
+	defer unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 0, 0, 0, 0)
+
+	ch := Default.Subscribe()
+	defer Default.Unsubscribe(ch)
+
+	// Start a single process.
+	cmd := helperCmd(t)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start process: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	// Give time to exit.
+	time.Sleep(200 * time.Millisecond)
+
+	if err := Reap(); err != nil {
+		t.Fatalf("Reap() failed: %v", err)
+	}
+
+	// Should get exactly one exit event for our pid.
+	received := 0
+	timeout := time.After(2 * time.Second)
+loop:
+	for {
+		select {
+		case e := <-ch:
+			if e.Pid == pid {
+				received++
+			}
+		case <-timeout:
+			break loop
+		}
+	}
+	if received != 1 {
+		t.Fatalf("expected 1 exit event for pid %d, got %d", pid, received)
+	}
+}
+
+// TestReapWithDelayedExit starts a process that exits after an initial Reap()
+// call and verifies that a subsequent Reap() catches it via the second scan.
+func TestReapWithDelayedExit(t *testing.T) {
+	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0); err != nil {
+		t.Skipf("cannot set subreaper: %v", err)
+	}
+	defer unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 0, 0, 0, 0)
+
+	ch := Default.Subscribe()
+	defer Default.Unsubscribe(ch)
+
+	// Start a process that sleeps briefly — will exit after first Reap scan.
+	cmd := helperCmd(t, 100*time.Millisecond)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start process: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	// First Reap — process hasn't exited yet, first scan gets nothing.
+	if err := Reap(); err != nil {
+		t.Fatalf("first Reap() failed: %v", err)
+	}
+
+	// Wait for process to exit.
+	time.Sleep(300 * time.Millisecond)
+
+	// Second Reap — the second scan inside should catch it.
+	if err := Reap(); err != nil {
+		t.Fatalf("Reap() failed: %v", err)
+	}
+
+	// Verify we got the exit event.
+	found := false
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case e := <-ch:
+			if e.Pid == pid {
+				found = true
+				goto done
+			}
+		case <-deadline:
+			goto done
+		}
+	}
+done:
+	if !found {
+		t.Fatalf("exit event for pid %d was not received", pid)
+	}
+}
+
+func drainChannel(ch chan runc.Exit) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Containers can get permanently stuck in `CONTAINER_RUNNING` state after the process exits, requiring a containerd restart to recover. kubelet enters an infinite `StopContainer` loop with `DeadlineExceeded` errors, leaving pods in `Terminating` state indefinitely.

Fixes #12678

## Root Cause

When `Reap()` processes exit notifications (with 1s timeout per event), SIGCHLD signals for new exits can be coalesced by the kernel. The `wait4(WNOHANG)` loop only runs once at the beginning of `Reap()`, so processes that exit during the notify phase are never reaped. This means:

1. `processExits()` never receives the exit event
2. `Init.SetExited()` is never called, `waitBlock` is never closed
3. `Init.Wait()` blocks forever
4. CRI plugin never updates container state to EXITED

The 1s timeout was introduced in 2019 (commit `2763639`) to prevent a deadlock between `Reap()` and `Wait()`. Buffer was reduced from 2048 to 32 in the same period (`21174cb`), increasing the likelihood of notify retries and thus the SIGCHLD coalescing window.

## Fix

Two complementary mechanisms:

**1. Second reap scan** (`pkg/sys/reaper/reaper_unix.go`)

After the notify loop completes, perform a second `reap(false)` call to catch any processes that exited during the window. This is a non-blocking `wait4(WNOHANG)` — zero cost when no exits are pending.

**2. Process liveness fallback** (`cmd/containerd-shim-runc-v2/process/init.go`)

`Init.Wait()` now periodically checks if the process still exists via `kill(pid, 0)`. If the process is gone but `waitBlock` was never closed (exit event lost), it forces `SetExited(255)` to unblock waiters. Default interval is 30s; configurable for testing.

## How to Reproduce

### Method 1: Fault injection (100% reliable)

Add `time.Sleep(2 * time.Second)` after `reap(false)` in `Reap()`, then:

```bash
crictl runp sandbox.json
CTR=$(crictl create $POD container.json sandbox.json)
crictl start $CTR
# Kill the container process externally during the sleep window
kill -9 $(crictl inspect $CTR | jq .info.pid)
# After 5s, check state — will be stuck as RUNNING without the fix
crictl inspect $CTR | jq .status.state
```

### Method 2: Channel buffer pressure

```bash
CTR=$(crictl create $POD container.json sandbox.json)
crictl start $CTR
# Fill subscriber channel buffer (>32 concurrent exits)
for i in $(seq 1 50); do
    crictl exec -d $CTR sh -c "sleep 0.5" &
done
sleep 0.4
crictl stop --timeout 1 $CTR
# Check for state inconsistency
sleep 5 && crictl inspect $CTR | jq .status.state
```

## Testing

6 new unit tests added:

**Reaper tests** (`pkg/sys/reaper/reaper_unix_test.go`):
- `TestReapSecondScanCatchesLateExits` — multiple exits are all captured
- `TestReapSecondScanNoFalsePositives` — no duplicate events
- `TestReapWithDelayedExit` — delayed exit caught by subsequent Reap

**Init.Wait tests** (`cmd/containerd-shim-runc-v2/process/init_wait_test.go`):
- `TestInitWaitLivenessCheck` — dead process detected and forced exit
- `TestInitWaitNormalExit` — normal path unaffected
- `TestInitWaitContextCancel` — context cancellation respected

```bash
go test -v ./pkg/sys/reaper/ -run TestReap
go test -v ./cmd/containerd-shim-runc-v2/process/ -run TestInitWait
```

All tests pass. Full build verified (`go build ./cmd/containerd/ ./cmd/containerd-shim-runc-v2/`).