### PR TITLE
core/remotes/docker: only fetch descriptor urls for foreign layers

### DIFF
--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -232,8 +232,18 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 	}
 
 	return newHTTPReadSeeker(desc.Size, func(offset int64) (io.ReadCloser, error) {
+		// The urls field carries external download locations for
+		// non-distributable (foreign) layers. Distributable content is always
+		// retrievable from the registry, so only honor urls for
+		// non-distributable descriptors; otherwise a crafted manifest could
+		// point any descriptor at an arbitrary host and make the fetcher
+		// request it.
+		urls := desc.URLs
+		if !images.IsNonDistributable(desc.MediaType) {
+			urls = nil
+		}
 		// firstly try fetch via external urls
-		for _, us := range desc.URLs {
+		for _, us := range urls {
 			u, err := url.Parse(us)
 			if err != nil {
 				log.G(ctx).WithError(err).Debugf("failed to parse %q", us)

--- a/core/remotes/docker/fetcher_test.go
+++ b/core/remotes/docker/fetcher_test.go
@@ -38,11 +38,15 @@ import (
 	"time"
 
 	"github.com/klauspost/compress/zstd"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 
+	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/containerd/v2/pkg/reference"
 )
 
 type writeFunc func(p []byte) (int, error)
@@ -785,4 +789,68 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 		return nil, errNoOverlap
 	}
 	return ranges, nil
+}
+
+func TestFetchDescriptorURLsNonDistributableOnly(t *testing.T) {
+	content := []byte("layer content")
+	dgst := digest.FromBytes(content)
+
+	var externalHit, registryHit atomic.Bool
+	serve := func(hit *atomic.Bool) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			hit.Store(true)
+			rw.Header().Set("content-length", strconv.Itoa(len(content)))
+			_, _ = rw.Write(content)
+		}))
+	}
+
+	external := serve(&externalHit)
+	defer external.Close()
+	registry := serve(&registryHit)
+	defer registry.Close()
+
+	ru, err := url.Parse(registry.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fetch := func(mediaType string) error {
+		externalHit.Store(false)
+		registryHit.Store(false)
+
+		f := dockerFetcher{&dockerBase{
+			refspec:    reference.Spec{Locator: "example.com/test"},
+			repository: "test",
+			hosts: []RegistryHost{{
+				Client:       registry.Client(),
+				Host:         ru.Host,
+				Scheme:       ru.Scheme,
+				Path:         ru.Path,
+				Capabilities: HostCapabilityPull | HostCapabilityResolve,
+			}},
+		}}
+
+		rc, err := f.Fetch(context.Background(), ocispec.Descriptor{
+			MediaType: mediaType,
+			Digest:    dgst,
+			Size:      int64(len(content)),
+			URLs:      []string{external.URL},
+		})
+		if err != nil {
+			return err
+		}
+		defer rc.Close()
+		_, err = io.ReadAll(rc)
+		return err
+	}
+
+	// A distributable descriptor must never be fetched from its urls; the
+	// content comes from the registry instead.
+	require.NoError(t, fetch(ocispec.MediaTypeImageLayerGzip))
+	assert.False(t, externalHit.Load(), "external url must not be contacted for a distributable descriptor")
+	assert.True(t, registryHit.Load(), "registry must be contacted for a distributable descriptor")
+
+	// A non-distributable (foreign) layer is served from its urls.
+	require.NoError(t, fetch(images.MediaTypeDockerSchema2LayerForeignGzip))
+	assert.True(t, externalHit.Load(), "external url must be used for a non-distributable descriptor")
 }


### PR DESCRIPTION
dockerFetcher.Fetch walks desc.URLs before it tries the registry endpoints and issues a GET to each one, checking only that the scheme is http or https. Those urls come straight from the image manifest, so a crafted image can put an arbitrary address on any descriptor (a config, a regular layer, even a child manifest) and make the daemon request it during a pull, for instance an internal service or a cloud metadata endpoint.

The urls field is the mechanism for non-distributable (foreign) layers, and distributable content is always available from the registry, which is exactly what the loop already falls through to. Gating on images.IsNonDistributable keeps foreign layers working while dropping urls on every other descriptor, so the check sits next to the request it guards instead of at each caller.