### PR TITLE
oci: use path.Join to fill CgroupsPath

### DIFF
--- a/pkg/oci/spec.go
+++ b/pkg/oci/spec.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"path/filepath"
+	"path"
 	"runtime"
 
 	"github.com/opencontainers/go-digest"
@@ -206,7 +206,7 @@ func populateDefaultUnixSpec(ctx context.Context, s *Spec, id string) error {
 				"/proc/sys",
 				"/proc/sysrq-trigger",
 			},
-			CgroupsPath: filepath.Join("/", ns, id),
+			CgroupsPath: path.Join("/", ns, id),
 			Resources: &specs.LinuxResources{
 				Devices: []specs.LinuxDeviceCgroup{
 					{

--- a/pkg/oci/spec_test.go
+++ b/pkg/oci/spec_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/containers"
@@ -252,6 +253,12 @@ func TestPopulateDefaultUnixSpec(t *testing.T) {
 	populateDefaultUnixSpec(ctx, &expected, c.ID)
 	if expected.Linux == nil {
 		t.Error("Cannot populate Unix Spec")
+	}
+
+	// CgroupsPath should never contain backslashes when the spec is generated
+	// on Windows.
+	if strings.Contains(expected.Linux.CgroupsPath, "\\") {
+		t.Errorf("CgroupsPath contains backslashes: %s", expected.Linux.CgroupsPath)
 	}
 }
 


### PR DESCRIPTION
`populateDefaultUnixSpec` uses `filepath.Join` to generate the default `CgroupsPath`. On Windows, this produces invalid paths as path elems are joined with backslash. Switch to `path.Join` instead.