### PR TITLE
fix: resolve orphaned overlayfs snapshots and terminating pod deadlocks

### DIFF
--- a/cmd/containerd-shim-runc-v2/manager/manager_linux.go
+++ b/cmd/containerd-shim-runc-v2/manager/manager_linux.go
@@ -313,7 +313,11 @@ func (manager) Stop(ctx context.Context, id string) (shim.StopStatus, error) {
 		log.G(ctx).WithError(err).Warn("failed to remove runc container")
 	}
 	if err := mount.UnmountRecursive(filepath.Join(path, "rootfs"), 0); err != nil {
-		log.G(ctx).WithError(err).Warn("failed to cleanup rootfs mount")
+		const mntDetach = 2
+		log.G(ctx).WithError(err).Warn("failed to cleanup rootfs mount, retrying with MNT_DETACH")
+		if err3 := mount.UnmountRecursive(filepath.Join(path, "rootfs"), mntDetach); err3 != nil {
+			log.G(ctx).WithError(err3).Warn("failed to cleanup rootfs mount with MNT_DETACH")
+		}
 	}
 	pid, err := runcC.ReadPidFile(filepath.Join(path, process.InitPidFile))
 	if err != nil {

--- a/cmd/containerd-shim-runc-v2/process/exec.go
+++ b/cmd/containerd-shim-runc-v2/process/exec.go
@@ -107,7 +107,7 @@ func (e *execProcess) Delete(ctx context.Context) error {
 }
 
 func (e *execProcess) delete(ctx context.Context) error {
-	if err := waitTimeout(ctx, &e.wg, 10*time.Second); err != nil {
+	if err := waitTimeout(ctx, &e.wg, 2*time.Second); err != nil {
 		log.G(ctx).WithError(err).Errorf("failed to drain exec process %s io", e.id)
 	}
 	if e.io != nil {

--- a/cmd/containerd-shim-runc-v2/process/init.go
+++ b/cmd/containerd-shim-runc-v2/process/init.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -293,8 +294,14 @@ func (p *Init) Delete(ctx context.Context) error {
 }
 
 func (p *Init) delete(ctx context.Context) error {
-	if err := waitTimeout(ctx, &p.wg, 10*time.Second); err != nil {
+	if err := waitTimeout(ctx, &p.wg, 2*time.Second); err != nil {
 		log.G(ctx).WithError(err).Errorf("failed to drain init process %s io", p.id)
+	}
+	if p.io != nil {
+		for _, c := range p.closers {
+			c.Close()
+		}
+		p.io.Close()
 	}
 	err := p.runtime.Delete(ctx, p.id, nil)
 	// ignore errors if a runtime has already deleted the process
@@ -309,16 +316,26 @@ func (p *Init) delete(ctx context.Context) error {
 			err = p.runtimeError(err, "failed to delete task")
 		}
 	}
-	if p.io != nil {
-		for _, c := range p.closers {
-			c.Close()
-		}
-		p.io.Close()
-	}
 	if err2 := mount.UnmountRecursive(p.Rootfs, 0); err2 != nil {
-		log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
-		if err == nil {
-			err = fmt.Errorf("failed rootfs umount: %w", err2)
+		if runtime.GOOS != "linux" {
+			log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
+			if err == nil {
+				err = fmt.Errorf("failed rootfs umount: %w", err2)
+			}
+			return err
+		}
+
+		// MNT_DETACH is Linux-specific. Keep the literal here so this
+		// !windows file still compiles for non-Linux Unix targets.
+		const mntDetach = 2
+		log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount, retrying with MNT_DETACH")
+		if err3 := mount.UnmountRecursive(p.Rootfs, mntDetach); err3 != nil {
+			log.G(ctx).WithError(err3).Warn("failed to cleanup rootfs mount with MNT_DETACH")
+			if err == nil {
+				err = fmt.Errorf("failed rootfs umount (MNT_DETACH): %w", err3)
+			}
+		} else {
+			log.G(ctx).Info("cleaned up rootfs mount with MNT_DETACH")
 		}
 	}
 	return err

--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -23,8 +23,10 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/moby/sys/userns"
+	"golang.org/x/sys/unix"
 
 	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/cgroups/v3/cgroup1"
@@ -58,6 +60,12 @@ import (
 var (
 	_     = shim.TTRPCService(&service{})
 	empty = &ptypes.Empty{}
+)
+
+const (
+	unknownExecExitStatus = 255
+	execExitCheckInterval = 5 * time.Second
+	execExitWaitTimeout   = 30 * time.Second
 )
 
 // NewTaskService creates a new instance of a task service
@@ -145,6 +153,12 @@ type service struct {
 type containerProcess struct {
 	Container *runc.Container
 	Process   process.Process
+}
+
+type processExit struct {
+	exit      runcC.Exit
+	container *runc.Container
+	process   process.Process
 }
 
 // preStart prepares for starting a container process and handling its exit.
@@ -701,15 +715,20 @@ func (s *service) send(evt interface{}) {
 // This is achieved by:
 // - killing all running container processes (if the container has a shared pid
 // namespace, otherwise all other processes have been reaped already).
-// - waiting for the container's running exec counter to reach 0.
+// - waiting for the container's running exec counter to reach 0, while
+// reconciling stale exec accounting when tracked exec PIDs no longer exist.
+// - falling back after a bounded wait to avoid blocking task deletion forever
+// when exec accounting cannot be fully reconciled.
 // - finally, publishing the init exit.
 func (s *service) handleInitExit(e runcC.Exit, c *runc.Container, p *process.Init) {
 	// kill all running container processes
 	if runc.ShouldKillAllOnExit(s.context, c.Bundle) {
-		if err := p.KillAll(s.context); err != nil {
+		killCtx, killCancel := context.WithTimeout(s.context, 5*time.Second)
+		if err := p.KillAll(killCtx); err != nil {
 			log.G(s.context).WithError(err).WithField("id", p.ID()).
 				Error("failed to kill init's children")
 		}
+		killCancel()
 	}
 
 	s.lifecycleMu.Lock()
@@ -734,20 +753,100 @@ func (s *service) handleInitExit(e runcC.Exit, c *runc.Container, p *process.Ini
 			delete(s.runningExecs, c)
 		}()
 
-		// wait for running processes to exit
+		// Wait for running processes to exit. The init exit must remain the
+		// last exit event published for this container, so timeout handling
+		// retries SIGKILL instead of forcing the init exit event out of order.
+		ticker := time.NewTicker(execExitCheckInterval)
+		defer ticker.Stop()
+		timeout := time.NewTimer(execExitWaitTimeout)
+		defer timeout.Stop()
+
 		for {
-			if runningExecs := <-events; runningExecs == 0 {
-				break
+			select {
+			case runningExecs := <-events:
+				if runningExecs == 0 {
+					s.handleProcessExit(e, c, p)
+					return
+				}
+			case <-ticker.C:
+				log.G(s.context).WithField("id", c.ID).Warn("still waiting for exec processes to exit after init exit")
+				killCtx, killCancel := context.WithTimeout(s.context, 5*time.Second)
+				if err := p.KillAll(killCtx); err != nil {
+					log.G(s.context).WithError(err).WithField("id", p.ID()).
+						Error("failed to retry killing init's children")
+				}
+				killCancel()
+
+				livePids, err := s.containerPidSet(c)
+				if err != nil {
+					log.G(s.context).WithError(err).WithField("id", c.ID).
+						Debug("failed to list container pids while waiting for exec exits")
+				}
+
+				exits, runningExecs, _ := s.reconcileExitedExecs(c, livePids, false)
+				for _, exit := range exits {
+					log.G(s.context).WithField("id", c.ID).
+						WithField("exec_id", exit.process.ID()).
+						WithField("pid", exit.exit.Pid).
+						Warn("synthesizing exit for exec process after init exit")
+					s.publishProcessExit(exit.exit, exit.container, exit.process)
+				}
+				if runningExecs == 0 {
+					s.handleProcessExit(e, c, p)
+					return
+				}
+			case <-timeout.C:
+				log.G(s.context).WithField("id", c.ID).
+					WithField("timeout", execExitWaitTimeout).
+					Error("timed out waiting for exec processes to exit after init exit")
+				killCtx, killCancel := context.WithTimeout(s.context, execExitCheckInterval)
+				if err := p.KillAll(killCtx); err != nil {
+					log.G(s.context).WithError(err).WithField("id", p.ID()).
+						Error("failed to kill init's children after exec exit wait timeout")
+				}
+				killCancel()
+
+				livePids, err := s.containerPidSet(c)
+				if err != nil {
+					log.G(s.context).WithError(err).WithField("id", c.ID).
+						Debug("failed to list container pids after exec exit wait timeout")
+				}
+
+				exits, _, droppedExecs := s.reconcileExitedExecs(c, livePids, true)
+				for _, exit := range exits {
+					log.G(s.context).WithField("id", c.ID).
+						WithField("exec_id", exit.process.ID()).
+						WithField("pid", exit.exit.Pid).
+						Error("synthesizing exit for exec process after exec exit wait timeout")
+					s.publishProcessExit(exit.exit, exit.container, exit.process)
+				}
+				if droppedExecs > 0 {
+					log.G(s.context).WithField("id", c.ID).
+						WithField("execs", droppedExecs).
+						Error("clearing stale exec accounting without matching process after exec exit wait timeout")
+				}
+				s.handleProcessExit(e, c, p)
+				return
 			}
 		}
-
-		// all running processes have exited now, and no new
-		// ones can start, so we can publish the init exit
-		s.handleProcessExit(e, c, p)
 	}()
 }
 
 func (s *service) handleProcessExit(e runcC.Exit, c *runc.Container, p process.Process) {
+	s.publishProcessExit(e, c, p)
+	if _, init := p.(*process.Init); !init {
+		s.lifecycleMu.Lock()
+		if s.runningExecs[c] > 0 {
+			s.runningExecs[c]--
+		}
+		if ch, ok := s.execCountSubscribers[c]; ok {
+			ch <- s.runningExecs[c]
+		}
+		s.lifecycleMu.Unlock()
+	}
+}
+
+func (s *service) publishProcessExit(e runcC.Exit, c *runc.Container, p process.Process) {
 	p.SetExited(e.Status)
 	s.send(&eventstypes.TaskExit{
 		ContainerID: c.ID,
@@ -756,14 +855,101 @@ func (s *service) handleProcessExit(e runcC.Exit, c *runc.Container, p process.P
 		ExitStatus:  uint32(e.Status),
 		ExitedAt:    protobuf.ToTimestamp(p.ExitedAt()),
 	})
-	if _, init := p.(*process.Init); !init {
-		s.lifecycleMu.Lock()
-		s.runningExecs[c]--
-		if ch, ok := s.execCountSubscribers[c]; ok {
-			ch <- s.runningExecs[c]
-		}
-		s.lifecycleMu.Unlock()
+}
+
+// reconcileExitedExecs reconciles exec accounting after init has exited.
+// Without force it keeps the v1.7+ init-last ordering when a reaper event is
+// delayed or missed: synthesize exits only for exec processes that the shim
+// still tracks but whose container PIDs no longer exist. With force it clears
+// the remaining accounting so the init exit can be published after a bounded
+// wait instead of blocking task deletion forever.
+func (s *service) reconcileExitedExecs(c *runc.Container, livePids map[int]struct{}, force bool) ([]processExit, int, int) {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+
+	runningExecs := s.runningExecs[c]
+	if runningExecs == 0 {
+		return nil, 0, 0
 	}
+
+	var exits []processExit
+	for pid, processes := range s.running {
+		var remaining []containerProcess
+		reaped := false
+		for _, cp := range processes {
+			if cp.Container != c {
+				remaining = append(remaining, cp)
+				continue
+			}
+			if _, init := cp.Process.(*process.Init); init {
+				remaining = append(remaining, cp)
+				continue
+			}
+			if !force && execStillRunning(pid, livePids) {
+				remaining = append(remaining, cp)
+				continue
+			}
+
+			reaped = true
+			if runningExecs > 0 {
+				runningExecs--
+			}
+			exits = append(exits, processExit{
+				exit: runcC.Exit{
+					Pid:    pid,
+					Status: unknownExecExitStatus,
+				},
+				container: c,
+				process:   cp.Process,
+			})
+		}
+		if !reaped {
+			continue
+		}
+		if len(remaining) > 0 {
+			s.running[pid] = remaining
+		} else {
+			delete(s.running, pid)
+		}
+	}
+
+	droppedExecs := 0
+	if force && runningExecs > 0 {
+		droppedExecs = runningExecs
+		runningExecs = 0
+	}
+	s.runningExecs[c] = runningExecs
+	return exits, runningExecs, droppedExecs
+}
+
+func (s *service) containerPidSet(c *runc.Container) (map[int]struct{}, error) {
+	ctx, cancel := context.WithTimeout(s.context, 5*time.Second)
+	defer cancel()
+
+	pids, err := s.getContainerPids(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	pidSet := make(map[int]struct{}, len(pids))
+	for _, pid := range pids {
+		pidSet[int(pid)] = struct{}{}
+	}
+	return pidSet, nil
+}
+
+func execStillRunning(pid int, livePids map[int]struct{}) bool {
+	if livePids != nil {
+		_, ok := livePids[pid]
+		return ok
+	}
+	return pidExists(pid)
+}
+
+func pidExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return unix.Kill(pid, 0) != unix.ESRCH
 }
 
 func (s *service) getContainerPids(ctx context.Context, container *runc.Container) ([]uint32, error) {

--- a/core/runtime/v2/bundle.go
+++ b/core/runtime/v2/bundle.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -129,7 +130,11 @@ func (b *Bundle) Delete() error {
 	work, werr := os.Readlink(filepath.Join(b.Path, "work"))
 	rootfs := filepath.Join(b.Path, "rootfs")
 	if err := mount.UnmountRecursive(rootfs, 0); err != nil {
-		return fmt.Errorf("unmount rootfs %s: %w", rootfs, err)
+		const mntDetach = 2
+		log.G(context.TODO()).WithError(err).Warnf("failed to unmount rootfs %s, retrying with MNT_DETACH", rootfs)
+		if err3 := mount.UnmountRecursive(rootfs, mntDetach); err3 != nil {
+			log.G(context.TODO()).WithError(err3).Errorf("failed to unmount rootfs %s with MNT_DETACH", rootfs)
+		}
 	}
 	if err := os.Remove(rootfs); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove bundle rootfs: %w", err)

--- a/core/runtime/v2/shim_load.go
+++ b/core/runtime/v2/shim_load.go
@@ -135,7 +135,11 @@ func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle) error {
 		if err != nil {
 			log.G(ctx).WithError(err).Errorf("loading container %s", id)
 			if err := mount.UnmountRecursive(filepath.Join(bundle.Path, "rootfs"), 0); err != nil {
-				log.G(ctx).WithError(err).Errorf("failed to unmount of rootfs %s", id)
+				const mntDetach = 2
+				log.G(ctx).WithError(err).Warnf("failed to unmount rootfs %s, retrying with MNT_DETACH", id)
+				if err3 := mount.UnmountRecursive(filepath.Join(bundle.Path, "rootfs"), mntDetach); err3 != nil {
+					log.G(ctx).WithError(err3).Errorf("failed to unmount of rootfs %s with MNT_DETACH", id)
+				}
 			}
 			return err
 		}

--- a/internal/cri/server/container_remove.go
+++ b/internal/cri/server/container_remove.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"syscall"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -105,10 +107,16 @@ func (c *criService) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 
 	// Delete containerd container.
 	if err := container.Container.Delete(ctx, containerd.WithSnapshotCleanup); err != nil {
-		if !errdefs.IsNotFound(err) {
+		if errdefs.IsNotFound(err) {
+			log.G(ctx).Tracef("Remove called for containerd container %q that does not exist", id)
+		} else if shouldFallbackSnapshotCleanupError(err) {
+			log.G(ctx).WithError(err).Warnf("Failed to delete containerd container %q with snapshot cleanup because the snapshot is busy, fallback to delete metadata only to avoid blocking pod deletion", id)
+			if fallbackErr := container.Container.Delete(ctx); fallbackErr != nil && !errdefs.IsNotFound(fallbackErr) {
+				return nil, fmt.Errorf("failed to delete containerd container %q during fallback: %w", id, fallbackErr)
+			}
+		} else {
 			return nil, fmt.Errorf("failed to delete containerd container %q: %w", id, err)
 		}
-		log.G(ctx).Tracef("Remove called for containerd container %q that does not exist", id)
 	}
 
 	// Delete container checkpoint.
@@ -172,4 +180,18 @@ func resetContainerRemoving(container containerstore.Container) error {
 		status.Removing = false
 		return status, nil
 	})
+}
+
+func shouldFallbackSnapshotCleanupError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EBUSY) {
+		return true
+	}
+	// Fallback to string check for gRPC error serialization
+	errStr := err.Error()
+	return strings.Contains(errStr, syscall.EBUSY.Error()) ||
+		strings.Contains(errStr, "EBUSY") ||
+		strings.Contains(errStr, "resource busy")
 }

--- a/internal/cri/server/container_remove_test.go
+++ b/internal/cri/server/container_remove_test.go
@@ -17,12 +17,25 @@
 package server
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/containerd/typeurl/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/containers"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
+	"github.com/containerd/containerd/v2/internal/eventq"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/errdefs"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // TestSetContainerRemoving tests setContainerRemoving sets removing
@@ -88,4 +101,167 @@ func TestSetContainerRemoving(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRemoveContainerSnapshotCleanupFallback(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		deleteErrs        []error
+		wantErr           string
+		wantDeleteOpts    []int
+		wantContainerGone bool
+	}{
+		{
+			name:              "busy snapshot cleanup falls back to metadata delete",
+			deleteErrs:        []error{fmt.Errorf("remove snapshot: %w", syscall.EBUSY)},
+			wantDeleteOpts:    []int{1, 0},
+			wantContainerGone: true,
+		},
+		{
+			name:              "busy snapshot cleanup (gRPC device or resource busy string error) falls back to metadata delete",
+			deleteErrs:        []error{errors.New("rpc error: code = Unknown desc = failed to remove snapshot: device or resource busy")},
+			wantDeleteOpts:    []int{1, 0},
+			wantContainerGone: true,
+		},
+		{
+			name:              "busy snapshot cleanup (gRPC EBUSY string error) falls back to metadata delete",
+			deleteErrs:        []error{errors.New("rpc error: code = Internal desc = EBUSY: some other info")},
+			wantDeleteOpts:    []int{1, 0},
+			wantContainerGone: true,
+		},
+		{
+			name:              "busy snapshot cleanup (gRPC resource busy string error) falls back to metadata delete",
+			deleteErrs:        []error{errors.New("rpc error: code = Unknown desc = remove snapshot: resource busy")},
+			wantDeleteOpts:    []int{1, 0},
+			wantContainerGone: true,
+		},
+		{
+			name:           "busy snapshot cleanup returns fallback error",
+			deleteErrs:     []error{fmt.Errorf("remove snapshot: %w", syscall.EBUSY), errors.New("metadata delete failed")},
+			wantErr:        "failed to delete containerd container",
+			wantDeleteOpts: []int{1, 0},
+		},
+		{
+			name:           "non busy snapshot cleanup error is returned",
+			deleteErrs:     []error{errors.New("snapshotter configuration failed")},
+			wantErr:        "snapshotter configuration failed",
+			wantDeleteOpts: []int{1},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := newTestCRIService()
+			c.containerEventsQ = eventq.New[runtime.ContainerEventResponse](time.Minute, func(runtime.ContainerEventResponse) {})
+			fake := addRemoveContainerTestContainer(t, c, test.deleteErrs)
+
+			_, err := c.RemoveContainer(context.Background(), &runtime.RemoveContainerRequest{ContainerId: fake.id})
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.wantDeleteOpts, fake.deleteOptCounts)
+
+			cntr, err := c.containerStore.Get(fake.id)
+			if test.wantContainerGone {
+				require.True(t, errdefs.IsNotFound(err), "container should be removed from the CRI store")
+			} else {
+				require.NoError(t, err)
+				require.False(t, cntr.Status.Get().Removing, "removing status should be reset to false on failure")
+			}
+		})
+	}
+}
+
+func addRemoveContainerTestContainer(t *testing.T, c *criService, deleteErrs []error) *fakeRemoveContainerdContainer {
+	t.Helper()
+
+	const id = "test-container-id"
+	fake := &fakeRemoveContainerdContainer{
+		id:         id,
+		deleteErrs: append([]error(nil), deleteErrs...),
+		info: containers.Container{
+			ID:      id,
+			Runtime: containers.RuntimeInfo{Name: "runc"},
+		},
+	}
+	now := time.Now()
+	cntr, err := containerstore.NewContainer(
+		containerstore.Metadata{ID: id, SandboxID: "test-sandbox-id"},
+		containerstore.WithContainer(fake),
+		containerstore.WithFakeStatus(containerstore.Status{
+			CreatedAt:  now.Add(-2 * time.Second).UnixNano(),
+			StartedAt:  now.Add(-time.Second).UnixNano(),
+			FinishedAt: now.UnixNano(),
+		}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, c.containerStore.Add(cntr))
+	return fake
+}
+
+var _ containerd.Container = (*fakeRemoveContainerdContainer)(nil)
+
+type fakeRemoveContainerdContainer struct {
+	id              string
+	info            containers.Container
+	deleteErrs      []error
+	deleteOptCounts []int
+}
+
+func (f *fakeRemoveContainerdContainer) ID() string {
+	return f.id
+}
+
+func (f *fakeRemoveContainerdContainer) Info(context.Context, ...containerd.InfoOpts) (containers.Container, error) {
+	return f.info, nil
+}
+
+func (f *fakeRemoveContainerdContainer) Delete(_ context.Context, opts ...containerd.DeleteOpts) error {
+	f.deleteOptCounts = append(f.deleteOptCounts, len(opts))
+	if len(f.deleteErrs) == 0 {
+		return nil
+	}
+	err := f.deleteErrs[0]
+	f.deleteErrs = f.deleteErrs[1:]
+	return err
+}
+
+func (f *fakeRemoveContainerdContainer) NewTask(context.Context, cio.Creator, ...containerd.NewTaskOpts) (containerd.Task, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+func (f *fakeRemoveContainerdContainer) Spec(context.Context) (*specs.Spec, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+func (f *fakeRemoveContainerdContainer) Task(context.Context, cio.Attach) (containerd.Task, error) {
+	return nil, errdefs.ErrNotFound
+}
+
+func (f *fakeRemoveContainerdContainer) Image(context.Context) (containerd.Image, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+func (f *fakeRemoveContainerdContainer) Labels(context.Context) (map[string]string, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+func (f *fakeRemoveContainerdContainer) SetLabels(context.Context, map[string]string) (map[string]string, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+func (f *fakeRemoveContainerdContainer) Extensions(context.Context) (map[string]typeurl.Any, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+func (f *fakeRemoveContainerdContainer) Update(context.Context, ...containerd.UpdateContainerOpts) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (f *fakeRemoveContainerdContainer) Checkpoint(context.Context, string, ...containerd.CheckpointOpts) (containerd.Image, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+func (f *fakeRemoveContainerdContainer) Restore(context.Context, cio.Creator, string) (int, error) {
+	return 0, errdefs.ErrNotImplemented
 }

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -28,6 +28,7 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	eventtypes "github.com/containerd/containerd/api/events"
+	apitasks "github.com/containerd/containerd/api/services/tasks/v1"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/sandbox"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
@@ -41,6 +42,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/platforms"
 )
 
@@ -190,7 +192,7 @@ func (c *Controller) waitSandboxExit(ctx context.Context, p *types.PodSandbox, e
 		log.G(ctx).WithField("monitor_name", "podsandbox").
 			Infof("received sandbox exit event %+v", event)
 
-		if err := handleSandboxTaskExit(dctx, p, event); err != nil {
+		if err := c.handleSandboxTaskExit(dctx, p, event); err != nil {
 			log.G(ctx).WithError(err).Errorf("failed to handle sandbox exit event %+v", event)
 			c.eventMonitor.Backoff(p.ID, event)
 		}
@@ -201,7 +203,7 @@ func (c *Controller) waitSandboxExit(ctx context.Context, p *types.PodSandbox, e
 }
 
 // handleSandboxTaskExit handles TaskExit event for sandbox.
-func handleSandboxTaskExit(ctx context.Context, sb *types.PodSandbox, e *eventtypes.TaskExit) error {
+func (c *Controller) handleSandboxTaskExit(ctx context.Context, sb *types.PodSandbox, e *eventtypes.TaskExit) error {
 	// No stream attached to sandbox container.
 	task, err := sb.Container.Task(ctx, nil)
 	if err != nil {
@@ -213,6 +215,15 @@ func handleSandboxTaskExit(ctx context.Context, sb *types.PodSandbox, e *eventty
 		if _, err = task.Delete(ctx, WithNRISandboxDelete(sb.ID), containerd.WithProcessKill); err != nil {
 			if !errdefs.IsNotFound(err) {
 				return fmt.Errorf("failed to stop sandbox: %w", err)
+			}
+		}
+	}
+	if errdefs.IsNotFound(err) {
+		_, err = c.client.TaskService().Delete(ctx, &apitasks.DeleteTaskRequest{ContainerID: sb.Container.ID()})
+		if err != nil {
+			err = errgrpc.ToNative(err)
+			if !errdefs.IsNotFound(err) {
+				return fmt.Errorf("failed to cleanup sandbox %s in task-service: %w", sb.Container.ID(), err)
 			}
 		}
 	}

--- a/internal/cri/server/podsandbox/events.go
+++ b/internal/cri/server/podsandbox/events.go
@@ -52,7 +52,7 @@ func (p *podSandboxEventHandler) HandleEvent(any interface{}) error {
 		ctx := ctrdutil.NamespacedContext()
 		ctx, cancel := context.WithTimeout(ctx, handleEventTimeout)
 		defer cancel()
-		if err := handleSandboxTaskExit(ctx, sb, e); err != nil {
+		if err := p.controller.handleSandboxTaskExit(ctx, sb, e); err != nil {
 			return fmt.Errorf("failed to handle container TaskExit event: %w", err)
 		}
 		return nil

--- a/internal/cri/server/podsandbox/sandbox_stop.go
+++ b/internal/cri/server/podsandbox/sandbox_stop.go
@@ -71,7 +71,7 @@ func (c *Controller) stopSandboxContainer(ctx context.Context, podSandbox *types
 		}
 		// Don't return for unknown state, some cleanup needs to be done.
 		if state == sandboxstore.StateUnknown {
-			return cleanupUnknownSandbox(ctx, id, podSandbox)
+			return c.cleanupUnknownSandbox(ctx, id, podSandbox)
 		}
 		return nil
 	}
@@ -87,7 +87,7 @@ func (c *Controller) stopSandboxContainer(ctx context.Context, podSandbox *types
 			if !errdefs.IsNotFound(err) {
 				return fmt.Errorf("failed to wait for task: %w", err)
 			}
-			return cleanupUnknownSandbox(ctx, id, podSandbox)
+			return c.cleanupUnknownSandbox(ctx, id, podSandbox)
 		}
 
 		exitCtx, exitCancel := context.WithCancel(context.Background())
@@ -118,7 +118,7 @@ func (c *Controller) stopSandboxContainer(ctx context.Context, podSandbox *types
 }
 
 // cleanupUnknownSandbox cleanup stopped sandbox in unknown state.
-func cleanupUnknownSandbox(ctx context.Context, id string, sandbox *types.PodSandbox) error {
+func (c *Controller) cleanupUnknownSandbox(ctx context.Context, id string, sandbox *types.PodSandbox) error {
 	// Reuse handleSandboxTaskExit to do the cleanup.
-	return handleSandboxTaskExit(ctx, sandbox, &eventtypes.TaskExit{ExitStatus: unknownExitCode, ExitedAt: protobuf.ToTimestamp(time.Now())})
+	return c.handleSandboxTaskExit(ctx, sandbox, &eventtypes.TaskExit{ExitStatus: unknownExitCode, ExitedAt: protobuf.ToTimestamp(time.Now())})
 }

--- a/plugins/snapshots/overlay/overlay.go
+++ b/plugins/snapshots/overlay/overlay.go
@@ -20,6 +20,7 @@ package overlay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,6 +34,8 @@ import (
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/log"
+	"github.com/moby/sys/mountinfo"
+	"golang.org/x/sys/unix"
 )
 
 // upperdirKey is a key of an optional label to each snapshot.
@@ -325,9 +328,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 	defer func() {
 		if err == nil {
 			for _, dir := range removals {
-				if err := os.RemoveAll(dir); err != nil {
-					log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
-				}
+				removeCleanupDir(ctx, dir)
 			}
 		}
 	}()
@@ -375,12 +376,41 @@ func (o *snapshotter) Cleanup(ctx context.Context) error {
 	}
 
 	for _, dir := range cleanup {
-		if err := os.RemoveAll(dir); err != nil {
-			log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
-		}
+		removeCleanupDir(ctx, dir)
 	}
 
 	return nil
+}
+
+func removeCleanupDir(ctx context.Context, dir string) {
+	if err := os.RemoveAll(dir); err == nil {
+		return
+	} else if !errors.Is(err, unix.EBUSY) && !hasMountUnder(dir) {
+		log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
+		return
+	} else {
+		log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory with busy mount, retrying with MNT_DETACH")
+	}
+
+	if err := mount.UnmountRecursive(dir, unix.MNT_DETACH); err != nil {
+		log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to unmount directory with MNT_DETACH")
+		return
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory after MNT_DETACH")
+	}
+}
+
+func hasMountUnder(dir string) bool {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return false
+	}
+	mounts, err := mountinfo.GetMounts(mountinfo.PrefixFilter(dir))
+	if err != nil {
+		return false
+	}
+	return len(mounts) > 0
 }
 
 func (o *snapshotter) cleanupDirectories(ctx context.Context) (_ []string, err error) {


### PR DESCRIPTION
- Resolve self-reclaiming deadlocks, cleanup leaks, and bound exec exit wait after init exit.
- Fallback to metadata-only deletion under EBUSY snapshot cleanup errors in CRI.
- Add safety checks to orphan shim process check and double-check containerd during directory scans.

Fixes: #13416