### PR TITLE
cri: add Kubernetes identity labels to CRI-created snapshots

### DIFF
--- a/core/snapshots/snapshotter.go
+++ b/core/snapshots/snapshotter.go
@@ -31,8 +31,10 @@ const (
 	// image content unpacked into them.
 	UnpackKeyPrefix = "extract"
 	// UnpackKeyFormat is the format for the snapshotter keys used for extraction
-	UnpackKeyFormat       = UnpackKeyPrefix + "-%s %s"
-	inheritedLabelsPrefix = "containerd.io/snapshot/"
+	UnpackKeyFormat = UnpackKeyPrefix + "-%s %s"
+	// LabelSnapshotPrefix is the prefix used for labels passed to snapshotters.
+	LabelSnapshotPrefix   = "containerd.io/snapshot/"
+	inheritedLabelsPrefix = LabelSnapshotPrefix
 	labelSnapshotRef      = "containerd.io/snapshot.ref"
 
 	// LabelSnapshotUIDMapping is the label used for UID mappings

--- a/internal/cri/annotations/annotations.go
+++ b/internal/cri/annotations/annotations.go
@@ -17,6 +17,9 @@
 package annotations
 
 import (
+	"maps"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -26,6 +29,9 @@ import (
 // Following OCI annotations are used by katacontainers now.
 // We'll switch to standard secure pod API after it is defined in CRI.
 const (
+	// SnapshotLabelPrefix is the label prefix used to pass labels to snapshotters.
+	SnapshotLabelPrefix = snapshots.LabelSnapshotPrefix
+
 	// ContainerTypeSandbox represents a pod sandbox container
 	ContainerTypeSandbox = "sandbox"
 
@@ -98,6 +104,11 @@ const (
 	WindowsHostProcess = "microsoft.com/hostprocess-container"
 )
 
+// SnapshotLabel returns the snapshot label name for a CRI annotation.
+func SnapshotLabel(name string) string {
+	return SnapshotLabelPrefix + name
+}
+
 // DefaultCRIAnnotations are the default set of CRI annotations to
 // pass to sandboxes and containers.
 func DefaultCRIAnnotations(
@@ -132,4 +143,59 @@ func DefaultCRIAnnotations(
 		)
 	}
 	return append(opts, customopts.WithAnnotation(ContainerType, ctrType))
+}
+
+// DefaultCRISnapshotLabelsForSandbox returns the default set of CRI identity
+// labels to pass to snapshotters for a sandbox.
+func DefaultCRISnapshotLabelsForSandbox(
+	sandboxID string,
+	imageName string,
+	config *runtime.PodSandboxConfig,
+) map[string]string {
+	labels := defaultCRISnapshotLabels(sandboxID, config, ContainerTypeSandbox)
+	labels[SnapshotLabel(SandboxImageName)] = imageName
+	return labels
+}
+
+// DefaultCRISnapshotLabelsForContainer returns the default set of CRI identity
+// labels to pass to snapshotters for a container.
+func DefaultCRISnapshotLabelsForContainer(
+	sandboxID string,
+	containerName string,
+	imageName string,
+	config *runtime.PodSandboxConfig,
+) map[string]string {
+	labels := defaultCRISnapshotLabels(sandboxID, config, ContainerTypeContainer)
+	labels[SnapshotLabel(ContainerName)] = containerName
+	labels[SnapshotLabel(ImageName)] = imageName
+	return labels
+}
+
+func defaultCRISnapshotLabels(
+	sandboxID string,
+	config *runtime.PodSandboxConfig,
+	containerType string,
+) map[string]string {
+	return map[string]string{
+		SnapshotLabel(SandboxID):        sandboxID,
+		SnapshotLabel(SandboxNamespace): config.GetMetadata().GetNamespace(),
+		SnapshotLabel(SandboxUID):       config.GetMetadata().GetUid(),
+		SnapshotLabel(SandboxName):      config.GetMetadata().GetName(),
+		SnapshotLabel(ContainerType):    containerType,
+	}
+}
+
+// MergeSnapshotLabels merges snapshot label maps in order. Later maps override
+// earlier maps, allowing inherited or user-provided labels to take precedence
+// over defaults.
+func MergeSnapshotLabels(labels ...map[string]string) map[string]string {
+	var total int
+	for _, labelSet := range labels {
+		total += len(labelSet)
+	}
+	merged := make(map[string]string, total)
+	for _, labelSet := range labels {
+		maps.Copy(merged, labelSet)
+	}
+	return merged
 }

--- a/internal/cri/annotations/annotations_test.go
+++ b/internal/cri/annotations/annotations_test.go
@@ -1,0 +1,91 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package annotations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+)
+
+func TestSnapshotLabelPrefixMatchesSnapshotsPackage(t *testing.T) {
+	assert.Equal(t, snapshots.LabelSnapshotPrefix, SnapshotLabelPrefix)
+}
+
+func TestDefaultCRISnapshotLabelsForContainer(t *testing.T) {
+	config := &runtime.PodSandboxConfig{
+		Metadata: &runtime.PodSandboxMetadata{
+			Name:      "pod-name",
+			Uid:       "pod-uid",
+			Namespace: "pod-namespace",
+		},
+	}
+
+	labels := DefaultCRISnapshotLabelsForContainer("sandbox-id", "container-name", "registry.k8s.io/pause:3.10", config)
+
+	assert.Equal(t, ContainerTypeContainer, labels[SnapshotLabel(ContainerType)])
+	assert.Equal(t, "sandbox-id", labels[SnapshotLabel(SandboxID)])
+	assert.Equal(t, "pod-namespace", labels[SnapshotLabel(SandboxNamespace)])
+	assert.Equal(t, "pod-uid", labels[SnapshotLabel(SandboxUID)])
+	assert.Equal(t, "pod-name", labels[SnapshotLabel(SandboxName)])
+	assert.Equal(t, "container-name", labels[SnapshotLabel(ContainerName)])
+	assert.Equal(t, "registry.k8s.io/pause:3.10", labels[SnapshotLabel(ImageName)])
+}
+
+func TestDefaultCRISnapshotLabelsForSandbox(t *testing.T) {
+	config := &runtime.PodSandboxConfig{
+		Metadata: &runtime.PodSandboxMetadata{
+			Name:      "pod-name",
+			Uid:       "pod-uid",
+			Namespace: "pod-namespace",
+		},
+	}
+
+	labels := DefaultCRISnapshotLabelsForSandbox("sandbox-id", "registry.k8s.io/pause:3.10", config)
+
+	assert.Equal(t, ContainerTypeSandbox, labels[SnapshotLabel(ContainerType)])
+	assert.Equal(t, "sandbox-id", labels[SnapshotLabel(SandboxID)])
+	assert.Equal(t, "pod-namespace", labels[SnapshotLabel(SandboxNamespace)])
+	assert.Equal(t, "pod-uid", labels[SnapshotLabel(SandboxUID)])
+	assert.Equal(t, "pod-name", labels[SnapshotLabel(SandboxName)])
+	assert.Equal(t, "registry.k8s.io/pause:3.10", labels[SnapshotLabel(SandboxImageName)])
+	_, ok := labels[SnapshotLabel(ContainerName)]
+	assert.False(t, ok)
+	_, ok = labels[SnapshotLabel(ImageName)]
+	assert.False(t, ok)
+}
+
+func TestMergeSnapshotLabelsAllowsOverrides(t *testing.T) {
+	defaults := map[string]string{
+		SnapshotLabel(SandboxID):   "default-sandbox-id",
+		SnapshotLabel(SandboxName): "default-pod-name",
+	}
+	overrides := map[string]string{
+		SnapshotLabel(SandboxID):        "inherited-sandbox-id",
+		"containerd.io/snapshot/custom": "custom-value",
+	}
+
+	labels := MergeSnapshotLabels(defaults, overrides)
+
+	assert.Equal(t, "inherited-sandbox-id", labels[SnapshotLabel(SandboxID)])
+	assert.Equal(t, "default-pod-name", labels[SnapshotLabel(SandboxName)])
+	assert.Equal(t, "custom-value", labels["containerd.io/snapshot/custom"])
+	assert.Equal(t, "default-sandbox-id", defaults[SnapshotLabel(SandboxID)])
+}

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -37,6 +37,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
@@ -351,6 +352,13 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 	if err != nil {
 		return "", err
 	}
+	defaultSnapshotLabels := annotations.DefaultCRISnapshotLabelsForContainer(
+		r.sandboxID,
+		r.containerName,
+		imageName,
+		r.podSandboxConfig,
+	)
+	sOpts = append([]snapshots.Opt{snapshots.WithLabels(defaultSnapshotLabels)}, sOpts...)
 
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -34,6 +34,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/sandbox"
 	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
@@ -181,7 +182,11 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 
 	sandboxLabels := ctrdutil.BuildLabels(config.Labels, imageSpec.Config.Labels, crilabels.ContainerKindSandbox)
 
-	snapshotterOpt := []snapshots.Opt{snapshots.WithLabels(snapshots.FilterInheritedLabels(config.Annotations))}
+	snapshotLabels := annotations.MergeSnapshotLabels(
+		annotations.DefaultCRISnapshotLabelsForSandbox(id, sandboxImage, config),
+		snapshots.FilterInheritedLabels(config.Annotations),
+	)
+	snapshotterOpt := []snapshots.Opt{snapshots.WithLabels(snapshotLabels)}
 	extraSOpts, err := sandboxSnapshotterOpts(config)
 	if err != nil {
 		return cin, err


### PR DESCRIPTION
Implement #13604 

This PR passes Kubernetes CRI workload identity metadata to snapshotters as snapshot labels.

The new labels use the existing CRI annotation keys with the `containerd.io/snapshot/` prefix, for example:

- `containerd.io/snapshot/io.kubernetes.cri.sandbox-id`
- `containerd.io/snapshot/io.kubernetes.cri.sandbox-namespace`
- `containerd.io/snapshot/io.kubernetes.cri.sandbox-uid`
- `containerd.io/snapshot/io.kubernetes.cri.sandbox-name`
- `containerd.io/snapshot/io.kubernetes.cri.container-type`
- `containerd.io/snapshot/io.kubernetes.cri.container-name`
- `containerd.io/snapshot/io.kubernetes.cri.image-name`

Some snapshotters need to make decisions during `Prepare` based on the Kubernetes workload identity, such as pod namespace/name/UID, sandbox ID, container name, and image name.CRI already propagates similar identity data to OCI annotations, but snapshotters do not receive that information when the CRI plugin prepares snapshots. This makes snapshotter-side policy, routing, accounting, or metadata handling harder to implement without out-of-band lookup or product-specific integrations.

This PR adds a shared helper for building CRI identity snapshot labels and applies those labels when preparing snapshots for both pod sandboxes and workload containers.

The change only adds metadata labels to snapshots. It does not change snapshotter selection, runtime selection, image unpacking, or container startup behavior.
