### PR TITLE
Add cri container/sandbox store metadata v2 and translations

### DIFF
--- a/internal/cri/server/podsandbox/sandbox_run_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_test.go
@@ -172,7 +172,7 @@ func TestTypeurlMarshalUnmarshalSandboxMeta(t *testing.T) {
 			assert.IsType(t, &sandboxstore.Metadata{}, data)
 			curMeta, ok := data.(*sandboxstore.Metadata)
 			assert.True(t, ok)
-			assert.Equal(t, meta, curMeta)
+			assert.EqualExportedValues(t, meta, curMeta)
 		})
 	}
 }

--- a/internal/cri/store/container/metadata.go
+++ b/internal/cri/store/container/metadata.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
+	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -27,8 +29,11 @@ import (
 // 1) Metadata is immutable after created.
 // 2) Metadata is checkpointed as containerd container label.
 
-// metadataVersion is current version of container metadata.
-const metadataVersion = "v1"
+// metadataVersion1 is legacy version of container metadata.
+const metadataVersion1 = "v1"
+
+// metadataVersion2 is current version of container metadata.
+const metadataVersion2 = "v2"
 
 // versionedMetadata is the internal versioned container metadata.
 type versionedMetadata struct {
@@ -39,7 +44,16 @@ type versionedMetadata struct {
 }
 
 // metadataInternal is for internal use.
-type metadataInternal Metadata
+type metadataInternal struct {
+	ID           string
+	Name         string
+	SandboxID    string
+	Config       json.RawMessage
+	ImageRef     string
+	LogPath      string
+	StopSignal   string
+	ProcessLabel string
+}
 
 // Metadata is the unversioned container metadata.
 type Metadata struct {
@@ -66,9 +80,13 @@ type Metadata struct {
 
 // MarshalJSON encodes Metadata into bytes in json format.
 func (c *Metadata) MarshalJSON() ([]byte, error) {
+	m, err := metadataToInternal(*c, metadataVersion2)
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(&versionedMetadata{
-		Version:  metadataVersion,
-		Metadata: metadataInternal(*c),
+		Version:  metadataVersion2,
+		Metadata: m,
 	})
 }
 
@@ -80,9 +98,103 @@ func (c *Metadata) UnmarshalJSON(data []byte) error {
 	}
 	// Handle old version after upgrade.
 	switch versioned.Version {
-	case metadataVersion:
-		*c = Metadata(versioned.Metadata)
+	case metadataVersion1, metadataVersion2:
+		*c = internalToMetadata(versioned.Metadata, versioned.Version)
 		return nil
 	}
+
 	return fmt.Errorf("unsupported version: %q", versioned.Version)
+}
+
+// TODO: remove support for legacy v1 config, which marshals runtime.ContainerConfig as JSON.
+// Marshaling protobuf messages as JSON is fragile and does not handle struct changes well.
+// v2 encodes runtime.ContainerConfig using native proto.Marshal/proto.Unmarshal, stored internally as []byte.
+
+func internalToMetadata(c metadataInternal, version string) Metadata {
+	// Config is intentionally left nil if it cannot be unmarshaled to trigger cleanup of containers with invalid ContainerConfig.
+	// Returning the error from Unmarshal prevents the container from being visible to the CRI container store, triggering creation of duplicate replacements.
+	// See: https://github.com/containerd/containerd/pull/13453#issuecomment-4755099592
+
+	m := Metadata{
+		ID:           c.ID,
+		Name:         c.Name,
+		SandboxID:    c.SandboxID,
+		ImageRef:     c.ImageRef,
+		LogPath:      c.LogPath,
+		StopSignal:   c.StopSignal,
+		ProcessLabel: c.ProcessLabel,
+	}
+
+	config := &runtime.ContainerConfig{}
+	switch version {
+	case metadataVersion1:
+		if err := json.Unmarshal(c.Config, config); err != nil {
+			log.L.WithError(err).WithField("container", c.ID).Errorf("Failed to unmarshal %s container metadata config", version)
+			return m
+		}
+	case metadataVersion2:
+		b := []byte{}
+		if err := json.Unmarshal(c.Config, &b); err != nil {
+			log.L.WithError(err).WithField("container", c.ID).Errorf("Failed to unmarshal %s container metadata config as JSON", version)
+			return m
+		}
+		if b == nil {
+			return m
+		}
+		if err := proto.Unmarshal(b, config); err != nil {
+			log.L.WithError(err).WithField("container", c.ID).Errorf("Failed to unmarshal %s container metadata config as protobuf", version)
+			return m
+		}
+	default:
+		log.L.WithError(fmt.Errorf("unsupported version: %q", version)).WithField("container", c.ID).Error("Failed to unmarshal container metadata config")
+		return m
+	}
+
+	m.Config = config
+	return m
+}
+
+func metadataToInternal(c Metadata, version string) (metadataInternal, error) {
+	m := metadataInternal{
+		ID:           c.ID,
+		Name:         c.Name,
+		SandboxID:    c.SandboxID,
+		ImageRef:     c.ImageRef,
+		LogPath:      c.LogPath,
+		StopSignal:   c.StopSignal,
+		ProcessLabel: c.ProcessLabel,
+	}
+
+	var config []byte
+	var err error
+	switch version {
+	case metadataVersion1:
+		// v1 stores ContainerConfig as JSON
+		config, err = json.Marshal(c.Config)
+		if err != nil {
+			log.L.WithError(err).WithField("container", c.ID).Errorf("Failed to marshal %s container metadata config", version)
+			return m, err
+		}
+	case metadataVersion2:
+		// v2 stores ContainerConfig marshalled as json []byte, holding marshalled protobuf
+		if c.Config != nil {
+			config, err = proto.Marshal(c.Config)
+			if err != nil {
+				log.L.WithError(err).WithField("container", c.ID).Errorf("Failed to marshal %s container metadata config as protobuf", version)
+				return m, err
+			}
+		}
+		config, err = json.Marshal(config)
+		if err != nil {
+			log.L.WithError(err).WithField("container", c.ID).Errorf("Failed to marshal %s container metadata config as JSON", version)
+			return m, err
+		}
+	default:
+		err = fmt.Errorf("unsupported version: %q", version)
+		log.L.WithError(err).WithField("container", c.ID).Error("Failed to marshal container metadata config")
+		return m, err
+	}
+
+	m.Config = config
+	return m, nil
 }

--- a/internal/cri/store/container/metadata_test.go
+++ b/internal/cri/store/container/metadata_test.go
@@ -34,6 +34,12 @@ func TestMetadataMarshalUnmarshal(t *testing.T) {
 				Name:    "test-name",
 				Attempt: 1,
 			},
+			Envs: []*runtime.KeyValue{
+				&runtime.KeyValue{
+					Key:   "foo",
+					Value: "bar",
+				},
+			},
 		},
 		ImageRef: "test-image-ref",
 		LogPath:  "/test/log/path",
@@ -43,38 +49,54 @@ func TestMetadataMarshalUnmarshal(t *testing.T) {
 	newMeta := &Metadata{}
 	newVerMeta := &versionedMetadata{}
 
-	t.Logf("should be able to do json.marshal")
+	t.Logf("should be able to do json.marshal and produce v2")
 	data, err := json.Marshal(meta)
 	assert.NoError(err)
+	metadataInternal, err := metadataToInternal(*meta, metadataVersion2)
+	assert.NoError(err)
 	data1, err := json.Marshal(&versionedMetadata{
-		Version:  metadataVersion,
-		Metadata: metadataInternal(*meta),
+		Version:  metadataVersion2,
+		Metadata: metadataInternal,
 	})
 	assert.NoError(err)
-	assert.Equal(data, data1)
+	assert.EqualExportedValues(data, data1)
 
 	t.Logf("should be able to do MarshalJSON")
 	data, err = meta.MarshalJSON()
 	assert.NoError(err)
 	assert.NoError(newMeta.UnmarshalJSON(data))
-	assert.Equal(meta, newMeta)
+	assert.EqualExportedValues(meta, newMeta)
 
 	t.Logf("should be able to do MarshalJSON and json.Unmarshal")
 	data, err = meta.MarshalJSON()
 	assert.NoError(err)
 	assert.NoError(json.Unmarshal(data, newVerMeta))
-	assert.Equal(meta, (*Metadata)(&newVerMeta.Metadata))
+	v2meta := internalToMetadata(newVerMeta.Metadata, metadataVersion2)
+	assert.EqualExportedValues(*meta, v2meta)
 
 	t.Logf("should be able to do json.Marshal and UnmarshalJSON")
 	data, err = json.Marshal(meta)
 	assert.NoError(err)
 	assert.NoError(newMeta.UnmarshalJSON(data))
-	assert.Equal(meta, newMeta)
+	assert.EqualExportedValues(meta, newMeta)
+
+	t.Logf("should be able to unmarshal legacy v1 metadata")
+	metadataInternal, err = metadataToInternal(*meta, metadataVersion1)
+	assert.NoError(err)
+	v1data, err := json.Marshal(&versionedMetadata{
+		Version:  metadataVersion1,
+		Metadata: metadataInternal,
+	})
+	assert.NoError(err)
+	assert.NoError(newMeta.UnmarshalJSON(v1data))
+	assert.EqualExportedValues(meta, newMeta)
 
 	t.Logf("should json.Unmarshal fail for unsupported version")
+	metadataInternal, err = metadataToInternal(*meta, metadataVersion1)
+	assert.NoError(err)
 	unsupported, err := json.Marshal(&versionedMetadata{
 		Version:  "random-test-version",
-		Metadata: metadataInternal(*meta),
+		Metadata: metadataInternal,
 	})
 	assert.NoError(err)
 	assert.Error(json.Unmarshal(unsupported, &newMeta))

--- a/internal/cri/store/sandbox/metadata.go
+++ b/internal/cri/store/sandbox/metadata.go
@@ -20,7 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	cni "github.com/containerd/go-cni"
+	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -28,8 +30,11 @@ import (
 // 1) Metadata is immutable after created.
 // 2) Metadata is checkpointed as containerd container label.
 
-// metadataVersion is current version of sandbox metadata.
-const metadataVersion = "v1"
+// metadataVersion1 is legacy version of sandbox metadata.
+const metadataVersion1 = "v1"
+
+// metadataVersion2 is current version of sandbox metadata.
+const metadataVersion2 = "v2"
 
 // versionedMetadata is the internal versioned sandbox metadata.
 type versionedMetadata struct {
@@ -40,7 +45,17 @@ type versionedMetadata struct {
 }
 
 // metadataInternal is for internal use.
-type metadataInternal Metadata
+type metadataInternal struct {
+	ID             string
+	Name           string
+	Config         json.RawMessage
+	NetNSPath      string
+	IP             string
+	AdditionalIPs  []string
+	RuntimeHandler string
+	CNIResult      *cni.Result
+	ProcessLabel   string
+}
 
 // Metadata is the unversioned sandbox metadata.
 type Metadata struct {
@@ -66,9 +81,13 @@ type Metadata struct {
 
 // MarshalJSON encodes Metadata into bytes in json format.
 func (c *Metadata) MarshalJSON() ([]byte, error) {
+	m, err := metadataToInternal(*c, metadataVersion2)
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(&versionedMetadata{
-		Version:  metadataVersion,
-		Metadata: metadataInternal(*c),
+		Version:  metadataVersion2,
+		Metadata: m,
 	})
 }
 
@@ -80,9 +99,104 @@ func (c *Metadata) UnmarshalJSON(data []byte) error {
 	}
 	// Handle old version after upgrade.
 	switch versioned.Version {
-	case metadataVersion:
-		*c = Metadata(versioned.Metadata)
+	case metadataVersion1, metadataVersion2:
+		*c = internalToMetadata(versioned.Metadata, versioned.Version)
 		return nil
 	}
 	return fmt.Errorf("unsupported version: %q", versioned.Version)
+}
+
+// TODO: remove support for legacy v1 config, which marshals runtime.PodSandboxConfig as JSON.
+// Marshaling protobuf messages as JSON is fragile and does not handle struct changes well.
+// v2 encodes runtime.PodSandboxConfig using native proto.Marshal/proto.Unmarshal, stored internally as []byte.
+
+func internalToMetadata(c metadataInternal, version string) Metadata {
+	// Config is intentionally left nil if it cannot be unmarshaled to trigger cleanup of sandboxes with invalid PodSandboxConfig.
+	// Returning the error from Unmarshal prevents the sandbox from being visible to the CRI sandbox store, triggering creation of duplicate replacements.
+	// See: https://github.com/containerd/containerd/pull/13453#issuecomment-4755099592
+
+	m := Metadata{
+		ID:             c.ID,
+		Name:           c.Name,
+		NetNSPath:      c.NetNSPath,
+		IP:             c.IP,
+		AdditionalIPs:  c.AdditionalIPs,
+		RuntimeHandler: c.RuntimeHandler,
+		CNIResult:      c.CNIResult,
+		ProcessLabel:   c.ProcessLabel,
+	}
+
+	config := &runtime.PodSandboxConfig{}
+	switch version {
+	case metadataVersion1:
+		if err := json.Unmarshal(c.Config, config); err != nil {
+			log.L.WithError(err).WithField("sandbox", c.ID).Errorf("Failed to unmarshal %s pod sandbox metadata config", version)
+			return m
+		}
+	case metadataVersion2:
+		b := []byte{}
+		if err := json.Unmarshal(c.Config, &b); err != nil {
+			log.L.WithError(err).WithField("sandbox", c.ID).Errorf("Failed to unmarshal %s pod sandbox metadata config as JSON", version)
+			return m
+		}
+		if b == nil {
+			return m
+		}
+		if err := proto.Unmarshal(b, config); err != nil {
+			log.L.WithError(err).WithField("sandbox", c.ID).Errorf("Failed to unmarshal %s pod sandbox metadata config as protobuf", version)
+			return m
+		}
+	default:
+		log.L.WithError(fmt.Errorf("unsupported version: %q", version)).WithField("sandbox", c.ID).Error("Failed to unmarshal pod sandbox metadata config")
+		return m
+	}
+
+	m.Config = config
+	return m
+}
+
+func metadataToInternal(c Metadata, version string) (metadataInternal, error) {
+	m := metadataInternal{
+		ID:             c.ID,
+		Name:           c.Name,
+		NetNSPath:      c.NetNSPath,
+		IP:             c.IP,
+		AdditionalIPs:  c.AdditionalIPs,
+		RuntimeHandler: c.RuntimeHandler,
+		CNIResult:      c.CNIResult,
+		ProcessLabel:   c.ProcessLabel,
+	}
+
+	var config []byte
+	var err error
+	switch version {
+	case metadataVersion1:
+		// v1 stores PodSandboxConfig as JSON
+		config, err = json.Marshal(c.Config)
+		if err != nil {
+			log.L.WithError(err).WithField("sandbox", c.ID).Errorf("Failed to marshal %s pod sandbox metadata config", version)
+			return m, err
+		}
+	case metadataVersion2:
+		// v2 stores PodSandboxConfig marshalled as json []byte, holding marshalled protobuf
+		if c.Config != nil {
+			config, err = proto.Marshal(c.Config)
+			if err != nil {
+				log.L.WithError(err).WithField("sandbox", c.ID).Errorf("Failed to marshal %s pod sandbox metadata config as protobuf", version)
+				return m, err
+			}
+		}
+		config, err = json.Marshal(config)
+		if err != nil {
+			log.L.WithError(err).WithField("sandbox", c.ID).Errorf("Failed to marshal %s pod sandbox metadata config as JSON", version)
+			return m, err
+		}
+	default:
+		err = fmt.Errorf("unsupported version: %q", version)
+		log.L.WithError(err).WithField("sandbox", c.ID).Error("Failed to marshal pod sandbox metadata config")
+		return m, err
+	}
+
+	m.Config = config
+	return m, nil
 }

--- a/internal/cri/store/sandbox/metadata_test.go
+++ b/internal/cri/store/sandbox/metadata_test.go
@@ -41,38 +41,54 @@ func TestMetadataMarshalUnmarshal(t *testing.T) {
 	newMeta := &Metadata{}
 	newVerMeta := &versionedMetadata{}
 
-	t.Logf("should be able to do json.marshal")
+	t.Logf("should be able to do json.marshal and produce v2")
 	data, err := json.Marshal(meta)
 	assert.NoError(err)
+	metadataInternal, err := metadataToInternal(*meta, metadataVersion2)
+	assert.NoError(err)
 	data1, err := json.Marshal(&versionedMetadata{
-		Version:  metadataVersion,
-		Metadata: metadataInternal(*meta),
+		Version:  metadataVersion2,
+		Metadata: metadataInternal,
 	})
 	assert.NoError(err)
-	assert.Equal(data, data1)
+	assert.EqualExportedValues(data, data1)
 
 	t.Logf("should be able to do MarshalJSON")
 	data, err = meta.MarshalJSON()
 	assert.NoError(err)
 	assert.NoError(newMeta.UnmarshalJSON(data))
-	assert.Equal(meta, newMeta)
+	assert.EqualExportedValues(meta, newMeta)
 
 	t.Logf("should be able to do MarshalJSON and json.Unmarshal")
 	data, err = meta.MarshalJSON()
 	assert.NoError(err)
 	assert.NoError(json.Unmarshal(data, newVerMeta))
-	assert.Equal(meta, (*Metadata)(&newVerMeta.Metadata))
+	v2meta := internalToMetadata(newVerMeta.Metadata, metadataVersion2)
+	assert.EqualExportedValues(*meta, v2meta)
 
 	t.Logf("should be able to do json.Marshal and UnmarshalJSON")
 	data, err = json.Marshal(meta)
 	assert.NoError(err)
 	assert.NoError(newMeta.UnmarshalJSON(data))
-	assert.Equal(meta, newMeta)
+	assert.EqualExportedValues(meta, newMeta)
+
+	t.Logf("should be able to unmarshal legacy v1 metadata")
+	metadataInternal, err = metadataToInternal(*meta, metadataVersion1)
+	assert.NoError(err)
+	v1data, err := json.Marshal(&versionedMetadata{
+		Version:  metadataVersion1,
+		Metadata: metadataInternal,
+	})
+	assert.NoError(err)
+	assert.NoError(newMeta.UnmarshalJSON(v1data))
+	assert.EqualExportedValues(meta, newMeta)
 
 	t.Logf("should json.Unmarshal fail for unsupported version")
+	metadataInternal, err = metadataToInternal(*meta, metadataVersion1)
+	assert.NoError(err)
 	unsupported, err := json.Marshal(&versionedMetadata{
 		Version:  "random-test-version",
-		Metadata: metadataInternal(*meta),
+		Metadata: metadataInternal,
 	})
 	assert.NoError(err)
 	assert.Error(json.Unmarshal(unsupported, &newMeta))


### PR DESCRIPTION
V2 marshals CRI protobuf messages as proto []byte, instead of json.

This is follow-up to:
* https://github.com/kubernetes/kubernetes/pull/139964
* https://github.com/containerd/containerd/pull/13453

K3s is in the process of shipping a similar set of changes in our v2.2 and v2.3 forks, to address the regression in unmarshaling env values in the current patch release of Kubernetes and cri-api.

cc @mikebrow @samuelkarp @liggitt @Random-Liu