### PR TITLE
snapshots/devmapper: avoid nil status deref after mkfs failure

### DIFF
--- a/plugins/snapshots/devmapper/snapshotter.go
+++ b/plugins/snapshots/devmapper/snapshotter.go
@@ -428,8 +428,13 @@ func (s *Snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 				errs = append(errs, sErr)
 			}
 
+			poolStatus := "unavailable"
+			if status != nil {
+				poolStatus = status.RawOutput
+			}
+
 			// Rollback thin device creation if mkfs failed
-			log.G(ctx).WithError(errors.Join(errs...)).Errorf("failed to initialize thin device %q for snapshot %s pool status %s", deviceName, snap.ID, status.RawOutput)
+			log.G(ctx).WithError(errors.Join(errs...)).Errorf("failed to initialize thin device %q for snapshot %s pool status %s", deviceName, snap.ID, poolStatus)
 			return nil, errors.Join(append(errs, s.pool.RemoveDevice(ctx, deviceName))...)
 		}
 	} else {


### PR DESCRIPTION
dmsetup.Status() returns a nil DeviceStatus when it fails.  The mkfs failure path records that error, but still unconditionally dereferences status when logging the pool status.

Avoid the panic by logging a fallback status string when dmsetup.Status() does not return a status.

Found by Linux Verification Center (linuxtesting.org) with SVACE.