### PR TITLE
[release/1.7] Clean up disk space in node e2e workflow

### DIFF
--- a/.github/workflows/node-e2e.yml
+++ b/.github/workflows/node-e2e.yml
@@ -16,6 +16,25 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     steps:
+      - name: Clean up disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet \
+            /usr/local/graalvm \
+            /usr/local/.ghcup \
+            /usr/local/share/powershell \
+            /usr/local/share/chromium \
+            /usr/local/share/firefox \
+            /usr/local/lib/android \
+            /usr/local/lib/node_modules \
+            /usr/local/share/podman \
+            /usr/local/aws-cli/ \
+            /usr/local/lib/heroku \
+            /usr/local/rustup \
+            /usr/local/cargo \
+            /usr/local/google-cloud-sdk
+          df -h
+
       - name: Checkout containerd
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
Add disk cleanup step before checking out repositories in node e2e workflow. GitHub Actions ubuntu-24.04 runners come preloaded with large toolchains that exhaust disk space during compilation of Kubernetes test binaries and containerd binaries. Cleaning up unused toolchains avoids kubelet DiskPressure condition and subsequent pod eviction failures.

This change isolates and backports the workflow disk cleanup step originally introduced to main in commit
9d5ee650146e3a20a687a9ed225d50f7812259a9.

Assisted-by: Antigravity