### PR TITLE
Reject CreateContainer on a non-ready sandbox

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -43,7 +43,7 @@ import (
 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
-	"github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/containerd/v2/internal/registrar"
 	"github.com/containerd/containerd/v2/pkg/blockio"
@@ -65,6 +65,12 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find sandbox id %q: %w", r.GetPodSandboxId(), err)
+	}
+
+	// The CRI spec requires that containers are only created in a running
+	// sandbox. Reject the request otherwise, matching StartContainer.
+	if sandbox.Status.Get().State != sandboxstore.StateReady {
+		return nil, fmt.Errorf("sandbox container %q is not running", sandbox.ID)
 	}
 
 	cstatus, err := c.sandboxService.SandboxStatus(ctx, sandbox.Sandboxer, sandbox.ID, false)
@@ -215,7 +221,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 type createContainerRequest struct {
 	ctx                   context.Context
 	containerID           string
-	sandbox               *sandbox.Sandbox
+	sandbox               *sandboxstore.Sandbox
 	sandboxID             string
 	imageID               string
 	containerConfig       *runtime.ContainerConfig

--- a/internal/cri/server/container_create_test.go
+++ b/internal/cri/server/container_create_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/constants"
 	"github.com/containerd/containerd/v2/internal/cri/opts"
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
@@ -763,4 +764,31 @@ func TestLinuxContainerMounts(t *testing.T) {
 			assert.Equal(t, test.expectedMounts, mounts, test.desc)
 		})
 	}
+}
+
+// TestCreateContainerNotReadySandbox verifies that CreateContainer is rejected
+// when its sandbox is not in the ready state, per the CRI spec.
+func TestCreateContainerNotReadySandbox(t *testing.T) {
+	c := newTestCRIService()
+	containerConfig, sandboxConfig, _, _ := getCreateContainerTestData()
+	const sandboxID = "test-not-ready-sandbox-id"
+	sb := sandboxstore.NewSandbox(
+		sandboxstore.Metadata{
+			ID:     sandboxID,
+			Name:   "test-not-ready-sandbox-name",
+			Config: sandboxConfig,
+		},
+		sandboxstore.Status{
+			State: sandboxstore.StateNotReady,
+		},
+	)
+	require.NoError(t, c.sandboxStore.Add(sb))
+
+	_, err := c.CreateContainer(context.Background(), &runtime.CreateContainerRequest{
+		PodSandboxId:  sandboxID,
+		Config:        containerConfig,
+		SandboxConfig: sandboxConfig,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not running")
 }


### PR DESCRIPTION
Fixes #13599

## Description

`CreateContainer` loads the sandbox (`c.sandboxStore.Get`) but never checks that the sandbox is in the ready state before proceeding. As a result a container can be created against a **stopped** sandbox, which violates the CRI spec — `RunPodSandbox`/`CreateContainer` require the sandbox to be running — and is what blocks the cri-tools conformance test referenced in #13599.

`StartContainer` already guards against this:

```go
if sandbox.Status.Get().State != sandboxstore.StateReady {
    return nil, fmt.Errorf("sandbox container %q is not running", sandboxID)
}
```

This applies the same guard in `CreateContainer`, right after the sandbox is loaded.

Note: `container_create.go` imported the sandbox store package as `sandbox`, which is shadowed by the local `sandbox` variable inside `CreateContainer`. I aliased the import to `sandboxstore` (matching `container_start.go`) so the `StateReady` constant can be referenced; the only other use of the package alias in the file (a struct field type) was updated accordingly.

## Test

Added `TestCreateContainerNotReadySandbox`, which adds a `StateNotReady` sandbox to the store and asserts `CreateContainer` fails with `is not running`.

```
--- PASS: TestCreateContainerNotReadySandbox (0.00s)
```

`go vet` and the existing `internal/cri/server` container/sandbox tests pass.
