### PR TITLE
hosts.toml: add dial_addr for unix socket dialing

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -29,6 +29,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/containerd/errdefs"
@@ -54,6 +55,7 @@ type hostConfig struct {
 	skipVerify  *bool
 
 	dialTimeout *time.Duration
+	dialAddr    string
 
 	header http.Header
 
@@ -171,9 +173,9 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil
 			explicitTLS := tlsConfigured || explicitTLSFromHost
 
-			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 {
+			if explicitTLSFromHost || host.dialTimeout != nil || host.dialAddr != "" || len(host.header) != 0 {
 				c := *client
-				if explicitTLSFromHost || host.dialTimeout != nil {
+				if explicitTLSFromHost || host.dialTimeout != nil || host.dialAddr != "" {
 					tr := defaultTransport.Clone()
 
 					if explicitTLSFromHost {
@@ -182,7 +184,16 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 						}
 					}
 
-					if host.dialTimeout != nil {
+					if host.dialAddr != "" {
+						timeout := 30 * time.Second
+						if host.dialTimeout != nil {
+							timeout = *host.dialTimeout
+						}
+						tr.DialContext = unixDialContext(host.dialAddr, timeout)
+						// dial_addr connects straight to the socket, so do not
+						// route through HTTP(S)_PROXY from the environment.
+						tr.Proxy = nil
+					} else if host.dialTimeout != nil {
 						tr.DialContext = (&net.Dialer{
 							Timeout:       *host.dialTimeout,
 							KeepAlive:     30 * time.Second,
@@ -374,6 +385,13 @@ type hostFileConfig struct {
 	// a connect to complete.
 	DialTimeout string `toml:"dial_timeout"`
 
+	// DialAddr, when non-empty, replaces the transport's dialer so
+	// that connections to this host are made to a Unix domain socket
+	// instead of over TCP. Only the "unix" scheme is accepted, either
+	// "unix:///absolute/path/to.sock" or "unix://@name" for a Linux
+	// abstract socket.
+	DialAddr string `toml:"dial_addr"`
+
 	// TODO: Credentials: helper? name? username? alternate domain? token?
 }
 
@@ -544,7 +562,120 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 		result.dialTimeout = &dialTimeout
 	}
 
+	if config.DialAddr != "" {
+		addr, err := parseUnixDialAddr(config.DialAddr)
+		if err != nil {
+			return hostConfig{}, err
+		}
+		result.dialAddr = addr
+	}
+
 	return result, nil
+}
+
+// maxUnixSocketPathLen is the size of sun_path in struct sockaddr_un, taken
+// from the platform's own sockaddr definition: 108 on Linux and Windows
+// (UNIX_PATH_MAX in afunix.h), 104 on the BSDs/macOS. The limit matches the
+// OS we build for.
+const maxUnixSocketPathLen = len(syscall.RawSockaddrUnix{}.Path)
+
+// parseUnixDialAddr validates a hosts.toml "dial_addr" and returns the unix
+// socket address for net.Dial("unix", ...).
+//
+// Accepted forms:
+//   - "unix:///absolute/path.sock" — pathname socket. Works on Linux, macOS,
+//     the BSDs, and modern Windows. On Windows the URL form is
+//     "unix:///C:/path/to.sock" (forward slashes, leading "/" before the
+//     drive letter, matching the file:// URI convention); the dialer
+//     converts to a native path before net.Dial.
+//   - "unix://@name" — abstract socket. The "@" syntax is accepted on every
+//     platform (Go's stdlib translates "@" to a leading NUL byte identically
+//     on Linux and Windows), but the abstract address family is a Linux
+//     kernel feature; on other platforms the connection attempt surfaces as
+//     a dial-time error from net.Dial rather than a parse error here.
+//
+// dial_addr is set by the operator, so the checks below aim to catch typos
+// early with a clear message.
+func parseUnixDialAddr(raw string) (string, error) {
+	// Extra spaces are usually a copy-paste slip.
+	if strings.TrimSpace(raw) != raw {
+		return "", fmt.Errorf("dial_addr %q must not have leading or trailing spaces", raw)
+	}
+	// Must begin with "unix://". The scheme is not case-sensitive.
+	const prefix = "unix://"
+	if len(raw) < len(prefix) || !strings.EqualFold(raw[:len(prefix)], prefix) {
+		return "", fmt.Errorf("dial_addr %q must start with \"unix://\"", raw)
+	}
+	if _, err := url.Parse(raw); err != nil {
+		return "", fmt.Errorf("unable to parse dial_addr %q: %w", raw, err)
+	}
+	// The text after "unix://" is used verbatim as the socket address, so a
+	// "?" or "#" anywhere in it would end up in the path handed to net.Dial.
+	// Reject them outright — including a bare trailing delimiter with an
+	// empty query or fragment, which url.Parse does not surface.
+	if strings.Contains(raw, "?") {
+		return "", fmt.Errorf("dial_addr %q must not contain a \"?\" query", raw)
+	}
+	if strings.Contains(raw, "#") {
+		return "", fmt.Errorf("dial_addr %q must not contain a \"#\" fragment", raw)
+	}
+	// Keep the text after "unix://" as-is: url.Parse drops a leading "@", which
+	// is needed for abstract names like "unix://@name".
+	addr := raw[len(prefix):]
+	if addr == "" {
+		return "", fmt.Errorf("dial_addr %q has no socket path after \"unix://\"", raw)
+	}
+	// The address must fit the OS limit. Measure the native form net.Dial
+	// receives: on Windows a drive-letter URL path carries an extra leading
+	// "/" that nativeUnixAddr strips before dialing.
+	if nativeLen := len(nativeUnixAddr(addr)); nativeLen > maxUnixSocketPathLen {
+		return "", fmt.Errorf(
+			"dial_addr socket path is too long: %d bytes, max is %d: %q",
+			nativeLen, maxUnixSocketPathLen, raw,
+		)
+	}
+	// A leading "@" means an abstract socket. The parser accepts it on every
+	// platform; whether the kernel services it is a runtime concern.
+	if strings.HasPrefix(addr, "@") {
+		if addr == "@" {
+			return "", fmt.Errorf("dial_addr %q has \"@\" but no abstract socket name", raw)
+		}
+		return addr, nil
+	}
+	// Otherwise it is a file path and must be absolute.
+	if !strings.HasPrefix(addr, "/") {
+		return "", fmt.Errorf(
+			"dial_addr %q must be an absolute path like \"unix:///run/foo.sock\" (note the three slashes)",
+			raw,
+		)
+	}
+	if strings.HasSuffix(addr, "/") {
+		return "", fmt.Errorf(
+			"dial_addr %q ends with \"/\"; it must point to a socket file, not a directory",
+			raw,
+		)
+	}
+	return addr, nil
+}
+
+// dialContextFunc is the http.Transport.DialContext signature. Named so the
+// unixDialContext signature stays readable.
+type dialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+// unixDialContext returns a DialContext that ignores the requested network
+// and address and instead dials the configured unix socket. The URL-form
+// path stored by parseUnixDialAddr is translated to a native filesystem
+// path via nativeUnixAddr, which is a no-op on POSIX and strips the leading
+// "/" before a drive letter (plus filepath.FromSlash) on Windows.
+func unixDialContext(addr string, timeout time.Duration) dialContextFunc {
+	d := &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+	}
+	native := nativeUnixAddr(addr)
+	return func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return d.DialContext(ctx, "unix", native)
+	}
 }
 
 // getSortedHosts returns the list of hosts in the order are they defined in the file.

--- a/core/remotes/docker/config/hosts_addr_unix.go
+++ b/core/remotes/docker/config/hosts_addr_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+// nativeUnixAddr returns the kernel-level address for net.Dial("unix", ...)
+// from a dial_addr URL path. On POSIX platforms the URL path and the
+// filesystem path are the same string.
+func nativeUnixAddr(addr string) string {
+	return addr
+}

--- a/core/remotes/docker/config/hosts_addr_windows.go
+++ b/core/remotes/docker/config/hosts_addr_windows.go
@@ -1,0 +1,45 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// nativeUnixAddr returns the kernel-level address for net.Dial("unix", ...)
+// from a dial_addr URL path. dial_addr is a URL (e.g. "unix:///C:/foo.sock"),
+// so paths reach us with forward slashes and a leading "/" before the drive
+// letter, matching the file:// URI convention. Go's net package on Windows
+// expects native paths (e.g. "C:\foo.sock"), so for any path whose first
+// character is "/" followed by a drive letter we strip the leading "/" and
+// convert separators to backslashes. Drive-less paths keep their leading "/"
+// but still have separators converted. Abstract addresses ("@name") are not
+// filesystem paths and pass through unchanged.
+func nativeUnixAddr(addr string) string {
+	if strings.HasPrefix(addr, "@") {
+		return addr
+	}
+	if len(addr) >= 3 && addr[0] == '/' && isDriveLetter(addr[1]) && addr[2] == ':' {
+		addr = addr[1:]
+	}
+	return filepath.FromSlash(addr)
+}
+
+func isDriveLetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}

--- a/core/remotes/docker/config/hosts_addr_windows_test.go
+++ b/core/remotes/docker/config/hosts_addr_windows_test.go
@@ -1,0 +1,119 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNativeUnixAddrWindows(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// Drive-letter path: the URL form is /C:/... (matches file://
+			// convention); strip the leading "/" and turn forward slashes
+			// into backslashes for the Windows filesystem.
+			name: "uppercase drive",
+			in:   "/C:/ProgramData/registry-cache/reg.sock",
+			want: `C:\ProgramData\registry-cache\reg.sock`,
+		},
+		{
+			// Drive letters are case-insensitive on Windows; accept lowercase.
+			name: "lowercase drive",
+			in:   "/c:/foo/bar.sock",
+			want: `c:\foo\bar.sock`,
+		},
+		{
+			name: "non-C drive",
+			in:   "/D:/data/reg.sock",
+			want: `D:\data\reg.sock`,
+		},
+		{
+			name: "shortest drive path",
+			in:   "/C:/a",
+			want: `C:\a`,
+		},
+		{
+			// No drive letter: leading "/" stays. Windows treats a path like
+			// "\foo\bar" as relative to the current drive root, so this is
+			// still meaningful even though it's an unusual configuration.
+			name: "drive-less absolute",
+			in:   "/run/foo.sock",
+			want: `\run\foo.sock`,
+		},
+		{
+			// Letter followed by a non-colon is NOT a drive letter; the path
+			// is treated as drive-less.
+			name: "letter without colon",
+			in:   "/abc/foo",
+			want: `\abc\foo`,
+		},
+		{
+			// Abstract names are not filesystem paths; pass through unchanged.
+			name: "abstract",
+			in:   "@registry-cache",
+			want: "@registry-cache",
+		},
+		{
+			// A "/" inside an abstract name is part of the name, not a path
+			// separator, so it must not be rewritten to "\".
+			name: "abstract with slash",
+			in:   "@registry/cache",
+			want: "@registry/cache",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nativeUnixAddr(tc.in)
+			if got != tc.want {
+				t.Fatalf("nativeUnixAddr(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseUnixDialAddrWindowsDriveLengthBoundary(t *testing.T) {
+	// The kernel limit applies to the native path, which for drive-letter
+	// paths is one byte shorter than the URL form ("/C:/..." -> "C:\...").
+	// A URL form one byte over the limit must still parse when the native
+	// form fits.
+	const prefix = "/C:/"
+	addr := prefix + strings.Repeat("a", maxUnixSocketPathLen-len(prefix)+1)
+	// len(addr) == maxUnixSocketPathLen+1, native form == maxUnixSocketPathLen.
+
+	got, err := parseUnixDialAddr("unix://" + addr)
+	if err != nil {
+		t.Fatalf("parseUnixDialAddr(unix://%s): unexpected error %v", addr, err)
+	}
+	if got != addr {
+		t.Fatalf("parseUnixDialAddr(unix://%s) = %q, want %q", addr, got, addr)
+	}
+	if n := len(nativeUnixAddr(got)); n != maxUnixSocketPathLen {
+		t.Fatalf("native form is %d bytes, want %d", n, maxUnixSocketPathLen)
+	}
+
+	// One more byte and the native form exceeds the limit.
+	if _, err := parseUnixDialAddr("unix://" + addr + "a"); err == nil ||
+		!strings.Contains(err.Error(), "too long") {
+		t.Fatalf("expected \"too long\" error for native path over the limit, got %v", err)
+	}
+}

--- a/core/remotes/docker/config/hosts_resolver_test.go
+++ b/core/remotes/docker/config/hosts_resolver_test.go
@@ -21,7 +21,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -210,6 +212,109 @@ server = "%s"
 		assert.False(t, mirrorTriggered.Load())
 		assert.False(t, serverTriggered.Load())
 	}
+}
+
+// TestResolverDialAddrUnixSocket is an integration test: it serves a registry
+// on a real unix socket and checks that a host with dial_addr resolves over the
+// socket, not over TCP. dial_addr changes only the dial, so the host stays a
+// plain http:// entry. Runs on Linux, macOS, the BSDs, and modern Windows
+// (where AF_UNIX is supported since Windows 10 1803 / Server 2019).
+func TestResolverDialAddrUnixSocket(t *testing.T) {
+	const (
+		name = "testname"
+		tag  = "latest"
+		base = "dial-addr-uds.registry"
+	)
+
+	m := newManifest(
+		newContent(ocispec.MediaTypeImageConfig, []byte("1")),
+		newContent(ocispec.MediaTypeImageLayerGzip, []byte("2")),
+	)
+	mc := newContent(ocispec.MediaTypeImageManifest, m.OCIManifest())
+	mux := http.NewServeMux()
+	m.RegisterHandler(mux, name)
+	mux.Handle(fmt.Sprintf("/v2/%s/manifests/%s", name, tag), mc)
+	mux.Handle(fmt.Sprintf("/v2/%s/manifests/%s", name, mc.Digest()), mc)
+
+	var hits atomic.Int64
+	counted := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		mux.ServeHTTP(rw, r)
+	})
+
+	sock := filepath.Join(t.TempDir(), "reg.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		// Match the Linux EAFNOSUPPORT and Windows WSAEAFNOSUPPORT texts
+		// without a build-tagged errors.Is check, as stdlib AF_UNIX tests
+		// skip rather than fail on unsupported platforms.
+		if strings.Contains(err.Error(), "address family not supported") ||
+			strings.Contains(err.Error(), "not supported by the protocol family") {
+			t.Skipf("unix sockets not supported in this environment: %v", err)
+		}
+		t.Fatalf("listen unix %q: %v", sock, err)
+	}
+	defer l.Close()
+	srv := &http.Server{Handler: counted}
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Serve(l) }()
+	defer func() {
+		srv.Close()
+		if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("unix socket server: %v", err)
+		}
+	}()
+
+	// dialAddrFor turns a native filesystem socket path into the URL-form path
+	// that goes after "unix://" in hosts.toml. On POSIX the two are identical;
+	// on Windows the native path is e.g. "C:\Users\…\reg.sock" and the URL form
+	// is "/C:/Users/…/reg.sock" (forward slashes, leading "/" before the drive
+	// letter — same form file:// URIs use for Windows paths).
+	dialAddrFor := func(sock string) string {
+		if runtime.GOOS == "windows" {
+			return "/" + filepath.ToSlash(sock)
+		}
+		return sock
+	}
+
+	resolveWith := func(t *testing.T, sock string) error {
+		dir := t.TempDir()
+		hostDir := filepath.Join(dir, base)
+		if err := os.MkdirAll(hostDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		hostTOML := fmt.Sprintf(`
+[host."http://%s"]
+  capabilities = ["pull", "resolve"]
+  dial_addr = "unix://%s"
+`, base, dialAddrFor(sock))
+		if err := os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hostTOML), 0644); err != nil {
+			t.Fatal(err)
+		}
+		options := docker.ResolverOptions{
+			Hosts: ConfigureHosts(context.TODO(), HostOptions{HostDir: HostDirFromRoot(dir)}),
+		}
+		resolver := docker.NewResolver(options)
+		_, _, err := resolver.Resolve(context.Background(), fmt.Sprintf("%s/%s:%s", base, name, tag))
+		return err
+	}
+
+	t.Run("served over socket", func(t *testing.T) {
+		before := hits.Load()
+		if err := resolveWith(t, sock); err != nil {
+			t.Fatalf("resolve over unix socket: %v", err)
+		}
+		if hits.Load() <= before {
+			t.Fatal("expected the registry handler to be reached over the unix socket")
+		}
+	})
+
+	t.Run("bogus socket fails", func(t *testing.T) {
+		bogus := filepath.Join(t.TempDir(), "nonexistent.sock")
+		if err := resolveWith(t, bogus); err == nil {
+			t.Fatal("expected resolve to fail when dial_addr points at a nonexistent socket")
+		}
+	})
 }
 
 func runBasicTest(t *testing.T, name string, sf func(h http.Handler) (string, docker.ResolverOptions, func())) {

--- a/core/remotes/docker/config/hosts_test.go
+++ b/core/remotes/docker/config/hosts_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -123,10 +124,18 @@ ca = "/etc/path/default"
 
 [host."https://dial-timeout.registry"]
   dial_timeout = "3s"
+
+[host."http://uds-pathname.registry"]
+  dial_addr = "unix:///run/registry-cache.sock"
+
+[host."http://uds-with-timeout.registry"]
+  dial_addr = "unix:///run/r.sock"
+  dial_timeout = "2s"
 `
 
 	var tb, fb = true, false
 	var dialTimeout = 3 * time.Second
+	var dialTimeout2s = 2 * time.Second
 	expected := []hostConfig{
 		{
 			scheme:       "https",
@@ -214,6 +223,21 @@ ca = "/etc/path/default"
 			path:         "/v2",
 			capabilities: allCaps,
 			dialTimeout:  &dialTimeout,
+		},
+		{
+			scheme:       "http",
+			host:         "uds-pathname.registry",
+			path:         "/v2",
+			capabilities: allCaps,
+			dialAddr:     "/run/registry-cache.sock",
+		},
+		{
+			scheme:       "http",
+			host:         "uds-with-timeout.registry",
+			path:         "/v2",
+			capabilities: allCaps,
+			dialAddr:     "/run/r.sock",
+			dialTimeout:  &dialTimeout2s,
 		},
 		{
 			scheme:       "https",
@@ -590,6 +614,10 @@ func compareHostConfig(j, k hostConfig) bool {
 		return false
 	}
 
+	if j.dialAddr != k.dialAddr {
+		return false
+	}
+
 	return true
 }
 
@@ -610,6 +638,9 @@ func printHostConfig(hc []hostConfig) string {
 		fmt.Fprintf(b, "\t\theader: %#v\n", hc[i].header)
 		if hc[i].dialTimeout != nil {
 			fmt.Fprintf(b, "\t\tdial-timeout: %v\n", hc[i].dialTimeout)
+		}
+		if hc[i].dialAddr != "" {
+			fmt.Fprintf(b, "\t\tdial-addr: %q\n", hc[i].dialAddr)
 		}
 	}
 	return b.String()
@@ -646,3 +677,306 @@ var (
 	-----END PRIVATE KEY-----
 	`)
 )
