### PR TITLE
cri: re-pull images with discarded layer content

### DIFF
--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -371,6 +371,42 @@ func (u *Unpacker) unpack(
 	copy(chainIDs, diffIDs)
 	chainIDs = identity.ChainIDs(chainIDs)
 
+	// Refill layer blobs whose snapshot for this snapshotter already exists
+	// but whose content has been discarded (e.g. left behind by a prior
+	// discard_unpacked_layers=true run). The snapshot loop below short-circuits
+	// on existing chainIDs and won't fetch, so do it here in parallel — reusing
+	// u.fetch's per-blob lock and concurrency limiter — before the per-chainID
+	// snapshot locks are taken.
+	//
+	// Check the content store first: on a healthy node every blob is present,
+	// so this avoids a snapshotter Stat per layer on every unpack. Only when a
+	// blob is missing do we Stat the snapshot to decide whether it needs
+	// refilling — if the snapshot is also missing, the loop below fetches and
+	// unpacks the layer as usual.
+	var missingBlobs []ocispec.Descriptor
+	for li, ldesc := range layers {
+		if _, err := cs.Info(ctx, ldesc.Digest); err == nil {
+			continue
+		} else if !errdefs.IsNotFound(err) {
+			log.G(ctx).WithError(err).WithField("digest", ldesc.Digest).Warn("content info failed during blob-refill preflight; assuming blob present")
+			continue
+		}
+		chainID := chainIDs[li].String()
+		if _, err := sn.Stat(ctx, chainID); err != nil {
+			if !errdefs.IsNotFound(err) {
+				log.G(ctx).WithError(err).WithField("chainid", chainID).Warn("snapshot stat failed during blob-refill preflight")
+			}
+			continue
+		}
+		missingBlobs = append(missingBlobs, ldesc)
+	}
+	if len(missingBlobs) > 0 {
+		log.G(ctx).WithField("count", len(missingBlobs)).Debug("refilling missing layer blobs whose snapshots already exist")
+		if err := u.fetch(ctx, h, missingBlobs, nil); err != nil {
+			return fmt.Errorf("failed to refill missing layer blobs: %w", err)
+		}
+	}
+
 	topHalf := func(i int, desc ocispec.Descriptor, span *tracing.Span, startAt time.Time) (<-chan *unpackStatus, error) {
 		var (
 			err     error

--- a/integration/image_discard_repull_linux_test.go
+++ b/integration/image_discard_repull_linux_test.go
@@ -1,0 +1,293 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/errdefs"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	criruntime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	containerdimages "github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/platforms"
+)
+
+// TestImageStatusDiscardedLayersSnapshotterSwitch reproduces the problem where
+// an image pulled with discard_unpacked_layers=true becomes unusable for a
+// snapshotter other than the one it was originally unpacked into, yet is still
+// reported as present by ImageStatus.
+//
+// With discard_unpacked_layers=true, the layer blobs are dropped from the
+// content store after the image is unpacked into the pull-time snapshotter
+// (here, overlayfs). If a container is later created with a runtime handler
+// backed by a different snapshotter (here, native), CreateContainer must unpack
+// the image into that snapshotter — but it has no fetcher, so with the blobs
+// gone the unpack is impossible. Before the fix, ImageStatus still reported the
+// image present, so kubelet (which holds the pull credentials) never re-pulled
+// it and container creation failed.
+//
+// The fix makes ImageStatus consult the snapshotter that the *queried* runtime
+// handler would use: the image is reported absent for the native handler (no
+// snapshot, blobs gone) while remaining present for the default overlayfs
+// handler (snapshot intact). Re-pulling — what kubelet does in response to the
+// absent status — then restores the discarded layer blobs to the content
+// store, healing the image (the native unpack itself happens later, when a
+// native container is created).
+func TestImageStatusDiscardedLayersSnapshotterSwitch(t *testing.T) {
+	workDir := t.TempDir()
+	cfgPath := filepath.Join(workDir, "config.toml")
+	cfg := `
+version = 3
+
+[plugins.'io.containerd.cri.v1.images']
+  snapshotter = "overlayfs"
+  discard_unpacked_layers = true
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd]
+  default_runtime_name = "runc"
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+  snapshotter = "overlayfs"
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.native]
+  runtime_type = "io.containerd.runc.v2"
+  snapshotter = "native"
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o600))
+
+	ctrd := newCtrdProc(t, *containerdBin, workDir, nil)
+	require.NoError(t, ctrd.isReady())
+
+	iSvc := ctrd.criImageService(t)
+	rSvc := ctrd.criRuntimeService(t)
+
+	ctrdClient, err := containerd.New(ctrd.grpcAddress(), containerd.WithDefaultNamespace(k8sNamespace))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Log("Dumping containerd config and logs due to test failure")
+			dumpFileContent(t, ctrd.configPath())
+			dumpFileContent(t, ctrd.logPath())
+		}
+		assert.NoError(t, ctrdClient.Close())
+		cleanupPods(t, rSvc)
+		assert.NoError(t, ctrd.kill(syscall.SIGTERM))
+		assert.NoError(t, ctrd.wait(5*time.Minute))
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// The native snapshotter must be registered and healthy, otherwise the
+	// snapshotter-switch scenario cannot be exercised.
+	resp, err := ctrdClient.IntrospectionService().Plugins(ctx, fmt.Sprintf("type==%s,id==%s", plugins.SnapshotPlugin, "native"))
+	require.NoError(t, err)
+	if len(resp.Plugins) == 0 {
+		t.Skip("native snapshotter plugin is not registered")
+	}
+	if initErr := resp.Plugins[0].InitErr; initErr != nil {
+		t.Skipf("native snapshotter plugin is not ready: %s", initErr.Message)
+	}
+
+	testImage := images.Get(images.BusyBox)
+
+	// 1. Pull with the default handler. The image is unpacked into overlayfs
+	//    and, because discard_unpacked_layers=true, its layer blobs become
+	//    unreferenced in the content store.
+	pullImagesByCRI(t, iSvc, testImage)
+
+	img, err := ctrdClient.GetImage(context.Background(), testImage)
+	require.NoError(t, err)
+
+	diffIDs, err := img.RootFS(context.Background())
+	require.NoError(t, err)
+	chainIDs := identity.ChainIDs(diffIDs)
+
+	manifest, err := containerdimages.Manifest(context.Background(), ctrdClient.ContentStore(), img.Target(), platforms.Default())
+	require.NoError(t, err)
+	require.NotEmpty(t, manifest.Layers)
+
+	// 2. Drop the now-unreferenced layer blobs, emulating the garbage
+	//    collection that discard_unpacked_layers relies on. content.Delete is
+	//    a direct removal, so this is deterministic regardless of GC timing.
+	cs := ctrdClient.ContentStore()
+	layerDigests := make([]digest.Digest, 0, len(manifest.Layers))
+	for _, layer := range manifest.Layers {
+		layerDigests = append(layerDigests, layer.Digest)
+		if err := cs.Delete(context.Background(), layer.Digest); err != nil && !errdefs.IsNotFound(err) {
+			require.NoErrorf(t, err, "failed to delete layer blob %s", layer.Digest)
+		}
+	}
+	for _, dgst := range layerDigests {
+		_, err := cs.Info(context.Background(), dgst)
+		require.Truef(t, errdefs.IsNotFound(err), "layer blob %s should be gone, got err=%v", dgst, err)
+	}
+
+	// Sanity: the image was never unpacked into the native snapshotter.
+	nativeSn := ctrdClient.SnapshotService("native")
+	for _, chainID := range chainIDs {
+		_, err := nativeSn.Stat(context.Background(), chainID.String())
+		require.Truef(t, errdefs.IsNotFound(err), "unexpected native snapshot for chainID %s", chainID)
+	}
+
+	// 3. The core assertion. ImageStatus for the native handler must report the
+	//    image absent (no native snapshot, blobs gone — it cannot be used),
+	//    while the default overlayfs handler still reports it present (the
+	//    overlayfs snapshot is intact). Before the fix both reported present.
+	nativeStatus, err := iSvc.ImageStatus(&criruntime.ImageSpec{Image: testImage, RuntimeHandler: "native"})
+	require.NoError(t, err)
+	assert.Nil(t, nativeStatus, "image unusable for the native snapshotter should be reported absent")
+
+	overlayStatus, err := iSvc.ImageStatus(&criruntime.ImageSpec{Image: testImage, RuntimeHandler: ""})
+	require.NoError(t, err)
+	require.NotNil(t, overlayStatus, "image is still usable for the default overlayfs handler")
+
+	// 4. Re-pull — the action kubelet takes in response to the absent status —
+	//    restores the discarded layer blobs to the content store, healing the
+	//    image. With a nil sandbox config the pull targets the default
+	//    (overlayfs) snapshotter, whose chainID snapshots already exist; the
+	//    unpacker therefore short-circuits the snapshot creation and the blobs
+	//    are restored by its blob-refill preflight. Layer blobs are
+	//    snapshotter-independent content, so this is what we assert on.
+	_, err = iSvc.PullImage(&criruntime.ImageSpec{Image: testImage}, nil, nil, "")
+	require.NoError(t, err)
+
+	for _, dgst := range layerDigests {
+		_, err := cs.Info(context.Background(), dgst)
+		require.NoErrorf(t, err, "layer blob %s should be restored to the content store after re-pull", dgst)
+	}
+}
+
+// TestImageStatusDiscardedLayersNoRuntimeHandler reproduces the same underlying
+// problem in the configuration where kubelet's RuntimeClassInImageCriAPI
+// feature gate is DISABLED, so ImageStatus is called with no runtime handler.
+//
+// This is the case the snapshotter-switch test cannot cover: with no handler,
+// ImageStatus resolves the default snapshotter, whose chainID snapshot exists,
+// so the snapshot-existence check passes. The only thing that can still detect
+// the discarded content is the independent blob check (active because
+// discard_unpacked_layers is false — the steady state after a node is switched
+// off discard). It must report the image absent so kubelet re-pulls and
+// restores the blobs; otherwise a later re-unpack (a different runtime's
+// snapshotter, or any operation needing the layers) fails with the layer
+// content missing from the content store.
+func TestImageStatusDiscardedLayersNoRuntimeHandler(t *testing.T) {
+	workDir := t.TempDir()
+	cfgPath := filepath.Join(workDir, "config.toml")
+	cfg := `
+version = 3
+
+[plugins.'io.containerd.cri.v1.images']
+  snapshotter = "overlayfs"
+  discard_unpacked_layers = false
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd]
+  default_runtime_name = "runc"
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+  snapshotter = "overlayfs"
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o600))
+
+	ctrd := newCtrdProc(t, *containerdBin, workDir, nil)
+	require.NoError(t, ctrd.isReady())
+
+	iSvc := ctrd.criImageService(t)
+	rSvc := ctrd.criRuntimeService(t)
+
+	ctrdClient, err := containerd.New(ctrd.grpcAddress(), containerd.WithDefaultNamespace(k8sNamespace))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Log("Dumping containerd config and logs due to test failure")
+			dumpFileContent(t, ctrd.configPath())
+			dumpFileContent(t, ctrd.logPath())
+		}
+		assert.NoError(t, ctrdClient.Close())
+		cleanupPods(t, rSvc)
+		assert.NoError(t, ctrd.kill(syscall.SIGTERM))
+		assert.NoError(t, ctrd.wait(5*time.Minute))
+	})
+
+	testImage := images.Get(images.BusyBox)
+
+	// 1. Pull (no handler) into the default overlayfs snapshotter. With
+	//    discard_unpacked_layers=false the layer blobs are retained.
+	pullImagesByCRI(t, iSvc, testImage)
+
+	img, err := ctrdClient.GetImage(context.Background(), testImage)
+	require.NoError(t, err)
+	manifest, err := containerdimages.Manifest(context.Background(), ctrdClient.ContentStore(), img.Target(), platforms.Default())
+	require.NoError(t, err)
+	require.NotEmpty(t, manifest.Layers)
+
+	// 2. Emulate the corrupt state a prior discard_unpacked_layers=true run
+	//    leaves once the node is switched to discard=false: the overlayfs
+	//    snapshot is intact, but the layer blobs are gone from the content
+	//    store.
+	cs := ctrdClient.ContentStore()
+	layerDigests := make([]digest.Digest, 0, len(manifest.Layers))
+	for _, layer := range manifest.Layers {
+		layerDigests = append(layerDigests, layer.Digest)
+		if err := cs.Delete(context.Background(), layer.Digest); err != nil && !errdefs.IsNotFound(err) {
+			require.NoErrorf(t, err, "failed to delete layer blob %s", layer.Digest)
+		}
+	}
+	for _, dgst := range layerDigests {
+		_, err := cs.Info(context.Background(), dgst)
+		require.Truef(t, errdefs.IsNotFound(err), "layer blob %s should be gone, got err=%v", dgst, err)
+	}
+
+	// 3. The core assertion. ImageStatus with NO runtime handler (gate
+	//    disabled) must still report the image absent: the snapshot exists but
+	//    the blobs are gone, and discard_unpacked_layers=false means they are
+	//    expected to be present. Reporting present here would leave the image
+	//    un-reunpackable with no re-pull triggered.
+	status, err := iSvc.ImageStatus(&criruntime.ImageSpec{Image: testImage})
+	require.NoError(t, err)
+	assert.Nil(t, status, "image with discarded blobs (discard=false, no handler) should be reported absent")
+
+	// 4. Re-pull heals it: the blobs are restored to the content store.
+	_, err = iSvc.PullImage(&criruntime.ImageSpec{Image: testImage}, nil, nil, "")
+	require.NoError(t, err)
+
+	for _, dgst := range layerDigests {
+		_, err := cs.Info(context.Background(), dgst)
+		require.NoErrorf(t, err, "layer blob %s should be restored to the content store after re-pull", dgst)
+	}
+
+	status, err = iSvc.ImageStatus(&criruntime.ImageSpec{Image: testImage})
+	require.NoError(t, err)
+	require.NotNil(t, status, "image should be reported present again after re-pull")
+}

