### PR TITLE
pkg/kernelversion: fix linting and sync with upstream

### DIFF
--- a/pkg/kernelversion/kernel_linux.go
+++ b/pkg/kernelversion/kernel_linux.go
@@ -14,10 +14,12 @@
    limitations under the License.
 */
 
-/*
-   File copied and customized based on
-   https://github.com/moby/moby/tree/v20.10.14/profiles/seccomp/kernel_linux.go
-*/
+// SPDX-FileCopyrightText: Copyright The containerd Authors
+// SPDX-FileCopyrightText: Copyright The Moby Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// File copied and customized based on
+// https://github.com/moby/profiles/blob/seccomp/v0.2.3/seccomp/kernel_linux.go
 
 package kernelversion
 

--- a/pkg/kernelversion/kernel_linux.go
+++ b/pkg/kernelversion/kernel_linux.go
@@ -42,24 +42,15 @@ func (k *KernelVersion) String() string {
 	return ""
 }
 
-var (
-	currentKernelVersion *KernelVersion
-	kernelVersionError   error
-	once                 sync.Once
-)
-
 // getKernelVersion gets the current kernel version.
-func getKernelVersion() (*KernelVersion, error) {
-	once.Do(func() {
-		var uts unix.Utsname
-		if err := unix.Uname(&uts); err != nil {
-			return
-		}
-		// Convert the NUL-terminated release field before parsing.
-		currentKernelVersion, kernelVersionError = parseRelease(unix.ByteSliceToString(uts.Release[:]))
-	})
-	return currentKernelVersion, kernelVersionError
-}
+var getKernelVersion = sync.OnceValues(func() (*KernelVersion, error) {
+	var uts unix.Utsname
+	if err := unix.Uname(&uts); err != nil {
+		return nil, err
+	}
+	// Convert the NUL-terminated release field before parsing.
+	return parseRelease(unix.ByteSliceToString(uts.Release[:]))
+})
 
 // parseRelease parses a string and creates a KernelVersion based on it.
 func parseRelease(release string) (*KernelVersion, error) {

--- a/pkg/kernelversion/kernel_linux.go
+++ b/pkg/kernelversion/kernel_linux.go
@@ -22,7 +22,6 @@
 package kernelversion
 
 import (
-	"bytes"
 	"fmt"
 	"sync"
 
@@ -56,8 +55,8 @@ func getKernelVersion() (*KernelVersion, error) {
 		if err := unix.Uname(&uts); err != nil {
 			return
 		}
-		// Remove the \x00 from the release for Atoi to parse correctly
-		currentKernelVersion, kernelVersionError = parseRelease(string(uts.Release[:bytes.IndexByte(uts.Release[:], 0)]))
+		// Convert the NUL-terminated release field before parsing.
+		currentKernelVersion, kernelVersionError = parseRelease(unix.ByteSliceToString(uts.Release[:]))
 	})
 	return currentKernelVersion, kernelVersionError
 }

