### PR TITLE
cri: delete leak sandbox

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -73,6 +73,7 @@ import (
 	"github.com/containerd/containerd/v2/core/transfer"
 	transferproxy "github.com/containerd/containerd/v2/core/transfer/proxy"
 	"github.com/containerd/containerd/v2/defaults"
+	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	"github.com/containerd/containerd/v2/pkg/dialer"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
@@ -333,6 +334,19 @@ func (c *Client) Containers(ctx context.Context, filters ...string) ([]Container
 		out[i] = containerFromRecord(c, container)
 	}
 	return out, nil
+}
+
+func (c *Client) GetSandboxcontainer(ctx context.Context, id string) (Container, error) {
+	r, err := c.ContainerService().List(ctx, crilabels.ContainerKindSandbox)
+	if err != nil {
+		return nil, err
+	}
+	for _, container := range r {
+		if container.ID == id {
+			return containerFromRecord(c, container), nil
+		}
+	}
+	return nil, fmt.Errorf("sandbox %s does not exist: %w", id, errdefs.ErrNotFound)
 }
 
 // NewContainer will create a new container with the provided id.

--- a/internal/cri/server/restart.go
+++ b/internal/cri/server/restart.go
@@ -103,7 +103,15 @@ func (c *criService) recover(ctx context.Context) error {
 		if _, err := c.sandboxStore.Get(sbx.ID); err == nil {
 			continue
 		}
-
+		if _, err := c.client.GetSandboxcontainer(ctx, sbx.ID); err != nil {
+			if errors.Is(err, errdefs.ErrNotFound) {
+				log.L.Warnf("delete leak sandbox %q", sbx.ID)
+				err = c.client.SandboxStore().Delete(ctx, sbx.ID)
+				if err != nil {
+					log.G(ctx).WithError(err).Errorf("failed to delete sandbox %q, in response to failure to retrieve metadata for sandbox", sbx.ID)
+				}
+			}
+		}
 		metadata := sandboxstore.Metadata{}
 		err := sbx.GetExtension(podsandbox.MetadataKey, &metadata)
 		if err != nil {


### PR DESCRIPTION
if  c.nri.RunPodSandbox return an error and containerd exited after step2 
```
func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest)
	defer func() {
            
		if retErr != nil && rollbackSandbox {
			deferCtx, deferCancel := util.DeferContext()
			defer deferCancel()
                       step2 
			cleanupErr = c.sandboxService.ShutdownSandbox(deferCtx, sandbox.Sandboxer, id)
                      // if containerd exited here
		}
	}()
       //  step1 :if here return an error 
	err = c.nri.RunPodSandbox(ctx, &sandbox)
	if err != nil {
		return nil, fmt.Errorf("NRI RunPodSandbox failed: %w", err)
	}
```
will cause data leak in db containers is empty but sandboxes is not empty
<img width="1281" height="605" alt="20260617223242608" src="https://github.com/user-attachments/assets/0f9f3d1e-8302-44a4-ba09-bf5eeb97de8c" />


if leak sandbox added into the store 
```
		if err := c.sandboxStore.Add(sb); err != nil {
			return fmt.Errorf("failed to add stored sandbox %q to store: %w", sbx.ID, err)
		}
```
it may cause containerd panic when restart it (I'm not sure here )

 failed to reserve sandbox name "xxxx": name "xxx" is reserved for "xxxxx""

@fuweid @mikebrow 