### PR TITLE
remotes/docker: support HTTP transport timeout overrides in hosts.toml

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -53,7 +53,11 @@ type hostConfig struct {
 	clientPairs [][2]string
 	skipVerify  *bool
 
-	dialTimeout *time.Duration
+	dialTimeout           *time.Duration
+	tlsHandshakeTimeout   *time.Duration
+	responseHeaderTimeout *time.Duration
+	expectContinueTimeout *time.Duration
+	idleConnTimeout       *time.Duration
 
 	header http.Header
 
@@ -170,10 +174,10 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 			// Allow setting for each host as well
 			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil
 			explicitTLS := tlsConfigured || explicitTLSFromHost
-
-			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 {
+			hasTimeouts := hasTransportTimeouts(host)
+			if explicitTLSFromHost || hasTimeouts || len(host.header) != 0 {
 				c := *client
-				if explicitTLSFromHost || host.dialTimeout != nil {
+				if explicitTLSFromHost || hasTimeouts {
 					tr := defaultTransport.Clone()
 
 					if explicitTLSFromHost {
@@ -188,6 +192,18 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 							KeepAlive:     30 * time.Second,
 							FallbackDelay: 300 * time.Millisecond,
 						}).DialContext
+					}
+					if host.tlsHandshakeTimeout != nil {
+						tr.TLSHandshakeTimeout = *host.tlsHandshakeTimeout
+					}
+					if host.responseHeaderTimeout != nil {
+						tr.ResponseHeaderTimeout = *host.responseHeaderTimeout
+					}
+					if host.expectContinueTimeout != nil {
+						tr.ExpectContinueTimeout = *host.expectContinueTimeout
+					}
+					if host.idleConnTimeout != nil {
+						tr.IdleConnTimeout = *host.idleConnTimeout
 					}
 
 					c.Transport = tr
@@ -237,6 +253,14 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 		return rhosts, nil
 	}
 
+}
+
+func hasTransportTimeouts(host hostConfig) bool {
+	return host.dialTimeout != nil ||
+		host.tlsHandshakeTimeout != nil ||
+		host.responseHeaderTimeout != nil ||
+		host.expectContinueTimeout != nil ||
+		host.idleConnTimeout != nil
 }
 
 func updateTLSConfigFromHost(tlsConfig *tls.Config, host *hostConfig) error {
@@ -373,6 +397,21 @@ type hostFileConfig struct {
 	// DialTimeout is the maximum amount of time a dial will wait for
 	// a connect to complete.
 	DialTimeout string `toml:"dial_timeout"`
+
+	// TLSHandshakeTimeout specifies the maximum amount of time waiting for a TLS handshake.
+	TLSHandshakeTimeout string `toml:"tls_handshake_timeout"`
+
+	// ResponseHeaderTimeout specifies the amount of time to wait for a server's response headers.
+	ResponseHeaderTimeout string `toml:"response_header_timeout"`
+
+	// ExpectContinueTimeout specifies the amount of time to wait for a server's first response
+	// headers after fully writing the request headers when the request contains
+	// an "Expect: 100-continue" header.
+	ExpectContinueTimeout string `toml:"expect_continue_timeout"`
+
+	// IdleConnTimeout specifies the maximum amount of time an idle connection
+	// will remain idle before closing itself.
+	IdleConnTimeout string `toml:"idle_conn_timeout"`
 
 	// TODO: Credentials: helper? name? username? alternate domain? token?
 }
@@ -539,9 +578,41 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 	if config.DialTimeout != "" {
 		dialTimeout, err := time.ParseDuration(config.DialTimeout)
 		if err != nil {
-			return hostConfig{}, err
+			return hostConfig{}, fmt.Errorf("invalid dial_timeout %q: %w", config.DialTimeout, err)
 		}
 		result.dialTimeout = &dialTimeout
+	}
+
+	if config.TLSHandshakeTimeout != "" {
+		tlsHandshakeTimeout, err := time.ParseDuration(config.TLSHandshakeTimeout)
+		if err != nil {
+			return hostConfig{}, fmt.Errorf("invalid tls_handshake_timeout %q: %w", config.TLSHandshakeTimeout, err)
+		}
+		result.tlsHandshakeTimeout = &tlsHandshakeTimeout
+	}
+
+	if config.ResponseHeaderTimeout != "" {
+		responseHeaderTimeout, err := time.ParseDuration(config.ResponseHeaderTimeout)
+		if err != nil {
+			return hostConfig{}, fmt.Errorf("invalid response_header_timeout %q: %w", config.ResponseHeaderTimeout, err)
+		}
+		result.responseHeaderTimeout = &responseHeaderTimeout
+	}
+
+	if config.IdleConnTimeout != "" {
+		idleConnTimeout, err := time.ParseDuration(config.IdleConnTimeout)
+		if err != nil {
+			return hostConfig{}, fmt.Errorf("invalid idle_conn_timeout %q: %w", config.IdleConnTimeout, err)
+		}
+		result.idleConnTimeout = &idleConnTimeout
+	}
+
+	if config.ExpectContinueTimeout != "" {
+		expectContinueTimeout, err := time.ParseDuration(config.ExpectContinueTimeout)
+		if err != nil {
+			return hostConfig{}, fmt.Errorf("invalid expect_continue_timeout %q: %w", config.ExpectContinueTimeout, err)
+		}
+		result.expectContinueTimeout = &expectContinueTimeout
 	}
 
 	return result, nil

--- a/core/remotes/docker/config/hosts_test.go
+++ b/core/remotes/docker/config/hosts_test.go
@@ -75,6 +75,97 @@ func TestDefaultHosts(t *testing.T) {
 	}
 }
 
+func TestConfigureHostsTransportTimeouts(t *testing.T) {
+	const registryHost = "timeout.registry"
+
+	const hostsTOML = `
+[host."https://timeout.registry"]
+  capabilities = ["pull", "resolve"]
+  tls_handshake_timeout = "11s"
+  response_header_timeout = "42s"
+  expect_continue_timeout = "7s"
+  idle_conn_timeout = "1m30s"
+`
+
+	root := t.TempDir()
+	hostDir := filepath.Join(root, registryHost)
+
+	if err := os.MkdirAll(hostDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hostsTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := logtest.WithT(context.Background(), t)
+	resolve := ConfigureHosts(ctx, HostOptions{
+		HostDir: HostDirFromRoot(root),
+	})
+
+	hosts, err := resolve(registryHost)
+	if err != nil {
+		t.Fatalf("failed to configure registry hosts: %v", err)
+	}
+
+	var transport *http.Transport
+
+	for _, host := range hosts {
+		if host.Host != registryHost || host.Scheme != "https" {
+			continue
+		}
+
+		tr, ok := host.Client.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected transport for host %q to be *http.Transport, got %T", host.Host, host.Client.Transport)
+		}
+
+		if tr.TLSHandshakeTimeout == 11*time.Second {
+			transport = tr
+			break
+		}
+	}
+
+	if transport == nil {
+		t.Fatal("failed to find registry host with configured transport timeouts")
+	}
+
+	tests := []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{
+			name: "TLS handshake timeout",
+			got:  transport.TLSHandshakeTimeout,
+			want: 11 * time.Second,
+		},
+		{
+			name: "response header timeout",
+			got:  transport.ResponseHeaderTimeout,
+			want: 42 * time.Second,
+		},
+		{
+			name: "expect continue timeout",
+			got:  transport.ExpectContinueTimeout,
+			want: 7 * time.Second,
+		},
+		{
+			name: "idle connection timeout",
+			got:  transport.IdleConnTimeout,
+			want: 90 * time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("timeout = %v, want %v", tc.got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseHostFile(t *testing.T) {
 	const testtoml = `
 server = "https://test-default.registry"
@@ -123,10 +214,28 @@ ca = "/etc/path/default"
 
 [host."https://dial-timeout.registry"]
   dial_timeout = "3s"
+
+[host."https://response-header-timeout.registry"]
+  response_header_timeout = "3s"
+
+[host."https://idle-conn-timeout.registry"]
+  idle_conn_timeout = "3s"
+
+[host."https://expect-continue-timeout.registry"]
+  expect_continue_timeout = "3s"
+
+[host."https://tls-handshake-timeout.registry"]
+  tls_handshake_timeout = "3s"
 `
 
 	var tb, fb = true, false
-	var dialTimeout = 3 * time.Second
+	var (
+		dialTimeout           = 3 * time.Second
+		responseHeaderTimeout = 3 * time.Second
+		idleConnTimeout       = 3 * time.Second
+		expectContinueTimeout = 3 * time.Second
+		tlsHandshakeTimeout   = 3 * time.Second
+	)
 	expected := []hostConfig{
 		{
 			scheme:       "https",
@@ -214,6 +323,34 @@ ca = "/etc/path/default"
 			path:         "/v2",
 			capabilities: allCaps,
 			dialTimeout:  &dialTimeout,
+		},
+		{
+			scheme:                "https",
+			host:                  "response-header-timeout.registry",
+			path:                  "/v2",
+			capabilities:          allCaps,
+			responseHeaderTimeout: &responseHeaderTimeout,
+		},
+		{
+			scheme:          "https",
+			host:            "idle-conn-timeout.registry",
+			path:            "/v2",
+			capabilities:    allCaps,
+			idleConnTimeout: &idleConnTimeout,
+		},
+		{
+			scheme:                "https",
+			host:                  "expect-continue-timeout.registry",
+			path:                  "/v2",
+			capabilities:          allCaps,
+			expectContinueTimeout: &expectContinueTimeout,
+		},
+		{
+			scheme:              "https",
+			host:                "tls-handshake-timeout.registry",
+			path:                "/v2",
+			capabilities:        allCaps,
+			tlsHandshakeTimeout: &tlsHandshakeTimeout,
 		},
 		{
 			scheme:       "https",
@@ -590,6 +727,38 @@ func compareHostConfig(j, k hostConfig) bool {
 		return false
 	}
 
+	if j.responseHeaderTimeout != nil && k.responseHeaderTimeout != nil {
+		if *j.responseHeaderTimeout != *k.responseHeaderTimeout {
+			return false
+		}
+	} else if j.responseHeaderTimeout != nil || k.responseHeaderTimeout != nil {
+		return false
+	}
+
+	if j.expectContinueTimeout != nil && k.expectContinueTimeout != nil {
+		if *j.expectContinueTimeout != *k.expectContinueTimeout {
+			return false
+		}
+	} else if j.expectContinueTimeout != nil || k.expectContinueTimeout != nil {
+		return false
+	}
+
+	if j.idleConnTimeout != nil && k.idleConnTimeout != nil {
+		if *j.idleConnTimeout != *k.idleConnTimeout {
+			return false
+		}
+	} else if j.idleConnTimeout != nil || k.idleConnTimeout != nil {
+		return false
+	}
+
+	if j.tlsHandshakeTimeout != nil && k.tlsHandshakeTimeout != nil {
+		if *j.tlsHandshakeTimeout != *k.tlsHandshakeTimeout {
+			return false
+		}
+	} else if j.tlsHandshakeTimeout != nil || k.tlsHandshakeTimeout != nil {
+		return false
+	}
+
 	return true
 }
 
@@ -609,7 +778,19 @@ func printHostConfig(hc []hostConfig) string {
 		}
 		fmt.Fprintf(b, "\t\theader: %#v\n", hc[i].header)
 		if hc[i].dialTimeout != nil {
-			fmt.Fprintf(b, "\t\tdial-timeout: %v\n", hc[i].dialTimeout)
+			fmt.Fprintf(b, "\t\tdial-timeout: %v\n", *hc[i].dialTimeout)
+		}
+		if hc[i].responseHeaderTimeout != nil {
+			fmt.Fprintf(b, "\t\tresponse-header-timeout: %v\n", *hc[i].responseHeaderTimeout)
+		}
+		if hc[i].idleConnTimeout != nil {
+			fmt.Fprintf(b, "\t\tidle-conn-timeout: %v\n", *hc[i].idleConnTimeout)
+		}
+		if hc[i].expectContinueTimeout != nil {
+			fmt.Fprintf(b, "\t\texpect-continue-timeout: %v\n", *hc[i].expectContinueTimeout)
+		}
+		if hc[i].tlsHandshakeTimeout != nil {
+			fmt.Fprintf(b, "\t\ttls-handshake-timeout: %v\n", *hc[i].tlsHandshakeTimeout)
 		}
 	}
 	return b.String()

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -373,6 +373,46 @@ A shorter timeout helps reduce delays when falling back to the original registry
 dial_timeout = "1s"
 ```
 
+## tls_handshake_timeout field
+
+`tls_handshake_timeout` specifies the maximum time allowed for completing a TLS handshake.
+This can be increased when communicating with registries over high-latency networks or through intermediaries that may delay TLS negotiation.
+(Defaults to `10s`)
+
+```
+tls_handshake_timeout = "15s"
+```
+
+## response_header_timeout field
+
+`response_header_timeout` specifies the amount of time to wait for a registry to return response headers after a request has been sent.
+A shorter timeout can help detect unresponsive registries more quickly and reduce delays before falling back to another mirror or retrying the request.
+(Defaults to `30s`)
+
+```
+response_header_timeout = "10s"
+```
+
+## expect_continue_timeout field
+
+`expect_continue_timeout` specifies the amount of time to wait for a server's initial response when using requests with the `Expect: 100-continue` header.
+This setting is primarily relevant for requests that send a request body and use the HTTP `100-continue` mechanism.
+(Defaults to `5s`)
+
+```
+expect_continue_timeout = "2s"
+```
+
+## idle_conn_timeout field
+
+`idle_conn_timeout` specifies the maximum amount of time an idle keep-alive connection is kept open before being closed.
+Increasing this value may help reduce connection establishment overhead for registries that are accessed frequently.
+(Defaults to `30s`)
+
+```
+idle_conn_timeout = "60s"
+```
+
 ## host field(s) (in the toml table format)
 
 `[host]."https://namespace"` and `[host]."http://namespace"` entries in the


### PR DESCRIPTION
## Description
This change extends registry `hosts.toml` configuration to support additional HTTP transport `timeout`settings. 

Containerd currently relies on several hardcoded timeout values provided by `DefaultHTTPTransport()`, including `TLSHandshakeTimeout`, `ResponseHeaderTimeout`, `ExpectContinueTimeout`, and `IdleConnTimeout`. Following the existing dial_timeout support introduced in #11106, this PR adds support for configuring: `response_header_timeout`, `tls_handshake_timeout`, `expect_continue_timeout`, `idle_conn_timeout`.

This allows operators to tune transport behavior on a per-registry basis rather than relying on global defaults, which can be useful in many cases.

Ref: https://github.com/containerd/containerd/issues/13570#issuecomment-4712795006


