### PR TITLE
Add support for ExecRequest.envs environment injection

### DIFF
--- a/internal/cri/server/container_execsync.go
+++ b/internal/cri/server/container_execsync.go
@@ -101,6 +101,7 @@ func (c *criService) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (
 // execOptions specifies how to execute command in container.
 type execOptions struct {
 	cmd     []string
+	env     []string
 	stdin   io.Reader
 	stdout  io.WriteCloser
 	stderr  io.WriteCloser
@@ -147,6 +148,10 @@ func (c *criService) execInternal(ctx context.Context, container containerd.Cont
 	pspec.Args = opts.cmd
 	// CommandLine may already be set on the container's spec, but we want to only use Args here.
 	pspec.CommandLine = ""
+
+	if len(opts.env) > 0 {
+		pspec.Env = mergeExecEnv(pspec.Env, opts.env)
+	}
 
 	if opts.stdout == nil {
 		opts.stdout = cio.NewDiscardLogger()

--- a/internal/cri/server/exec_env.go
+++ b/internal/cri/server/exec_env.go
@@ -1,0 +1,94 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import "strings"
+
+// mergeExecEnv merges overlay environment variables into the base process
+// environment. If a key exists in both base and overlay, the overlay value
+// wins. New keys from overlay are appended in their original order.
+//
+// Both base and overlay use "KEY=VALUE" format strings. The key is the
+// portion before the first '='. Values may contain '=' characters.
+func mergeExecEnv(base, overlay []string) []string {
+	if len(overlay) == 0 {
+		return base
+	}
+
+	// Parse overlay into a map (last entry wins for duplicates)
+	overrideMap := make(map[string]string, len(overlay))
+	order := make([]string, 0, len(overlay))
+	seen := make(map[string]struct{}, len(overlay))
+
+	for _, entry := range overlay {
+		k, v := splitEnvEntry(entry)
+		if k == "" {
+			continue
+		}
+		overrideMap[k] = v
+		if _, exists := seen[k]; !exists {
+			seen[k] = struct{}{}
+			order = append(order, k)
+		}
+	}
+
+	// Track which keys exist in base
+	baseKeys := make(map[string]struct{}, len(base))
+	for _, entry := range base {
+		k, _ := splitEnvEntry(entry)
+		if k != "" {
+			baseKeys[k] = struct{}{}
+		}
+	}
+
+	// Build result: base entries with overrides applied in-place
+	result := make([]string, 0, len(base)+len(order))
+	for _, entry := range base {
+		k, _ := splitEnvEntry(entry)
+		if k == "" {
+			result = append(result, entry)
+			continue
+		}
+		if val, override := overrideMap[k]; override {
+			result = append(result, k+"="+val)
+		} else {
+			result = append(result, entry)
+		}
+	}
+
+	// Append new keys not present in base
+	for _, k := range order {
+		if _, inBase := baseKeys[k]; !inBase {
+			result = append(result, k+"="+overrideMap[k])
+		}
+	}
+
+	return result
+}
+
+// splitEnvEntry splits "KEY=VALUE" into key and value.
+// If there is no '=', key is the entire string and value is empty.
+func splitEnvEntry(entry string) (key, value string) {
+	parts := strings.SplitN(entry, "=", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return "", ""
+	}
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return parts[0], ""
+}

--- a/internal/cri/server/exec_env_test.go
+++ b/internal/cri/server/exec_env_test.go
@@ -1,0 +1,106 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeExecEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    []string
+		overlay []string
+		want    []string
+	}{
+		{
+			name:    "nil overlay returns base unchanged",
+			base:    []string{"A=1", "B=2"},
+			overlay: nil,
+			want:    []string{"A=1", "B=2"},
+		},
+		{
+			name:    "empty overlay returns base unchanged",
+			base:    []string{"A=1"},
+			overlay: []string{},
+			want:    []string{"A=1"},
+		},
+		{
+			name:    "override existing key",
+			base:    []string{"A=1", "B=2"},
+			overlay: []string{"B=3"},
+			want:    []string{"A=1", "B=3"},
+		},
+		{
+			name:    "append new key",
+			base:    []string{"A=1"},
+			overlay: []string{"C=3"},
+			want:    []string{"A=1", "C=3"},
+		},
+		{
+			name:    "override and append",
+			base:    []string{"A=1", "B=2"},
+			overlay: []string{"B=x", "C=y"},
+			want:    []string{"A=1", "B=x", "C=y"},
+		},
+		{
+			name:    "duplicate overlay keys last wins",
+			base:    []string{"A=1"},
+			overlay: []string{"B=first", "B=second"},
+			want:    []string{"A=1", "B=second"},
+		},
+		{
+			name:    "value containing equals sign",
+			base:    []string{"A=b=c"},
+			overlay: []string{"A=d=e=f"},
+			want:    []string{"A=d=e=f"},
+		},
+		{
+			name:    "empty overlay value",
+			base:    []string{"A=1"},
+			overlay: []string{"B="},
+			want:    []string{"A=1", "B="},
+		},
+		{
+			name:    "case sensitive keys",
+			base:    []string{"a=1", "A=2"},
+			overlay: []string{"A=upper"},
+			want:    []string{"a=1", "A=upper"},
+		},
+		{
+			name:    "audit ID injection scenario",
+			base:    []string{"PATH=/usr/bin", "HOME=/root"},
+			overlay: []string{"KUBERNETES_EXEC_AUDIT_ID=f4a3b2c1-1234-5678-9abc-def012345678"},
+			want:    []string{"PATH=/usr/bin", "HOME=/root", "KUBERNETES_EXEC_AUDIT_ID=f4a3b2c1-1234-5678-9abc-def012345678"},
+		},
+		{
+			name:    "no variable expansion",
+			base:    []string{"FOO=bar"},
+			overlay: []string{"BAZ=$FOO"},
+			want:    []string{"FOO=bar", "BAZ=$FOO"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeExecEnv(tc.base, tc.overlay)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/cri/server/streaming.go
+++ b/internal/cri/server/streaming.go
@@ -39,10 +39,11 @@ func newStreamRuntime(c *criService) streaming.Runtime {
 
 // Exec executes a command inside the container. executil.ExitError is returned if the command
 // returns non-zero exit code.
-func (s *streamRuntime) Exec(ctx context.Context, containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser,
+func (s *streamRuntime) Exec(ctx context.Context, containerID string, cmd []string, env []string, stdin io.Reader, stdout, stderr io.WriteCloser,
 	tty bool, resize <-chan remotecommand.TerminalSize) error {
 	exitCode, err := s.c.execInContainer(ctrdutil.WithNamespace(ctx), containerID, execOptions{
 		cmd:    cmd,
+		env:    env,
 		stdin:  stdin,
 		stdout: stdout,
 		stderr: stderr,

--- a/vendor/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
+++ b/vendor/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
@@ -7333,7 +7333,11 @@ type ExecRequest struct {
 	// If `tty` is true, `stderr` MUST be false. Multiplexing is not supported
 	// in this case. The output of stdout and stderr will be combined to a
 	// single stream.
-	Stderr        bool `protobuf:"varint,6,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	Stderr bool `protobuf:"varint,6,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	// Environment variables to inject into the exec'd process.
+	// Each entry is a key-value pair that the runtime MUST add to the
+	// process environment. Values are injected literally.
+	Envs          []*KeyValue `protobuf:"bytes,7,rep,name=envs,proto3" json:"envs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7408,6 +7412,13 @@ func (x *ExecRequest) GetStderr() bool {
 		return x.Stderr
 	}
 	return false
+}
+
+func (x *ExecRequest) GetEnvs() []*KeyValue {
+	if x != nil {
+		return x.Envs
+	}
+	return nil
 }
 
 type ExecResponse struct {

--- a/vendor/k8s.io/cri-streaming/pkg/streaming/remotecommand/exec.go
+++ b/vendor/k8s.io/cri-streaming/pkg/streaming/remotecommand/exec.go
@@ -31,13 +31,13 @@ import (
 type Executor interface {
 	// ExecInContainer executes a command in a container in the pod, copying data
 	// between in/out/err and the container's stdin/stdout/stderr.
-	ExecInContainer(ctx context.Context, name string, uid string, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan TerminalSize, timeout time.Duration) error
+	ExecInContainer(ctx context.Context, name string, uid string, container string, cmd []string, env []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan TerminalSize, timeout time.Duration) error
 }
 
 // ServeExec handles requests to execute a command in a container. After
 // creating/receiving the required streams, it delegates the actual execution
 // to the executor.
-func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podName string, uid string, container string, cmd []string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
+func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podName string, uid string, container string, cmd []string, env []string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
 	ctx, ok := createStreams(req, w, streamOpts, supportedProtocols, idleTimeout, streamCreationTimeout)
 	if !ok {
 		// error is handled by createStreams
@@ -45,7 +45,7 @@ func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podN
 	}
 	defer ctx.conn.Close()
 
-	err := executor.ExecInContainer(req.Context(), podName, uid, container, cmd, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
+	err := executor.ExecInContainer(req.Context(), podName, uid, container, cmd, env, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
 	if err != nil {
 		if exitErr, ok := err.(utilexec.ExitError); ok && exitErr.Exited() {
 			rc := exitErr.ExitStatus()

--- a/vendor/k8s.io/cri-streaming/pkg/streaming/server.go
+++ b/vendor/k8s.io/cri-streaming/pkg/streaming/server.go
@@ -59,7 +59,7 @@ type Server interface {
 
 // Runtime is the interface to execute the commands and provide the streams.
 type Runtime interface {
-	Exec(ctx context.Context, containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error
+	Exec(ctx context.Context, containerID string, cmd []string, env []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error
 	Attach(ctx context.Context, containerID string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error
 	PortForward(ctx context.Context, podSandboxID string, port int32, stream io.ReadWriteCloser) error
 }
@@ -288,6 +288,7 @@ func (s *server) serveExec(req *restful.Request, resp *restful.Response) {
 		"", // unusued: podUID
 		exec.ContainerId,
 		exec.Cmd,
+		keyValuesToEnvSlice(exec.Envs),
 		streamOpts,
 		s.config.StreamIdleTimeout,
 		s.config.StreamCreationTimeout,
@@ -367,8 +368,8 @@ var _ remotecommandserver.Executor = &criAdapter{}
 var _ remotecommandserver.Attacher = &criAdapter{}
 var _ portforward.PortForwarder = &criAdapter{}
 
-func (a *criAdapter) ExecInContainer(ctx context.Context, podName string, podUID string, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize, timeout time.Duration) error {
-	return a.Runtime.Exec(ctx, container, cmd, in, out, err, tty, resize)
+func (a *criAdapter) ExecInContainer(ctx context.Context, podName string, podUID string, container string, cmd []string, env []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize, timeout time.Duration) error {
+	return a.Runtime.Exec(ctx, container, cmd, env, in, out, err, tty, resize)
 }
 
 func (a *criAdapter) AttachContainer(ctx context.Context, podName string, podUID string, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error {
@@ -377,4 +378,15 @@ func (a *criAdapter) AttachContainer(ctx context.Context, podName string, podUID
 
 func (a *criAdapter) PortForward(ctx context.Context, podName string, podUID string, port int32, stream io.ReadWriteCloser) error {
 	return a.Runtime.PortForward(ctx, podName, port, stream)
+}
+
+func keyValuesToEnvSlice(kvs []*runtimeapi.KeyValue) []string {
+	if len(kvs) == 0 {
+		return nil
+	}
+	env := make([]string, 0, len(kvs))
+	for _, kv := range kvs {
+		env = append(env, kv.Key+"="+kv.Value)
+	}
+	return env
 }


### PR DESCRIPTION
### What this PR does / why we need it:

Pod exec currently has no CRI-level way to pass additional environment variables that apply only to the process being exec'd inside a container. The usual workaround is to prepend an `env` invocation to the command (`kubectl exec pod -- env FOO=BAR /bin/bash`), which depends on the `env` binary being present in the container image.

This PR implements the container runtime side of the exec environment contract by honoring the new `envs` field in `ExecRequest`. When an exec process is created, the requested environment variables are merged into the existing process environment before handing off to the low-level runtime (runc).

If a key is present in both the existing environment and `ExecRequest.Envs`, the value from `ExecRequest.Envs` takes precedence. This lets kubelet inject environment variables specifically for the exec'd process without requiring the runtime to understand the semantic meaning of those variables.

### Which issue(s) this PR is related to:
- https://github.com/kubernetes/enhancements/issues/6035