### PR TITLE
[release/2.2] Add deferred call to ShutdownSandbox to avoid leaks

### DIFF
--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -293,6 +293,16 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, fmt.Errorf("failed to start sandbox %q: %w", id, err)
 	}
 
+	// Shutdown the sandbox if we fail before adding it to store.
+	rollbackSandbox := true
+	defer func() {
+		if retErr != nil && rollbackSandbox {
+			deferCtx, deferCancel := util.DeferContext()
+			defer deferCancel()
+			cleanupErr = c.sandboxService.ShutdownSandbox(deferCtx, sandbox.Sandboxer, id)
+		}
+	}()
+
 	if ctrl.Address != "" {
 		sandbox.Endpoint = sandboxstore.Endpoint{
 			Version: ctrl.Version,
@@ -349,6 +359,8 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err := c.sandboxStore.Add(sandbox); err != nil {
 		return nil, fmt.Errorf("failed to add sandbox %+v into store: %w", sandbox, err)
 	}
+	// We no longer need to stop sandbox with a cleanup defer since it is in the store.
+	rollbackSandbox = false
 
 	// Send CONTAINER_CREATED event with both ContainerId and SandboxId equal to SandboxId.
 	// Note that this has to be done after sandboxStore.Add() because we need to get


### PR DESCRIPTION
Between starting the sandbox and adding it to the
sandbox store, there are opportunities for failures including in any NRI RunPodSandbox prehooks. This defer is added to that period so if they fail, this function will try to clean it up itself. If the sandbox is
already added to the persistent store, it will not attempt to stop the sandbox as it can now be recognized by other components from the CRI store. ShutdownSandbox is used instead of StopSandbox as it both stops it and cleans up all its directories.


(cherry picked from commit 2b2b80f558e592610dd2484f1dd8cb43246cce0e)