--- a/pkg/kernelversion/kernel_linux.go
+++ b/pkg/kernelversion/kernel_linux.go
@@ -63,7 +63,7 @@ func getKernelVersion() (*KernelVersion, error) {
 
 // parseRelease parses a string and creates a KernelVersion based on it.
 func parseRelease(release string) (*KernelVersion, error) {
-	var version = KernelVersion{}
+	var version KernelVersion
 
 	// We're only make sure we get the "kernel" and "major revision". Sometimes we have
 	// 3.12.25-gentoo, but sometimes we just have 3.12-1-amd64.

--- a/pkg/kernelversion/kernel_linux_test.go
+++ b/pkg/kernelversion/kernel_linux_test.go
@@ -14,10 +14,12 @@
    limitations under the License.
 */
 
-/*
-   File copied and customized based on
-   https://github.com/moby/moby/tree/v20.10.14/profiles/seccomp/kernel_linux_test.go
-*/
+// SPDX-FileCopyrightText: Copyright The containerd Authors
+// SPDX-FileCopyrightText: Copyright The Moby Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// File copied and customized based on
+// https://github.com/moby/profiles/blob/seccomp/v0.2.3/seccomp/kernel_linux_test.go
 
 package kernelversion
 

--- a/pkg/kernelversion/kernel_linux_test.go
+++ b/pkg/kernelversion/kernel_linux_test.go
@@ -22,7 +22,7 @@
 package kernelversion
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 )
 
@@ -55,19 +55,19 @@ func TestParseRelease(t *testing.T) {
 		{in: "3.12-1-amd64", out: KernelVersion{Kernel: 3, Major: 12}},
 		{in: "3.12foobar", out: KernelVersion{Kernel: 3, Major: 12}},
 		{in: "99.999.999-19-generic", out: KernelVersion{Kernel: 99, Major: 999}},
-		{in: "", expectedErr: fmt.Errorf(`failed to parse kernel version "": EOF`)},
-		{in: "3", expectedErr: fmt.Errorf(`failed to parse kernel version "3": unexpected EOF`)},
-		{in: "3.", expectedErr: fmt.Errorf(`failed to parse kernel version "3.": EOF`)},
-		{in: "3a", expectedErr: fmt.Errorf(`failed to parse kernel version "3a": input does not match format`)},
-		{in: "3.a", expectedErr: fmt.Errorf(`failed to parse kernel version "3.a": expected integer`)},
-		{in: "a", expectedErr: fmt.Errorf(`failed to parse kernel version "a": expected integer`)},
-		{in: "a.a", expectedErr: fmt.Errorf(`failed to parse kernel version "a.a": expected integer`)},
-		{in: "a.a.a-a", expectedErr: fmt.Errorf(`failed to parse kernel version "a.a.a-a": expected integer`)},
-		{in: "-3", expectedErr: fmt.Errorf(`failed to parse kernel version "-3": expected integer`)},
-		{in: "-3.", expectedErr: fmt.Errorf(`failed to parse kernel version "-3.": expected integer`)},
-		{in: "-3.8", expectedErr: fmt.Errorf(`failed to parse kernel version "-3.8": expected integer`)},
-		{in: "-3.-8", expectedErr: fmt.Errorf(`failed to parse kernel version "-3.-8": expected integer`)},
-		{in: "3.-8", expectedErr: fmt.Errorf(`failed to parse kernel version "3.-8": expected integer`)},
+		{in: "", expectedErr: errors.New(`failed to parse kernel version "": EOF`)},
+		{in: "3", expectedErr: errors.New(`failed to parse kernel version "3": unexpected EOF`)},
+		{in: "3.", expectedErr: errors.New(`failed to parse kernel version "3.": EOF`)},
+		{in: "3a", expectedErr: errors.New(`failed to parse kernel version "3a": input does not match format`)},
+		{in: "3.a", expectedErr: errors.New(`failed to parse kernel version "3.a": expected integer`)},
+		{in: "a", expectedErr: errors.New(`failed to parse kernel version "a": expected integer`)},
+		{in: "a.a", expectedErr: errors.New(`failed to parse kernel version "a.a": expected integer`)},
+		{in: "a.a.a-a", expectedErr: errors.New(`failed to parse kernel version "a.a.a-a": expected integer`)},
+		{in: "-3", expectedErr: errors.New(`failed to parse kernel version "-3": expected integer`)},
+		{in: "-3.", expectedErr: errors.New(`failed to parse kernel version "-3.": expected integer`)},
+		{in: "-3.8", expectedErr: errors.New(`failed to parse kernel version "-3.8": expected integer`)},
+		{in: "-3.-8", expectedErr: errors.New(`failed to parse kernel version "-3.-8": expected integer`)},
+		{in: "3.-8", expectedErr: errors.New(`failed to parse kernel version "3.-8": expected integer`)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.in, func(t *testing.T) {


### PR DESCRIPTION
### pkg/kernelversion: use unix.ByteSliceToString for utsname fields

similar to [moby@8a5c131]

[moby@8a5c131]: https://github.com/moby/moby/commit/8a5c13155e3d94fcbc8e7642738df0fefceeb96b

### pkg/kernelversion: fix minor linting issues

### pkg/kernelversion: simplify code with sync.OnceValues

### pkg/kernelversion: update links to upstream source

The package was moved to a separate module; update the links to
make it easier to discover the current version of upstream.