### PR TITLE
archive/diff: map host IDs back to container IDs on snapshot diff export

### DIFF
--- a/internal/userns/idmap.go
+++ b/internal/userns/idmap.go
@@ -79,6 +79,23 @@ func (i *IDMap) ToHost(pair User) (User, error) {
 	return target, nil
 }
 
+// ToContainer returns the container user ID pair for the host user ID pair.
+func (i *IDMap) ToContainer(pair User) (User, error) {
+	var (
+		target User
+		err    error
+	)
+	target.Uid, err = toContainer(pair.Uid, i.UidMap)
+	if err != nil {
+		return invalidUser, err
+	}
+	target.Gid, err = toContainer(pair.Gid, i.GidMap)
+	if err != nil {
+		return invalidUser, err
+	}
+	return target, nil
+}
+
 // Marshal serializes the IDMap object into two strings:
 // one uidmap list and another one for gidmap list
 func (i *IDMap) Marshal() (string, string) {
@@ -139,6 +156,29 @@ func toHost(contID uint32, idMap []specs.LinuxIDMapping) (uint32, error) {
 		}
 	}
 	return invalidID, fmt.Errorf("container ID %d cannot be mapped to a host ID", contID)
+}
+
+// toContainer takes an id mapping and a remapped ID, and translates the
+// ID to the mapped container ID. If no map is provided, then the translation
+// assumes a 1-to-1 mapping and returns the passed in id #
+func toContainer(hostID uint32, idMap []specs.LinuxIDMapping) (uint32, error) {
+	if idMap == nil {
+		return hostID, nil
+	}
+	for _, m := range idMap {
+		high, err := safeSum(m.HostID, m.Size)
+		if err != nil {
+			break
+		}
+		if hostID >= m.HostID && hostID < high {
+			contID, err := safeSum(m.ContainerID, hostID-m.HostID)
+			if err != nil || contID == invalidID {
+				break
+			}
+			return contID, nil
+		}
+	}
+	return invalidID, fmt.Errorf("host ID %d cannot be mapped to a container ID", hostID)
 }
 
 // safeSum returns the sum of x and y. or an error if the result overflows

--- a/internal/userns/idmap_test.go
+++ b/internal/userns/idmap_test.go
@@ -179,6 +179,112 @@ func TestToHost(t *testing.T) {
 	}
 }
 
