### PR TITLE
core/content/proxy: Convert reader errors to native errdefs

### DIFF
--- a/core/content/proxy/content_reader.go
+++ b/core/content/proxy/content_reader.go
@@ -18,8 +18,10 @@ package proxy
 
 import (
 	"context"
+	"io"
 
 	contentapi "github.com/containerd/containerd/api/services/content/v1"
+	"github.com/containerd/errdefs/pkg/errgrpc"
 	digest "github.com/opencontainers/go-digest"
 )
 
@@ -48,7 +50,7 @@ func (ra *remoteReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 	defer cancel()
 	rc, err := ra.client.Read(childCtx, rr)
 	if err != nil {
-		return 0, err
+		return 0, errgrpc.ToNative(err)
 	}
 
 	for len(p) > 0 {
@@ -56,7 +58,10 @@ func (ra *remoteReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 		// fill our buffer up until we can fill p.
 		resp, err = rc.Recv()
 		if err != nil {
-			return n, err
+			if err == io.EOF {
+				return n, err
+			}
+			return n, errgrpc.ToNative(err)
 		}
 
 		copied := copy(p, resp.Data)


### PR DESCRIPTION
Most content proxy operations normalize remote RPC errors before returning them, including stream receive errors from Walk and write errors from the remote writer. remoteReaderAt.ReadAt was an outlier and returned raw status errors from Read and Recv.

Callers that use content.ReadBlob through the proxy can then fail errdefs checks, such as treating concurrent content deletion as NotFound.

Convert non-EOF read stream errors with errgrpc.ToNative so ReaderAt matches the rest of the content proxy while preserving io.EOF.