+
+func TestParseHostFileDialAddrInvalid(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{
+			name:    "empty after scheme",
+			value:   `unix://`,
+			wantErr: "no socket path",
+		},
+		{
+			name:    "missing scheme bare path",
+			value:   `/run/registry.sock`,
+			wantErr: "must start with",
+		},
+		{
+			name:    "tcp scheme",
+			value:   `tcp://127.0.0.1:5000`,
+			wantErr: "must start with",
+		},
+		{
+			name:    "http scheme",
+			value:   `http://localhost`,
+			wantErr: "must start with",
+		},
+		{
+			name:    "scheme only no slashes",
+			value:   `unix:`,
+			wantErr: "must start with",
+		},
+		{
+			name:    "malformed URL",
+			value:   `unix://%ZZ`,
+			wantErr: "unable to parse",
+		},
+		{
+			name:    "relative path",
+			value:   `unix://run/r.sock`,
+			wantErr: "must be an absolute path",
+		},
+		{
+			name:    "trailing slash pathname",
+			value:   `unix:///run/r.sock/`,
+			wantErr: "not a directory",
+		},
+		{
+			name:    "query string",
+			value:   `unix:///run/r.sock?foo=bar`,
+			wantErr: "query",
+		},
+		{
+			name:    "empty query delimiter",
+			value:   `unix:///run/r.sock?`,
+			wantErr: "query",
+		},
+		{
+			name:    "fragment",
+			value:   `unix:///run/r.sock#frag`,
+			wantErr: "fragment",
+		},
+		{
+			name:    "empty fragment delimiter",
+			value:   `unix:///run/r.sock#`,
+			wantErr: "fragment",
+		},
+		{
+			name:    "empty abstract name",
+			value:   `unix://@`,
+			wantErr: "no abstract socket name",
+		},
+		{
+			name:    "leading space",
+			value:   ` unix:///run/r.sock`,
+			wantErr: "leading or trailing spaces",
+		},
+		{
+			name:    "trailing space",
+			value:   `unix:///run/r.sock `,
+			wantErr: "leading or trailing spaces",
+		},
+		{
+			name:    "path too long",
+			value:   `unix:///` + strings.Repeat("a", 120),
+			wantErr: "too long",
+		},
+		{
+			name:    "newline injection",
+			value:   "unix:///run/r.sock\nfoo",
+			wantErr: "unable to parse",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			toml := fmt.Sprintf(`[host."http://example.registry"]
+  dial_addr = %q
+`, tc.value)
+			_, err := parseHostsFile("", []byte(toml))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestParseUnixDialAddrValid(t *testing.T) {
+	// A path at the OS limit is still accepted; one byte over is rejected
+	// by TestParseHostFileDialAddrInvalid/path_too_long.
+	maxPath := "/" + strings.Repeat("a", maxUnixSocketPathLen-1)
+
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "pathname",
+			value: `unix:///run/r.sock`,
+			want:  "/run/r.sock",
+		},
+		{
+			name:  "shortest absolute",
+			value: `unix:///a`,
+			want:  "/a",
+		},
+		{
+			name:  "uppercase scheme",
+			value: `UNIX:///run/r.sock`,
+			want:  "/run/r.sock",
+		},
+		{
+			name:  "max length path",
+			value: "unix://" + maxPath,
+			want:  maxPath,
+		},
+		// Abstract names: stdlib translates "@" -> NUL identically on Linux
+		// and Windows, so the parser accepts them on every platform. Whether
+		// the kernel services the address is a runtime concern, not a parse
+		// error.
+		{
+			name:  "abstract",
+			value: `unix://@registry-cache`,
+			want:  "@registry-cache",
+		},
+		// Windows URL form (matches file:// convention): forward slashes,
+		// leading "/" before the drive letter. nativeUnixAddr translates
+		// this to a native Windows path before net.Dial; the parser stores
+		// it as-is, so these cases pass on every platform.
+		{
+			name:  "windows path",
+			value: `unix:///C:/ProgramData/registry-cache/reg.sock`,
+			want:  "/C:/ProgramData/registry-cache/reg.sock",
+		},
+		{
+			// Drive letters are case-insensitive on Windows; accept lowercase.
+			name:  "windows lowercase drive",
+			value: `unix:///c:/foo/bar.sock`,
+			want:  "/c:/foo/bar.sock",
+		},
+		{
+			name:  "windows non-C drive",
+			value: `unix:///D:/data/reg.sock`,
+			want:  "/D:/data/reg.sock",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseUnixDialAddr(tc.value)
+			if err != nil {
+				t.Fatalf("parseUnixDialAddr(%q): unexpected error %v", tc.value, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseUnixDialAddr(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseUnixDialAddrInvalidDirect(t *testing.T) {
+	// Inputs TOML cannot carry (e.g. a raw NUL byte) are tested by calling the
+	// parser directly. These document that url.Parse rejects control characters.
+	cases := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{name: "null byte in path", value: "unix:///run/r\x00.sock", wantErr: "unable to parse"},
+		{name: "raw newline in path", value: "unix:///run/r.sock\nfoo", wantErr: "unable to parse"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseUnixDialAddr(tc.value); err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("parseUnixDialAddr(%q): want error containing %q, got %v", tc.value, tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestConfigureHostsDialAddrWiresTransport(t *testing.T) {
+	ctx := logtest.WithT(context.Background(), t)
+
+	cases := []struct {
+		name                string
+		hostToml            string
+		wantSharedClient    bool
+		wantDialErrContains string
+	}{
+		{
+			name: "only dial_addr set",
+			hostToml: `
+[host."http://uds.registry"]
+  dial_addr = "unix:///nonexistent-uds-test.sock"
+`,
+			wantDialErrContains: "nonexistent-uds-test.sock",
+		},
+		{
+			name: "dial_addr with dial_timeout",
+			hostToml: `
+[host."http://uds.registry"]
+  dial_addr = "unix:///nonexistent-uds-timeout.sock"
+  dial_timeout = "100ms"
+`,
+			wantDialErrContains: "nonexistent-uds-timeout.sock",
+		},
+		{
+			name: "neither set (control)",
+			hostToml: `
+[host."http://plain.registry"]
+`,
+			wantSharedClient: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rhosts := configureFromHostToml(t, ctx, tc.hostToml)
+			if tc.wantSharedClient {
+				assertClientSharedBetweenHosts(t, rhosts)
+				return
+			}
+			assertDialerTargetsUnixSocket(t, ctx, rhosts[0].Client, tc.wantDialErrContains)
+		})
+	}
+}
+
+func configureFromHostToml(t *testing.T, ctx context.Context, hostToml string) []docker.RegistryHost {
+	t.Helper()
+	hostDir := filepath.Join(t.TempDir(), "example.registry")
+	if err := os.MkdirAll(hostDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hostToml), 0600); err != nil {
+		t.Fatal(err)
+	}
+	opts := HostOptions{HostDir: func(string) (string, error) { return hostDir, nil }}
+	rhosts, err := ConfigureHosts(ctx, opts)("example.registry")
+	if err != nil {
+		t.Fatalf("ConfigureHosts: %v", err)
+	}
+	if len(rhosts) == 0 {
+		t.Fatal("expected at least one host")
+	}
+	return rhosts
+}
+
+func assertClientSharedBetweenHosts(t *testing.T, rhosts []docker.RegistryHost) {
+	t.Helper()
+	if len(rhosts) < 2 {
+		t.Fatalf("expected at least 2 hosts to compare clients, got %d", len(rhosts))
+	}
+	if rhosts[0].Client != rhosts[1].Client {
+		t.Errorf("expected shared *http.Client across hosts without dial_addr, got distinct clients")
+	}
+}
+
+func assertDialerTargetsUnixSocket(t *testing.T, ctx context.Context, client *http.Client, wantErrSubstr string) {
+	t.Helper()
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	if tr.DialContext == nil {
+		t.Fatal("expected per-host DialContext to be set")
+	}
+	// A dial_addr host always connects directly to the socket, so the
+	// transport must not route via HTTP(S)_PROXY (Proxy must be cleared).
+	if tr.Proxy != nil {
+		t.Error("expected Proxy to be nil for a dial_addr host")
+	}
+	_, derr := tr.DialContext(ctx, "tcp", "ignored:443")
+	if derr == nil {
+		t.Fatal("expected dial to a nonexistent unix socket to fail")
+	}
+	if !strings.Contains(derr.Error(), wantErrSubstr) {
+		t.Errorf("expected dial error to mention %q, got %q", wantErrSubstr, derr.Error())
+	}
+}

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -373,6 +373,81 @@ A shorter timeout helps reduce delays when falling back to the original registry
 dial_timeout = "1s"
 ```
 
+## dial_addr field
+
+`dial_addr` replaces the transport's dialer for this host so that connections
+are made to a local Unix domain socket instead of over TCP. The request URL
+(scheme, host, path) is unchanged, so the configured host's `Host:` header
+still reaches the local proxy and any existing auth/scope logic continues to
+work. Only the `unix` scheme is accepted.
+
+This lets containerd reach a host-local service over a Unix domain socket — for
+example a co-located local proxy or pull-through cache. It avoids the loopback
+TCP stack for the host-local hop and lets filesystem permissions on the socket
+replace TCP ACLs (no listener needs to be exposed on `lo`).
+
+Accepted forms:
+
+- `unix:///absolute/path/to.sock` — pathname socket. Works on Linux, macOS,
+  the BSDs, and Windows 10 / Server 2019 or newer (older Windows has no
+  `AF_UNIX` support). On Windows the URL form is
+  `unix:///C:/path/to.sock` — forward slashes, with a leading `/` before
+  the drive letter — matching the convention `file://` URIs use for
+  Windows paths. The dialer converts this to a native filesystem path
+  (`C:\path\to.sock`) before connecting, so the listener should be bound
+  to the native form. Backslashes are also accepted inside the URL but
+  forward slashes are recommended because TOML basic strings (`"..."`)
+  interpret backslashes as escape characters (`\f`, `\r`, `\t`, etc.).
+- `unix://@name` — abstract socket. A Linux kernel feature. Go's standard
+  library translates the `@` prefix to a leading NUL byte identically on
+  Linux and Windows, so the parser accepts this form on every platform;
+  on platforms whose kernel does not service abstract addresses the
+  connection attempt surfaces as a dial-time error rather than a parse
+  error.
+
+`dial_addr` composes with `dial_timeout` (the timeout still applies to the
+unix dial).
+
+Because `dial_addr` connects directly to the socket, the `HTTP_PROXY` /
+`HTTPS_PROXY` environment variables are ignored for hosts that set it; the
+socket is always the direct connection target.
+
+The host entry may be `http://` or `https://`. `dial_addr` only redirects the
+transport — it does **not** change the scheme — so an `https://` host still
+performs a full TLS handshake over the socket against the configured host name.
+The process listening on the socket must therefore terminate TLS and present a
+certificate valid for that host name (or the host must set `skip_verify = true`).
+An `http://` host does not negotiate TLS; `dial_addr` does not tunnel plain HTTP
+under an `https://` entry.
+
+```toml
+server = "https://registry-1.docker.io"
+
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
+  dial_addr = "unix:///run/registry-cache.sock"
+  dial_timeout = "5s"
+```
+
+On Windows the same configuration uses the drive-letter URL form:
+
+```toml
+server = "https://registry-1.docker.io"
+
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
+  dial_addr = "unix:///C:/ProgramData/registry-cache/reg.sock"
+  dial_timeout = "5s"
+```
+
+As with any `hosts.toml` field that redirects traffic, the socket path is
+trusted to the same degree as the `hosts.toml` file itself, so the file
+and the socket should be protected by appropriate filesystem permissions. Note
+that a pathname socket inherits the permissions of its parent directory: an
+unprivileged proxy cannot `bind()` a socket directly in a root-owned directory
+such as `/run` (it returns `EACCES`); place the socket in a directory the proxy
+owns (for example a systemd `RuntimeDirectory`).
+
 ## host field(s) (in the toml table format)
 
 `[host]."https://namespace"` and `[host]."http://namespace"` entries in the


### PR DESCRIPTION
## Summary

- Adds a per-host `dial_addr` field to `hosts.toml` that overrides the dialer for that host so connections go to a local Unix domain socket instead of TCP.
- Accepted forms: `unix:///path` (pathname socket) and `unix://@name` (Linux abstract socket).
- Swaps only the transport — the HTTP request still targets the configured host (`Host:` unchanged); only the dial is redirected.
- Composes with `dial_timeout`; works with both `http://` and `https://` host entries.
- Purely additive: a `[host]` block without `dial_addr` behaves exactly as before. Touches only `core/remotes/docker/config/hosts.go` (+ test + `docs/hosts.md`); no `go.mod`/`go.sum`/`vendor/` changes.

```toml
[host."http://127.0.0.1:8088"]
  capabilities = ["pull", "resolve"]
  dial_addr = "unix:///run/nginx/cache-oci.sock"
```

## Why

Pulling images through a local reverse-proxy/cache co-located on the host (e.g. nginx with `proxy_pass` to the upstream registry). A UDS avoids the loopback TCP stack on the host-local hop and lets filesystem permissions on the socket replace TCP ACLs, with no listener on `lo`.

## Testing

**Unit:** `go test ./core/remotes/docker/config/...` — table-driven tests added (valid forms, invalid-input rejection, wiring smoke test).

**End-to-end (NixOS MicroVM, containerd v2 + nerdctl):** containerd is built from this branch and configured with the `hosts.toml` above; it pulls through a co-located nginx (OpenResty) that listens on **both** the TCP port and the Unix socket for the same vhost. Steps and results:

1. **Patched binary is the one running** (REVISION/VERSION baked at build):

```
$ containerd --version
containerd github.com/containerd/containerd/v2 v2.2.1-uds fa814b150932cbc80dc6ce9a123c34837d27b430
```

2. **Both listeners are up** — nginx serves the same server block on TCP and the socket; the TCP listener is retained, only containerd's dial moves to the UDS:

```
$ ss -lxp | grep cache-oci.sock
u_str LISTEN 0 511 /run/nginx/cache-oci.sock 12989 * 0 users:(("nginx",pid=1729,fd=10),("nginx",pid=1703,fd=10))

$ ss -lntp | grep :8088
LISTEN 0 511 0.0.0.0:8088 0.0.0.0:* users:(("nginx",pid=1729,fd=9),("nginx",pid=1703,fd=9))
```

3. **A pull goes over the socket** — during `nerdctl pull docker.io/library/busybox:latest`, `ss -xp` shows connections established on the socket and the nginx access log grows, proving the hop took the UDS rather than TCP:

```
$ ss -xp | grep cache-oci.sock     # sampled during the pull
u_str ESTAB 0 0 /run/nginx/cache-oci.sock 13660 * 14398 users:(("nginx",pid=1729,fd=19))
u_str ESTAB 0 0 /run/nginx/cache-oci.sock 15415 * 14456 users:(("nginx",pid=1729,fd=20))
# nginx manifests access-log delta over the pull: +2
```

**Why the `ss`/log check matters:** with an unbindable/misconfigured socket, containerd silently falls back to the `server =` direct path and the pull *still succeeds* — so pull success alone does not prove the transport. The established-connection + access-log evidence above is what confirms it.

**Operational note (proxy side):** a pathname socket inherits its directory's permissions, so an unprivileged proxy can't `bind()` in a root-owned dir like `/run` (`EACCES`). Placing the socket in a directory the proxy owns (here nginx's `RuntimeDirectory`, `/run/nginx/`) resolves it; containerd connecting as root is unaffected. Might be worth a line next to the `dial_addr` example in `docs/hosts.md`.

**No regression on TCP:** the existing Docker Engine pull path (its own bundled containerd over the retained TCP listener) was unaffected — pulls completed and the cache served HIT/MISS as before.

Signed-off-by: David Seddon <dave.seddon.ca@gmail.com>
