### PR TITLE
core/proxy: Convert stream proxy errors to native errdefs

### DIFF
--- a/core/events/proxy/remote_events.go
+++ b/core/events/proxy/remote_events.go
@@ -19,6 +19,7 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"io"
 
 	api "github.com/containerd/containerd/api/services/events/v1"
 	"github.com/containerd/containerd/api/types"
@@ -108,7 +109,7 @@ func (p *grpcEventsProxy) Subscribe(ctx context.Context, filters ...string) (ch 
 		Filters: filters,
 	})
 	if err != nil {
-		errq <- err
+		errq <- errgrpc.ToNative(err)
 		close(errq)
 		return
 	}
@@ -119,6 +120,9 @@ func (p *grpcEventsProxy) Subscribe(ctx context.Context, filters ...string) (ch 
 		for {
 			ev, err := session.Recv()
 			if err != nil {
+				if err != io.EOF {
+					err = errgrpc.ToNative(err)
+				}
 				errq <- err
 				return
 			}
@@ -189,7 +193,7 @@ func (p *ttrpcEventsProxy) Subscribe(ctx context.Context, filters ...string) (ch
 		Filters: filters,
 	})
 	if err != nil {
-		errq <- err
+		errq <- errgrpc.ToNative(err)
 		close(errq)
 		return
 	}
@@ -200,6 +204,9 @@ func (p *ttrpcEventsProxy) Subscribe(ctx context.Context, filters ...string) (ch
 		for {
 			ev, err := session.Recv()
 			if err != nil {
+				if err != io.EOF {
+					err = errgrpc.ToNative(err)
+				}
 				errq <- err
 				return
 			}

--- a/core/streaming/proxy/streaming.go
+++ b/core/streaming/proxy/streaming.go
@@ -74,7 +74,7 @@ type streamCreator struct {
 func (sc *streamCreator) Create(ctx context.Context, id string) (streaming.Stream, error) {
 	stream, err := sc.client.Stream(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errgrpc.ToNative(err)
 	}
 
 	a, err := typeurl.MarshalAny(&streamingapi.StreamInit{


### PR DESCRIPTION
Some proxy stream setup and receive paths still returned raw RPC status errors while neighboring proxy methods normalized them with errgrpc.ToNative. This made errdefs checks depend on which proxy API surfaced the same remote failure.

Normalize event subscription setup and receive errors, and streaming stream creation errors, while preserving io.EOF for completed receive streams.