### PR TITLE
Allow trusted mirrors to use upstream registry credentials

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -57,6 +57,7 @@ type hostConfig struct {
 
 	header http.Header
 
+	passUpstreamCredentials bool
 	// TODO: Add credential configuration (domain alias, username)
 }
 
@@ -374,6 +375,9 @@ type hostFileConfig struct {
 	// a connect to complete.
 	DialTimeout string `toml:"dial_timeout"`
 
+	// PassUpstreamCredentials indicates whether the credentials for
+	// upstream registry should be passed to the mirror registry.
+	PassUpstreamCredentials bool `toml:"pass_upstream_credentials"`
 	// TODO: Credentials: helper? name? username? alternate domain? token?
 }
 
@@ -543,6 +547,8 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 		}
 		result.dialTimeout = &dialTimeout
 	}
+
+	result.passUpstreamCredentials = config.PassUpstreamCredentials
 
 	return result, nil
 }

--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -166,13 +166,14 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 		authOpts = append(authOpts, options.AuthorizerOpts...)
 		authorizer := docker.NewDockerAuthorizer(authOpts...)
 
+		upstreamHost := host
 		rhosts := make([]docker.RegistryHost, len(hosts))
 		for i, host := range hosts {
 			// Allow setting for each host as well
 			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil
 			explicitTLS := tlsConfigured || explicitTLSFromHost
 
-			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 {
+			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 || host.passUpstreamCredentials {
 				c := *client
 				if explicitTLSFromHost || host.dialTimeout != nil {
 					tr := defaultTransport.Clone()
@@ -204,6 +205,11 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 				authOpts := authOpts
 				if len(host.header) != 0 {
 					authOpts = append(authOpts, docker.WithAuthHeader(host.header))
+				}
+				if host.passUpstreamCredentials && options.Credentials != nil {
+					authOpts = append(authOpts, docker.WithAuthCreds(func(string) (string, string, error) {
+						return options.Credentials(upstreamHost)
+					}))
 				}
 
 				rhosts[i].Client = &c

--- a/core/remotes/docker/config/hosts_test.go
+++ b/core/remotes/docker/config/hosts_test.go
@@ -75,6 +75,100 @@ func TestDefaultHosts(t *testing.T) {
 	}
 }
 
+func TestHostPassUpstreamCredentials(t *testing.T) {
+	const (
+		upstreamHost = "upstream.registry"
+		mirrorHost   = "mirror.registry"
+	)
+
+	for _, tc := range []struct {
+		name                   string
+		hostsTOML              string
+		requestHost            string
+		expectedCredentialHost string
+	}{
+		{
+			name: "pass upstream credentials uses upstream host for credentials",
+			hostsTOML: `
+[host."https://mirror.registry"]
+  capabilities = ["pull"]
+  pass_upstream_credentials = true
+	`,
+			requestHost:            mirrorHost,
+			expectedCredentialHost: upstreamHost,
+		},
+		{
+			name: "disabled pass upstream credentials uses mirror host for credentials",
+			hostsTOML: `
+[host."https://mirror.registry"]
+  capabilities = ["pull"]
+  pass_upstream_credentials = false
+	`,
+			requestHost:            mirrorHost,
+			expectedCredentialHost: mirrorHost,
+		},
+		{
+			name: "default uses mirror host for credentials",
+			hostsTOML: `
+[host."https://mirror.registry"]
+  capabilities = ["pull"]
+	`,
+			requestHost:            mirrorHost,
+			expectedCredentialHost: mirrorHost,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			hostDir := filepath.Join(dir, hostDirectory(upstreamHost))
+			if err := os.MkdirAll(hostDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(tc.hostsTOML), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			var credentialHost string
+			resolve := ConfigureHosts(logtest.WithT(context.Background(), t), HostOptions{
+				HostDir: HostDirFromRoot(dir),
+				Credentials: func(host string) (string, string, error) {
+					credentialHost = host
+					return "user", "secret", nil
+				},
+			})
+
+			hosts, err := resolve(upstreamHost)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(hosts) == 0 {
+				t.Fatal("expected at least one registry host")
+			}
+			if hosts[0].Host != tc.requestHost {
+				t.Fatalf("expected registry host %q, got %q", tc.requestHost, hosts[0].Host)
+			}
+
+			req, err := http.NewRequest(http.MethodGet, "https://"+tc.requestHost+"/v2/test/manifests/latest", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			header := http.Header{}
+			header.Set("WWW-Authenticate", `Basic realm="registry"`)
+			resp := &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Request:    req,
+				Header:     header,
+			}
+			if err := hosts[0].Authorizer.AddResponses(context.Background(), []*http.Response{resp}); err != nil {
+				t.Fatal(err)
+			}
+
+			if credentialHost != tc.expectedCredentialHost {
+				t.Fatalf("expected credentials for %q, got %q", tc.expectedCredentialHost, credentialHost)
+			}
+		})
+	}
+}
+
 func TestParseHostFile(t *testing.T) {
 	const testtoml = `
 server = "https://test-default.registry"

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -373,6 +373,17 @@ A shorter timeout helps reduce delays when falling back to the original registry
 dial_timeout = "1s"
 ```
 
+## pass_upstream_credentials field
+
+`pass_upstream_credentials` allows a configured host to use credentials for the
+upstream registry namespace instead of credentials for the host itself. This is
+intended for trusted mirrors which require the same credentials as the upstream
+registry to serve private content. (Defaults to `false`)
+
+```toml
+pass_upstream_credentials = true
+```
+
 ## host field(s) (in the toml table format)
 
 `[host]."https://namespace"` and `[host]."http://namespace"` entries in the
@@ -414,6 +425,11 @@ for this registry host namespace:
 [host."https://non-compliant-mirror.registry/v2/upstream"]
   capabilities = ["pull"]
   override_path = true
+
+[host."https://trusted-mirror.registry/v2/upstream"]
+  capabilities = ["pull", "resolve"]
+  override_path = true
+  pass_upstream_credentials = true
 ```
 
 **Note**: Recursion is not supported in the specification of host mirror


### PR DESCRIPTION
Add a `pass_upstream_credentials` option for registry hosts.

This lets a trusted mirror authenticate using credentials for the upstream registry namespace, which is useful when the mirror serves private upstream content and expects the same credentials as the original registry.

The option defaults to `false`, so existing mirror credential behavior is unchanged.

Tests cover enabled, disabled, and default behavior. Documentation is added to `docs/hosts.md`.

implemented in the way mentioned in https://github.com/containerd/containerd/issues/10540#issuecomment-3907646841

closes  #10540
