### PR TITLE
pkg/oci: resolve symlinks on intermediate path components in openUserFile

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1838,11 +1838,10 @@ type readLinker interface {
 }
 
 // openUserFile attempts to open a file within the root fs.
-// It handles cases where the file is an absolute symlink (e.g., NixOS /etc/passwd -> /nix/store/...),
-// which triggers "path escapes from parent" errors in Go 1.24+ due to stricter os.DirFS validation.
-//
-// The returned file rejects non-regular sources and returns an error if more
-// than maxUserFileBytes are read from it.
+// It handles cases where the file or any intermediate directory component is
+// an absolute or relative symlink (e.g., NixOS /etc/passwd -> /nix/store/...,
+// Android /etc -> /system/etc), which triggers "path escapes from parent" errors
+// in Go 1.24+ due to stricter os.DirFS sandboxing.
 func openUserFile(root fs.FS, name string) (fs.File, error) {
 	f, err := root.Open(name)
 	if err == nil {
@@ -1852,29 +1851,76 @@ func openUserFile(root fs.FS, name string) (fs.File, error) {
 	// Check if the FS implements our local ReadLink interface.
 	// We use a local interface instead of fs.ReadLinkFS to avoid strict dependency
 	// issues in some build environments.
-	if lfs, ok := root.(readLinker); ok {
-		if target, lerr := lfs.ReadLink(name); lerr == nil {
-			// Use filepath.IsAbs to handle platform-agnostic absolute path checks
-			if filepath.IsAbs(target) {
-				// Re-anchor the absolute path to the root.
-				// e.g. /nix/store/... becomes nix/store/... (relative to root fs)
-				// We use filepath.Rel to safely strip the leading separator.
-				rel, rerr := filepath.Rel(string(filepath.Separator), target)
-				if rerr == nil {
-					// filepath.Rel might return OS-specific separators (backslashes on Windows).
-					// fs.Open strictly expects forward slashes, so we convert it.
-					f, oerr := root.Open(filepath.ToSlash(rel))
-					if oerr != nil {
-						return nil, oerr
-					}
-					return wrapUserFile(f, name)
-				}
-			}
-		}
+	lfs, ok := root.(readLinker)
+	if !ok {
+		return nil, err
 	}
 
-	// Return the original error if we couldn't resolve it
-	return nil, err
+	// Walk the path component by component, resolving symlinks at each level.
+	// This handles both "final file is a symlink" (NixOS) and "intermediate
+	// directory is a symlink" (Android /etc -> /system/etc) cases.
+	resolved, rerr := resolvePathSymlinks(lfs, name, 8)
+	if rerr != nil {
+		return nil, rerr
+	}
+	if resolved == name {
+		return nil, err
+	}
+	return root.Open(resolved)
+}
+
+// resolvePathSymlinks walks each component of name, resolving absolute or
+// relative symlinks at each step. depth limits recursion to prevent loops.
+// Returns the fully resolved path, which equals name when no symlinks are found.
+func resolvePathSymlinks(lfs readLinker, name string, depth int) (string, error) {
+	if depth == 0 {
+		return "", errors.New("openUserFile: too many levels of symbolic links")
+	}
+	parts := strings.Split(name, "/")
+	current := ""
+	for i, part := range parts {
+		if current == "" {
+			current = part
+		} else {
+			current = current + "/" + part
+		}
+
+		target, lerr := lfs.ReadLink(current)
+		if lerr != nil {
+			// Not a symlink or unreadable — continue accumulating path.
+			continue
+		}
+
+		var next string
+		if filepath.IsAbs(target) {
+			// Absolute symlink: re-anchor to root by stripping the leading separator.
+			// e.g. /system/etc becomes system/etc (relative to root fs).
+			rel, rerr := filepath.Rel(string(filepath.Separator), target)
+			if rerr != nil {
+				return "", rerr
+			}
+			next = filepath.ToSlash(rel)
+		} else {
+			// Relative symlink: resolve relative to the parent directory.
+			parent := strings.Join(parts[:i], "/")
+			if parent == "" {
+				next = target
+			} else {
+				next = parent + "/" + target
+			}
+			// Normalise to collapse any "." or ".." components.
+			next = filepath.ToSlash(filepath.Clean(next))
+		}
+
+		// Append remaining path components after the resolved symlink target.
+		if remaining := parts[i+1:]; len(remaining) > 0 {
+			next = next + "/" + strings.Join(remaining, "/")
+		}
+
+		// Recurse to resolve any newly introduced symlinks in the resolved path.
+		return resolvePathSymlinks(lfs, next, depth-1)
+	}
+	return current, nil
 }
 
 // maxUserFileBytes caps how much data is read from any user-database file

--- a/pkg/oci/spec_test.go
+++ b/pkg/oci/spec_test.go
@@ -425,6 +425,104 @@ func TestGroupLookup_AbsoluteSymlink(t *testing.T) {
 	}
 }
 
+// TestOpenUserFile_IntermediateDirSymlink tests that openUserFile resolves
+// absolute symlinks on intermediate directory components, not just the final
+// file. This covers rootfs layouts like Android emulator images where /etc is
+// an absolute symlink to /system/etc, so etc/passwd is only reachable via
+// the chain etc -> /system/etc -> system/etc/passwd.
+func TestOpenUserFile_IntermediateDirSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	expectedContent := []byte("root:x:0:0:root:/root:/bin/sh\n")
+
+	root := t.TempDir()
+	if err := fstest.Apply(
+		fstest.CreateDir("/system", 0o755),
+		fstest.CreateDir("/system/etc", 0o755),
+		fstest.CreateFile("/system/etc/passwd", expectedContent, 0o644),
+		fstest.CreateFile("/system/etc/group", []byte("root:x:0:\n"), 0o644),
+		// /etc -> /system/etc  (absolute symlink to a directory)
+		fstest.Symlink("/system/etc", "/etc"),
+	).Apply(root); err != nil {
+		t.Fatal(err)
+	}
+
+	wrapFS := func(base string) fs.FS {
+		plain := os.DirFS(base)
+		if _, ok := plain.(readLinker); ok {
+			return plain
+		}
+		return readLinkFS{root: base, fs: plain}
+	}
+
+	t.Run("passwd via absolute dir symlink", func(t *testing.T) {
+		f, err := openUserFile(wrapFS(root), "etc/passwd")
+		if err != nil {
+			t.Fatalf("openUserFile failed for etc/passwd through absolute dir symlink: %v", err)
+		}
+		defer f.Close()
+		got, readErr := io.ReadAll(f)
+		if readErr != nil {
+			t.Fatalf("io.ReadAll failed: %v", readErr)
+		}
+		if string(got) != string(expectedContent) {
+			t.Errorf("content mismatch: got %q, want %q", got, expectedContent)
+		}
+	})
+
+	t.Run("group via absolute dir symlink", func(t *testing.T) {
+		f, err := openUserFile(wrapFS(root), "etc/group")
+		if err != nil {
+			t.Fatalf("openUserFile failed for etc/group through absolute dir symlink: %v", err)
+		}
+		defer f.Close()
+	})
+
+}
+
+// TestOpenUserFile_RelativeDirSymlink tests that openUserFile resolves
+// relative symlinks on intermediate directory components.
+func TestOpenUserFile_RelativeDirSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	expectedContent := []byte("root:x:0:0:root:/root:/bin/sh\n")
+
+	root := t.TempDir()
+	if err := fstest.Apply(
+		fstest.CreateDir("/real_etc", 0o755),
+		fstest.CreateFile("/real_etc/passwd", expectedContent, 0o644),
+		// /etc -> real_etc  (relative symlink to a directory)
+		fstest.Symlink("real_etc", "/etc"),
+	).Apply(root); err != nil {
+		t.Fatal(err)
+	}
+
+	wrapFS := func(base string) fs.FS {
+		plain := os.DirFS(base)
+		if _, ok := plain.(readLinker); ok {
+			return plain
+		}
+		return readLinkFS{root: base, fs: plain}
+	}
+
+	f, err := openUserFile(wrapFS(root), "etc/passwd")
+	if err != nil {
+		t.Fatalf("openUserFile failed for etc/passwd through relative dir symlink: %v", err)
+	}
+	defer f.Close()
+	got, readErr := io.ReadAll(f)
+	if readErr != nil {
+		t.Fatalf("io.ReadAll failed: %v", readErr)
+	}
+	if string(got) != string(expectedContent) {
+		t.Errorf("content mismatch: got %q, want %q", got, expectedContent)
+	}
+}
+
 // Helpers for testing ReadLink support
 type readLinkFS struct {
 	root string


### PR DESCRIPTION
## Root cause

The existing fix for Go 1.24+'s stricter `os.DirFS` sandboxing (PR #12732, commit 85b5418e) only handled the case where the **final file** itself is an absolute symlink (NixOS: `/etc/passwd -> /nix/store/.../passwd`). It left broken the equally common case where an **intermediate directory component** is a symlink — e.g., Android emulator images where `/etc` is an absolute symlink to `/system/etc`.

`openUserFile` called `ReadLink(name)` on the entire path (`"etc/passwd"`). When `etc/passwd` is not itself a symlink but `etc` is, `ReadLink` returns an error and the function falls through to the original "path escapes from parent" error.

## Fix

Replace the single `ReadLink` call with `resolvePathSymlinks`, which walks every component of the path and resolves both absolute and relative symlinks at each step. Recursion is limited to 8 levels to prevent symlink loops.

The absolute-symlink resolution logic (`etc` → `/system/etc` becomes `system/etc` anchored at the root) is the same pattern already used for final-file symlinks; it is now applied to every directory component along the way.

## Test cases added

- **Absolute dir symlink**: rootfs with `/etc -> /system/etc` (absolute), file at `/system/etc/passwd`
- **Relative dir symlink**: rootfs with `/etc -> real_etc` (relative), file at `/real_etc/passwd`

The existing `TestOpenUserFile_AbsoluteSymlink` and `TestGroupLookup_AbsoluteSymlink` tests (final-file symlink cases) continue to pass.

Fixes #13382