### PR TITLE
feat: add loong64 (LoongArch) build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
             goarch: amd64
           - goos: freebsd
             goarch: arm64
+          - goos: linux
+            goarch: loong64
           - goos: windows
             goarch: arm64
 
@@ -167,6 +169,9 @@ jobs:
             echo "CC=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
             ;;
           windows/arm64)
+            echo "CGO_ENABLED=0" >> $GITHUB_ENV
+            ;;
+          linux/loong64)
             echo "CGO_ENABLED=0" >> $GITHUB_ENV
             ;;
           esac

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -20,7 +20,7 @@ COMMANDS += containerd-shim-runc-v2
 
 # check GOOS for cross compile builds
 ifeq ($(GOOS),linux)
-  ifneq ($(GOARCH),$(filter $(GOARCH),mips mipsle mips64 mips64le ppc64))
+  ifneq ($(GOARCH),$(filter $(GOARCH),mips mipsle mips64 mips64le ppc64 loong64))
     ifeq ($(STATIC),)
 	    GO_GCFLAGS += -buildmode=pie
     endif

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -237,6 +237,7 @@ verification. Users are free to build from source for their own use.
 | linux/s390x     |  2   | ✅                | ✅             | ❌                    | ✅                    |
 | linux/arm/v7    |  3   | ❌                | ❌             | ❌                    | ✅                    |
 | linux/arm/v5    |  3   | ❌                | ❌             | ❌                    | ✅                    |
+| linux/loong64   |  3   | ❌                | ❌             | ❌                    | ✅                    |
 | darwin/arm64    |  3   | ❌                | ❌             | ❌                    | ✅                    |
 | freebsd/amd64   |  3   | ❌                | ❌             | ❌                    | ✅                    |
 | freebsd/arm64   |  3   | ❌                | ❌             | ❌                    | ✅                    |


### PR DESCRIPTION
Add loong64 (LoongArch) architecture support to the build system and CI:

- Makefile.linux: add loong64 to architectures that don't use -buildmode=pie
  (consistent with other non-amd64 architectures like mips, ppc64)
- ci.yml: add linux/loong64 to crossbuild matrix with CGO_ENABLED=0
- RELEASES.md: add linux/loong64 as Tier 3 (Build-verified) platform

loong64 nightly and release builds are intentionally excluded until the
cross-compilation toolchain becomes available in Ubuntu 22.04 apt repositories
(no crossbuild-essential-loong64 package). These will be re-enabled once the
upstream tonistiigi/xx base image provides the loong64 cross-compilation
toolchain.

Go has supported GOARCH=loong64 as a first-class port since Go 1.21.
The seccomp default profile already includes loong64 support (contrib/seccomp).

Fixes: https://github.com/containerd/containerd/issues/13641