### PR TITLE
Fix nil pointer dereference in NRI GetIPs

### DIFF
--- a/internal/cri/nri/nri_api_linux.go
+++ b/internal/cri/nri/nri_api_linux.go
@@ -682,7 +682,8 @@ func (p *criPodSandbox) GetPid() uint32 {
 }
 
 func (p *criPodSandbox) GetIPs() []string {
-	if p.IP == "" {
+	// IP and AdditionalIPs are promoted fields from the embedded Sandbox struct.
+	if p.Sandbox == nil || p.IP == "" {
 		return nil
 	}
 	ips := append([]string{p.IP}, p.AdditionalIPs...)

--- a/internal/cri/nri/nri_api_linux_test.go
+++ b/internal/cri/nri/nri_api_linux_test.go
@@ -1,0 +1,81 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package nri
+
+import (
+	"testing"
+
+	sstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCRIPodSandboxGetIPs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pod      *criPodSandbox
+		expected []string
+	}{
+		{
+			name: "nil Sandbox",
+			pod: &criPodSandbox{
+				Sandbox: nil,
+			},
+			expected: nil,
+		},
+		{
+			name: "empty primary IP",
+			pod: &criPodSandbox{
+				Sandbox: &sstore.Sandbox{
+					Metadata: sstore.Metadata{
+						IP: "",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "single primary IP",
+			pod: &criPodSandbox{
+				Sandbox: &sstore.Sandbox{
+					Metadata: sstore.Metadata{
+						IP: "10.0.0.1",
+					},
+				},
+			},
+			expected: []string{"10.0.0.1"},
+		},
+		{
+			name: "primary and additional IPs",
+			pod: &criPodSandbox{
+				Sandbox: &sstore.Sandbox{
+					Metadata: sstore.Metadata{
+						IP:            "10.0.0.1",
+						AdditionalIPs: []string{"fd00::1"},
+					},
+				},
+			},
+			expected: []string{"10.0.0.1", "fd00::1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ips := tc.pod.GetIPs()
+			assert.Equal(t, tc.expected, ips)
+		})
+	}
+}


### PR DESCRIPTION
Adds a `nil` guard to `GetIPs` on `criPodSandbox` before accessing promoted struct fields on the embedded `Sandbox` pointer.

During pod sandbox teardown or race conditions during container exit events, `nriPodSandbox` can return a `criPodSandbox` instance where the embedded `Sandbox` pointer is `nil`.

Assisted-by: Antigravity