### PR TITLE
Return 'unknown' for mislabeled OCI uncompressed layers

### DIFF
--- a/core/images/mediatypes.go
+++ b/core/images/mediatypes.go
@@ -103,7 +103,11 @@ func DiffCompression(ctx context.Context, mediaType string) (string, error) {
 				return "zstd", nil
 			}
 		}
-		return "", nil
+		// This media type should be uncompressed, but the actual blob
+		// may be gzip-compressed due to mislabeling (e.g. tools that
+		// incorrectly record the media type). Return "unknown" so the
+		// decompression function can auto-detect and handle it.
+		return "unknown", nil
 	default:
 		return "", fmt.Errorf("unrecognised mediatype %s: %w", mediaType, errdefs.ErrNotImplemented)
 	}


### PR DESCRIPTION
When DiffCompression returns "" (empty string) for
application/vnd.oci.image.layer.v1.tar, the compressedHandler in
core/diff/stream.go passes the raw blob bytes directly to the tar
reader without attempting decompression. If a layer is actually
gzip-compressed but incorrectly labeled as uncompressed, this
causes "archive/tar: invalid tar header" during unpack.

Docker media types (MediaTypeDockerSchema2Layer) already return
"unknown" with the comment: "These media types may have been
compressed but failed to use the correct media type. The
decompression function should detect and handle this case."

Apply the same reasoning to OCI types. compression.DecompressStream
already does Peek(10) + DetectCompression to auto-detect from magic
bytes, so returning "unknown" is safe for both correctly uncompressed
and mislabeled compressed layers.

Fixes containerd/containerd#10134