### PR TITLE
fix: prevent network resource and namespace leaks on sandbox rollback failures

### DIFF
--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -79,6 +79,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	// If cleanup is not completed for some reason, the CRI-plugin will leave the sandbox
 	// in a not-ready state, which can later be cleaned up by the next execution of the kubelet's syncPod workflow.
 	var cleanupErr error
+	var shutdownErr error
 
 	// Reserve the sandbox name to avoid concurrent `RunPodSandbox` request starting the
 	// same sandbox.
@@ -162,15 +163,19 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, fmt.Errorf("failed to save sandbox metadata: %w", err)
 	}
 	defer func() {
-		if retErr != nil && cleanupErr == nil {
+		if retErr != nil && cleanupErr == nil && shutdownErr == nil {
 			cleanupErr = c.client.SandboxStore().Delete(ctx, id)
 		}
 	}()
 
 	defer func() {
 		// Put the sandbox into sandbox store when some resources fail to be cleaned.
-		if retErr != nil && cleanupErr != nil {
-			log.G(ctx).WithError(cleanupErr).Errorf("encountered an error cleaning up failed sandbox %q, marking sandbox state as SANDBOX_UNKNOWN", id)
+		if retErr != nil && (cleanupErr != nil || shutdownErr != nil) {
+			err := cleanupErr
+			if err == nil {
+				err = shutdownErr
+			}
+			log.G(ctx).WithError(err).Errorf("encountered an error cleaning up failed sandbox %q, marking sandbox state as SANDBOX_UNKNOWN", id)
 			if err := c.sandboxStore.Add(sandbox); err != nil {
 				log.G(ctx).WithError(err).Errorf("failed to add sandbox %+v into store", sandbox)
 			}
@@ -326,7 +331,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		if retErr != nil && rollbackSandbox {
 			deferCtx, deferCancel := util.DeferContext()
 			defer deferCancel()
-			cleanupErr = c.sandboxService.ShutdownSandbox(deferCtx, sandbox.Sandboxer, id)
+			shutdownErr = c.sandboxService.ShutdownSandbox(deferCtx, sandbox.Sandboxer, id)
 		}
 	}()
 

--- a/internal/cri/server/sandbox_run_test.go
+++ b/internal/cri/server/sandbox_run_test.go
@@ -18,15 +18,19 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/core/sandbox"
+	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/go-cni"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 )
 
 func TestToCNIPortMappings(t *testing.T) {
@@ -232,4 +236,214 @@ func TestDisablePauseImagePullConfig(t *testing.T) {
 			assert.Equal(t, test.DisablePauseImagePull, ociRuntime.DisablePauseImagePull)
 		})
 	}
+}
+
+type mockSandboxService struct {
+	fakeSandboxService
+	startSandboxFunc    func(ctx context.Context, sandboxer string, sandboxID string) (sandbox.ControllerInstance, error)
+	shutdownSandboxFunc func(ctx context.Context, sandboxer string, sandboxID string) error
+}
+
+func (m *mockSandboxService) StartSandbox(ctx context.Context, sandboxer string, sandboxID string) (sandbox.ControllerInstance, error) {
+	if m.startSandboxFunc != nil {
+		return m.startSandboxFunc(ctx, sandboxer, sandboxID)
+	}
+	return sandbox.ControllerInstance{}, nil
+}
+
+func (m *mockSandboxService) ShutdownSandbox(ctx context.Context, sandboxer string, sandboxID string) error {
+	if m.shutdownSandboxFunc != nil {
+		return m.shutdownSandboxFunc(ctx, sandboxer, sandboxID)
+	}
+	return nil
+}
+
+func (m *mockSandboxService) CreateSandbox(ctx context.Context, info sandbox.Sandbox, opts ...sandbox.CreateOpt) error {
+	return nil
+}
+
+func (m *mockSandboxService) WaitSandbox(ctx context.Context, sandboxer string, sandboxID string) (<-chan containerd.ExitStatus, error) {
+	ch := make(chan containerd.ExitStatus)
+	return ch, nil
+}
+
+type fakeSandboxRunStore struct {
+	sandbox.Store
+	createdSandbox *sandbox.Sandbox
+	deletedID      string
+	updateErr      error
+}
+
+func (f *fakeSandboxRunStore) Create(ctx context.Context, sb sandbox.Sandbox) (sandbox.Sandbox, error) {
+	f.createdSandbox = &sb
+	return sb, nil
+}
+
+func (f *fakeSandboxRunStore) Delete(ctx context.Context, id string) error {
+	f.deletedID = id
+	return nil
+}
+
+func (f *fakeSandboxRunStore) Update(ctx context.Context, sb sandbox.Sandbox, fields ...string) (sandbox.Sandbox, error) {
+	if f.updateErr != nil {
+		return sandbox.Sandbox{}, f.updateErr
+	}
+	return sb, nil
+}
+
+type fakeLeasesManager struct {
+	leases.Manager
+}
+
+func (f *fakeLeasesManager) Create(ctx context.Context, opts ...leases.Opt) (leases.Lease, error) {
+	var l leases.Lease
+	for _, opt := range opts {
+		if err := opt(&l); err != nil {
+			return leases.Lease{}, err
+		}
+	}
+	return l, nil
+}
+
+func (f *fakeLeasesManager) Delete(ctx context.Context, l leases.Lease, opts ...leases.DeleteOpt) error {
+	return nil
+}
+
+func TestRunPodSandboxRollback(t *testing.T) {
+	t.Run("post-StartSandbox failure with ShutdownSandbox success", func(t *testing.T) {
+		fakeStore := &fakeSandboxRunStore{
+			updateErr: errors.New("fake update error"),
+		}
+		fakeLeases := &fakeLeasesManager{}
+
+		shutdownCalled := false
+		mockSB := &mockSandboxService{
+			startSandboxFunc: func(ctx context.Context, sandboxer string, sandboxID string) (sandbox.ControllerInstance, error) {
+				return sandbox.ControllerInstance{
+					Pid: 1234,
+				}, nil
+			},
+			shutdownSandboxFunc: func(ctx context.Context, sandboxer string, sandboxID string) error {
+				shutdownCalled = true
+				return nil
+			},
+		}
+
+		c := newTestCRIService(func(service *criService) {
+			runtimes := service.config.ContainerdConfig.Runtimes
+			if runtimes == nil {
+				runtimes = make(map[string]criconfig.Runtime)
+			}
+			rt := runtimes[service.config.ContainerdConfig.DefaultRuntimeName]
+			rt.DisablePauseImagePull = true
+			runtimes[service.config.ContainerdConfig.DefaultRuntimeName] = rt
+			service.config.ContainerdConfig.Runtimes = runtimes
+
+			client, _ := containerd.New("", containerd.WithServices(
+				containerd.WithSandboxStore(fakeStore),
+				containerd.WithLeasesService(fakeLeases),
+			))
+			service.client = client
+			service.sandboxService = mockSB
+		})
+
+		req := &runtime.RunPodSandboxRequest{
+			Config: &runtime.PodSandboxConfig{
+				Metadata: &runtime.PodSandboxMetadata{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					Uid:       "uid-123",
+				},
+				Linux: &runtime.LinuxPodSandboxConfig{
+					SecurityContext: &runtime.LinuxSandboxSecurityContext{
+						NamespaceOptions: &runtime.NamespaceOption{
+							Network: runtime.NamespaceMode_NODE, // Use host network to avoid netns setup
+						},
+					},
+				},
+			},
+		}
+
+		resp, err := c.RunPodSandbox(context.Background(), req)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		assert.True(t, shutdownCalled, "ShutdownSandbox should be called during rollback")
+
+		// Because ShutdownSandbox returned success (nil), metadata cleanup should succeed
+		// and the sandbox should NOT be in the memory store.
+		assert.NotEmpty(t, fakeStore.deletedID, "Sandbox metadata should be deleted from store")
+		_, err = c.sandboxStore.Get(fakeStore.deletedID)
+		assert.Error(t, err, "Sandbox should not be added to memory store on successful rollback")
+	})
+
+	t.Run("post-StartSandbox failure with ShutdownSandbox failure", func(t *testing.T) {
+		fakeStore := &fakeSandboxRunStore{
+			updateErr: errors.New("fake update error"),
+		}
+		fakeLeases := &fakeLeasesManager{}
+
+		shutdownCalled := false
+		mockSB := &mockSandboxService{
+			startSandboxFunc: func(ctx context.Context, sandboxer string, sandboxID string) (sandbox.ControllerInstance, error) {
+				return sandbox.ControllerInstance{
+					Pid: 1234,
+				}, nil
+			},
+			shutdownSandboxFunc: func(ctx context.Context, sandboxer string, sandboxID string) error {
+				shutdownCalled = true
+				return errors.New("fake shutdown error")
+			},
+		}
+
+		c := newTestCRIService(func(service *criService) {
+			runtimes := service.config.ContainerdConfig.Runtimes
+			if runtimes == nil {
+				runtimes = make(map[string]criconfig.Runtime)
+			}
+			rt := runtimes[service.config.ContainerdConfig.DefaultRuntimeName]
+			rt.DisablePauseImagePull = true
+			runtimes[service.config.ContainerdConfig.DefaultRuntimeName] = rt
+			service.config.ContainerdConfig.Runtimes = runtimes
+
+			client, _ := containerd.New("", containerd.WithServices(
+				containerd.WithSandboxStore(fakeStore),
+				containerd.WithLeasesService(fakeLeases),
+			))
+			service.client = client
+			service.sandboxService = mockSB
+		})
+
+		req := &runtime.RunPodSandboxRequest{
+			Config: &runtime.PodSandboxConfig{
+				Metadata: &runtime.PodSandboxMetadata{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					Uid:       "uid-123",
+				},
+				Linux: &runtime.LinuxPodSandboxConfig{
+					SecurityContext: &runtime.LinuxSandboxSecurityContext{
+						NamespaceOptions: &runtime.NamespaceOption{
+							Network: runtime.NamespaceMode_NODE, // Use host network to avoid netns setup
+						},
+					},
+				},
+			},
+		}
+
+		resp, err := c.RunPodSandbox(context.Background(), req)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		assert.True(t, shutdownCalled, "ShutdownSandbox should be called during rollback")
+
+		// Because ShutdownSandbox failed, the sandbox metadata should NOT be deleted from store
+		// and it should be added to the memory store in StateUnknown state.
+		assert.Empty(t, fakeStore.deletedID, "Sandbox metadata should not be deleted from store when shutdown fails")
+
+		// Check that the sandbox is now in the memory store
+		sbList := c.sandboxStore.List()
+		assert.Len(t, sbList, 1, "Sandbox should be added to memory store on failed rollback")
+		if len(sbList) > 0 {
+			assert.Equal(t, sandboxstore.StateUnknown, sbList[0].Status.Get().State)
+		}
+	})
 }

--- a/internal/cri/server/sandbox_run_test.go
+++ b/internal/cri/server/sandbox_run_test.go
@@ -361,6 +361,11 @@ func TestRunPodSandboxRollback(t *testing.T) {
 						},
 					},
 				},
