### PR TITLE
test: fix flaky image timestamp check on coarse clocks

### DIFF
--- a/core/metadata/images_test.go
+++ b/core/metadata/images_test.go
@@ -563,6 +563,17 @@ func TestImagesCreateUpdateDelete(t *testing.T) {
 
 			checkImagesEqual(t, &created, &testcase.original, "unexpected image on creation")
 
+			// Wait for the wall clock to advance past the creation timestamp
+			// before updating. Create and Update both stamp time.Now().UTC()
+			// (which strips the monotonic reading), and on platforms with a
+			// coarse timer resolution (e.g. Windows) two back-to-back stamps
+			// can be identical, making updatedat == createdat. Spinning here
+			// keeps the strict "updatedat after createdat" assertion below
+			// meaningful without depending on clock resolution.
+			for !time.Now().After(created.UpdatedAt) {
+				time.Sleep(time.Millisecond)
+			}
+
 			// Update
 			now = time.Now()
 			updated, err := store.Update(ctx, testcase.input, testcase.fieldpaths...)


### PR DESCRIPTION
TestImagesCreateUpdateDelete asserts that an image's updatedat is strictly after its createdat. Both timestamps are stamped via time.Now().UTC(), which strips the monotonic reading, so the comparison falls back to the wall clock. On platforms with coarse timer resolution (e.g. Windows, which advances system time at the ~15.6ms tick), the Create and Update calls can land in the same tick and produce identical timestamps, making the strict After() check fail intermittently.

Wait for the wall clock to advance past the creation timestamp before updating so the assertion stays meaningful without depending on clock resolution. On fine-resolution clocks the loop runs zero iterations.

### Testing

#### Before

```
~/Workspace/containerd (main)
$ go test -run ^TestImagesCreateUpdateDelete$ -count 2 ./core/metadata/
--- FAIL: TestImagesCreateUpdateDelete (0.03s)
    --- FAIL: TestImagesCreateUpdateDelete/ReplaceLabelsAnnotationsFieldPath (0.00s)
        images_test.go:579: timestamp for updatedat not after createdat: 2026-06-12 19:46:25.9847699 +0000 UTC <= 2026-06-12 19:46:25.9847699 +0000 UTC
FAIL
FAIL    github.com/containerd/containerd/v2/core/metadata       0.430s
FAIL
```

#### After

```
~/Workspace/containerd (fix-flaky-images-create-update-delete-test)
$ go test -run ^TestImagesCreateUpdateDelete$ -count 1000 ./core/metadata/
ok      github.com/containerd/containerd/v2/core/metadata       26.076s
```

### Additional context

- > === Failed
=== FAIL: core/metadata TestImagesCreateUpdateDelete/ReplaceLabelsAnnotationsFieldPath (0.01s)
    images_test.go:579: timestamp for updatedat not after createdat: 2026-06-12 17:11:33.7569733 +0000 UTC <= 2026-06-12 17:11:33.7569733 +0000 UTC

Seen in https://github.com/containerd/containerd/actions/runs/27430461506/job/81079589148