### PR TITLE
Update stale PR policy

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,10 +1,10 @@
-name: 'Close stale issues and PRs'
+name: "Close stale issues and PRs"
 on:
   schedule:
     - cron: "0 0 * * *" # Every day at midnight
   pull_request:
     paths:
-      - '.github/workflows/stale.yml'
+      - ".github/workflows/stale.yml"
 
 permissions:
   contents: read
@@ -23,19 +23,37 @@ jobs:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         # All stale bot options: https://github.com/actions/stale#all-options
         with:
-          # Idle number of days before marking issues/PRs stale
-          days-before-stale: 90
-          # Idle number of days before closing stale issues/PRs
-          days-before-close: 7
-          # Only issues/PRs with ANY of these labels are checked
-          any-of-labels: 'status/more-info-needed,status/needs-update,needs-rebase'
-          # Comment on the staled issues
-          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 7 days unless new comments are made or the stale label is removed.'
-          # Comment on the staled PRs
-          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. This PR will be closed in 7 days unless new comments are made or the stale label is removed.'
-          # Comment on the staled issues while closed
-          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
-          # Comment on the staled PRs while closed
-          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          # Issues: stale after 12 months, close after 2 weeks
+          days-before-issue-stale: 365
+          days-before-issue-close: 14
+          # PRs: stale after 6 months, close after 2 weeks
+          days-before-pr-stale: 180
+          days-before-pr-close: 14
+
+          stale-issue-label: "Stale"
+          stale-pr-label: "Stale"
+
+          # Exempt if assigned to a milestone
+          exempt-all-issue-milestones: true
+          exempt-all-pr-milestones: true
+
+          # Messages
+          stale-issue-message: >
+            This issue has not been updated in 12 months and is now marked as stale.
+            It will be closed in 2 weeks unless there is new activity or it is
+            assigned to a milestone.
+          close-issue-message: >
+            This issue was closed because it has been stale for 2 weeks with no activity.
+            Feel free to reopen or create a new issue if you would like to continue
+            working on it.
+          stale-pr-message: >
+            This PR has not been updated in 6 months and is now marked as stale.
+            It will be closed in 2 weeks unless there is new activity or it is
+            assigned to a milestone.
+          close-pr-message: >
+            This PR was closed because it has been stale for 2 weeks with no activity.
+            Feel free to reopen or create a new PR if you would like to continue
+            working on it.
+
           # Enable dry-run when changing this file from a PR.
-          debug-only: github.event_name == 'pull_request'
+          debug-only: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
As discussed during the community call today.
- PRs: stale after 6 months, close after 2 weeks
- Issues: stale after 12 months, close after 2 weeks
- Exempt if assigned to a milestone