### PR TITLE
docs: fix duplicated word in NRI guide

### DIFF
--- a/docs/NRI.md
+++ b/docs/NRI.md
@@ -117,7 +117,7 @@ make
 ./build/bin/logger -idx 00
 ```
 
-You should see the logger plugin receiving receiving a list of existing pods
+You should see the logger plugin receiving a list of existing pods
 and containers. If you then create or remove further pods and containers
 using crictl or kubectl you should see detailed logs of the corresponding NRI
 events printed by the logger.


### PR DESCRIPTION
The NRI guide read "the logger plugin receiving receiving a list of existing pods" — removed the duplicated "receiving".
