### PR TITLE
Add forward References to the GC collection context

### DIFF
--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -150,6 +150,24 @@ type collectionWithBackRefs interface {
 	ActiveWithBackRefs(namespace string, fn func(gc.Node), bref func(gc.Node, gc.Node))
 }
 
+// collectionWithReferences is an optional interface a CollectionContext may
+// implement to emit forward references lazily during graph traversal.
+//
+// It is the forward-reference analogue of collectionWithBackRefs.  Whereas
+// ActiveWithBackRefs must enumerate every edge up-front — and the gcContext
+// holds all of them in its backRefs map for the entire collection — References
+// is invoked on demand when the GC visits a single node of the collector's
+// resource type.  A collector whose resources fan out to many other nodes
+// (for example an index blob that references many content blobs) can
+// therefore emit those edges without bloating memory for the whole pass.
+//
+// References is consulted by gcContext.references after the built-in core
+// resource types have been handled, so a collector only needs to handle the
+// resource type(s) it registered.
+type collectionWithReferences interface {
+	References(ctx context.Context, node gc.Node, fn func(gc.Node))
+}
+
 // Collector is an interface to manage resource collection for any collectible
 // resource registered for garbage collection.
 type Collector interface {
@@ -184,6 +202,11 @@ type gcContext struct {
 	labelHandlers []referenceLabelHandler
 	contexts      map[gc.ResourceType]CollectionContext
 	backRefs      map[gc.Node][]gc.Node
+	// refContexts holds, per resource type, the collection contexts that emit
+	// references (see collectionWithReferences). Separate from contexts to avoid
+	// repeated type assertion when called by references() after the
+	// built-in core type switch.
+	refContexts map[gc.ResourceType]collectionWithReferences
 }
 
 type referenceLabelHandler struct {
@@ -374,6 +397,7 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 			},
 		},
 	}
+	var refContexts map[gc.ResourceType]collectionWithReferences
 	if len(collectors) > 0 {
 		contexts = map[gc.ResourceType]CollectionContext{}
 		for rt, collector := range collectors {
@@ -400,6 +424,14 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 				})
 			}
 			contexts[rt] = c
+
+			// Register the forward-reference emitter, if implemented.
+			if rc, ok := c.(collectionWithReferences); ok {
+				if refContexts == nil {
+					refContexts = map[gc.ResourceType]collectionWithReferences{}
+				}
+				refContexts[rt] = rc
+			}
 		}
 		// Sort labelHandlers to ensure key seeking is always forward
 		sort.Slice(labelHandlers, func(i, j int) bool {
@@ -410,6 +442,7 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 		labelHandlers: labelHandlers,
 		contexts:      contexts,
 		backRefs:      make(map[gc.Node][]gc.Node),
+		refContexts:   refContexts,
 	}
 }
 
@@ -886,6 +919,14 @@ func (c *gcContext) references(ctx context.Context, tx *bolt.Tx, node gc.Node, f
 		}
 
 		return c.sendLabelRefs(node.Namespace, bkt, labelRefCallbacks{fn: fn})
+	}
+
+	// Collectible resource types that emit forward references (see collectionWithReferences)
+	// are handled here, after the built-in core types.  This lets a collector
+	// reference core types, without having to pre-compute and hold every edge in
+	// backRefs for the whole gc context.
+	if rc, ok := c.refContexts[node.Type]; ok {
+		rc.References(ctx, node, fn)
 	}
 
 	return nil

--- a/core/metadata/gc_test.go
+++ b/core/metadata/gc_test.go
@@ -634,6 +634,113 @@ func TestCollectibleResources(t *testing.T) {
 	})
 }
 
