### PR TITLE
Expose CRI image config

### DIFF
--- a/docs/cri/crictl.md
+++ b/docs/cri/crictl.md
@@ -325,6 +325,31 @@ $ crictl info
     "stateDir": "/run/containerd/io.containerd.grpc.v1.cri"
   },
   "golang": "go1.20.3",
+  "imageconfig": {
+    "concurrentLayerFetchBuffer": 0,
+    "disableSnapshotAnnotations": true,
+    "discardUnpackedLayers": false,
+    "imageDecryption": {
+      "keyModel": "node"
+    },
+    "imagePullProgressTimeout": "5m0s",
+    "imagePullWithSyncFs": false,
+    "maxConcurrentDownloads": 3,
+    "pinned_images": {
+      "sandbox": "registry.k8s.io/pause:3.10.2"
+    },
+    "registry": {
+      "auths": null,
+      "configPath": "/etc/containerd/certs.d:/etc/docker/certs.d",
+      "configs": null,
+      "headers": null,
+      "mirrors": null
+    },
+    "runtimePlatforms": null,
+    "snapshotter": "overlayfs",
+    "statsCollectPeriod": 10,
+    "useLocalImagePull": false
+  },
   "lastCNILoadStatus": "OK",
   "lastCNILoadStatus.default": "OK"
 }

--- a/internal/cri/server/status.go
+++ b/internal/cri/server/status.go
@@ -90,6 +90,17 @@ func (c *criService) Status(ctx context.Context, r *runtime.StatusRequest) (*run
 			resp.Info["cniconfig"] = string(cniConfig)
 		}
 
+		imageSvcConfig := c.ImageService.Config()
+		// Avoid leaking registry credentials or sensitive headers via the CRI Status endpoint.
+		imageSvcConfig.Registry.Auths = nil
+		imageSvcConfig.Registry.Configs = nil
+		imageSvcConfig.Registry.Headers = nil
+		imageConfig, err := json.Marshal(imageSvcConfig)
+		if err != nil {
+			return nil, err
+		}
+		resp.Info["imageconfig"] = string(imageConfig)
+
 		defaultStatus := "OK"
 		for name, h := range c.cniNetConfMonitor {
 			s := "OK"


### PR DESCRIPTION
Back in Containerd 1.7 the mirror configuration was included as part of the verbose config from the CRI info endpoint. This was later removed in 2.0 due to the re-architecture of the plugin system which made it impossible to get hold of the loaded configuration. It seems like we are able to access this configuration again from the CRI service making it possible to expose once again. This change adds this configuration back to the output. 

The reason this is useful, is because it is otherwise very difficult to determine what configuration has actually been loaded at runtime. Due to different schema versions and import paths actually ensuring that mirroring is enabled can be very challenging. 

Fixes #10780