### PR TITLE
gha: pin remaining actions and apply hardening from zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,12 @@ updates:
       otel:
         patterns:
           - "go.opentelemetry.io/*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7

--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           releasever=${GITHUB_REF}
           releasever="${releasever#refs/tags/}"
-          TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||
+          TAGCHECK=$(git tag -v "${releasever}" 2>&1 >/dev/null) ||
           echo "${TAGCHECK}" | grep -q "error" && {
               echo "::error::tag ${releasever} is not a signed tag. Failing release process."
               exit 1
@@ -47,7 +47,7 @@ jobs:
         run: |
           RELEASEVER=${GITHUB_REF}
           echo "stringver=${RELEASEVER#refs/tags/api/v}" >> $GITHUB_OUTPUT
-          git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
+          git tag -l "${RELEASEVER#refs/tags/}" -n20000 | tail -n +3 | cut -c 5- >release-notes.md
         working-directory: src/github.com/containerd/containerd
 
       - name: Save release notes

--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -26,12 +26,11 @@ jobs:
         with:
           ref: ${{ github.ref }}
           path: src/github.com/containerd/containerd
+          persist-credentials: false
 
       - name: Check signature
-        env:
-          REF: ${{ github.ref }}
         run: |
-          releasever="$REF"
+          releasever=${GITHUB_REF}
           releasever="${releasever#refs/tags/}"
           TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||
           echo "${TAGCHECK}" | grep -q "error" && {
@@ -45,10 +44,8 @@ jobs:
 
       - name: Release content
         id: contentrel
-        env:
-          REF: ${{ github.ref }}
         run: |
-          RELEASEVER="$REF"
+          RELEASEVER=${GITHUB_REF}
           echo "stringver=${RELEASEVER#refs/tags/api/v}" >> $GITHUB_OUTPUT
           git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
         working-directory: src/github.com/containerd/containerd

--- a/.github/workflows/buf-breaking.yml
+++ b/.github/workflows/buf-breaking.yml
@@ -23,8 +23,8 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: bufbuild/buf-action@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
           version: 1.63.0
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/buf-breaking.yml
+++ b/.github/workflows/buf-breaking.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
           version: 1.63.0

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: src/github.com/containerd/containerd
+          persist-credentials: false
 
       - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
 

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -162,11 +162,11 @@ jobs:
         run: |
           make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up setup-buildx
 
-          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up build-registry PROJ="$PROJECT" REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
-          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up push-manifest PROJ="$PROJECT" REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up build-registry PROJ="$PROJECT" REMOTE_DOCKER_URL="${{ env.PUBLIC_IP }}:2376"
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up push-manifest PROJ="$PROJECT" REMOTE_DOCKER_URL="${{ env.PUBLIC_IP }}:2376"
 
-          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-ownership build-registry PROJ="$PROJECT" REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
-          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-ownership push-manifest PROJ="$PROJECT" REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-ownership build-registry PROJ="$PROJECT" REMOTE_DOCKER_URL="${{ env.PUBLIC_IP }}:2376"
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-ownership push-manifest PROJ="$PROJECT" REMOTE_DOCKER_URL="${{ env.PUBLIC_IP }}:2376"
 
       - name: Cleanup resources
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/install-go
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee  # v9.2.1
         with:
@@ -53,6 +55,7 @@ jobs:
         with:
           path: src/github.com/containerd/containerd
           fetch-depth: 100
+          persist-credentials: false
 
       - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
 
@@ -88,6 +91,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: src/github.com/containerd/containerd
+          persist-credentials: false
 
       - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
 
@@ -107,6 +111,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/install-go
       - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.7
       - run: make man
@@ -137,6 +143,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/install-go
       - run: |
           set -e -x
@@ -193,6 +201,8 @@ jobs:
           - os: ${{ github.event.repository.private && 'ubuntu-24.04-arm' || '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/install-go
         with:
           go-version: ${{ matrix.go-version }}
@@ -228,6 +238,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: src/github.com/containerd/containerd
+          persist-credentials: false
 
       - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
 
@@ -236,6 +247,7 @@ jobs:
           repository: kubernetes-sigs/cri-tools
           path: src/github.com/kubernetes-sigs/cri-tools
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set env
         run: |
@@ -388,6 +400,8 @@ jobs:
       GOTEST: gotestsum --
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/install-go
 
       - name: Install containerd dependencies
@@ -628,6 +642,8 @@ jobs:
           cat /proc/cpuinfo
           free -mt
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /root/.vagrant.d
@@ -684,6 +700,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up cgroup v2 delegation
         run: |
           sudo mkdir -p /etc/systemd/system/user@.service.d
@@ -733,6 +751,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/install-go
       - run: script/setup/install-gotestsum
       - run: script/setup/install-teststat

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/install-go
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -41,6 +41,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/install-go
       - run: script/go-test-fuzz.sh
       - name: Upload Crash

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -73,8 +73,8 @@ jobs:
 
           echo "Mirroring $upstream to $mirror"
 
-          sudo ctr content fetch --all-platforms ${upstream}
+          sudo ctr content fetch --all-platforms "${upstream}"
           sudo ctr images ls
-          sudo ctr --debug images push -u ${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }} ${mirror} ${upstream}
+          sudo ctr --debug images push -u "${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}" "${mirror}" "${upstream}"
 
-          sudo kill $containerd_pid
+          sudo kill "$containerd_pid"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: src/github.com/containerd/containerd
+          persist-credentials: false
 
       - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
 
@@ -74,6 +75,6 @@ jobs:
 
           sudo ctr content fetch --all-platforms ${upstream}
           sudo ctr images ls
-          sudo ctr --debug images push -u ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} ${mirror} ${upstream}
+          sudo ctr --debug images push -u ${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }} ${mirror} ${upstream}
 
           sudo kill $containerd_pid

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: src/github.com/containerd/containerd
+          persist-credentials: false
 
       - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
 
@@ -141,6 +142,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: src/github.com/containerd/containerd
+          persist-credentials: false
 
       - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
 

--- a/.github/workflows/node-e2e.yml
+++ b/.github/workflows/node-e2e.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           path: src/github.com/containerd/containerd
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Checkout Kubernetes
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -48,6 +49,7 @@ jobs:
           path: src/k8s.io/kubernetes
           ref: ${{ inputs.k8s_version }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Go
         uses: ./src/github.com/containerd/containerd/.github/actions/install-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           git config --global gpg.ssh.allowedSignersFile ${{ runner.temp }}/empty-allowedSignersFile
           releasever=${GITHUB_REF}
           releasever="${releasever#refs/tags/}"
-          TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||
+          TAGCHECK=$(git tag -v "${releasever}" 2>&1 >/dev/null) ||
           echo "${TAGCHECK}" | grep -q "error" && {
               echo "::error::tag ${releasever} is not a signed tag. Failing release process."
               exit 1
@@ -54,7 +54,7 @@ jobs:
         run: |
           RELEASEVER=${GITHUB_REF}
           echo "stringver=${RELEASEVER#refs/tags/v}" >> $GITHUB_OUTPUT
-          git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
+          git tag -l "${RELEASEVER#refs/tags/}" -n20000 | tail -n +3 | cut -c 5- >release-notes.md
         working-directory: src/github.com/containerd/containerd
 
       - name: Save release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,14 @@ jobs:
         with:
           ref: ${{ github.ref }}
           path: src/github.com/containerd/containerd
+          persist-credentials: false
 
       - name: Check signature
         run: |
           # git tag -v requires an allowedSignersFile to be configured and exist for ssh signature verification
           touch ${{ runner.temp }}/empty-allowedSignersFile
           git config --global gpg.ssh.allowedSignersFile ${{ runner.temp }}/empty-allowedSignersFile
-          releasever=${{ github.ref }}
+          releasever=${GITHUB_REF}
           releasever="${releasever#refs/tags/}"
           TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||
           echo "${TAGCHECK}" | grep -q "error" && {
@@ -51,7 +52,7 @@ jobs:
       - name: Release content
         id: contentrel
         run: |
-          RELEASEVER=${{ github.ref }}
+          RELEASEVER=${GITHUB_REF}
           echo "stringver=${RELEASEVER#refs/tags/v}" >> $GITHUB_OUTPUT
           git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
         working-directory: src/github.com/containerd/containerd
@@ -86,7 +87,7 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         shell: bash
         run: |
-          releasever=${{ github.ref }}
+          releasever=${GITHUB_REF}
           releasever="${releasever#refs/tags/}"
           echo "RELEASE_VER=${releasever}" >> $GITHUB_ENV
       - name: Checkout containerd
@@ -98,6 +99,7 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ github.ref }}
           path: src/github.com/containerd/containerd
+          persist-credentials: false
 
       - name: Setup buildx instance
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -8,7 +8,8 @@ on:
     branches: [ "main" ]
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag=v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # tag=v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -41,7 +41,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag=v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -49,6 +49,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # tag=v4.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,8 @@ on:
     paths:
       - '.github/workflows/stale.yml'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   stale:

--- a/.github/workflows/windows-hyperv-periodic-trigger.yml
+++ b/.github/workflows/windows-hyperv-periodic-trigger.yml
@@ -22,7 +22,7 @@ jobs:
     # upstream containerd repository should be replaced with the following to
     # potentially allow contributors to enable periodic Windows tests on forks as well:
     # uses: "${{ github.repository }}/.github/workflows/windows-hyperv-periodic.yml@${{ github.ref_name }}"
-    uses: containerd/containerd/.github/workflows/windows-hyperv-periodic.yml@main
+    uses: containerd/containerd/.github/workflows/windows-hyperv-periodic.yml@main # zizmor: ignore[unpinned-uses] reusable workflow intentionally tracks containerd/main
     secrets:
       AZURE_SUB_ID: "${{ secrets.AZURE_SUB_ID }}"
       AZURE_CREDS: "${{ secrets.AZURE_CREDS }}"

--- a/.github/workflows/windows-hyperv-periodic.yml
+++ b/.github/workflows/windows-hyperv-periodic.yml
@@ -45,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install required packages
         run: |

--- a/.github/workflows/windows-periodic-trigger.yml
+++ b/.github/workflows/windows-periodic-trigger.yml
@@ -22,7 +22,7 @@ jobs:
     # upstream containerd repository should be replaced with the following to
     # potentially allow contributors to enable periodic Windows tests on forks as well:
     # uses: "${{ github.repository }}/.github/workflows/windows-periodic.yml@${{ github.ref_name }}"
-    uses: containerd/containerd/.github/workflows/windows-periodic.yml@main
+    uses: containerd/containerd/.github/workflows/windows-periodic.yml@main # zizmor: ignore[unpinned-uses] reusable workflow intentionally tracks containerd/main
     secrets:
       AZURE_SUB_ID: "${{ secrets.AZURE_SUB_ID }}"
       AZURE_CREDS: "${{ secrets.AZURE_CREDS }}"

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -45,6 +45,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install required packages
         run: |


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/13531

### gha: buf-breaking: pin actions by sha

### gha: apply zizmor fixes

Results of automated fixes using;

    zizmor --fix=all --min-severity medium .

### gha: suppress zizmor warning for intentionally un-pinned workflows

### gha: remove uses of "read-all" permissions

"read-all" is overly permissive as a default. Change it to contents: read
to align with other defaults.

Note that this does not actually impact the workflows, because the defaults
are overwritten in the actual check.


### gha: quote some values

Quote values to address CoPilot review comments
