### PR TITLE
fix: prevent tar extraction data corruption by limiting reader size

### DIFF
--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -349,13 +349,16 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 		if err != nil {
 			return err
 		}
-
-		_, err = copyBuffered(ctx, file, reader)
+		limitedSrc := io.LimitReader(reader, hdr.Size)
+		nWritten, err := copyBuffered(ctx, file, limitedSrc)
 		if err1 := file.Close(); err == nil {
 			err = err1
 		}
 		if err != nil {
 			return err
+		}
+		if hdr.Size != nWritten {
+			return fmt.Errorf("file %s incomplete: expect %d bytes wrote %d", file.Name(), hdr.Size, nWritten)
 		}
 
 	case tar.TypeBlock, tar.TypeChar:


### PR DESCRIPTION

we find sometimes extract a  binary file from a blob, binary is broken

ls -l fabric-manager_bad fabric-manager_ok
-rwxr-xr-x 1 root root 44538840 6月  12 15:44 fabric-manager_bad
-rwxr-xr-x 1 root root 44538840 6月  12 15:44 fabric-manager_ok


```
cmp -l  fabric-manager_bad  fabric-manager_ok 
 5525505 177  75
 5525506 376 272
 5525571 377 203
 5525572 377  75
 5525573 377 167
 5525574 377 222
 5525575 377 126
 5525576 377   2
 5525577 377   0
 5525578 377 164
 5525579 377  13
 5525580 377 110
 5525581 377 213
 5525582 377  20
 5525583 377 350
 5525584 377 255
 5525585 377 107
 5525586 377 264
 5525588 377 111
 5525589 377 211
 5525590 377  23
 5525591 377 110
 5525592 377 215
 5525593 377  25
 5525594 377 344
 5525595 377 314
 5525596 377 102
 5525597 377   1
 5525598 377 110
 5525599 377 211
 5525600 377  20
 5525601 377 110
 5525602 377 215
 5525603 377   5
 5525604 377 231
 5525605 377 127
 5525606 377  22
 5525607 377   1
 5525608 377 110
 5525609 377 213
 5525610 377 134
 5525611 377  44
 5525612 377  40
 5525613 377 110
 5525614 377 215
 5525615 377  15
 5525616 377  51
 5525617 377  37
 5525618 377  70
 5525619 377   1
 5525620 377 277
 5525621 377  16
 5525622 377   0
 5525623 377   0
 5525624 377   0
 5525625 377 350
 5525626 377 303
 5525627 377 255
 5525628 377 254
 5525630 377 110
 5525631 377 307
 5525632 377 100
 5525633 377  10
 5525634 377 160
 5525635 377   0
 5525636 377   0
 5525637 377   0
 5525638 377 203
 5525639 377  75
 5525640 377  64
 5525641 377 222
 5525642 377 126
 5525643 377   2
 5525644 377   0
 5525645 377 164
 5525646 377  13
 5525647 377 110
 5525648 377 213
 5525649 377  20
 5525650 377 350
 5525651 377 152
 5525652 377 107
 5525653 377 264
 5525655 377 111
 5525656 377 211
 5525657 377  23
 5525658 377 110
 5525659 377 215
 5525660 377  25
 5525661 377   4
 5525662 377  70
 5525663 377 100
 5525664 377   1
 5525665 377 110
 5525666 377 211
 5525667 377  20
 5525668 377 110
 5525669 377 215
 5525670 377   5
 5525671 377 126
 5525672 377 127
 5525673 377  22
 5525674 377   1
 5525675 377 110
 5525676 377 213
 5525677 377 134
 5525678 377  44
 5525679 377  40
 5525680 377 110
 5525681 377 215
 5525682 377  15
 5525683 377 172
 5525684 377 140
 5525685 377  67
 5525686 377   1
 5525687 377 277
 5525688 377   5
 5525689 377   0
 5525690 377   0
 5525691 377   0
 5525692 377  17
 5525693 377  37
 5525694 377 104
 5525695 377   0
 5525696 377   0
 5525697 377 350
 5525698 377 173
 5525699 377 255
 5525700 377 254
 5525702 377 110
 5525703 377 307
 5525704 377 100
 5525705 377  10
 5525706 377 124
 5525707 377   5
 5525708 377   0
 5525709 377   0
 5525710 377 203
 5525711 377  75
 5525712 377 354
 5525713 377 221
 5525714 377 126
 5525715 377   2
 5525716 377   0
 5525717 377 164
 5525718 377  13
 5525719 377 110
 5525720 377 213
 5525721 377  20
 5525722 377 350
 5525723 377  42
 5525724 377 107
 5525725 377 264
 5525727 377 111
 5525728 377 211
 5525729 377  23
 5525730 377 110
 5525731 377 215
 5525732 377  25
 5525733 377 163
 5525734 377 305
 5525735 377 106
 5525736 377   1
 5525737 377 110
 5525738 377 211
 5525739 377  20
 5525740 377 110
 5525741 377 215
 5525742 377   5
 5525743 377  16
 5525744 377 127
 5525745 377  22
 5525746 377   1
 5525747 377 110
 5525748 377 213
 5525749 377 134
 5525750 377  44
 5525751 377  40
 5525752 377 110
 5525753 377 215
 5525754 377  15
 5525755 377  77
 5525756 377 243
 5525757 377  67
 5525758 377   1
 5525759 377 277
 5525760 377  10
 5525761 377   0
 5525762 377   0
 5525763 377   0
 5525764 377 350
 5525765 377  70
 5525766 377 255
 5525767 377 254
 5525769 377 110
 5525770 377 307
 5525771 377 100
 5525772 377  10
 5525773 377 307
 5525774 377   4
 5525775 377   0
 5525776 377   0
 5525777 377 203
 5525778 377  75
 5525779 377 251
 5525780 377 221
 5525781 377 126
 5525782 377   2
 5525783 377   0
 5525784 377 164
 5525785 377  17
 5525786 377 110
 5525787 377 213
 5525788 377  20
 5525789 377  17
 5525790 377  37
 5525791 377 100
 5525792 377   0
 5525793 377 350
 5525794 377 333
 5525795 377 106
 5525796 377 264
 5525798 377 111
 5525799 377 211
 5525800 377  23
 5525801 377 110
 5525802 377 215
 5525803 377  25
 5525804 377 335
 5525805 377 214
 5525806 377 106
 5525807 377   1
 5525808 377 110
 5525809 377 211
 5525810 377  20
 5525811 377 110
 5525812 377 215
 5525813 377   5
 5525814 377 307
 5525815 377 126
 5525816 377  22
 5525817 377   1
 5525818 377 110
 5525819 377 213
 5525820 377 134
 5525821 377  44
 5525822 377  40
 5525823 377 110
 5525824 377 215
 5525825 377  15
 5525826 377 260
 5525827 377 156
 5525828 377  70
 5525829 377   1
 5525830 377 277
 5525831 377  21
 5525832 377   0
 5525833 377   0
 5525834 377   0
 5525835 377 350
 5525836 377 361
 5525837 377 254
 5525838 377 254
 5525840 377 110
 5525841 377 307
 5525842 377 100
 5525843 377  10
 5525844 377 144
 5525845 377   5
 5525846 377   0
 5525847 377   0
 5525848 377 203
 5525849 377  75
 5525850 377 142
 5525851 377 221
 5525852 377 126
 5525853 377   2
 5525854 377   0
 5525855 377 146
 5525856 377 220
 5525857 377 165
 5525858 377   7
 5525859 377 110
 5525860 377 213
 5525861 377 124
 5525862 377  44
 5525863 377  40
 5525864 377 353
 5525865 377  37
 5525866 377 110
 5525867 377 213
 5525868 377  15
 5525869 377 300
 5525870 377 117
 5525871 377 123
 5525872 377   2
 5525873 377 110
 5525874 377 213
 5525875 377  20
 5525876 377 350
 5525877 377 310
 5525878 377 106
 5525879 377 264
 5525881 377 111
 5525882 377 211
 5525883 377  23
 5525884 377 110
 5525885 377 213
 5525886 377 124
 5525887 377  44
 5525888 377  40
 5525889 377 111
 5525890 377 211
 5525891 377 123
 5525892 377  10
 5525893 377 111
 5525894 377 211
 5525895 377 113
 5525896 377  20
 5525897 377 110
 5525898 377 215
 5525899 377  15
 5525900 377  40
 5525901 377 312
 5525902 377 106
 5525903 377   1
 5525904 377 110
 5525905 377 211
 5525906 377  10
 5525907 377 110
 5525908 377 211
 5525909 377  25
 5525910 377 227
 5525911 377 117
 5525912 377 123
 5525913 377   2
 5525914 377 110
 5525915 377 203
 5525916 377 304
 5525917 377  50
 5525918 377 135
 5525919 377 303
 5525920 377 220
 5525921 377 350
 5525922 377  33
 5525923 377  51
 5525924 377 264
 5525926 377 351
 5525927 377 266
 5525928 377 374
 5525931 377 314
 5525932 377 314
 5525933 377 314
 5525934 377 314
 5525935 377 314
 5525936 377 314
 5525937 377 314
 5525938 377 314
 5525939 377 314
 5525940 377 314
 5525941 377 314
 5525942 377 314
 5525943 377 314
 5525944 377 314
 5525945 377 314
 5525946 377 314
 5525947 377 314
 5525948 377 314
 5525949 377 314
 5525950 377 314
 5525951 377 314
 5525952 377 314
 5525953 377 111
 5525954 377  73

```