### PR TITLE
*: disable bbolt stat usage

### DIFF
--- a/core/snapshots/storage/metastore.go
+++ b/core/snapshots/storage/metastore.go
@@ -84,6 +84,11 @@ func NewMetaStore(dbfile string, opts ...Opt) (*MetaStore, error) {
 		opts:   *bolt.DefaultOptions,
 	}
 
+	// Disable stat usage since we never consume the data.
+	// This can reduce unnecessary contention during transactions.
+	// https://github.com/etcd-io/bbolt/pull/977
+	store.opts.NoStatistics = true
+
 	for _, f := range opts {
 		if err := f(&store.opts); err != nil {
 			return nil, err

--- a/plugins/metadata/plugin.go
+++ b/plugins/metadata/plugin.go
@@ -138,6 +138,11 @@ func init() {
 			// Without the timeout, bbolt.Open would block indefinitely due to flock(2).
 			options.Timeout = timeout.Get(boltOpenTimeout)
 
+			// Disable stat usage since we never consume the data.
+			// This can reduce unnecessary contention during transactions.
+			// https://github.com/etcd-io/bbolt/pull/977
+			options.NoStatistics = true
+
 			shared := true
 			ic.Meta.Exports["policy"] = SharingPolicyShared
 			if cfg, ok := ic.Config.(*BoltConfig); ok {

--- a/plugins/mount/manager.go
+++ b/plugins/mount/manager.go
@@ -81,7 +81,14 @@ func init() {
 
 			metadb := filepath.Join(root, "mounts.db")
 
-			db, err := bolt.Open(metadb, 0600, nil)
+			options := *bolt.DefaultOptions
+
+			// Disable stat usage since we never consume the data.
+			// This can reduce unnecessary contention during transactions.
+			// https://github.com/etcd-io/bbolt/pull/977
+			options.NoStatistics = true
+
+			db, err := bolt.Open(metadb, 0600, &options)
 			if err != nil {
 				return nil, fmt.Errorf("failed to open database file: %w", err)
 			}


### PR DESCRIPTION
Disable stat usage since we never consume the data.
This can reduce unnecessary contention during transactions.