### PR TITLE
seccomp: support to use clone3 if user don't have SYS_ADMIN capability

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -20,11 +20,18 @@ package seccomp
 
 import (
 	"runtime"
+	"sync"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/containerd/v2/pkg/kernelversion"
 	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+var (
+	once            sync.Once
+	clone3Supported bool
 )
 
 func arches() []specs.Arch {
@@ -789,16 +796,38 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				},
 			})
 		}
-		// clone3 is explicitly requested to give ENOSYS instead of the default EPERM, when CAP_SYS_ADMIN is unset
-		// https://github.com/moby/moby/pull/42681
-		s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
-			Names: []string{
-				"clone3",
-			},
-			Action:   specs.ActErrno,
-			ErrnoRet: &nosys,
-		})
+		if !isClone3Supported() {
+			// clone3 is explicitly requested to give ENOSYS instead of the default EPERM, when CAP_SYS_ADMIN is unset
+			// https://github.com/moby/moby/pull/42681
+			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+				Names: []string{
+					"clone3",
+				},
+				Action:   specs.ActErrno,
+				ErrnoRet: &nosys,
+			})
+		} else {
+			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+				Names: []string{
+					"clone3",
+				},
+				Action: specs.ActAllow,
+				Args:   []specs.LinuxSeccompArg{},
+			})
+		}
 	}
 
 	return s
+}
+
+func isClone3Supported() bool {
+	once.Do(func() {
+		var args [80]byte
+		const sysClone3 = unix.SYS_CLONE3
+		// Try to call clone3 with an invalid size (0). On kernels that implement clone3 this should fail with EINVAL;
+		// if the syscall is not implemented it returns ENOSYS.
+		_, _, err := unix.RawSyscall(sysClone3, uintptr(unsafe.Pointer(&args[0])), 0, 0)
+		clone3Supported = err == unix.EINVAL
+	})
+	return clone3Supported
 }

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -20,11 +20,18 @@ package seccomp
 
 import (
 	"runtime"
+	"sync"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/containerd/v2/pkg/kernelversion"
 	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+var (
+	once            sync.Once
+	clone3Supported bool
 )
 
 func arches() []specs.Arch {
@@ -789,16 +796,39 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				},
 			})
 		}
-		// clone3 is explicitly requested to give ENOSYS instead of the default EPERM, when CAP_SYS_ADMIN is unset
-		// https://github.com/moby/moby/pull/42681
-		s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
-			Names: []string{
-				"clone3",
-			},
-			Action:   specs.ActErrno,
-			ErrnoRet: &nosys,
-		})
+		if !isClone3Supported() {
+			// If the kernel doesn't implement clone3, explicitly return ENOSYS instead of the default EPERM
+			// so libc can fall back to clone.
+			// https://github.com/moby/moby/pull/42681
+			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+				Names: []string{
+					"clone3",
+				},
+				Action:   specs.ActErrno,
+				ErrnoRet: &nosys,
+			})
+		} else {
+			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+				Names: []string{
+					"clone3",
+				},
+				Action: specs.ActAllow,
+				Args:   []specs.LinuxSeccompArg{},
+			})
+		}
 	}
 
 	return s
+}
+
+func isClone3Supported() bool {
+	once.Do(func() {
+		var args byte
+		const sysClone3 = unix.SYS_CLONE3
+		// Try to call clone3 with an invalid size (0). On kernels that implement clone3 this should fail with EINVAL;
+		// if the syscall is not implemented it returns ENOSYS.
+		_, _, err := unix.RawSyscall(sysClone3, uintptr(unsafe.Pointer(&args)), 0, 0)
+		clone3Supported = err == unix.EINVAL
+	})
+	return clone3Supported
 }


### PR DESCRIPTION
if kernel support clone3 and user doesn't have SYS_ADMIN capability, clone3 will fall back to clone
 
reproduce 
```
nerdctl run -it  --cap-add=SYS_PTRACE    --network=host -v /etc/yum.repos.d/:/etc/yum.repos.d/ -v /root:/root registry.openanolis.cn/openanolis/anolisos:23.3 bash

[root]# strace -f -e trace=clone3,clone python3 -c 'import threading; threading.Thread(None, lambda: print(123)).start()'
clone3({flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, child_tid=0x7f4eba13e990, parent_tid=0x7f4eba13e990, exit_signal=0, stack=0x7f4eb993e000, stack_size=0x7fff80, tls=0x7f4eba13e6c0}, 88) = -1 ENOSYS (Function not implemented)
clone(child_stack=0x7f4eba13df70, flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTIDstrace: Process 36 attached
, parent_tid=[36], tls=0x7f4eba13e6c0, child_tidptr=0x7f4eba13e990) = 36
123
[pid    36] +++ exited with 0 +++
+++ exited with 0 +++
```
@AkihiroSuda  