--- a/internal/cri/server/images/image_status.go
+++ b/internal/cri/server/images/image_status.go
@@ -23,10 +23,12 @@ import (
 	"strconv"
 	"strings"
 
+	containerdimages "github.com/containerd/containerd/v2/core/images"
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
 	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
 
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -44,8 +46,35 @@ func (c *CRIImageService) ImageStatus(ctx context.Context, r *runtime.ImageStatu
 		}
 		return nil, fmt.Errorf("can not resolve %q locally: %w", r.GetImage().GetImage(), err)
 	}
-	// TODO(random-liu): [P0] Make sure corresponding snapshot exists. What if snapshot
-	// doesn't exist?
+
+	// Verify the corresponding snapshot exists for the snapshotter that would
+	// be used by the next container creation. If it doesn't, the image is not
+	// usable as-is (e.g. layer content has been discarded by
+	// discard_unpacked_layers and the snapshotter has since changed) and
+	// reporting it absent prompts the caller to re-pull it with credentials
+	// they hold, restoring any missing layer content along the way. This fires
+	// when kubelet passes the pod's runtime handler (RuntimeClassInImageCriAPI
+	// feature gate enabled), so the per-runtime snapshotter is consulted.
+	if !c.imageSnapshotExists(ctx, image, r.GetImage()) {
+		return &runtime.ImageStatusResponse{}, nil
+	}
+
+	// When discard_unpacked_layers is false, every layer blob should be in the
+	// content store. If any is missing, the image is in the corrupt state left
+	// behind by a prior discard_unpacked_layers=true run (which discarded the
+	// blobs while keeping the manifest and snapshot intact). A present snapshot
+	// is not sufficient: re-unpacking the image — for another snapshotter, or
+	// any operation that needs the layers — requires the blobs, and the CRI
+	// container path has no fetcher of its own. This check is independent of
+	// imageSnapshotExists on purpose: it is the only signal available when the
+	// runtime handler is not passed (RuntimeClassInImageCriAPI disabled), where
+	// the snapshot check only ever sees the default snapshotter. Reporting the
+	// image absent triggers kubelet (which holds the pull credentials) to
+	// re-pull, and the unpacker repopulates the blobs even when it
+	// short-circuits on an existing snapshot.
+	if !c.config.DiscardUnpackedLayers && !c.imageBlobsPresent(ctx, image) {
+		return &runtime.ImageStatusResponse{}, nil
+	}
 
 	runtimeImage := toCRIImage(image)
 	info, err := c.toCRIImageInfo(ctx, &image, r.GetVerbose())
