### PR TITLE
ci: pin fog-json to resolve gem conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,6 +662,8 @@ jobs:
           sudo systemctl enable --now libvirtd
           sudo apt-get build-dep -y ruby-libvirt
           sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev
+          sudo env VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT=1 vagrant plugin uninstall fog-json || true
+          sudo env VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT=1 vagrant plugin install fog-json --plugin-version 1.2.0
           sudo env VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT=1 vagrant plugin install vagrant-libvirt
       - name: Boot VM
         run: |


### PR DESCRIPTION
Vagrant 2.4.x bundles an embedded Ruby 3.3.0 runtime that loads the default specification json-2.7.2 during initialization. When installing vagrant-libvirt, RubyGems resolves the newly released fog-json 1.4.0, which requires json (~> 2.19). Because json-2.7.2 is already active in memory when Vagrant starts up, RubyGems raises a Gem::ConflictError.

Pinning fog-json to version 1.2.0 before installing vagrant-libvirt ensures compatible gem resolution against Vagrant's embedded default json specification.

Assisted-by: Antigravity