### PR TITLE
Run CI against dev branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
   merge_group:
   pull_request:
-    branches: ['main', 'release/**']
+    branches: ['main', 'release/**', 'dev/**']
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read


### PR DESCRIPTION
Something we discussed during community call, for certain long running work streams, we'd want to create dev/ branches. It'd good to run our CI against these branches to keep things in order.