### PR TITLE
pkg/shim: Return JSON bootstrap results to legacy callers

### DIFF
--- a/pkg/shim/compat.go
+++ b/pkg/shim/compat.go
@@ -23,12 +23,55 @@ package shim
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 
 	bootapi "github.com/containerd/containerd/api/runtime/bootstrap/v1"
 	"github.com/containerd/containerd/api/types/runc/options"
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 )
+
+// parseBootstrapParams decodes the shim start payload and reports whether it
+// uses the new bootstrap protocol.
+//
+// The runtime-options Any used by pre-2.3 containerd shares protobuf field
+// numbers with BootstrapParams, so both payloads unmarshal successfully.
+// Compare the decoded instance ID and namespace with the command-line values
+// to distinguish the two.
+func parseBootstrapParams(input []byte, parsedID, parsedNamespace string) (*bootapi.BootstrapParams, bool) {
+	params := &bootapi.BootstrapParams{}
+	if len(input) == 0 || proto.Unmarshal(input, params) != nil {
+		return &bootapi.BootstrapParams{}, false
+	}
+
+	// TODO: Remove CLI identity matching together with support for the
+	// deprecated startup fields.
+	if params.InstanceID != parsedID || params.Namespace != parsedNamespace {
+		// Do not let fields decoded from a legacy or malformed payload affect
+		// bootstrap behavior.
+		return &bootapi.BootstrapParams{}, false
+	}
+	return params, true
+}
+
+func marshalBootstrapResponse(result *bootapi.BootstrapResult, usesBootstrapProtocol bool) ([]byte, error) {
+	if usesBootstrapProtocol {
+		return proto.Marshal(result)
+	}
+
+	// containerd 2.0-2.2 expects a JSON BootstrapParams response.
+	// This compatibility path does not support containerd 1.x.
+	// The JSON envelope is legacy, but Version selects the task service API,
+	// so preserve the shim result.
+	// Marshal the legacy type to preserve its field names and omit unsupported
+	// capabilities and metadata.
+	return json.Marshal(&BootstrapParams{ //nolint:staticcheck // Required for compatibility with containerd 2.0-2.2.
+		Version:  int(result.Version),
+		Address:  result.Address,
+		Protocol: result.Protocol,
+	})
+}
 
 func readBootstrapParamsFromDeprecatedFields(input []byte, params *bootapi.BootstrapParams, parsedID string, parsedNamespace string, parsedBinary string, parsedDebug bool) error {
 	params.InstanceID = parsedID

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -279,10 +279,12 @@ func run(ctx context.Context, manager Shim, config Config) error {
 			return fmt.Errorf("failed to read stdin: %w", err)
 		}
 
-		var params bootapi.BootstrapParams
-		if len(input) == 0 || proto.Unmarshal(input, &params) != nil {
-			// TODO: Return error once the new API is stable
-			if err := readBootstrapParamsFromDeprecatedFields(input, &params, id, namespaceFlag, containerdBinaryFlag, debugFlag); err != nil {
+		// A pre-2.3 runtime-options Any can unmarshal as BootstrapParams.
+		// Matching its decoded ID and namespace against the command-line values
+		// distinguishes it from the new protocol.
+		params, usesBootstrapProtocol := parseBootstrapParams(input, id, namespaceFlag)
+		if !usesBootstrapProtocol {
+			if err := readBootstrapParamsFromDeprecatedFields(input, params, id, namespaceFlag, containerdBinaryFlag, debugFlag); err != nil {
 				return err
 			}
 		}
@@ -295,7 +297,7 @@ func run(ctx context.Context, manager Shim, config Config) error {
 			}
 		}
 
-		result, err := manager.Start(ctx, &params)
+		result, err := manager.Start(ctx, params)
 		if err != nil {
 			return err
 		}
@@ -309,9 +311,9 @@ func run(ctx context.Context, manager Shim, config Config) error {
 			return fmt.Errorf("shim pipe not ready: %w", err)
 		}
 
-		data, err := proto.Marshal(result)
+		data, err := marshalBootstrapResponse(result, usesBootstrapProtocol)
 		if err != nil {
-			return fmt.Errorf("failed to marshal bootstrap params: %w", err)
+			return fmt.Errorf("failed to marshal bootstrap response: %w", err)
 		}
 
 		if _, err := os.Stdout.Write(data); err != nil {

--- a/pkg/shim/shim_test.go
+++ b/pkg/shim/shim_test.go
@@ -20,6 +20,11 @@ import (
 	"context"
 	"runtime"
 	"testing"
+
+	bootapi "github.com/containerd/containerd/api/runtime/bootstrap/v1"
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
+	"github.com/containerd/containerd/v2/pkg/protobuf/types"
+	googleproto "google.golang.org/protobuf/proto"
 )
 
 func TestRuntimeWithEmptyMaxEnvProcs(t *testing.T) {
@@ -59,4 +64,95 @@ func TestShimOptWithValue(t *testing.T) {
 	if !op.Debug {
 		t.Fatal("opts.Debug should be true")
 	}
+}
+
+func TestParseBootstrapParams(t *testing.T) {
+	const (
+		id        = "container-id"
+		namespace = "moby"
+	)
+
+	t.Run("new bootstrap protocol", func(t *testing.T) {
+		want := &bootapi.BootstrapParams{
+			InstanceID: id,
+			Namespace:  namespace,
+		}
+		input, err := proto.Marshal(want)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, usesBootstrapProtocol := parseBootstrapParams(input, id, namespace)
+		if !usesBootstrapProtocol {
+			t.Fatal("new bootstrap params detected as deprecated")
+		}
+		if !googleproto.Equal(got, want) {
+			t.Fatalf("bootstrap params not preserved: got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("2.2 runtime options Any", func(t *testing.T) {
+		// Containerd 2.2 sends an Any whose fields decode as non-empty
+		// BootstrapParams ID and namespace values.
+		input, err := proto.Marshal(&types.Any{
+			TypeUrl: "types.containerd.io/containerd.runc.v1.Options",
+			Value:   []byte("runc options"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var collided bootapi.BootstrapParams
+		if err := proto.Unmarshal(input, &collided); err != nil {
+			t.Fatal(err)
+		}
+		if collided.InstanceID == "" || collided.Namespace == "" {
+			t.Fatalf("test payload did not reproduce field collision: %+v", &collided)
+		}
+
+		params, usesBootstrapProtocol := parseBootstrapParams(input, id, namespace)
+		if usesBootstrapProtocol {
+			t.Fatal("containerd 2.2 runtime options detected as new bootstrap params")
+		}
+		if !googleproto.Equal(params, &bootapi.BootstrapParams{}) {
+			t.Fatalf("legacy payload fields preserved: %+v", params)
+		}
+	})
+}
+
+func TestMarshalBootstrapResponse(t *testing.T) {
+	result := &bootapi.BootstrapResult{
+		Version:  3,
+		Address:  "unix:///run/containerd/shim.sock",
+		Protocol: "ttrpc",
+		Metadata: map[string]string{
+			"unsupported": "value",
+		},
+	}
+
+	t.Run("legacy JSON", func(t *testing.T) {
+		data, err := marshalBootstrapResponse(result, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := `{"version":3,"address":"unix:///run/containerd/shim.sock","protocol":"ttrpc"}`
+		if got := string(data); got != want {
+			t.Fatalf("unexpected legacy response: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("bootstrap protobuf", func(t *testing.T) {
+		data, err := marshalBootstrapResponse(result, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var got bootapi.BootstrapResult
+		if err := proto.Unmarshal(data, &got); err != nil {
+			t.Fatal(err)
+		}
+		if !googleproto.Equal(&got, result) {
+			t.Fatalf("bootstrap result not preserved: got %+v, want %+v", &got, result)
+		}
+	})
 }


### PR DESCRIPTION
- fix: https://github.com/containerd/containerd/issues/13763

A containerd 2.2 daemon cannot start a containerd 2.3 `containerd-shim-runc-v2`.

The 2.3 shim accepts the deprecated CLI, environment, and stdin startup interface, but returns a protobuf-encoded `BootstrapResult`. Containerd 2.2 expects a JSON `BootstrapParams` response or a plain socket address. It therefore interprets the protobuf payload as the socket address and fails with an error similar to:

```text
failed to create TTRPC connection: unsupported protocol: \b\x03\x12Yunix
```

Detect legacy callers by comparing the identity decoded from stdin with the identity supplied through the compatibility CLI fields. This comparison is necessary because containerd 2.2 sends runtime options as a protobuf `Any`.
The `Any` fields can decode as non-empty `BootstrapParams.instance_id` and `.namespace` fields, so successful protobuf unmarshalling alone cannot distinguish the protocols.

For legacy callers, return the JSON `BootstrapParams` response they expect.
For new bootstrap callers, continue returning the protobuf `BootstrapResult`.

The legacy JSON response preserves the expected field names, always includes the version, and excludes unsupported capabilities and metadata.