+func TestToContainer(t *testing.T) {
+	idmap := IDMap{
+		UidMap: []specs.LinuxIDMapping{
+			{
+				ContainerID: 0,
+				HostID:      1,
+				Size:        2,
+			},
+			{
+				ContainerID: 2,
+				HostID:      4,
+				Size:        1000,
+			},
+		},
+		GidMap: []specs.LinuxIDMapping{
+			{
+				ContainerID: 0,
+				HostID:      2,
+				Size:        4,
+			},
+			{
+				ContainerID: 4,
+				HostID:      8,
+				Size:        1000,
+			},
+		},
+	}
+	for _, test := range []struct {
+		host      User
+		container User
+	}{
+		{
+			host: User{
+				Uid: 1,
+				Gid: 2,
+			},
+			container: User{
+				Uid: 0,
+				Gid: 0,
+			},
+		},
+		{
+			host: User{
+				Uid: 2,
+				Gid: 3,
+			},
+			container: User{
+				Uid: 1,
+				Gid: 1,
+			},
+		},
+		{
+			host: User{
+				Uid: 4,
+				Gid: 8,
+			},
+			container: User{
+				Uid: 2,
+				Gid: 4,
+			},
+		},
+		{
+			host: User{
+				Uid: 102,
+				Gid: 204,
+			},
+			container: User{
+				Uid: 100,
+				Gid: 200,
+			},
+		},
+		{
+			host: User{
+				Uid: 1003,
+				Gid: 1007,
+			},
+			container: User{
+				Uid: 1001,
+				Gid: 1003,
+			},
+		},
+		{
+			host: User{
+				Uid: 1004,
+				Gid: 1008,
+			},
+			container: invalidUser,
+		},
+		{
+			host: User{
+				Uid: 2000,
+				Gid: 2000,
+			},
+			container: invalidUser,
+		},
+	} {
+		r, err := idmap.ToContainer(test.host)
+		assert.Equal(t, test.container, r)
+		if r == invalidUser {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
 func TestToHostOverflow(t *testing.T) {
 	for _, test := range []struct {
 		idmap IDMap

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -601,14 +601,15 @@ func (cw *ChangeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 		}
 
 		if cw.idMap != nil {
-			pair, err := cw.idMap.ToContainer(internaluserns.User{
+			pair, mapErr := cw.idMap.ToContainer(internaluserns.User{
 				Uid: uint32(hdr.Uid),
 				Gid: uint32(hdr.Gid),
 			})
-			if err == nil {
-				hdr.Uid = int(pair.Uid)
-				hdr.Gid = int(pair.Gid)
+			if mapErr != nil {
+				return fmt.Errorf("failed to map file ownership for %q (uid=%d gid=%d): %w", p, hdr.Uid, hdr.Gid, mapErr)
 			}
+			hdr.Uid = int(pair.Uid)
+			hdr.Gid = int(pair.Gid)
 		}
 
 		hdr.Mode = int64(chmodTarEntry(os.FileMode(hdr.Mode)))

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/moby/sys/userns"
 
+	internaluserns "github.com/containerd/containerd/v2/internal/userns"
 	"github.com/containerd/containerd/v2/pkg/archive/tarheader"
 	"github.com/containerd/containerd/v2/pkg/epoch"
 	"github.com/containerd/continuity/fs"
@@ -107,6 +108,9 @@ func writeDiffNaive(ctx context.Context, w io.Writer, a, b string, o WriteDiffOp
 		opts = append(opts, WithModTimeUpperBound(*o.SourceDateEpoch))
 		// Since containerd v2.0, the whiteout timestamps are set to zero (1970-01-01),
 		// not to the source date epoch
+	}
+	if o.IDMap != nil {
+		opts = append(opts, WithChangeWriterIDMap(o.IDMap))
 	}
 	cw := NewChangeWriter(w, b, opts...)
 	err := fs.Changes(ctx, a, b, cw.HandleChange)
@@ -509,6 +513,7 @@ type ChangeWriter struct {
 	inodeSrc          map[uint64]string
 	inodeRefs         map[uint64][]string
 	addedDirs         map[string]struct{}
+	idMap             *internaluserns.IDMap
 }
 
 // ChangeWriterOpt can be specified in NewChangeWriter.
@@ -518,6 +523,13 @@ type ChangeWriterOpt func(cw *ChangeWriter)
 func WithModTimeUpperBound(tm time.Time) ChangeWriterOpt {
 	return func(cw *ChangeWriter) {
 		cw.modTimeUpperBound = &tm
+	}
+}
+
+// WithChangeWriterIDMap sets the IDMap for user namespace remapping.
+func WithChangeWriterIDMap(idMap *internaluserns.IDMap) ChangeWriterOpt {
+	return func(cw *ChangeWriter) {
+		cw.idMap = idMap
 	}
 }
 
@@ -586,6 +598,17 @@ func (cw *ChangeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 		hdr, err := tarheader.FileInfoHeaderNoLookups(f, link)
 		if err != nil {
 			return err
+		}
+
+		if cw.idMap != nil {
+			pair, err := cw.idMap.ToContainer(internaluserns.User{
+				Uid: uint32(hdr.Uid),
+				Gid: uint32(hdr.Gid),
+			})
+			if err == nil {
+				hdr.Uid = int(pair.Uid)
+				hdr.Gid = int(pair.Gid)
+			}
 		}
 
 		hdr.Mode = int64(chmodTarEntry(os.FileMode(hdr.Mode)))

--- a/pkg/archive/tar_linux_test.go
+++ b/pkg/archive/tar_linux_test.go
@@ -17,6 +17,7 @@
 package archive
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"fmt"
@@ -26,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/mount"
+	internaluserns "github.com/containerd/containerd/v2/internal/userns"
 	"github.com/containerd/containerd/v2/pkg/testutil"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
 	"github.com/containerd/continuity/fs"
@@ -169,3 +171,56 @@ func (d overlayDiffApplier) Apply(ctx context.Context, a fstest.Applier) (string
 
 	return oc.merged, nil, nil
 }
+
+func TestWriteDiffIDMap(t *testing.T) {
+	testutil.RequiresRoot(t)
+
+	lower := t.TempDir()
+	upper := t.TempDir()
+
+	// Create file in upper directory
+	filePath := filepath.Join(upper, "testfile")
+	if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change ownership of the file to 524288:524288
+	if err := os.Chown(filePath, 524288, 524288); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup IDMap: mapping container 0 -> host 524288 with size 65536
+	var idMap internaluserns.IDMap
+	if err := idMap.Unmarshal("0:524288:65536", "0:524288:65536"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call WriteDiff with WithIDMap option
+	buf := new(bytes.Buffer)
+	if err := WriteDiff(context.Background(), buf, lower, upper, WithIDMap(&idMap)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the tar stream and verify the header UID/GID are mapped back to 0:0
+	tr := tar.NewReader(buf)
+	found := false
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Name == "testfile" {
+			found = true
+			if hdr.Uid != 0 || hdr.Gid != 0 {
+				t.Errorf("expected UID/GID to be mapped to 0:0, got %d:%d", hdr.Uid, hdr.Gid)
+			}
+		}
+	}
+	if !found {
+		t.Error("testfile not found in the tar archive")
+	}
+}
+

--- a/pkg/archive/tar_opts.go
+++ b/pkg/archive/tar_opts.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"io"
 	"time"
+
+	internaluserns "github.com/containerd/containerd/v2/internal/userns"
 )
 
 // ApplyOptions provides additional options for an Apply operation
@@ -97,6 +99,9 @@ type WriteDiffOptions struct {
 	//
 	// See also https://reproducible-builds.org/docs/source-date-epoch/ .
 	SourceDateEpoch *time.Time
+
+	// IDMap specifies the ID mapping to translate file ownership back to container namespace
+	IDMap *internaluserns.IDMap
 }
 
 // WriteDiffOpt allows setting mutable archive write properties on creation
@@ -106,6 +111,14 @@ type WriteDiffOpt func(options *WriteDiffOptions) error
 func WithSourceDateEpoch(tm *time.Time) WriteDiffOpt {
 	return func(options *WriteDiffOptions) error {
 		options.SourceDateEpoch = tm
+		return nil
+	}
+}
+
+// WithIDMap specifies the IDMap used to map file owners back to container IDs.
+func WithIDMap(idMap *internaluserns.IDMap) WriteDiffOpt {
+	return func(options *WriteDiffOptions) error {
+		options.IDMap = idMap
 		return nil
 	}
 }

--- a/plugins/diff/erofs/compare_linux.go
+++ b/plugins/diff/erofs/compare_linux.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/containerd/continuity/fs"
@@ -34,6 +35,7 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/mount"
+	internaluserns "github.com/containerd/containerd/v2/internal/userns"
 	"github.com/containerd/containerd/v2/internal/erofsutils"
 	"github.com/containerd/containerd/v2/pkg/archive"
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
@@ -41,8 +43,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/labels"
 )
 
-func writeDiff(ctx context.Context, w io.Writer, lower []mount.Mount, upperRoot string) error {
-	var opts []archive.ChangeWriterOpt
+func writeDiff(ctx context.Context, w io.Writer, lower []mount.Mount, upperRoot string, opts ...archive.ChangeWriterOpt) error {
 
 	return mount.WithTempMount(ctx, lower, func(lowerRoot string) error {
 		cw := archive.NewChangeWriter(w, upperRoot, opts...)
@@ -70,6 +71,29 @@ func (s erofsDiff) Compare(ctx context.Context, lower, upper []mount.Mount, opts
 	}
 	if tm := epoch.FromContext(ctx); tm != nil && config.SourceDateEpoch == nil {
 		config.SourceDateEpoch = tm
+	}
+
+	var idMap *internaluserns.IDMap
+	for _, m := range upper {
+		var uidmap, gidmap string
+		for _, opt := range m.Options {
+			if after, ok := strings.CutPrefix(opt, "uidmap="); ok {
+				uidmap = after
+			} else if after, ok := strings.CutPrefix(opt, "gidmap="); ok {
+				gidmap = after
+			}
+		}
+		if uidmap != "" || gidmap != "" {
+			idMap = &internaluserns.IDMap{}
+			if err := idMap.Unmarshal(uidmap, gidmap); err != nil {
+				return emptyDesc, fmt.Errorf("failed to unmarshal snapshot ID mapped options: %w", err)
+			}
+			break
+		}
+	}
+	var writeDiffOpts []archive.ChangeWriterOpt
+	if idMap != nil {
+		writeDiffOpts = append(writeDiffOpts, archive.WithChangeWriterIDMap(idMap))
 	}
 
 	if config.MediaType == "" {
@@ -137,7 +161,7 @@ func (s erofsDiff) Compare(ctx context.Context, lower, upper []mount.Mount, opts
 				return emptyDesc, fmt.Errorf("failed to get compressed stream: %w", errOpen)
 			}
 		}
-		errOpen = writeDiff(ctx, io.MultiWriter(compressed, dgstr.Hash()), lower, upperRoot)
+		errOpen = writeDiff(ctx, io.MultiWriter(compressed, dgstr.Hash()), lower, upperRoot, writeDiffOpts...)
 		compressed.Close()
 		if errOpen != nil {
 			return emptyDesc, fmt.Errorf("failed to write compressed diff: %w", errOpen)
@@ -148,7 +172,7 @@ func (s erofsDiff) Compare(ctx context.Context, lower, upper []mount.Mount, opts
 		}
 		config.Labels[labels.LabelUncompressed] = dgstr.Digest().String()
 	} else {
-		err := writeDiff(ctx, cw, lower, upperRoot)
+		err := writeDiff(ctx, cw, lower, upperRoot, writeDiffOpts...)
 		if err != nil {
 			return emptyDesc, fmt.Errorf("failed to create diff tar stream: %w", err)
 		}

--- a/plugins/diff/erofs/compare_linux.go
+++ b/plugins/diff/erofs/compare_linux.go
@@ -84,9 +84,12 @@ func (s erofsDiff) Compare(ctx context.Context, lower, upper []mount.Mount, opts
 			}
 		}
 		if uidmap != "" || gidmap != "" {
+			if uidmap == "" || gidmap == "" {
+				return emptyDesc, fmt.Errorf("invalid snapshot ID mapped options: both uidmap and gidmap must be set (uidmap=%q gidmap=%q)", uidmap, gidmap)
+			}
 			idMap = &internaluserns.IDMap{}
 			if err := idMap.Unmarshal(uidmap, gidmap); err != nil {
-				return emptyDesc, fmt.Errorf("failed to unmarshal snapshot ID mapped options: %w", err)
+				return emptyDesc, fmt.Errorf("failed to unmarshal snapshot ID mapped options (uidmap=%q gidmap=%q): %w", uidmap, gidmap, err)
 			}
 			break
 		}

--- a/plugins/diff/walking/differ.go
+++ b/plugins/diff/walking/differ.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/containerd/errdefs"
@@ -33,6 +34,7 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/mount"
+	internaluserns "github.com/containerd/containerd/v2/internal/userns"
 	"github.com/containerd/containerd/v2/pkg/archive"
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/containerd/containerd/v2/pkg/epoch"
@@ -73,6 +75,28 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 	var writeDiffOpts []archive.WriteDiffOpt
 	if config.SourceDateEpoch != nil {
 		writeDiffOpts = append(writeDiffOpts, archive.WithSourceDateEpoch(config.SourceDateEpoch))
+	}
+
+	var idMap *internaluserns.IDMap
+	for _, m := range upper {
+		var uidmap, gidmap string
+		for _, opt := range m.Options {
+			if after, ok := strings.CutPrefix(opt, "uidmap="); ok {
+				uidmap = after
+			} else if after, ok := strings.CutPrefix(opt, "gidmap="); ok {
+				gidmap = after
+			}
+		}
+		if uidmap != "" || gidmap != "" {
+			idMap = &internaluserns.IDMap{}
+			if err := idMap.Unmarshal(uidmap, gidmap); err != nil {
+				return emptyDesc, fmt.Errorf("failed to unmarshal snapshot ID mapped options: %w", err)
+			}
+			break
+		}
+	}
+	if idMap != nil {
+		writeDiffOpts = append(writeDiffOpts, archive.WithIDMap(idMap))
 	}
 
 	compressionType := compression.Uncompressed

--- a/plugins/diff/walking/differ.go
+++ b/plugins/diff/walking/differ.go
@@ -88,9 +88,12 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 			}
 		}
 		if uidmap != "" || gidmap != "" {
+			if uidmap == "" || gidmap == "" {
+				return emptyDesc, fmt.Errorf("invalid snapshot ID mapped options: both uidmap and gidmap must be set (uidmap=%q gidmap=%q)", uidmap, gidmap)
+			}
 			idMap = &internaluserns.IDMap{}
 			if err := idMap.Unmarshal(uidmap, gidmap); err != nil {
-				return emptyDesc, fmt.Errorf("failed to unmarshal snapshot ID mapped options: %w", err)
+				return emptyDesc, fmt.Errorf("failed to unmarshal snapshot ID mapped options (uidmap=%q gidmap=%q): %w", uidmap, gidmap, err)
 			}
 			break
 		}


### PR DESCRIPTION
### Context
When diffing an idmapped overlay active snapshot (e.g. during a commit or image export of a container using user namespaces), files in the upper directory are owned by host subordinate UIDs/GIDs. Currently, `ctr snapshots diff` exports these host-mapped UID/GID values directly into the OCI layer tar headers, leading to non-portable images.

### Changes
* **internal/userns**: Added `ToContainer` remapping utility to map host IDs back to container namespace IDs.
* **pkg/archive**: Extended `WriteDiffOptions` and `ChangeWriter` to accept an `IDMap` and translate file ownership in `HandleChange` before generating tar headers.
* **plugins/diff/walking**: Parsed `uidmap` and `gidmap` from the `upper` mount list and configured `WriteDiff` with the mapping.
* **plugins/diff/erofs**: Updated `erofs` differ to parse and pass `IDMap` to `ChangeWriter`.
* **pkg/archive/tar_linux_test.go**: Added `TestWriteDiffIDMap` to verify the remapping works under simulated overlay diff.

### Verification
* Ran `go test -v ./internal/userns/...` (Passed)
* Ran `go test -v ./pkg/archive/...` (Passed `TestWriteDiffIDMap`)
* Verified compilation for both `walking` and `erofs` differs.

### PR Checklist
- [x] Code conforms to codebase style
- [x] Integration/unit tests added and passing
- [x] No regressions introduced
