### PR TITLE
nri: fix AddEnv/RemoveEnv silently ignored for pre-existing env vars

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -502,6 +502,13 @@ func WithLogPath(path string) ContainerOpts {
 	}
 }
 
+// WithEnvVar sets an environment variable in the container config.
+func WithEnvVar(key, value string) ContainerOpts {
+	return func(c *runtime.ContainerConfig) {
+		c.Envs = append(c.Envs, &runtime.KeyValue{Key: key, Value: value})
+	}
+}
+
 // WithRunAsUser sets the uid.
 func WithRunAsUser(uid int64) ContainerOpts {
 	return func(c *runtime.ContainerConfig) {

--- a/integration/nri_test.go
+++ b/integration/nri_test.go
@@ -223,6 +223,58 @@ func TestNriEnvironmentInjection(t *testing.T) {
 	require.Equal(t, "TEST_ENV_VALUE\n", string(chk), "check result")
 }
 
+// Test that NRI plugins can override environment variables already present in the container.
+func TestNriEnvironmentOverride(t *testing.T) {
+	skipNriTestIfNecessary(t)
+
+	t.Log("Test that NRI plugins can override environment variables already present in the container.")
+
+	var (
+		out = t.TempDir()
+		tc  = &nriTest{
+			t:       t,
+			plugins: []*mockPlugin{{}},
+		}
+		// Override an env var that already exists in the container (set via CRI Envs).
+		// Also remove another pre-existing env var to verify RemoveEnv works on existing vars.
+		overrideEnv = func(p *mockPlugin, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+			adjust := &api.ContainerAdjustment{}
+			adjust.AddMount(&api.Mount{
+				Destination: "/out",
+				Source:      out,
+				Type:        "bind",
+				Options:     []string{"bind"},
+			})
+			// Override the pre-existing value with an NRI-provided value.
+			adjust.RemoveEnv("EXISTING_KEY")
+			adjust.AddEnv("EXISTING_KEY", "nri-overridden-value")
+			// Remove a pre-existing variable entirely.
+			adjust.RemoveEnv("KEY_TO_REMOVE")
+			return adjust, nil, nil
+		}
+	)
+
+	tc.plugins[0].createContainer = overrideEnv
+	tc.setup()
+
+	podID := tc.runPod("pod0")
+	tc.startContainer(podID, "ctr0",
+		WithEnvVar("EXISTING_KEY", "original-value"),
+		WithEnvVar("KEY_TO_REMOVE", "should-be-gone"),
+		WithCommand("/bin/sh", "-c",
+			"echo $EXISTING_KEY > /out/result; "+
+				"if [ -z \"${KEY_TO_REMOVE+x}\" ]; then echo 'KEY_TO_REMOVE=unset' >> /out/result; else echo KEY_TO_REMOVE=$KEY_TO_REMOVE >> /out/result; fi; "+
+				"sleep 3600"),
+	)
+
+	chk, err := waitForFileAndRead(filepath.Join(out, "result"), time.Second)
+	require.NoError(t, err, "read result")
+	lines := strings.Split(strings.TrimRight(string(chk), "\n"), "\n")
+	require.Len(t, lines, 2, "expected two output lines")
+	require.Equal(t, "nri-overridden-value", lines[0], "EXISTING_KEY should be overridden by NRI")
+	require.Equal(t, "KEY_TO_REMOVE=unset", lines[1], "KEY_TO_REMOVE should be removed by NRI")
+}
+
 // Test annotation injection by NRI plugins.
 func TestNriAnnotationInjection(t *testing.T) {
 	skipNriTestIfNecessary(t)

--- a/internal/cri/nri/nri_api_linux.go
+++ b/internal/cri/nri/nri_api_linux.go
@@ -368,7 +368,7 @@ func (a *API) WithContainerAdjustment() containerd.NewContainerOpts {
 			return nil
 		}
 
-		sgen := generate.Generator{Config: spec}
+		sgen := generate.NewFromSpec(spec)
 		ngen := nrigen.SpecGenerator(&sgen, generatorOptions...)
 
 		err = ngen.Adjust(adjust)

--- a/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
@@ -318,11 +318,14 @@ func NewFromTemplate(r io.Reader) (Generator, error) {
 	}, nil
 }
 
-// createEnvCacheMap creates a hash map with the ENV variables given by the config
+// createEnvCacheMap creates a hash map with the ENV variables given by the config.
+// The map is keyed by the variable name (the part before the first '=') so that
+// addEnv can look up existing entries by name and replace them in-place.
 func createEnvCacheMap(env []string) map[string]int {
 	envMap := make(map[string]int, len(env))
 	for i, val := range env {
-		envMap[val] = i
+		name, _, _ := strings.Cut(val, "=")
+		envMap[name] = i
 	}
 	return envMap
 }


### PR DESCRIPTION
## What this PR does

Fixes a bug where NRI plugin `AddEnv`/`RemoveEnv` operations are silently
dropped for environment variables that already exist in the container
(from image config or CRI container `Envs`). Adding a brand-new variable
worked correctly; overriding or removing an existing one had no effect.

Fixes #13432

## Root cause

Two related issues combined to cause this:

**1. `opencontainers/runtime-tools` `createEnvCacheMap` keyed by full `NAME=value` string**

`createEnvCacheMap` in `vendor/github.com/opencontainers/runtime-tools/generate/generate.go`
built the env variable cache with the full `"NAME=value"` string as key:

```go
func createEnvCacheMap(env []string) map[string]int {
    envMap := make(map[string]int, len(env))
    for i, val := range env {
        envMap[val] = i  // BUG: key is "NAME=value", not "NAME"
    }
    return envMap
}
```

But `addEnv` looked up by variable name only:

```go
func (g *Generator) addEnv(env, key string) { // key == "NAME"
    if idx, ok := g.envMap[key]; ok {          // always misses the "NAME=value" cache
        g.Config.Process.Env[idx] = env        // replace — unreachable for seeded vars
    } else {
        g.Config.Process.Env = append(g.Config.Process.Env, env) // appends a DUPLICATE
        g.envMap[key] = len(g.Config.Process.Env) - 1
    }
}
```

Any generator seeded from an existing spec (via `NewFromSpec`) could never
replace a pre-existing env var: the cache lookup always missed, causing
`addEnv` to append a duplicate `NAME=newvalue` instead. The process saw
both `NAME=oldvalue` and `NAME=newvalue` in its environment; `getenv`
returns the first match, so the new value was silently ignored.

**2. `WithContainerAdjustment` used a struct literal instead of `NewFromSpec`**

`internal/cri/nri/nri_api_linux.go` `WithContainerAdjustment` built the
generator as:

```go
sgen := generate.Generator{Config: spec}  // envMap is nil
```

Using the struct literal left `envMap` uninitialized (`nil`), making cache
behavior inconsistent. `generate.NewFromSpec(spec)` correctly seeds the
cache from the existing spec env.

## Fix

- **`vendor/github.com/opencontainers/runtime-tools/generate/generate.go`**:
  `createEnvCacheMap` now keys by variable name only (using
  `strings.Cut(val, "=")`), matching the lookup key used by `addEnv`.
  This is the root-cause fix and also corrects `AddProcessEnv`
  replace-in-place for all callers of the runtime-tools library.

- **`internal/cri/nri/nri_api_linux.go`**: replace
  `generate.Generator{Config: spec}` with `generate.NewFromSpec(spec)` so
  the env cache is properly seeded before NRI adjustments are applied.

- **`integration/nri_test.go`**: add `TestNriEnvironmentOverride` which
  reproduces the exact regression: a container with pre-existing env vars
  (via CRI `Envs`) and an NRI plugin that calls `RemoveEnv` + `AddEnv`
  to override one and `RemoveEnv` to delete another. The test verifies
  the NRI value takes effect and the removed variable is gone.

## Notes

A corresponding fix for the upstream `opencontainers/runtime-tools` package
is being tracked in opencontainers/runtime-tools#808. This PR patches the
vendored copy directly so containerd users get the fix without waiting for
the upstream release cycle.