### PR TITLE
[release/1.7] Prepare release notes for v1.7.33

### DIFF
--- a/container_opts.go
+++ b/container_opts.go
@@ -26,10 +26,12 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	"github.com/opencontainers/image-spec/identity"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -114,6 +116,10 @@ func WithContainerLabels(labels map[string]string) NewContainerOpts {
 // The existing labels are cleared as this is expected to be the first
 // operation in setting up a container's labels. Use WithAdditionalContainerLabels
 // to add/overwrite the existing image config labels.
+//
+// Image config labels in the namespaces reserved for containerd
+// (containerd.io/) and the CRI plugin (io.cri-containerd) are not copied
+// to the container.
 func WithImageConfigLabels(image Image) NewContainerOpts {
 	return func(ctx context.Context, _ *Client, c *containers.Container) error {
 		ic, err := image.Config(ctx)
@@ -139,6 +145,15 @@ func WithImageConfigLabels(image Image) NewContainerOpts {
 			return fmt.Errorf("unknown image config media type %s", ic.MediaType)
 		}
 		c.Labels = config.Labels
+		// Labels in the containerd.io/* namespace are interpreted by containerd
+		// itself, and labels in the io.cri-containerd.* namespace are interpreted
+		// by the CRI plugin, so they are not copied from untrusted image configs.
+		for k := range c.Labels {
+			if labels.IsReserved(k) {
+				log.G(ctx).Warnf("skipping image label %q: the label namespace is reserved for containerd; possible malicious image attempting to alter containerd behavior", k)
+				delete(c.Labels, k)
+			}
+		}
 		return nil
 	}
 }

--- a/container_opts_test.go
+++ b/container_opts_test.go
@@ -1,0 +1,75 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containerd
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/content"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeImage implements the subset of Image used by WithImageConfigLabels:
+// Config returns a descriptor with the config blob inlined in Data, so the
+// content store is never consulted.
+type fakeImage struct {
+	Image
+	config ocispec.Descriptor
+}
+
+func (i fakeImage) Config(context.Context) (ocispec.Descriptor, error) {
+	return i.config, nil
+}
+
+func (i fakeImage) ContentStore() content.Store {
+	return nil
+}
+
+func TestWithImageConfigLabels(t *testing.T) {
+	blob, err := json.Marshal(ocispec.Image{
+		Config: ocispec.ImageConfig{
+			Labels: map[string]string{
+				"foo":                          "bar",
+				"containerd.io/restart.policy": "always",
+				"io.cri-containerd.kind":       "sandbox",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	img := fakeImage{
+		config: ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageConfig,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
+			Data:      blob,
+		},
+	}
+
+	var c containers.Container
+	require.NoError(t, WithImageConfigLabels(img)(t.Context(), nil, &c))
+
+	// labels in the namespaces reserved for containerd and the CRI plugin
+	// are not copied from the image config
+	assert.Equal(t, map[string]string{"foo": "bar"}, c.Labels)
+}

--- a/labels/labels.go
+++ b/labels/labels.go
@@ -16,6 +16,18 @@
 
 package labels
 
+// ReservedPrefix is the prefix of the label namespace reserved for labels
+// defined and consumed by containerd itself. Labels in this namespace must
+// not be copied from untrusted sources such as image config labels. Use
+// IsReserved to check for such labels.
+const ReservedPrefix = "containerd.io/"
+
+// CRIContainerdPrefix is the prefix of the label namespace reserved for
+// labels defined and consumed by containerd's CRI plugin. Labels in this
+// namespace must not be copied from untrusted sources such as image config
+// labels. Use IsReserved to check for such labels.
+const CRIContainerdPrefix = "io.cri-containerd"
+
 // LabelUncompressed is added to compressed layer contents.
 // The value is digest of the uncompressed content.
 const LabelUncompressed = "containerd.io/uncompressed"

--- a/labels/validate.go
+++ b/labels/validate.go
@@ -18,6 +18,7 @@ package labels
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containerd/containerd/errdefs"
 )
@@ -38,4 +39,12 @@ func Validate(k, v string) error {
 		return fmt.Errorf("label key and value length (%d bytes) greater than maximum size (%d bytes), key: %s: %w", total, maxSize, k, errdefs.ErrInvalidArgument)
 	}
 	return nil
+}
+
+// IsReserved returns true if the label key is in a namespace reserved for
+// containerd (ReservedPrefix) or its CRI plugin (CRIContainerdPrefix).
+// Reserved labels are interpreted by containerd and must not be copied from
+// untrusted sources such as image config labels.
+func IsReserved(k string) bool {
+	return strings.HasPrefix(k, ReservedPrefix) || strings.HasPrefix(k, CRIContainerdPrefix)
 }

--- a/labels/validate_test.go
+++ b/labels/validate_test.go
@@ -53,6 +53,23 @@ func TestInvalidLabels(t *testing.T) {
 	}
 }
 
+func TestIsReserved(t *testing.T) {
+	for key, reserved := range map[string]bool{
+		"containerd.io/":               true,
+		"containerd.io/restart.status": true,
+		"containerd.io/gc.ref.content": true,
+		"io.cri-containerd":            true,
+		"io.cri-containerd.kind":       true,
+		"io.cri-containerd.image":      true,
+		"io.cri-containerdfoo":         true,
+		"containerd.io":                false,
+		"io.containerd.something":      false,
+		"com.example.app":              false,
+	} {
+		assert.Equal(t, reserved, IsReserved(key), "IsReserved(%q)", key)
+	}
+}
+
 func TestLongKey(t *testing.T) {
 	key := strings.Repeat("s", keyMaxLen+1)
 	value := strings.Repeat("v", maxSize-len(key))

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -931,7 +932,12 @@ func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 			if err != nil {
 				return err
 			}
-			ugroups, groupErr := user.ParseGroupFile(gpath)
+			var ugroups []user.Group
+			f, groupErr := openBoundedUserFile(gpath)
+			if groupErr == nil {
+				ugroups, groupErr = user.ParseGroup(f)
+				f.Close()
+			}
 			if groupErr != nil && !os.IsNotExist(groupErr) {
 				return groupErr
 			}
@@ -1091,7 +1097,12 @@ func UserFromPath(root string, filter func(user.User) bool) (user.User, error) {
 	if err != nil {
 		return user.User{}, err
 	}
-	users, err := user.ParsePasswdFileFilter(ppath, filter)
+	f, err := openBoundedUserFile(ppath)
+	if err != nil {
+		return user.User{}, err
+	}
+	defer f.Close()
+	users, err := user.ParsePasswdFilter(f, filter)
 	if err != nil {
 		return user.User{}, err
 	}
@@ -1111,7 +1122,12 @@ func GIDFromPath(root string, filter func(user.Group) bool) (gid uint32, err err
 	if err != nil {
 		return 0, err
 	}
-	groups, err := user.ParseGroupFileFilter(gpath, filter)
+	f, err := openBoundedUserFile(gpath)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	groups, err := user.ParseGroupFilter(f, filter)
 	if err != nil {
 		return 0, err
 	}
@@ -1127,7 +1143,12 @@ func getSupplementalGroupsFromPath(root string, filter func(user.Group) bool) ([
 	if err != nil {
 		return []uint32{}, err
 	}
-	groups, err := user.ParseGroupFileFilter(gpath, filter)
+	f, err := openBoundedUserFile(gpath)
+	if err != nil {
+		return []uint32{}, err
+	}
+	defer f.Close()
+	groups, err := user.ParseGroupFilter(f, filter)
 	if err != nil {
 		return []uint32{}, err
 	}
@@ -1670,4 +1691,59 @@ func WithWindowsNetworkNamespace(ns string) SpecOpts {
 		s.Windows.Network.NetworkNamespace = ns
 		return nil
 	}
+}
+
+// maxUserFileBytes caps how much data is read from any user-database file
+// opened via openBoundedUserFile. Real systems keep these files well under
+// 1 MiB; 10 MiB is generous headroom while keeping peak memory during
+// user.ParsePasswd/ParseGroup bounded to single-digit MiB.
+const maxUserFileBytes = 10 << 20
+
+// openBoundedUserFile opens path and returns an io.ReadCloser that errors out
+// if more than maxUserFileBytes are read from it. Non-regular sources are
+// rejected before opening, so callers never block on FIFOs or device files
+// and parsers never consume bytes from them.
+//
+// openBoundedUserFile does NOT perform any path validation. It does not guard
+// against symlink traversal or paths that escape the container rootfs, and it
+// follows symlinks both when stat-ing and when opening. Callers are responsible
+// for confining path to the intended root beforehand (e.g. via fs.RootPath,
+// which resolves every symlink component and re-anchors absolute links to the
+// root) and must not pass attacker-controlled, unresolved paths directly.
+func openBoundedUserFile(path string) (io.ReadCloser, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return &limitedFile{
+		Closer: f,
+		// Allow one byte past the cap so an overflow surfaces as an
+		// error rather than a silent EOF that the parser would treat as
+		// a clean end-of-file (and miss any entries past the cap).
+		r:    &io.LimitedReader{R: f, N: maxUserFileBytes + 1},
+		name: path,
+	}, nil
+}
+
+// limitedFile is an io.ReadCloser whose Read returns an error once more than
+// maxUserFileBytes have been read.
+type limitedFile struct {
+	io.Closer
+	r    *io.LimitedReader
+	name string
+}
+
+func (l *limitedFile) Read(p []byte) (int, error) {
+	n, err := l.r.Read(p)
+	if l.r.N == 0 {
+		return n, fmt.Errorf("%q exceeds %d bytes", l.name, maxUserFileBytes)
+	}
+	return n, err
 }

--- a/oci/spec_opts_linux_test.go
+++ b/oci/spec_opts_linux_test.go
@@ -752,7 +752,7 @@ func TestWithAppendAdditionalGroupsNoEtcGroup(t *testing.T) {
 		{
 			name:     "no additional gids, append root group",
 			groups:   []string{"root"},
-			err:      fmt.Sprintf("unable to find group root: open %s: no such file or directory", filepath.Join(td, "etc", "group")),
+			err:      fmt.Sprintf("unable to find group root: stat %s: no such file or directory", filepath.Join(td, "etc", "group")),
 			expected: []uint32{0},
 		},
 		{

--- a/oci/spec_opts_user_bounds_test.go
+++ b/oci/spec_opts_user_bounds_test.go
@@ -1,0 +1,101 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package oci
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/moby/sys/user"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOpenBoundedUserFileCapsReads asserts the boundary behavior of the read
+// cap: well below, ending exactly at, and past maxUserFileBytes.
+func TestOpenBoundedUserFileCapsReads(t *testing.T) {
+	t.Parallel()
+
+	beyond := []byte("\nbeyond:x:42:\n")
+
+	for _, tc := range []struct {
+		name     string
+		padBytes int
+		wantGids []uint32
+		wantErr  bool
+	}{
+		{
+			name:     "pad below cap, beyond is parsed",
+			padBytes: 100,
+			wantGids: []uint32{42},
+		},
+		{
+			name:     "beyond ends exactly at cap, is parsed",
+			padBytes: maxUserFileBytes - len(beyond),
+			wantGids: []uint32{42},
+		},
+		{
+			name:     "pad past cap, read errors out",
+			padBytes: maxUserFileBytes,
+			wantErr:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(root, "etc"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			data := append(bytes.Repeat([]byte{0}, tc.padBytes), beyond...)
+			if err := os.WriteFile(filepath.Join(root, "etc", "group"), data, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			gids, err := getSupplementalGroupsFromPath(root, func(g user.Group) bool {
+				return g.Name == "beyond"
+			})
+			if tc.wantErr {
+				assert.ErrorContains(t, err, "exceeds")
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantGids, gids)
+		})
+	}
+}
+
+// TestOpenBoundedUserFileRejectsNonRegularFiles verifies that non-regular
+// files are refused before any byte is read from them.
+func TestOpenBoundedUserFileRejectsNonRegularFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(root, "etc", "group"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := getSupplementalGroupsFromPath(root, nil)
+	assert.ErrorContains(t, err, "not a regular file")
+}

--- a/pkg/cri/labels/labels.go
+++ b/pkg/cri/labels/labels.go
@@ -16,9 +16,13 @@
 
 package labels
 
+import (
+	clabels "github.com/containerd/containerd/labels"
+)
+
 const (
 	// criContainerdPrefix is common prefix for cri-containerd
-	criContainerdPrefix = "io.cri-containerd"
+	criContainerdPrefix = clabels.CRIContainerdPrefix
 	// ImageLabelKey is the label key indicating the image is managed by cri plugin.
 	ImageLabelKey = criContainerdPrefix + ".image"
 	// ImageLabelValue is the label value indicating the image is managed by cri plugin.

--- a/pkg/cri/sbserver/helpers.go
+++ b/pkg/cri/sbserver/helpers.go
@@ -313,11 +313,21 @@ func filterLabel(k, v string) string {
 	return fmt.Sprintf("labels.%q==%q", k, v)
 }
 
-// buildLabel builds the labels from config to be passed to containerd
+// buildLabels builds the labels from config to be passed to containerd.
+// Image config labels in the namespaces reserved for containerd
+// (containerd.io/) and the CRI plugin (io.cri-containerd) are not copied
+// to the container.
 func buildLabels(configLabels, imageConfigLabels map[string]string, containerType string) map[string]string {
 	labels := make(map[string]string)
 
 	for k, v := range imageConfigLabels {
+		// Labels in the containerd.io/* namespace are interpreted by containerd
+		// itself, and labels in the io.cri-containerd.* namespace are interpreted
+		// by the CRI plugin, so they are not copied from untrusted image configs.
+		if clabels.IsReserved(k) {
+			logrus.Warnf("skipping image label %q: the label namespace is reserved for containerd; possible malicious image attempting to alter containerd behavior", k)
+			continue
+		}
 		if err := clabels.Validate(k, v); err == nil {
 			labels[k] = v
 		} else {

--- a/pkg/cri/sbserver/helpers_test.go
+++ b/pkg/cri/sbserver/helpers_test.go
@@ -128,21 +128,29 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 
 func TestBuildLabels(t *testing.T) {
 	imageConfigLabels := map[string]string{
-		"a":          "z",
-		"d":          "y",
-		"long-label": strings.Repeat("example", 10000),
+		"a":                            "z",
+		"d":                            "y",
+		"long-label":                   strings.Repeat("example", 10000),
+		"containerd.io/restart.policy": "always",
+		"io.cri-containerd.image":      "managed",
 	}
 	configLabels := map[string]string{
 		"a": "b",
 		"c": "d",
+		// reserved namespaces are only filtered for image config labels, not
+		// for labels from the CRI request
+		"containerd.io/restart.status": "stopped",
 	}
 	newLabels := buildLabels(configLabels, imageConfigLabels, containerKindSandbox)
-	assert.Len(t, newLabels, 4)
+	assert.Len(t, newLabels, 5)
 	assert.Equal(t, "b", newLabels["a"])
 	assert.Equal(t, "d", newLabels["c"])
 	assert.Equal(t, "y", newLabels["d"])
+	assert.Equal(t, "stopped", newLabels["containerd.io/restart.status"])
 	assert.Equal(t, containerKindSandbox, newLabels[containerKindLabel])
 	assert.NotContains(t, newLabels, "long-label")
+	assert.NotContains(t, newLabels, "containerd.io/restart.policy")
+	assert.NotContains(t, newLabels, "io.cri-containerd.image")
 
 	newLabels["a"] = "e"
 	assert.Empty(t, configLabels[containerKindLabel], "should not add new labels into original label")

--- a/pkg/cri/sbserver/podsandbox/helpers.go
+++ b/pkg/cri/sbserver/podsandbox/helpers.go
@@ -122,11 +122,21 @@ func getUserFromImage(user string) (*int64, string) {
 	return &uid, ""
 }
 
-// buildLabel builds the labels from config to be passed to containerd
+// buildLabels builds the labels from config to be passed to containerd.
+// Image config labels in the namespaces reserved for containerd
+// (containerd.io/) and the CRI plugin (io.cri-containerd) are not copied
+// to the container.
 func buildLabels(configLabels, imageConfigLabels map[string]string, containerType string) map[string]string {
 	labels := make(map[string]string)
 
 	for k, v := range imageConfigLabels {
+		// Labels in the containerd.io/* namespace are interpreted by containerd
+		// itself, and labels in the io.cri-containerd.* namespace are interpreted
+		// by the CRI plugin, so they are not copied from untrusted image configs.
+		if clabels.IsReserved(k) {
+			logrus.Warnf("skipping image label %q: the label namespace is reserved for containerd; possible malicious image attempting to alter containerd behavior", k)
+			continue
+		}
 		if err := clabels.Validate(k, v); err == nil {
 			labels[k] = v
 		} else {

--- a/pkg/cri/sbserver/podsandbox/helpers_test.go
+++ b/pkg/cri/sbserver/podsandbox/helpers_test.go
@@ -111,21 +111,29 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 
 func TestBuildLabels(t *testing.T) {
 	imageConfigLabels := map[string]string{
-		"a":          "z",
-		"d":          "y",
-		"long-label": strings.Repeat("example", 10000),
+		"a":                            "z",
+		"d":                            "y",
+		"long-label":                   strings.Repeat("example", 10000),
+		"containerd.io/restart.policy": "always",
+		"io.cri-containerd.image":      "managed",
 	}
 	configLabels := map[string]string{
 		"a": "b",
 		"c": "d",
+		// reserved namespaces are only filtered for image config labels, not
+		// for labels from the CRI request
+		"containerd.io/restart.status": "stopped",
 	}
 	newLabels := buildLabels(configLabels, imageConfigLabels, containerKindSandbox)
-	assert.Len(t, newLabels, 4)
+	assert.Len(t, newLabels, 5)
 	assert.Equal(t, "b", newLabels["a"])
 	assert.Equal(t, "d", newLabels["c"])
 	assert.Equal(t, "y", newLabels["d"])
+	assert.Equal(t, "stopped", newLabels["containerd.io/restart.status"])
 	assert.Equal(t, containerKindSandbox, newLabels[containerKindLabel])
 	assert.NotContains(t, newLabels, "long-label")
+	assert.NotContains(t, newLabels, "containerd.io/restart.policy")
+	assert.NotContains(t, newLabels, "io.cri-containerd.image")
 
 	newLabels["a"] = "e"
 	assert.Empty(t, configLabels[containerKindLabel], "should not add new labels into original label")

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -282,11 +282,21 @@ func filterLabel(k, v string) string {
 	return fmt.Sprintf("labels.%q==%q", k, v)
 }
 
-// buildLabel builds the labels from config to be passed to containerd
+// buildLabels builds the labels from config to be passed to containerd.
+// Image config labels in the namespaces reserved for containerd
+// (containerd.io/) and the CRI plugin (io.cri-containerd) are not copied
+// to the container.
 func buildLabels(configLabels, imageConfigLabels map[string]string, containerType string) map[string]string {
 	labels := make(map[string]string)
 
 	for k, v := range imageConfigLabels {
+		// Labels in the containerd.io/* namespace are interpreted by containerd
+		// itself, and labels in the io.cri-containerd.* namespace are interpreted
+		// by the CRI plugin, so they are not copied from untrusted image configs.
+		if clabels.IsReserved(k) {
+			logrus.Warnf("skipping image label %q: the label namespace is reserved for containerd; possible malicious image attempting to alter containerd behavior", k)
+			continue
+		}
 		if err := clabels.Validate(k, v); err == nil {
 			labels[k] = v
 		} else {

--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -128,21 +128,29 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 
 func TestBuildLabels(t *testing.T) {
 	imageConfigLabels := map[string]string{
-		"a":          "z",
-		"d":          "y",
-		"long-label": strings.Repeat("example", 10000),
+		"a":                            "z",
+		"d":                            "y",
+		"long-label":                   strings.Repeat("example", 10000),
+		"containerd.io/restart.policy": "always",
+		"io.cri-containerd.image":      "managed",
 	}
 	configLabels := map[string]string{
 		"a": "b",
 		"c": "d",
+		// reserved namespaces are only filtered for image config labels, not
+		// for labels from the CRI request
+		"containerd.io/restart.status": "stopped",
 	}
 	newLabels := buildLabels(configLabels, imageConfigLabels, containerKindSandbox)
-	assert.Len(t, newLabels, 4)
+	assert.Len(t, newLabels, 5)
 	assert.Equal(t, "b", newLabels["a"])
 	assert.Equal(t, "d", newLabels["c"])
 	assert.Equal(t, "y", newLabels["d"])
+	assert.Equal(t, "stopped", newLabels["containerd.io/restart.status"])
 	assert.Equal(t, containerKindSandbox, newLabels[containerKindLabel])
 	assert.NotContains(t, newLabels, "long-label")
+	assert.NotContains(t, newLabels, "containerd.io/restart.policy")
+	assert.NotContains(t, newLabels, "io.cri-containerd.image")
 
 	newLabels["a"] = "e"
 	assert.Empty(t, configLabels[containerKindLabel], "should not add new labels into original label")

--- a/releases/v1.7.33.toml
+++ b/releases/v1.7.33.toml
@@ -1,0 +1,36 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.32"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The thirty-third patch release for containerd 1.7 contains various fixes
+and updates including security patches.
+
+### Security Updates
+
+* **containerd**
+  * [**CVE-2026-53488**](https://github.com/containerd/containerd/security/advisories/GHSA-xhf5-7wjv-pqxp)
+  * [**CVE-2026-47262**](https://github.com/containerd/containerd/security/advisories/GHSA-jpcc-p29g-p8mq)
+
+* **go-jose**
+  * [**CVE-2026-34986**](https://github.com/go-jose/go-jose/security/advisories/GHSA-78h2-9frx-2jm8)
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.32+unknown"
+	Version = "1.7.33+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
containerd 1.7.33

Welcome to the v1.7.33 release of containerd!

The thirty-third patch release for containerd 1.7 contains various fixes
and updates including security patches.

### Security Updates

* **containerd**
  * [**CVE-2026-53488**](https://github.com/containerd/containerd/security/advisories/GHSA-xhf5-7wjv-pqxp)
  * [**CVE-2026-47262**](https://github.com/containerd/containerd/security/advisories/GHSA-jpcc-p29g-p8mq)

* **go-jose**
  * [**CVE-2026-34986**](https://github.com/go-jose/go-jose/security/advisories/GHSA-78h2-9frx-2jm8)

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Samuel Karp
* Chris Henzie
* Akihiro Suda
* Akhil Mohan
* Ben Cressey
* Davanum Srinivas
* Sopho Merkviladze

### Changes
<details><summary>16 commits</summary>
<p>

  * [`7517e6737`](https://github.com/containerd/containerd/commit/7517e6737a6077dbdb5d403e693169cb8163549d) Prepare release notes for v1.7.33
  * [`ab306518a`](https://github.com/containerd/containerd/commit/ab306518a326fe7e4c27f64a8cf62b7a0fb3e9c6) Merge commit from fork
  * [`d34cdafda`](https://github.com/containerd/containerd/commit/d34cdafdaf51e1db435f1e0898f16d0da5038557) Merge commit from fork
  * [`9ab2b7a89`](https://github.com/containerd/containerd/commit/9ab2b7a894d15738f8323f69def272c29277b57f) Bound user-database file reads in openBoundedUserFile
  * [`1e9806f90`](https://github.com/containerd/containerd/commit/1e9806f90d934f2e0180c279fa9f0019537f2704) Merge commit from fork
  * [`4d8ba4d23`](https://github.com/containerd/containerd/commit/4d8ba4d23561c9ec21b0113ddcfc22f41792b25e) Do not propagate reserved labels from image configs
* update runc binary to v1.3.6 ([#13615](https://github.com/containerd/containerd/pull/13615))
  * [`74c728c13`](https://github.com/containerd/containerd/commit/74c728c13487844c43620b14cc66dc05dca96836) update runc binary to v1.3.6
* update go to 1.26.4/1.25.11 ([#13579](https://github.com/containerd/containerd/pull/13579))
  * [`947caa4b7`](https://github.com/containerd/containerd/commit/947caa4b7469fd3b71ee62d0f7410b00252f5842) update go to 1.26.4/1.25.11
* Configure udevd children-max for root-test ([#13564](https://github.com/containerd/containerd/pull/13564))
  * [`e884e964e`](https://github.com/containerd/containerd/commit/e884e964e31c4fb61fcdc376a2fa3151ac245a65) Configure udevd children-max for root-test
* Clean up disk space in node e2e workflow ([#13552](https://github.com/containerd/containerd/pull/13552))
  * [`b9e756888`](https://github.com/containerd/containerd/commit/b9e7568888325736b12c9f50271045bc618dc9b9) Clean up disk space in node e2e workflow
* Bump go-jose/go-jose/v3 to v3.0.5 to fix GHSA-78h2-9frx-2jm8 ([#13467](https://github.com/containerd/containerd/pull/13467))
  * [`4dfc1844e`](https://github.com/containerd/containerd/commit/4dfc1844e8cb46a6c04a8c57211ab50e1412ccc1) Bump go-jose to v3.0.5 to address CVE-2026-34986
</p>
</details>

### Dependency Changes

* **github.com/go-jose/go-jose/v3**  v3.0.4 -> v3.0.5

Previous release can be found at [v1.7.32](https://github.com/containerd/containerd/releases/tag/v1.7.32)
