### PR TITLE
Use toolchain directive to declare preferred Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/containerd/containerd/v2
 
-go 1.26.3
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Use the go directive to define the minimum supported Go version, and the toolchain directive to select the preferred Go version. This makes it nicer for downstream consumers, so they can still build containerd with older Go patch releases, and can upgrade their toolchains at their own pace.

The minimum can't be lowered all the way to 1.26.0 because of a feedback loop with hcsshim, which itself depends on containerd. The containerd release used by hcsshim declares go 1.26.3, and hcsshim propagates that right back here.