### PR TITLE
shim: send event to a queue to prevent event to be dropped

### DIFF
--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -87,6 +87,7 @@ func NewTaskService(ctx context.Context, publisher shim.Publisher, sd shutdown.S
 		execCountSubscribers: make(map[*runc.Container]chan<- int),
 		containerInitExit:    make(map[*runc.Container]runcC.Exit),
 		exitSubscribers:      make(map[*map[int][]runcC.Exit]struct{}),
+		eventQueue:           newEventQueue(),
 	}
 	go s.processExits()
 	runcC.Monitor = reaper.Default
@@ -139,6 +140,7 @@ type service struct {
 	exitSubscribers map[*map[int][]runcC.Exit]struct{}
 
 	shutdown shutdown.Service
+	*eventQueue
 }
 
 type containerProcess struct {
@@ -656,42 +658,81 @@ func (s *service) Stats(ctx context.Context, r *taskAPI.StatsRequest) (*taskAPI.
 	}, nil
 }
 
+type eventQueue struct {
+	qmu  sync.Mutex
+	cond *sync.Cond
+	buf  []runcC.Exit
+}
+
+func (s *eventQueue) enqueue(e runcC.Exit) {
+	s.qmu.Lock()
+	defer s.qmu.Unlock()
+	s.buf = append(s.buf, e)
+	s.cond.Signal()
+}
+
+func (s *eventQueue) dequeue() runcC.Exit {
+	s.qmu.Lock()
+	defer s.qmu.Unlock()
+	for len(s.buf) == 0 {
+		s.cond.Wait()
+	}
+	event := s.buf[0]
+	s.buf = s.buf[1:]
+	return event
+}
+
+func newEventQueue() *eventQueue {
+	eq := &eventQueue{buf: make([]runcC.Exit, 0)}
+	eq.cond = sync.NewCond(&eq.qmu)
+	return eq
+}
+
 func (s *service) processExits() {
+	go func() {
+		for {
+			e := s.dequeue()
+			// While unlikely, it is not impossible for a container process to exit
+			// and have its PID be recycled for a new container process before we
+			// have a chance to process the first exit. As we have no way to tell
+			// for sure which of the processes the exit event corresponds to (until
+			// pidfd support is implemented) there is no way for us to handle the
+			// exit correctly in that case.
+
+			s.lifecycleMu.Lock()
+			// Inform any concurrent s.Start() calls so they can handle the exit
+			// if the PID belongs to them.
+			for subscriber := range s.exitSubscribers {
+				(*subscriber)[e.Pid] = append((*subscriber)[e.Pid], e)
+			}
+			// Handle the exit for a created/started process. If there's more than
+			// one, assume they've all exited. One of them will be the correct
+			// process.
+			var cps []containerProcess
+			for _, cp := range s.running[e.Pid] {
+				_, init := cp.Process.(*process.Init)
+				if init {
+					s.containerInitExit[cp.Container] = e
+				}
+				cps = append(cps, cp)
+			}
+			delete(s.running, e.Pid)
+			s.lifecycleMu.Unlock()
+
+			for _, cp := range cps {
+				if ip, ok := cp.Process.(*process.Init); ok {
+					s.handleInitExit(e, cp.Container, ip)
+				} else {
+					s.handleProcessExit(e, cp.Container, cp.Process)
+				}
+			}
+
+		}
+	}()
+
 	for e := range s.ec {
-		// While unlikely, it is not impossible for a container process to exit
-		// and have its PID be recycled for a new container process before we
-		// have a chance to process the first exit. As we have no way to tell
-		// for sure which of the processes the exit event corresponds to (until
-		// pidfd support is implemented) there is no way for us to handle the
-		// exit correctly in that case.
-
-		s.lifecycleMu.Lock()
-		// Inform any concurrent s.Start() calls so they can handle the exit
-		// if the PID belongs to them.
-		for subscriber := range s.exitSubscribers {
-			(*subscriber)[e.Pid] = append((*subscriber)[e.Pid], e)
-		}
-		// Handle the exit for a created/started process. If there's more than
-		// one, assume they've all exited. One of them will be the correct
-		// process.
-		var cps []containerProcess
-		for _, cp := range s.running[e.Pid] {
-			_, init := cp.Process.(*process.Init)
-			if init {
-				s.containerInitExit[cp.Container] = e
-			}
-			cps = append(cps, cp)
-		}
-		delete(s.running, e.Pid)
-		s.lifecycleMu.Unlock()
-
-		for _, cp := range cps {
-			if ip, ok := cp.Process.(*process.Init); ok {
-				s.handleInitExit(e, cp.Container, ip)
-			} else {
-				s.handleProcessExit(e, cp.Container, cp.Process)
-			}
-		}
+		// send events to a queue to prevent event to be dropped because of timeout.
+		s.enqueue(e)
 	}
 }
 


