### PR TITLE
cri: reject CreateContainer when sandbox is not running

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -43,7 +43,7 @@ import (
 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
-	"github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/containerd/v2/internal/registrar"
 	"github.com/containerd/containerd/v2/pkg/blockio"
@@ -76,6 +76,9 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		sandboxID  = cstatus.SandboxID
 		sandboxPid = cstatus.Pid
 	)
+	if sandbox.Status.Get().State != sandboxstore.StateReady {
+		return nil, fmt.Errorf("sandbox container %q is not running", sandboxID)
+	}
 	span.SetAttributes(
 		tracing.Attribute("sandbox.id", sandboxID),
 		tracing.Attribute("sandbox.pid", sandboxPid),
@@ -215,7 +218,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 type createContainerRequest struct {
 	ctx                   context.Context
 	containerID           string
-	sandbox               *sandbox.Sandbox
+	sandbox               *sandboxstore.Sandbox
 	sandboxID             string
 	imageID               string
 	containerConfig       *runtime.ContainerConfig


### PR DESCRIPTION
## What does this PR do?

`CreateContainer` currently proceeds without checking whether the sandbox is in a running (`StateReady`) state. If the sandbox has already stopped or is in an unknown state, the call silently creates a container shell that is unusable.

`StartContainer` already has the correct guard (added in the existing code):

```go
if sandbox.Status.Get().State != sandboxstore.StateReady {
    return nil, fmt.Errorf("sandbox container %q is not running", sandboxID)
}
```

This PR applies the identical check in `CreateContainer`, right after the sandbox state is resolved, so callers receive an actionable error instead of a dangling container.

## Why is it needed?

The CRI specification requires `CreateContainer` to fail when the target sandbox is not running. The `cri-tools` test at https://github.com/kubernetes-sigs/cri-tools/pull/2126 exercises this exact case and currently fails against containerd.

Fixes #13599

## Testing

- Existing `container_create_test.go` unit tests continue to pass (they exercise `buildContainerSpec`, which is unaffected).
- The failing `cri-tools` conformance test referenced in #13599 will now pass with this guard in place.