### PR TITLE
fix(oci): skip pids limit in spec when value is 0

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1614,9 +1614,17 @@ func WithMemorySwap(swap int64) SpecOpts {
 }
 
 // WithPidsLimit sets the container's pid limit or maximum. It is a no-op on non-Linux specs.
+// A limit of 0 means "no limit" and will clear any existing pids constraint from the spec,
+// which is the expected behavior for runc >= 1.4 (where 0 is rejected as invalid).
 func WithPidsLimit(limit int64) SpecOpts {
 	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
 		if s.Linux == nil {
+			return nil
+		}
+		if limit == 0 {
+			if s.Linux.Resources != nil {
+				s.Linux.Resources.Pids = nil
+			}
 			return nil
 		}
 		setResources(s)

--- a/pkg/oci/spec_opts_test.go
+++ b/pkg/oci/spec_opts_test.go
@@ -392,6 +392,38 @@ func TestWithPidsLimit(t *testing.T) {
 	}
 }
 
+// TestWithPidsLimitZero verifies that WithPidsLimit(0) does not set the Pids
+// field in the spec. runc >= 1.4 rejects limit=0 as invalid, so "no limit"
+// must be represented by omitting the field entirely.
+func TestWithPidsLimitZero(t *testing.T) {
+	t.Run("fresh spec without resources", func(t *testing.T) {
+		spec := Spec{Linux: &specs.Linux{}}
+		err := WithPidsLimit(0)(nil, nil, nil, &spec)
+		assert.NoError(t, err)
+		if spec.Linux.Resources != nil {
+			assert.Nil(t, spec.Linux.Resources.Pids, "pids should not be set when limit is 0")
+		}
+	})
+
+	t.Run("clears pre-existing pids limit", func(t *testing.T) {
+		existing := int64(512)
+		spec := Spec{Linux: &specs.Linux{
+			Resources: &specs.LinuxResources{
+				Pids: &specs.LinuxPids{Limit: &existing},
+			},
+		}}
+		err := WithPidsLimit(0)(nil, nil, nil, &spec)
+		assert.NoError(t, err)
+		assert.Nil(t, spec.Linux.Resources.Pids, "pids should be cleared when limit is 0")
+	})
+
+	t.Run("non-linux spec is no-op", func(t *testing.T) {
+		spec := Spec{}
+		err := WithPidsLimit(0)(nil, nil, nil, &spec)
+		assert.NoError(t, err)
+	})
+}
+
 func TestWithBlockIO(t *testing.T) {
 	for name, spec := range emptySpecs {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

runc >= 1.4.0 has a [breaking change](https://github.com/opencontainers/runc/releases/tag/v1.4.0) that rejects `pids.limit = 0` in the OCI bundle spec. Previously this meant "no limit", but now it returns an error.

`WithPidsLimit(0)` in containerd would generate `"limit": 0` in the spec JSON, which triggers this runc error.

Fixes #12607

## Root Cause

`WithPidsLimit` unconditionally sets `Pids.Limit = &limit` regardless of whether the value is 0. When serialized to JSON, this produces `{"pids": {"limit": 0}}` which runc 1.4 rejects.

## Fix

When `limit == 0`, `WithPidsLimit` now returns early without modifying the spec. This means "no limit" is represented by omitting the `pids` field entirely (which is correct OCI spec semantics).

Note: The CRI plugin path (`internal/cri/opts/spec_linux_opts.go` `WithResources`) does not set pids at all — it is only the public `WithPidsLimit` API that had this issue.

## Testing

```bash
go test -v ./pkg/oci/ -run TestWithPidsLimit
```

- `TestWithPidsLimit` — existing test, validates non-zero limit works
- `TestWithPidsLimitZero` — new test, validates limit=0 does not set pids in spec