@@ -57,6 +86,103 @@ func (c *CRIImageService) ImageStatus(ctx context.Context, r *runtime.ImageStatu
 		Image: runtimeImage,
 		Info:  info,
 	}, nil
+}
+
+// targetSnapshotter resolves the snapshotter that the runtime handler in spec
+// would use for the next container creation, mirroring RuntimeSnapshotter in
+// the container-create path: a per-runtime snapshotter override if the handler
+// has one, otherwise the configured default. This is the only image-state axis
+// that varies per runtime here — the platform does not, because the CRI image
+// store records a single chainID computed for platforms.Default() and the
+// container-create unpack (unpackImage) likewise unpacks platforms.Default().
+func (c *CRIImageService) targetSnapshotter(spec *runtime.ImageSpec) string {
+	snapshotter := c.config.Snapshotter
+	if spec != nil {
+		if rh := spec.GetRuntimeHandler(); rh != "" {
+			if p, ok := c.runtimePlatforms[rh]; ok && p.Snapshotter != "" {
+				snapshotter = p.Snapshotter
+			}
+		}
+	}
+	return snapshotter
+}
+
+// imageSnapshotExists reports whether the chainID-rooted snapshot for the
+// given image exists in the snapshotter that would handle the next container
+// creation. It returns false only when the snapshot is conclusively missing;
+// whenever the check cannot be performed conclusively — missing chainID, no
+// tracked snapshotters, the target snapshotter not registered with this
+// service, or a transient snapshotter error — it returns true so that the
+// usability check never turns into an availability regression for ImageStatus.
+func (c *CRIImageService) imageSnapshotExists(ctx context.Context, image imagestore.Image, spec *runtime.ImageSpec) bool {
+	if image.ChainID == "" {
+		return true
+	}
+	if len(c.snapshotters) == 0 {
+		return true
+	}
+	snapshotterName := c.targetSnapshotter(spec)
+	sn, ok := c.snapshotters[snapshotterName]
+	if !ok {
+		return true
+	}
+	if _, err := sn.Stat(ctx, image.ChainID); err != nil {
+		if errdefs.IsNotFound(err) {
+			log.G(ctx).Debugf("ImageStatus: snapshot %q not found in snapshotter %q for image %q; reporting as not present so it will be re-pulled", image.ChainID, snapshotterName, image.ID)
+			return false
+		}
+		log.G(ctx).WithError(err).Warnf("ImageStatus: failed to stat snapshot %q in snapshotter %q; treating image %q as present", image.ChainID, snapshotterName, image.ID)
+	}
+	return true
+}
+
+// imageBlobsPresent reports whether every layer blob referenced by the image's
+// manifest is currently in the content store. It is consulted only when
+// discard_unpacked_layers is false, where blob presence is the expected steady
+// state; a missing blob then indicates the corrupt state left by a prior
+// discard_unpacked_layers=true run and the image must be re-pulled to restore
+// it. The manifest is selected for platforms.Default(), matching both the
+// chainID the CRI image store records and the platform unpackImage unpacks on
+// the container-create path. The check is tolerant: if anything along the way
+// (image lookup, manifest read, content store access) prevents a definitive
+// answer, the image is treated as present so this check never turns into an
+// availability regression for ImageStatus.
+func (c *CRIImageService) imageBlobsPresent(ctx context.Context, image imagestore.Image) bool {
+	if c.content == nil || c.images == nil {
+		return true
+	}
+	if len(image.References) == 0 {
+		return true
+	}
+	var (
+		img containerdimages.Image
+		err error
+	)
+	for _, ref := range image.References {
+		img, err = c.images.Get(ctx, ref)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		log.G(ctx).WithError(err).Debugf("ImageStatus: unable to look up image record for blob presence check; assuming present")
+		return true
+	}
+	manifest, mErr := containerdimages.Manifest(ctx, c.content, img.Target, platforms.Default())
+	if mErr != nil {
+		log.G(ctx).WithError(mErr).Debugf("ImageStatus: unable to read manifest for %q; assuming blobs present", image.ID)
+		return true
+	}
+	for _, layer := range manifest.Layers {
+		if _, infoErr := c.content.Info(ctx, layer.Digest); infoErr != nil {
+			if errdefs.IsNotFound(infoErr) {
+				log.G(ctx).Debugf("ImageStatus: layer blob %q missing from content store for image %q; reporting as not present so it will be re-pulled", layer.Digest, image.ID)
+				return false
+			}
+			log.G(ctx).WithError(infoErr).Warnf("ImageStatus: failed to stat blob %q; assuming present", layer.Digest)
+		}
+	}
+	return true
 }
 
 // toCRIImage converts internal image object to CRI runtime.Image.