### PR DESCRIPTION
@dmcgowan  @fuweid  @mxpv  can you take a look.
fix https://github.com/containerd/containerd/issues/12678 
```
func (s *service) processExits() {
	for e := range s.ec {
         // if consumer use much time more than 1s event will be dropped
        }
```
because  notify will drop new events if consumer use more than 1s
```
func Reap() error {
	now := time.Now()
	exits, err := reap(false)
	for _, e := range exits {
		done := Default.notify(runc.Exit{
			Timestamp: now,
			Pid:       e.Pid,
			Status:    e.Status,
		})

		select {
		case <-done:
		case <-time.After(1 * time.Second):
		}
	}
	return err
}
```
I create a queue to add this event into it it will make consumer  consume event quickly 
It's easy to reproduce it add some sleep here (simulate high-load scenarios because sometimes wait  lifecycleMu lock may quite a while) 
```
func (s *service) processExits() {
	for e := range s.ec {
              // add some sleep
		time.Sleep(time.Second * 3)
		s.lifecycleMu.Lock()
```




reproduce 
```
✦2 ❯ cat container.json
{
  "metadata": {
    "name": "TESTFAILPOINTPROFILE_delayUpdate5"
  },
  "image": {
    "image": "busybox:latest"
  },
  "command": [
    'sleep','infinity'
  ],
  "log_path": "busybox5.log",
      "linux": {
        "resources": {
          "memory": {
            "limit": 20971
          }
        }
      }
 }

root in /home/nmx/pods via 🐹 v1.26.3 
✦2 ❯ cat pod.json
{
    "metadata": {
        "name": "busybox-sandbox2",
        "namespace": "default",
        "attempt": 1
    },
      "annotations": {
  },
    "log_directory": "/tmp"
}
```
crictl  run    --no-pull container.json  pod.json
66abdf4d13
go run main.go

cat main.go 
```
package main

import (
	"fmt"
	"os/exec"
	"sync"
	"time"
)

func main() {
	const (
		totalTask = 100
		maxConcur = 50
	)
	var wg sync.WaitGroup
	ch := make(chan struct{}, maxConcur)

	go func() {
		time.Sleep(time.Second*2)
		cmd := exec.Command("sh", "-c", "kill -9 $(pidof sleep)")
		cmd.CombinedOutput()
	}()
	for i := 0; i < totalTask; i++ {
		ch <- struct{}{}
		wg.Add(1)
		go func(idx int) {
			defer func() {
				<-ch
				wg.Done()
			}()
			cmd := exec.Command("sh", "-c", "crictl exec 66abdf4d13 date")
			_, err := cmd.CombinedOutput()
			if err != nil {
				fmt.Printf("Task %d execution failed: %v\n", idx, err)
			}
		}(i)
	}

	wg.Wait()
	close(ch)
	fmt.Println("done")
}

```

```
crictl  ps|grep 66a
66abdf4d13b04       busybox:latest      About a minute ago   Running             TESTFAILPOINTPROFILE_delayUpdate5   0                   bb4899de19161       unknown             unknown

crictl  exec  66a date
FATA[0000] execing command in container 66a: Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "35d0a3f6180055dcc2694b39c53d7e4215613850e622222cb78be205f1016fae": OCI runtime exec failed: exec failed: cannot exec in a stopped container
````
container is still running even main process is exited.

@evgfitil