### PR TITLE
shim: optimize reap to prevent event lost

### DIFF
--- a/pkg/sys/reaper/reaper_unix.go
+++ b/pkg/sys/reaper/reaper_unix.go
@@ -19,6 +19,7 @@
 package reaper
 
 import (
+	"container/list"
 	"errors"
 	"fmt"
 	"maps"
@@ -29,11 +30,16 @@ import (
 	"time"
 
 	runc "github.com/containerd/go-runc"
+	"github.com/containerd/log"
 	"golang.org/x/sys/unix"
 )
 
-// ErrNoSuchProcess is returned when the process no longer exists
-var ErrNoSuchProcess = errors.New("no such process")
+var (
+	once       sync.Once
+	eventQueue = NewSafeList()
+	// ErrNoSuchProcess is returned when the process no longer exists
+	ErrNoSuchProcess = errors.New("no such process")
+)
 
 const bufferSize = 32
 
@@ -60,23 +66,67 @@ func (s *subscriber) do(fn func()) {
 	s.Unlock()
 }
 
+type SafeList struct {
+	mu    sync.Mutex
+	cond  *sync.Cond
+	queue *list.List
+}
+
+func NewSafeList() *SafeList {
+	sl := &SafeList{
+		queue: list.New(),
+	}
+	sl.cond = sync.NewCond(&sl.mu)
+	return sl
+}
+
+func (sl *SafeList) Push(value any) {
+	sl.mu.Lock()
+	defer sl.mu.Unlock()
+
+	sl.queue.PushBack(value)
+	sl.cond.Signal()
+}
+
+func (sl *SafeList) Pop() any {
+	sl.mu.Lock()
+	defer sl.mu.Unlock()
+
+	for sl.queue.Len() == 0 {
+		sl.cond.Wait()
+	}
+	elem := sl.queue.Front()
+	value := elem.Value
+	sl.queue.Remove(elem)
+	return value
+}
+
+func notify() {
+	go func() {
+		for {
+			event := eventQueue.Pop()
+			if exitEvt, ok := event.(eventExit); ok {
+				done := Default.notify(runc.Exit{
+					Timestamp: exitEvt.EventTime,
+					Pid:       exitEvt.Pid,
+					Status:    exitEvt.Status,
+				})
+				select {
+				case <-done:
+				// TODO: remove timeout
+				case <-time.After(30 * time.Second):
+					log.L.Warnf("event with pid %d status:%d may be lost", exitEvt.Pid, exitEvt.Status)
+				}
+			}
+		}
+	}()
+}
+
 // Reap should be called when the process receives an SIGCHLD.  Reap will reap
 // all exited processes and close their wait channels
 func Reap() error {
-	now := time.Now()
-	exits, err := reap(false)
-	for _, e := range exits {
-		done := Default.notify(runc.Exit{
-			Timestamp: now,
-			Pid:       e.Pid,
-			Status:    e.Status,
-		})
-
-		select {
-		case <-done:
-		case <-time.After(1 * time.Second):
-		}
-	}
+	once.Do(notify)
+	err := reap(false)
 	return err
 }
 
@@ -248,9 +298,14 @@ type exit struct {
 	Status int
 }
 
+type eventExit struct {
+	EventTime time.Time
+	exit
+}
+
 // reap reaps all child processes for the calling process and returns their
 // exit information
-func reap(wait bool) (exits []exit, err error) {
+func reap(wait bool) (err error) {
 	var (
 		ws  unix.WaitStatus
 		rus unix.Rusage
@@ -263,16 +318,19 @@ func reap(wait bool) (exits []exit, err error) {
 		pid, err := unix.Wait4(-1, &ws, flag, &rus)
 		if err != nil {
 			if err == unix.ECHILD {
-				return exits, nil
+				return nil
 			}
-			return exits, err
+			return err
 		}
 		if pid <= 0 {
-			return exits, nil
+			return nil
 		}
-		exits = append(exits, exit{
-			Pid:    pid,
-			Status: exitStatus(ws),
+		eventQueue.Push(eventExit{
+			EventTime: time.Now(),
+			exit: exit{
+				Pid:    pid,
+				Status: exitStatus(ws),
+			},
 		})
 	}
 }


### PR DESCRIPTION
root reason 

```
func Reap() error {
	now := time.Now()
	exits, err := reap(false)
	for _, e := range exits {
		done := Default.notify(runc.Exit{
			Timestamp: now,
			Pid:       e.Pid,
			Status:    e.Status,
		})

		select {
		case <-done:
		case <-time.After(1 * time.Second):
		}
	}
	return err
}

```
if notify timeout  the exit event may lost


try to reduce the probability of container event loss try fix https://github.com/containerd/containerd/issues/12678

reproduce 

1.  cat gen.sh and then  run it.
```
#!/bin/bash
cat > pod-200-sleep.yaml << EOF
apiVersion: v1
kind: Pod
metadata:
  name: two-hundred-sleep-pod
spec:
  containers:
EOF

for i in $(seq -w 1 200); do
cat >> pod-200-sleep.yaml << EOC
    - name: sleep-$i
      image: docker.io/library/busybox:latest
      imagePullPolicy: IfNotPresent
      command: ["sleep", "1000"]
      resources:
        requests:
          cpu: 1m
          memory: 10Mi
        limits:
          cpu: 10m
          memory: 50Mi
EOC
done


cat >> pod-200-sleep.yaml << EOF
  restartPolicy: Never
EOF

echo "已生成 pod-200-sleep.yaml，共200个sleep容器"
```


2. add some sleep  and set const bufferSize = 1 (default is const bufferSize = 32)


```
			for _, s := range subscribers {
				s.do(func() {
					if s.closed {
						return
					}
					if _, ok := success[s.c]; ok {
						return
					}
					timer.Reset(timeout)
					recv := true
					if _, err := os.Stat("/tmp/debug2"); err == nil {
						time.Sleep(time.Second)
					}
````

3. kubectl create -f pod-200-sleep.yaml 
after pod is running 
echo 11> /tmp/debug2
4 . kill -9 `pidof sleep`
5.crictl ps |grep sleep |wc -l  
```
[root@host-10-234-74-247 nmx]# crictl  ps |grep sleep|grep ddd
ddd071824e258       fa152d3b2cb95       9 minutes ago       Running             sleep-001                  0                   2a0bdd76b4e8c       two-hundred-sleep-pod
[root@host-10-234-74-247 nmx]# crictl  exec ddd date
FATA[0000] execing command in container: Internal error occurred: error executing command in container: failed to exec in container: failed to create exec "086bef8279ee5828d269c317d16b3fb3102948b9db4a91310779daca0f2543b3": cannot exec in a stopped state: unknown 


```

containerd --version
containerd github.com/containerd/containerd v1.7.27 05044ec0a9a75232cad458027ca83437aae3f4da


shim stack 
[666666.txt](https://github.com/user-attachments/files/28712526/666666.txt)

repeat log 
```
Jun 08 22:04:20 host-10-234-74-247 containerd[52219]: time="2026-06-08T22:04:20.832301365+08:00" level=info msg="received exit event container_id:\"ddd071824e258f0d65094a903481e2f0e6e10b79aebad1f890066ac83cafedcb\"  id:\"ddd071824e258f0d65094a903481e2f0e6e10b79aebad1f890066ac83cafedcb\"  pid:85061  exit_status:137  exited_at:{seconds:1780927460  nanos:832086580}"
Jun 08 22:04:23 host-10-234-74-247 containerd[52219]: time="2026-06-08T22:04:23.622300440+08:00" level=error msg="collecting metrics for ddd071824e258f0d65094a903481e2f0e6e10b79aebad1f890066ac83cafedcb" error="cgroups: cgroup deleted: unknown"
Jun 08 22:04:30 host-10-234-74-247 containerd[52219]: time="2026-06-08T22:04:30.832839191+08:00" level=error msg="failed to handle container TaskExit event container_id:\"ddd071824e258f0d65094a903481e2f0e6e10b79aebad1f890066ac83cafedcb\"  id:\"ddd071824e258f0d65094a903481e2f0e6e10b79aebad1f890066ac83cafedcb\"  pid:85061  exit_status:137  exited_at:{seconds:1780927460  nanos:832086580}" error="failed to stop container: context deadline exceeded: unknown"
```

ctr -n k8s.io t ls|grep ddd    is hanging