### PR TITLE
docs: add note on systemd unit path creation and fallback

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,14 @@ Users of such distributions may have to install containerd from the source or a 
 
 
 ##### systemd
+
+> **Note:** `/usr/local/lib/systemd/system/` is not created by default.
+> run `mkdir -p /usr/local/lib/systemd/system` before placing the unit file.
+> On older distros running systemd older than v246 (check with `systemd --version`),
+> this path may not be in the unit search path at all. Verify with:
+> `sudo systemctl --no-pager --property UnitPath show`
+> If it's missing, use `/etc/systemd/system/` instead.
+
 If you intend to start containerd via systemd, you should also download the `containerd.service` unit file from
 https://raw.githubusercontent.com/containerd/containerd/main/containerd.service into `/usr/local/lib/systemd/system/containerd.service`,
 and run the following commands:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,8 +43,8 @@ Users of such distributions may have to install containerd from the source or a 
 ##### systemd
 
 > **Note:** `/usr/local/lib/systemd/system/` is not created by default.
-> run `mkdir -p /usr/local/lib/systemd/system` before placing the unit file.
-> most distros running systemd < v246 (check with `systemd --version`),
+> Run `mkdir -p /usr/local/lib/systemd/system` before placing the unit file.
+> On distros running systemd < v246 (check with `systemd --version`),
 > this path may not be in the unit search path at all. Verify with:
 > `sudo systemctl --no-pager --property UnitPath show`
 > If it's missing, use `/etc/systemd/system/` instead.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,7 +44,7 @@ Users of such distributions may have to install containerd from the source or a 
 
 > **Note:** `/usr/local/lib/systemd/system/` is not created by default.
 > run `mkdir -p /usr/local/lib/systemd/system` before placing the unit file.
-> On older distros running systemd older than v246 (check with `systemd --version`),
+> most distros running systemd < v246 (check with `systemd --version`),
 > this path may not be in the unit search path at all. Verify with:
 > `sudo systemctl --no-pager --property UnitPath show`
 > If it's missing, use `/etc/systemd/system/` instead.


### PR DESCRIPTION
What
Adds a note to docs/getting-started.md about /usr/local/lib/systemd/system/.

Why
The documented path /usr/local/lib/systemd/system/ is not created by default on any distro, causing silent failures. On systemd older than v246, the path is not even in the unit search path — making /etc/systemd/system/ the only safe fallback on older distros. Reported in #11736 (closed as stale) but the docs still have the same issue.

Change
Additive note only — no existing instruction changed.

Covers:

mkdir -p requirement for modern distros.

systemd --version to check version.

sudo systemctl --no-pager --property UnitPath show to verify search paths.

/etc/systemd/system/ as fallback for systemd < v246.

Testing
Verified UnitPath output across multiple distros:
<img width="927" height="335" alt="Screenshot 2026-06-15 123438" src="https://github.com/user-attachments/assets/cdacf334-27c2-4a75-a6f9-6cc21706f952" />

On systemd < 246 only /etc/systemd/system/ is reliably present. On 246+, /usr/local/lib/systemd/system/ is in UnitPath but must be created with mkdir -p before use.
proofs:
<img width="1633" height="471" alt="Screenshot (13)" src="https://github.com/user-attachments/assets/9627c700-c342-4799-9c05-020d21eeda5d" />
<img width="1623" height="608" alt="Screenshot (14)" src="https://github.com/user-attachments/assets/d4dd1c0f-7a9a-4c69-a05b-9c1345bbdeba" />
<img width="1175" height="755" alt="Screenshot (15)" src="https://github.com/user-attachments/assets/2ef05205-9e47-4b9a-804d-633026aab2fb" />
<img width="1939" height="488" alt="Screenshot (16)" src="https://github.com/user-attachments/assets/c1fc150e-c723-43e8-8ba6-4720490d7286" />
<img width="1316" height="373" alt="Screenshot (17)" src="https://github.com/user-attachments/assets/8934a9f1-3fc3-424b-95a8-fe557ed3d0a6" />
<img width="821" height="396" alt="Screenshot (19)" src="https://github.com/user-attachments/assets/01e3d469-e1b7-44b7-bf40-fe1d7551f126" />

Ref: https://github.com/containerd/containerd/issues/11736