+// TestCollectionWithReferences verifies that gcContext.references invokes the
+// collectionWithReferences hook for externally-registered resource types and
+// that built-in core-type references are unaffected.
+func TestCollectionWithReferences(t *testing.T) {
+	db, err := newDatabase(t)
+	require.NoError(t, err)
+
+	testResource := gc.ResourceType(0x20)
+
+	// Set up a content blob that the forward-reference collector will reference.
+	alters := []alterFunc{
+		addContent("ns1", dgst(1), nil),
+		addContent("ns1", dgst(2), labelmap(string(labelGCContentRef), dgst(1).String())),
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		v1bkt, err := tx.CreateBucketIfNotExists(bucketKeyVersion)
+		if err != nil {
+			return err
+		}
+		for _, alter := range alters {
+			if err := alter(v1bkt); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("Update failed: %+v", err)
+	}
+
+	// refNode is the node the collector will emit as a forward reference.
+	refNode := gcnode(ResourceContent, "ns1", dgst(1).String())
+	testNode := gcnode(testResource, "ns1", "myresource")
+
+	collector := &testForwardRefCollector{
+		testCollector: testCollector{
+			all: []gc.Node{testNode},
+		},
+		refs: map[gc.Node][]gc.Node{
+			testNode: {refNode},
+		},
+	}
+
+	ctx := context.Background()
+	c := startGCContext(ctx, map[gc.ResourceType]Collector{
+		testResource: collector,
+	})
+
+	// The external resource type should emit forward references via collectionWithReferences.
+	checkNodeC(ctx, t, db, []gc.Node{refNode}, func(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Node) error {
+		return c.references(ctx, tx, testNode, func(n gc.Node) {
+			select {
+			case nc <- n:
+			case <-ctx.Done():
+			}
+		})
+	})
+
+	// Core type (content blob with a label ref) must still resolve its own
+	// forward references without interference from the collector.
+	content2 := gcnode(ResourceContent, "ns1", dgst(2).String())
+	checkNodeC(ctx, t, db, []gc.Node{gcnode(ResourceContent, "ns1", dgst(1).String())},
+		func(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Node) error {
+			return c.references(ctx, tx, content2, func(n gc.Node) {
+				select {
+				case nc <- n:
+				case <-ctx.Done():
+				}
+			})
+		})
+
+	// A node whose type is not registered with a forward-reference collector
+	// should produce no references (other than those from built-in logic).
+	unknownNode := gcnode(testResource, "ns1", "notregistered")
+	unknownCollector := &testCollector{
+		all: []gc.Node{unknownNode},
+	}
+	c2 := startGCContext(ctx, map[gc.ResourceType]Collector{
+		testResource: unknownCollector,
+	})
+	checkNodeC(ctx, t, db, nil, func(ctx context.Context, tx *bolt.Tx, nc chan<- gc.Node) error {
+		return c2.references(ctx, tx, unknownNode, func(n gc.Node) {
+			select {
+			case nc <- n:
+			case <-ctx.Done():
+			}
+		})
+	})
+}
+
+// testForwardRefCollector extends testCollector with collectionWithReferences
+// support, emitting pre-configured forward edges for each visited node.
+type testForwardRefCollector struct {
+	testCollector
+	refs map[gc.Node][]gc.Node
+}
+
+func (tc *testForwardRefCollector) StartCollection(context.Context) (CollectionContext, error) {
+	return tc, nil
+}
+
+func (tc *testForwardRefCollector) References(_ context.Context, node gc.Node, fn func(gc.Node)) {
+	for _, ref := range tc.refs[node] {
+		fn(ref)
+	}
+}
+
 type testCollector struct {
 	all    []gc.Node
 	active []gc.Node


### PR DESCRIPTION
Extend the garbage-collection framework so a collectible resource can emit forward references during graph traversal, in addition to the existing back-reference mechanism.

A CollectionContext may now implement the optional collectionWithReferences interface:

	References(ctx context.Context, node gc.Node, fn func(gc.Node))

When the GC visits a node whose resource type was registered by an external collector, gcContext.references consults the per-type References implementation after the built-in core resource types are handled.

This is the forward-reference analogue of collectionWithBackRefs.  Whereas ActiveWithBackRefs must enumerate every edge up front and the gcContext holds all of them in its backRefs map for the entire collection, References is invoked on demand for a single node.  A collector whose resources fan out to many other nodes can therefore emit those edges without retaining them in memory for the gc context.

This commit is intentionally a no-op: no plugin registers a collector that uses collectionWithReferences yet.  It is isolated here so that concurrent development efforts that depend on this interface can be proposed and reviewed upstream independently. This is useful for implementing chunked storage as a plugin, which will directly reference blobs in the content store. This is also useful for any plugin that might hold a reference to a core containerd type.

```release-note
Add forward References to the GC collection context
```
