### PR TITLE
content: support size based filtering in AdaptInfo

### DIFF
--- a/core/content/adaptor.go
+++ b/core/content/adaptor.go
@@ -17,6 +17,7 @@
 package content
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/containerd/containerd/v2/pkg/filters"
@@ -33,7 +34,7 @@ func AdaptInfo(info Info) filters.Adaptor {
 		case "digest":
 			return info.Digest.String(), true
 		case "size":
-			// TODO: support size based filtering
+			return fmt.Sprint(info.Size), true
 		case "labels":
 			return checkMap(fieldpath[1:], info.Labels)
 		}

--- a/core/content/adaptor_test.go
+++ b/core/content/adaptor_test.go
@@ -50,8 +50,8 @@ func TestAdaptInfo(t *testing.T) {
 			"size fieldpath",
 			Info{},
 			[]string{"size"},
-			"",
-			false,
+			"0",
+			true,
 		},
 		{
 			"labels fieldpath",


### PR DESCRIPTION
The `size` fieldpath in `AdaptInfo` was a no-op that returned `("", false)`, making size-based filters always fail. Now it returns the content size as a string via `fmt.Sprint(info.Size)`, enabling filters like `size==1024` or `size!=0` when querying content.

Fixes the TODO at `core/content/adaptor.go:36`.