### PR TITLE
pkg/oci: update TestOpenUserFileCapsReads to use newlined data

### DIFF
--- a/pkg/oci/spec_opts_user_bounds_test.go
+++ b/pkg/oci/spec_opts_user_bounds_test.go
@@ -30,6 +30,8 @@ import (
 
 // TestOpenUserFileCapsReads asserts the boundary behavior of the read cap:
 // well below, ending exactly at, and past maxUserFileBytes.
+//
+// Regression test for CVE-2026-47262 / GHSA-jpcc-p29g-p8mq
 func TestOpenUserFileCapsReads(t *testing.T) {
 	t.Parallel()
 
@@ -60,7 +62,13 @@ func TestOpenUserFileCapsReads(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			data := append(bytes.Repeat([]byte{0}, tc.padBytes), beyond...)
+			pattern := []byte("# padding\n")
+			pad := bytes.Repeat(pattern, (tc.padBytes+len(pattern)-1)/len(pattern))[:tc.padBytes]
+			if len(pad) > 0 {
+				pad[len(pad)-1] = '\n'
+			}
+
+			data := append(pad, beyond...)
 			fsys := fstest.MapFS{
 				"etc/group": &fstest.MapFile{Data: data, Mode: 0o644},
 			}


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/13670#issuecomment-4803542840
- relates to https://github.com/containerd/containerd/pull/13626


This test verifies the maximum file-size constraints that were added in [containerd7b05ec4]. However, github.com/moby/sys@v0.4.1 adds similar constraints, including a constraint on line-length (1M): [moby/sys@2c56c3d] that may hit before the file-size limit is reached if the data does not contain newlines.

This patch updates the test to use data that includes newlines to make sure it's testing the file-size constraints, not line-limit constraints.

[containerd7b05ec4]: https://github.com/containerd/containerd/commit/7b05ec421d0a07b33964c74145b6bf5dff58f476
[moby/sys@2c56c3d]: https://github.com/moby/sys/commit/2c56c3d5d089bfa66d01b6c0bb69428e9d5d18c5