+				Windows: &runtime.WindowsPodSandboxConfig{
+					SecurityContext: &runtime.WindowsSandboxSecurityContext{
+						HostProcess: true,
+					},
+				},
 			},
 		}
 
@@ -425,6 +430,11 @@ func TestRunPodSandboxRollback(t *testing.T) {
 						NamespaceOptions: &runtime.NamespaceOption{
 							Network: runtime.NamespaceMode_NODE, // Use host network to avoid netns setup
 						},
+					},
+				},
+				Windows: &runtime.WindowsPodSandboxConfig{
+					SecurityContext: &runtime.WindowsSandboxSecurityContext{
+						HostProcess: true,
 					},
 				},
 			},


### PR DESCRIPTION
PR #13399  introduced a rollback defer block to stop the running sandbox via  ShutdownSandbox  if failure occurs after  StartSandbox . 
This block assigned the rollback error  directly to the shared  cleanupErr  variable. Due to the LIFO execution order of Go defers, this error assignment occurs before other resource cleanup steps. 
Consequently, subsequent  defers checking  cleanupErr == nil  are bypassed, skipping:
      1.  c.teardownPodNetwork  (CNI teardown, sandbox_run.go)
      2.  sandbox.NetNS.Remove  (Namespace removal, sandbox_run.go)
      3.  c.client.SandboxStore().Delete  (Metadata cleanup, sandbox_run.go)

Fix: 
Isolated rollback  ShutdownSandbox  error using new  shutdownErr  variable. Network  teardown and namespace removal now run independently of sandbox shutdown status. Both errors  are evaluated together only when persisting sandbox to store or deleting metadata.
  
  