### PR TITLE
Add config parameter to specify Windows snapshotter rootfs size

### DIFF
--- a/plugins/snapshots/windows/common.go
+++ b/plugins/snapshots/windows/common.go
@@ -44,9 +44,10 @@ type windowsBaseSnapshotter struct {
 	root string
 	ms   *storage.MetaStore
 	info hcsshim.DriverInfo
+	opts []snapshots.Opt
 }
 
-func newBaseSnapshotter(root string) (*windowsBaseSnapshotter, error) {
+func newBaseSnapshotter(root string, opts ...snapshots.Opt) (*windowsBaseSnapshotter, error) {
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
 	}
@@ -64,6 +65,7 @@ func newBaseSnapshotter(root string) (*windowsBaseSnapshotter, error) {
 		root: root,
 		ms:   ms,
 		info: hcsshim.DriverInfo{HomeDir: filepath.Join(root, "snapshots")},
+		opts: opts,
 	}, nil
 }
 

--- a/plugins/snapshots/windows/windows.go
+++ b/plugins/snapshots/windows/windows.go
@@ -21,10 +21,13 @@ package windows
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/Microsoft/go-winio"
@@ -41,16 +44,44 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+	"github.com/docker/go-units"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+type Config struct {
+	RootFSSize string `toml:"rootfs_size"`
+}
+
 func init() {
 	registry.Register(&plugin.Registration{
-		Type: plugins.SnapshotPlugin,
-		ID:   "windows",
+		Type:   plugins.SnapshotPlugin,
+		ID:     "windows",
+		Config: &Config{},
 		InitFn: func(ic *plugin.InitContext) (any, error) {
 			ic.Meta.Platforms = []ocispec.Platform{platforms.DefaultSpec()}
-			return NewWindowsSnapshotter(ic.Properties[plugins.PropertyRootDir])
+
+			config, ok := ic.Config.(*Config)
+			if !ok {
+				return nil, errors.New("invalid windows snapshotter configuration")
+			}
+
+			var opts []snapshots.Opt
+
+			if len(config.RootFSSize) > 0 {
+				rootfsSize, err := units.RAMInBytes(config.RootFSSize)
+				if err != nil {
+					return nil, fmt.Errorf("invalid rootfs_size in config %q: %w", config.RootFSSize, err)
+				}
+
+				if rootfsSize > 0 {
+					opts = append(opts, snapshots.WithLabels(map[string]string{
+						rootfsSizeInBytesLabel: strconv.FormatInt(rootfsSize, 10),
+					}))
+				}
+			}
+
+			root := ic.Properties[plugins.PropertyRootDir]
+			return NewWindowsSnapshotter(root, opts...)
 		},
 	})
 }
@@ -73,7 +104,7 @@ type wcowSnapshotter struct {
 }
 
 // NewWindowsSnapshotter returns a new windows snapshotter
-func NewWindowsSnapshotter(root string) (snapshots.Snapshotter, error) {
+func NewWindowsSnapshotter(root string, opts ...snapshots.Opt) (snapshots.Snapshotter, error) {
 	fsType, err := winfs.GetFileSystemType(root)
 	if err != nil {
 		return nil, err
@@ -82,7 +113,7 @@ func NewWindowsSnapshotter(root string) (snapshots.Snapshotter, error) {
 		return nil, fmt.Errorf("%s is not on an NTFS volume - only NTFS volumes are supported: %w", root, errdefs.ErrInvalidArgument)
 	}
 
-	baseSn, err := newBaseSnapshotter(root)
+	baseSn, err := newBaseSnapshotter(root, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -142,8 +173,9 @@ func (s *wcowSnapshotter) Commit(ctx context.Context, name, key string, opts ...
 
 func (s *wcowSnapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ []mount.Mount, err error) {
 	var newSnapshot storage.Snapshot
+	mergedOpts := slices.Concat(s.opts, opts)
 	err = s.ms.WithTransaction(ctx, true, func(ctx context.Context) (retErr error) {
-		newSnapshot, err = storage.CreateSnapshot(ctx, kind, key, parent, opts...)
+		newSnapshot, err = storage.CreateSnapshot(ctx, kind, key, parent, mergedOpts...)
 		if err != nil {
 			return fmt.Errorf("failed to create snapshot: %w", err)
 		}
@@ -183,7 +215,7 @@ func (s *wcowSnapshotter) createSnapshot(ctx context.Context, kind snapshots.Kin
 
 		parentLayerPaths := s.parentIDsToParentPaths(newSnapshot.ParentIDs)
 		var snapshotInfo snapshots.Info
-		for _, o := range opts {
+		for _, o := range mergedOpts {
 			o(&snapshotInfo)
 		}
 


### PR DESCRIPTION
Windows snapshotter defaults to 20GB VHD size that is often too small for production use.

There are _some_ pre-existing codepaths in containerd that support adjusting rootfs size (for example, CRI has `RootfsSizeInBytes`); however, they do not cover other real-world cases like using Docker with containerd snapshotter, or BuildKit, or Podman, or whatever. Note that if such places eventually become capable of passing rootfs size, they will override default value from config file.

For future readers: if you plan to extend configurability of rootfs, consider adding support for [`SandboxSize`](https://github.com/containerd/containerd/blob/v2.3.2/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go#L670).

See https://github.com/moby/moby/issues/53030

Usage:

`C:\Program Files\containerd\config.toml`:

```toml
[plugins."io.containerd.snapshotter.v1.windows"]
rootfs_size = "100GB"
```

Not sure about `rootfs_size` naming, open for better suggestions. Inferred it from `containerd.io/snapshot/windows/rootfs.sizebytes` label name.

Possibly I should add this to the docs, but don't know where.