### PR TITLE
Configure udevd children-max for root-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,8 @@ jobs:
           GOTESTSUM_JUNITFILE: ${{github.workspace}}/test-unit-root-junit.xml
           GOTESTSUM_JSONFILE: ${{github.workspace}}/test-unit-root-gotest.json
         run: |
+          # Prevent udevd worker exhaustion on larger runners caused by parallel loopback creations.
+          sudo udevadm control --children-max=500
           make test
           sudo -E PATH=$PATH make root-test
       - run: if [ -f *-gotest.json ]; then echo '# Root Test' >> $GITHUB_STEP_SUMMARY; teststat -markdown *-gotest.json >> $GITHUB_STEP_SUMMARY; fi


### PR DESCRIPTION
GHA runners occasionally experience I/O constraints during root-test test execution. While concurrent tests rapidly allocate loopback devices, background udev probing stalls. This quickly exhausts systemd-udevd's default worker pool ceiling (20 children max), stalling netlink uevent processing so device-mapper device nodes are never created for subsequent dm-verity test execution.

Logging cgroups v2 pids.peak telemetry confirmed peak in-flight udev workers accumulate to 325 during test execution. Raising the children-max limit to 500 provides comfortable buffer room so udevd freely spawns worker processes without entering event lockup or causing test timeouts.

Assisted-by: Antigravity