--- a/internal/cri/server/images/service.go
+++ b/internal/cri/server/images/service.go
@@ -69,6 +69,15 @@ type CRIImageService struct {
 	imageStore *imagestore.Store
 	// snapshotStore stores information of all snapshots.
 	snapshotStore *snapshotstore.Store
+	// snapshotters is the map of snapshotter name to snapshotter used to
+	// verify that an image's snapshot still exists during ImageStatus, so that
+	// images whose content has been discarded (and is no longer usable for the
+	// configured snapshotter) are reported as absent and re-pulled.
+	snapshotters map[string]snapshots.Snapshotter
+	// content is the raw content store used by ImageStatus to verify that
+	// layer blobs are still present (relevant when discard_unpacked_layers is
+	// false and prior discard_unpacked_layers=true pulls left layers missing).
+	content content.Store
 	// transferrer is used to pull image with transfer service
 	transferrer transfer.Transferrer
 	// unpackDuplicationSuppressor is used to make sure that there is only
@@ -123,6 +132,8 @@ func NewService(config criconfig.ImageConfig, options *CRIImageServiceOptions) (
 		imageFSPaths:                options.ImageFSPaths,
 		runtimePlatforms:            options.RuntimePlatforms,
 		snapshotStore:               snapshotstore.NewStore(),
+		snapshotters:                options.Snapshotters,
+		content:                     options.Content,
 		transferrer:                 options.Transferrer,
 		unpackDuplicationSuppressor: kmutex.New(),
 		downloadLimiter:             downloadLimiter,

--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -19,6 +19,7 @@ package images
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"runtime"
 
@@ -115,11 +116,16 @@ func init() {
 
 			allSnapshotters := mdb.Snapshotters()
 			defaultSnapshotter := config.Snapshotter
-			if s, ok := allSnapshotters[defaultSnapshotter]; ok {
-				options.Snapshotters[defaultSnapshotter] = s
-			} else {
+			if _, ok := allSnapshotters[defaultSnapshotter]; !ok {
 				return nil, fmt.Errorf("failed to find snapshotter %q", defaultSnapshotter)
 			}
+			// Register every available snapshotter, not just the default. Runtime
+			// plugins propagate their per-runtime snapshotters (e.g. kata's
+			// containerd.runtimes.<name>.snapshotter) via UpdateRuntimeSnapshotter
+			// *after* this plugin initializes, so any snapshotter referenced later
+			// must already be present here for ImageStatus's snapshot-existence
+			// check to consult the correct snapshotter.
+			maps.Copy(options.Snapshotters, allSnapshotters)
 
 			snapshotRoot := func(snapshotter string) (snapshotRoot string) {
 				if plugin := ic.Plugins().Get(plugins.SnapshotPlugin, snapshotter); plugin != nil {


### PR DESCRIPTION
Switching discard_unpacked_layers on a node that already has running pods breaks new pods: they fail to start with errors about content missing from the content store. Being able to flip discard_unpacked_layers after the node has already started accepting containers is required to set up new snapshotters via a daemon set on managed Kubernetes.

With discard_unpacked_layers=true, layer blobs are removed after unpack, leaving the manifest and snapshot behind. ImageStatus still reports the image present, but it can't be re-unpacked (for another snapshotter, or anything else that needs the layers) because the blobs are gone. kubelet holds the pull credentials and never re-pulls, so this only shows up later at container creation. Today the only fix is wiping /var/lib/containerd, which takes out the pods already on the node.

### Solution

Report an image as absent from ImageStatus when it isn't actually usable, so kubelet re-pulls it and the content is restored.

ImageStatus runs two checks before reporting an image present:

- imageSnapshotExists: the chainID snapshot exists in the snapshotter the next container would use (resolved from the request's runtime handler).
- imageBlobsPresent: when discard_unpacked_layers is false, every layer blob in the image's manifest (host platform) is still in the content store.

Both are tolerant: if anything is inconclusive (missing data, transient error, unregistered snapshotter) the image is treated as present, so neither check can make a healthy image disappear.

The checks are kept separate on purpose, to cover both states of kubelet's RuntimeClassInImageCriAPI feature gate:

- Gate on: kubelet passes the runtime handler, so imageSnapshotExists checks the per-runtime snapshotter (e.g. erofs for kata).
- Gate off (default): no handler reaches ImageStatus, so the snapshot check only sees the default snapshotter, whose snapshot is fine. imageBlobsPresent is the only thing that catches the discarded content here.

Merging them into one "snapshot exists OR blobs present" condition would miss the gate-off case, since the intact default snapshot would hide the missing blobs.

### Supporting changes

- plugins/cri/images/plugin.go: register all available snapshotters, not just the default. Per-runtime snapshotters are added via UpdateRuntimeSnapshotter after this plugin initializes, so they need to be present up front for the snapshot check to find them.
- internal/cri/server/images/service.go: add snapshotters and content fields to CRIImageService, populated from the existing service options.
- core/unpack/unpacker.go: the unpacker skips fetching a layer when its snapshot already exists, so a re-pull wouldn't restore a discarded blob. Add a preflight pass that finds layers whose snapshot exists but whose blob is gone and re-fetches just those (reusing the existing per-blob lock and limiter) before the snapshot loop.

### Testing

Two integration tests in integration/image_discard_repull_linux_test.go:

- TestImageStatusDiscardedLayersSnapshotterSwitch: gate-on path. An image pulled into overlayfs with blobs discarded is reported absent for a handler using a different snapshotter, present for the default handler, and restored by a re-pull.
- TestImageStatusDiscardedLayersNoRuntimeHandler: gate-off path. With no handler and the snapshot intact, the blob check still reports the image absent so it's re-pulled.