### PR TITLE
runtime/v2: use cleanup context for shim teardown

### DIFF
--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -572,6 +572,9 @@ func (s *shimTask) delete(ctx context.Context, sandboxed bool, removeTask func(c
 		removeTask(ctx, s.ID())
 	}
 
+	cleanupCtx, cancel := timeout.WithContext(context.WithoutCancel(ctx), cleanupTimeout)
+	defer cancel()
+
 	const supportSandboxAPIVersion = 3
 	if _, apiVer := s.ShimInstance.Endpoint(); apiVer < supportSandboxAPIVersion {
 		sandboxed = false
@@ -580,22 +583,18 @@ func (s *shimTask) delete(ctx context.Context, sandboxed bool, removeTask func(c
 	// Don't shutdown sandbox as there may be other containers running.
 	// Let controller decide when to shutdown.
 	if !sandboxed {
-		if err := s.waitShutdown(ctx); err != nil {
-			// FIXME(fuweid):
-			//
-			// If the error is context canceled, should we use context.TODO()
-			// to wait for it?
+		if err := s.waitShutdown(cleanupCtx); err != nil {
 			log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to shutdown shim task and the shim might be leaked")
 		}
 	}
 
-	if err := s.ShimInstance.Delete(ctx); err != nil {
+	if err := s.ShimInstance.Delete(cleanupCtx); err != nil {
 		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to delete shim")
 	}
 
 	// remove self from the runtime task list
 	// this seems dirty but it cleans up the API across runtimes, tasks, and the service
-	removeTask(ctx, s.ID())
+	removeTask(cleanupCtx, s.ID())
 
 	if shimErr != nil {
 		return nil, shimErr

--- a/core/runtime/v2/shim_task_test.go
+++ b/core/runtime/v2/shim_task_test.go
@@ -1,0 +1,106 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/containerd/containerd/api/runtime/task/v3"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestShimTaskDeleteUsesCleanupContextAfterTaskDelete(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	taskClient := &fakeTaskServiceClient{
+		afterDelete: cancel,
+	}
+	shim := &fakeShimInstance{id: "test-task"}
+	shimTask := &shimTask{
+		ShimInstance: shim,
+		task:         taskClient,
+	}
+
+	var removeTaskErrs []error
+	_, err := shimTask.delete(ctx, false, func(ctx context.Context, id string) {
+		require.Equal(t, shim.ID(), id)
+		removeTaskErrs = append(removeTaskErrs, ctx.Err())
+	})
+	require.NoError(t, err)
+	require.NoError(t, taskClient.deleteCtxErr)
+	require.NoError(t, taskClient.shutdownCtxErr)
+	require.NoError(t, shim.deleteCtxErr)
+	require.Len(t, removeTaskErrs, 2)
+	require.ErrorIs(t, removeTaskErrs[0], context.Canceled)
+	require.NoError(t, removeTaskErrs[1])
+}
+
+type fakeShimInstance struct {
+	id           string
+	deleteCtxErr error
+}
+
+func (f *fakeShimInstance) Close() error {
+	return nil
+}
+
+func (f *fakeShimInstance) ID() string {
+	return f.id
+}
+
+func (f *fakeShimInstance) Namespace() string {
+	return "default"
+}
+
+func (f *fakeShimInstance) Bundle() string {
+	return ""
+}
+
+func (f *fakeShimInstance) Client() any {
+	return nil
+}
+
+func (f *fakeShimInstance) Delete(ctx context.Context) error {
+	f.deleteCtxErr = ctx.Err()
+	return f.deleteCtxErr
+}
+
+func (f *fakeShimInstance) Endpoint() (string, int) {
+	return "", CurrentShimVersion
+}
+
+type fakeTaskServiceClient struct {
+	TaskServiceClient
+
+	afterDelete    func()
+	deleteCtxErr   error
+	shutdownCtxErr error
+}
+
+func (f *fakeTaskServiceClient) Delete(ctx context.Context, _ *api.DeleteRequest) (*api.DeleteResponse, error) {
+	f.deleteCtxErr = ctx.Err()
+	if f.afterDelete != nil {
+		f.afterDelete()
+	}
+	return &api.DeleteResponse{}, nil
+}
+
+func (f *fakeTaskServiceClient) Shutdown(ctx context.Context, _ *api.ShutdownRequest) (*emptypb.Empty, error) {
+	f.shutdownCtxErr = ctx.Err()
+	return &emptypb.Empty{}, f.shutdownCtxErr
+}


### PR DESCRIPTION
### Summary

- keep shim teardown on a bounded cleanup context after task delete succeeds
- avoid reusing a caller context that may be canceled or expired before `Shutdown`, shim deletion, and final task removal run
- add a regression test for cancellation immediately after task delete

Addresses #13692.

### Testing

- `go test ./core/runtime/v2`

### AI assistance disclosure

This PR was prepared with AI assistance. The human author should review the code and PR text before marking this draft ready for maintainer review.
