### PR TITLE
cri: fix duplicated image env vars on checkpoint import

### DIFF
--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -371,7 +371,7 @@ func (c *criService) CRImportCheckpoint(
 	for _, e := range meta.Config.GetEnvs() {
 		env = append(env, e.GetKey()+"="+e.GetValue())
 	}
-	imageConfig.Env = append(imageConfig.Env, env...)
+	imageConfig.Env = env
 
 	originalAnnotations["restored"] = "true"
 	originalAnnotations["checkpointedAt"] = config.CheckpointedAt.Format(time.RFC3339Nano)


### PR DESCRIPTION
`CRImportCheckpoint` built the combined environment (image env followed by the CRI container env) into a local slice, then re-appended that slice to `imageConfig.Env`, duplicating every image environment variable on the restored container.

This assigns the combined slice directly instead.

Fixes #13611
