### PR TITLE
Snapshot fs testsuite

### DIFF
--- a/core/snapshots/testsuite/fs_helpers.go
+++ b/core/snapshots/testsuite/fs_helpers.go
@@ -1,0 +1,1422 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testsuite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/internal/fsview"
+	"github.com/containerd/containerd/v2/internal/randutil"
+	erofs "github.com/erofs/go-erofs"
+)
+
+// erofsChardev is the EROFS mode type for a character device (0020000 octal),
+// reproduced here to avoid importing an internal go-erofs package. Overlay
+// whiteouts are character devices with rdev 0.
+const erofsChardev uint16 = 0o020000
+
+// ---------------------------------------------------------------------------
+// Change model
+//
+// A test describes a layer's filesystem operations once as a slice of
+// fsChange values. The suite then applies the same operations two ways:
+//
+//   - As a layer on top of a parent snapshot (overlay whiteouts for removals,
+//     opaque directories for replaced directories, copy-up from the parent).
+//   - As the flattened final state of all layers so far (removals actually
+//     delete, renames actually move).
+//
+// Both applications produce a committed snapshot; their fs.FS views are then
+// compared for equality. Defining the operations once removes the risk of a
+// hand-written expected-state model drifting from the real mutations.
+// ---------------------------------------------------------------------------
+
+type changeKind int
+
+const (
+	changeCreateFile changeKind = iota
+	changeMkdir
+	changeRemove
+	changeChown
+	changeLink
+	changeRename
+)
+
+// fsChange is a single filesystem operation within a layer.
+type fsChange struct {
+	kind     changeKind
+	path     string
+	old      string // source path for rename and link
+	content  []byte
+	mode     fs.FileMode
+	uid, gid int
+}
+
+// fsCreateFile creates or overwrites a regular file.
+func fsCreateFile(name string, content []byte, mode fs.FileMode) fsChange {
+	return fsChange{kind: changeCreateFile, path: name, content: content, mode: mode}
+}
+
+// fsMkdir creates a directory.
+func fsMkdir(name string, mode fs.FileMode) fsChange {
+	return fsChange{kind: changeMkdir, path: name, mode: mode}
+}
+
+// fsRemove removes a file or directory (recursively).
+func fsRemove(name string) fsChange {
+	return fsChange{kind: changeRemove, path: name}
+}
+
+// fsChown sets ownership on an existing path.
+func fsChown(name string, uid, gid int) fsChange {
+	return fsChange{kind: changeChown, path: name, uid: uid, gid: gid}
+}
+
+// fsLink creates newname as a hard link to oldname.
+func fsLink(oldname, newname string) fsChange {
+	return fsChange{kind: changeLink, path: newname, old: oldname}
+}
+
+// fsRename moves oldname to newname.
+func fsRename(oldname, newname string) fsChange {
+	return fsChange{kind: changeRename, path: newname, old: oldname}
+}
+
+// ---------------------------------------------------------------------------
+// In-memory model used to flatten layers into a resolved tree
+// ---------------------------------------------------------------------------
+
+// node is a single entry in the flattened filesystem model.
+type node struct {
+	mode     fs.FileMode
+	content  []byte
+	target   string
+	uid, gid int
+	owned    bool   // ownership was explicitly set (may be 0:0)
+	linkTo   string // canonical path of the inode this hard link shares
+}
+
+// tree is the resolved state produced by replaying every layer's changes.
+type tree struct {
+	nodes map[string]*node // clean absolute path ("/foo") -> node
+}
+
+func newTree() *tree {
+	return &tree{nodes: map[string]*node{"/": {mode: fs.ModeDir | 0o755}}}
+}
+
+func cleanAbs(p string) string {
+	return path.Clean("/" + p)
+}
+
+// ensureParents creates any missing parent directories for p.
+func (t *tree) ensureParents(p string) {
+	for d := path.Dir(p); d != "/" && d != "."; d = path.Dir(d) {
+		if _, ok := t.nodes[d]; !ok {
+			t.nodes[d] = &node{mode: fs.ModeDir | 0o755}
+		}
+	}
+}
+
+func (t *tree) removeRecursive(p string) {
+	delete(t.nodes, p)
+	prefix := p + "/"
+	for k := range t.nodes {
+		if strings.HasPrefix(k, prefix) {
+			delete(t.nodes, k)
+		}
+	}
+}
+
+// apply replays a single change onto the tree.
+func (t *tree) apply(c fsChange) {
+	p := cleanAbs(c.path)
+	switch c.kind {
+	case changeCreateFile:
+		t.ensureParents(p)
+		t.nodes[p] = &node{mode: c.mode, content: c.content}
+	case changeMkdir:
+		t.ensureParents(p)
+		t.nodes[p] = &node{mode: c.mode | fs.ModeDir}
+	case changeRemove:
+		t.removeRecursive(p)
+	case changeChown:
+		if n := t.nodes[p]; n != nil {
+			n.uid, n.gid = c.uid, c.gid
+			n.owned = true
+		}
+	case changeLink:
+		old := cleanAbs(c.old)
+		if src := t.nodes[old]; src != nil {
+			t.ensureParents(p)
+			cp := *src
+			// Both names share one inode; record the canonical target.
+			if src.linkTo != "" {
+				cp.linkTo = src.linkTo
+			} else {
+				cp.linkTo = old
+			}
+			t.nodes[p] = &cp
+		}
+	case changeRename:
+		old := cleanAbs(c.old)
+		src := t.nodes[old]
+		if src == nil {
+			return
+		}
+		t.ensureParents(p)
+		// Move the entry and any descendants.
+		moved := map[string]*node{p: src}
+		oldPrefix := old + "/"
+		newPrefix := p + "/"
+		for k, n := range t.nodes {
+			if strings.HasPrefix(k, oldPrefix) {
+				moved[newPrefix+k[len(oldPrefix):]] = n
+			}
+		}
+		t.removeRecursive(old)
+		for k, n := range moved {
+			t.nodes[k] = n
+		}
+	}
+}
+
+// flatten replays all layers in order and returns the resolved tree with hard
+// link groups normalized.
+func flatten(layers [][]fsChange) *tree {
+	t := newTree()
+	for _, layer := range layers {
+		for _, c := range layer {
+			t.apply(c)
+		}
+	}
+	t.resolveLinks()
+	return t
+}
+
+// resolveLinks normalizes hard link groups after flattening. Each group's
+// canonical inode may have been removed or renamed, so it repoints every
+// surviving member at the lexically-first survivor and clears linkTo when a
+// group has a single member. This keeps the flat tree writable as a set of one
+// primary node plus links.
+func (t *tree) resolveLinks() {
+	// Group every node by its canonical inode key, then normalize any group
+	// with more than one surviving member.
+	groups := map[string][]string{}
+	linked := false
+	for p, n := range t.nodes {
+		if n.linkTo != "" {
+			linked = true
+		}
+		groups[n.inodeKey(p)] = append(groups[n.inodeKey(p)], p)
+	}
+	if !linked {
+		return
+	}
+	for _, members := range groups {
+		if len(members) < 2 {
+			// Single survivor (or a plain file): it owns its inode.
+			t.nodes[members[0]].linkTo = ""
+			continue
+		}
+		sort.Strings(members)
+		primary := members[0]
+		t.nodes[primary].linkTo = ""
+		for _, m := range members[1:] {
+			t.nodes[m].linkTo = primary
+		}
+	}
+}
+
+// inodeKey returns the canonical identifier of the inode a node belongs to.
+func (n *node) inodeKey(self string) string {
+	if n.linkTo != "" {
+		return n.linkTo
+	}
+	return self
+}
+
+// sortedPaths returns all non-root paths in the tree, parents before children.
+func (t *tree) sortedPaths() []string {
+	ps := make([]string, 0, len(t.nodes))
+	for p := range t.nodes {
+		if p != "/" {
+			ps = append(ps, p)
+		}
+	}
+	sort.Strings(ps)
+	return ps
+}
+
+// ---------------------------------------------------------------------------
+// Layer and flat writers
+//
+// Emission is shared via the entrySink interface: an erofsSink writes into a
+// go-erofs image while a dirSink writes into an on-disk directory. The flat
+// and layered emitters are backend-agnostic and drive a sink; each snapshotter
+// only differs in which sink it supplies. The native snapshotter is the one
+// exception: its active directory is a real mutable copy of the parent, so it
+// applies the raw changes sequentially instead (see writeNativeDir).
+// ---------------------------------------------------------------------------
+
+// concreteNode is the backend-independent description of a single filesystem
+// entry to materialize (not a whiteout or hard link).
+type concreteNode struct {
+	mode     fs.FileMode
+	content  []byte
+	target   string // symlink target
+	uid, gid int
+	owned    bool // ownership explicitly set (apply even when 0:0)
+	opaque   bool // directory hides lower-layer content (overlay opaque)
+}
+
+// entrySink materializes filesystem entries for one backend. Paths are clean
+// absolute ("/foo"). Implementations copy lower-layer entries up as needed so
+// that mutations and references to inherited paths resolve correctly.
+type entrySink interface {
+	// ensureParents materializes the ancestor directories of path.
+	ensureParents(path string) error
+	// node writes a concrete file, directory or symlink.
+	node(path string, n concreteNode) error
+	// whiteout hides a lower-layer path.
+	whiteout(path string) error
+	// link creates a hard link at path to the entry at target.
+	link(path, target string) error
+	// copyUp materializes the parent entry at src into the sink at dst.
+	copyUp(src, dst string) error
+	// chown mutates the ownership of an already-materialized entry.
+	chown(path string, uid, gid int) error
+}
+
+// emitFlat writes a resolved tree (the flattened reference state) to a sink.
+func emitFlat(sink entrySink, t *tree) error {
+	for _, p := range t.sortedPaths() {
+		n := t.nodes[p]
+		if err := sink.ensureParents(p); err != nil {
+			return err
+		}
+		if n.linkTo != "" {
+			if err := sink.link(p, n.linkTo); err != nil {
+				return fmt.Errorf("link %s -> %s: %w", p, n.linkTo, err)
+			}
+			continue
+		}
+		if err := sink.node(p, n.concrete()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitLayer writes a resolved layer (an overlay on top of the parent) to a sink.
+func emitLayer(sink entrySink, m *layerModel) error {
+	for _, p := range m.sortedPaths() {
+		e := m.entries[p]
+		if err := sink.ensureParents(p); err != nil {
+			return err
+		}
+		switch e.kind {
+		case entryWhiteout:
+			if err := sink.whiteout(p); err != nil {
+				return fmt.Errorf("whiteout %s: %w", p, err)
+			}
+
+		case entryLink:
+			if err := sink.link(p, e.link); err != nil {
+				return fmt.Errorf("link %s -> %s: %w", p, e.link, err)
+			}
+
+		case entryCopyFrom:
+			// Rename whose source is in a lower layer: materialize its content
+			// at the destination.
+			if err := sink.copyUp(e.link, p); err != nil {
+				return err
+			}
+
+		case entryNode:
+			if e.fromParent {
+				// Metadata-only change to a lower-layer entry: copy up first.
+				if err := sink.copyUp(p, p); err != nil {
+					return err
+				}
+				if e.setOwner {
+					if err := sink.chown(p, e.uid, e.gid); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+			if err := sink.node(p, e.concrete()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// concrete converts a flattened node to a backend-independent concreteNode.
+func (n *node) concrete() concreteNode {
+	return concreteNode{
+		mode:    n.mode,
+		content: n.content,
+		target:  n.target,
+		uid:     n.uid,
+		gid:     n.gid,
+		owned:   n.owned || n.uid != 0 || n.gid != 0,
+	}
+}
+
+// concrete converts a resolved layer entry to a backend-independent concreteNode.
+func (e *layerEntry) concrete() concreteNode {
+	return concreteNode{
+		mode:    e.mode,
+		content: e.content,
+		target:  e.target,
+		uid:     e.uid,
+		gid:     e.gid,
+		owned:   e.setOwner,
+		opaque:  e.opaque,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EROFS sink
+// ---------------------------------------------------------------------------
+
+// erofsSink writes entries into a go-erofs image, copying lower-layer entries
+// up from parent when they must be materialized in this layer.
+type erofsSink struct {
+	w       *erofs.Writer
+	parent  fs.FS
+	created map[string]bool
+}
+
+func newErofsSink(w *erofs.Writer, parent fs.FS) *erofsSink {
+	return &erofsSink{w: w, parent: parent, created: map[string]bool{}}
+}
+
+func (s *erofsSink) ensureParents(p string) error {
+	// Copy existing parent directories up with their real attributes so they
+	// do not shadow the lower layer; fabricate genuinely new ancestors 0755.
+	for _, d := range missingAncestors(p, func(d string) bool {
+		if s.created[d] {
+			return true
+		}
+		_, err := s.w.Stat(d)
+		return err == nil
+	}) {
+		if s.copyUpDir(d) {
+			continue
+		}
+		if err := s.w.Mkdir(d, 0o755); err != nil {
+			return err
+		}
+		s.created[d] = true
+	}
+	return nil
+}
+
+func (s *erofsSink) node(p string, n concreteNode) error {
+	switch {
+	case n.mode.IsDir():
+		if err := s.w.Mkdir(p, n.mode.Perm()); err != nil {
+			return fmt.Errorf("mkdir %s: %w", p, err)
+		}
+		if n.opaque {
+			if err := s.w.Setxattr(p, "trusted.overlay.opaque", "y"); err != nil {
+				return err
+			}
+		}
+	case n.mode&fs.ModeSymlink != 0:
+		if err := s.w.Symlink(n.target, p); err != nil {
+			return fmt.Errorf("symlink %s: %w", p, err)
+		}
+	default:
+		f, err := s.w.Create(p)
+		if err != nil {
+			return fmt.Errorf("create %s: %w", p, err)
+		}
+		if len(n.content) > 0 {
+			if _, err := f.Write(n.content); err != nil {
+				f.Close()
+				return fmt.Errorf("write %s: %w", p, err)
+			}
+		}
+		if err := f.Chmod(n.mode.Perm()); err != nil {
+			f.Close()
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+	s.created[p] = true
+	if n.owned {
+		return s.w.Chown(p, n.uid, n.gid)
+	}
+	return nil
+}
+
+func (s *erofsSink) whiteout(p string) error {
+	s.created[p] = true
+	return s.w.Mknod(p, erofsChardev, 0)
+}
+
+func (s *erofsSink) link(p, target string) error {
+	if err := s.copyUp(target, target); err != nil {
+		return err
+	}
+	s.created[p] = true
+	return s.w.Link(target, p)
+}
+
+func (s *erofsSink) chown(p string, uid, gid int) error { return s.w.Chown(p, uid, gid) }
+
+// copyUp materializes the parent entry at src into the writer at dst.
+func (s *erofsSink) copyUp(src, dst string) error {
+	if s.created[dst] {
+		return nil
+	}
+	if _, err := s.w.Stat(dst); err == nil {
+		return nil
+	}
+	fi, ok := statParentEntry(s.parent, src)
+	if !ok {
+		return nil // absent from parent; nothing to copy up
+	}
+	if err := s.ensureParents(dst); err != nil {
+		return err
+	}
+	uid, gid, owned := ownerOf(fi)
+	n := concreteNode{mode: fi.Mode(), uid: uid, gid: gid, owned: owned}
+	switch {
+	case fi.Mode()&fs.ModeSymlink != 0:
+		target, err := readlinkParent(s.parent, strings.TrimPrefix(src, "/"))
+		if err != nil {
+			return err
+		}
+		n.target = target
+	case !fi.IsDir():
+		data, err := fs.ReadFile(s.parent, strings.TrimPrefix(src, "/"))
+		if err != nil {
+			return err
+		}
+		n.content = data
+	}
+	return s.node(dst, n)
+}
+
+// copyUpDir copies a parent directory into the writer with its real mode and
+// owner, reporting whether it existed in the parent.
+func (s *erofsSink) copyUpDir(d string) bool {
+	fi, ok := statParentEntry(s.parent, d)
+	if !ok || !fi.IsDir() {
+		return false
+	}
+	if err := s.w.Mkdir(d, fi.Mode().Perm()); err != nil {
+		return false
+	}
+	if uid, gid, owned := ownerOf(fi); owned {
+		_ = s.w.Chown(d, uid, gid)
+	}
+	s.created[d] = true
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// Per-layer resolution
+//
+// resolveLayer collapses an ordered change list into a single intent per path.
+// This lets the EROFS writer emit each path once regardless of how many
+// operations touched it in the source layer.
+// ---------------------------------------------------------------------------
+
+type entryKind int
+
+const (
+	entryNode     entryKind = iota // a concrete file/dir/symlink in this layer
+	entryWhiteout                  // a deletion of a lower-layer path
+	entryLink                      // a hard link to another path
+	entryCopyFrom                  // a copy-up of a parent path to this path
+)
+
+type layerEntry struct {
+	kind     entryKind
+	mode     fs.FileMode
+	content  []byte
+	target   string
+	link     string // source path for entryLink
+	uid, gid int
+	setOwner bool
+	opaque   bool
+	// fromParent marks an entry that only carries metadata changes to a path
+	// inherited from a lower layer (needs copy-up rather than fresh creation).
+	fromParent bool
+}
+
+type layerModel struct {
+	entries map[string]*layerEntry
+}
+
+func (m *layerModel) sortedPaths() []string {
+	ps := make([]string, 0, len(m.entries))
+	for p := range m.entries {
+		ps = append(ps, p)
+	}
+	sort.Strings(ps)
+	return ps
+}
+
+// resolveLayer replays a layer's changes into per-path intents.
+func resolveLayer(changes []fsChange) *layerModel {
+	m := &layerModel{entries: map[string]*layerEntry{}}
+	// removedHere tracks paths removed in this layer, to detect
+	// remove-then-recreate (opaque) and to know when a rename source needs a
+	// whiteout.
+	removedHere := map[string]bool{}
+
+	setNode := func(p string, e *layerEntry) {
+		if removedHere[p] {
+			e.opaque = e.mode.IsDir()
+			removedHere[p] = false
+		}
+		m.entries[p] = e
+	}
+
+	for _, c := range changes {
+		p := cleanAbs(c.path)
+		switch c.kind {
+		case changeCreateFile:
+			setNode(p, &layerEntry{kind: entryNode, mode: c.mode, content: c.content})
+		case changeMkdir:
+			setNode(p, &layerEntry{kind: entryNode, mode: c.mode | fs.ModeDir})
+		case changeRemove:
+			m.removeSubtree(p)
+			removedHere[p] = true
+			m.entries[p] = &layerEntry{kind: entryWhiteout}
+		case changeChown:
+			e := m.mutable(p)
+			e.uid, e.gid, e.setOwner = c.uid, c.gid, true
+		case changeLink:
+			old := cleanAbs(c.old)
+			if src := m.entries[old]; src != nil && src.kind == entryNode {
+				// Source created in this layer: a true hard link works.
+				setNode(p, &layerEntry{kind: entryLink, link: old})
+			} else {
+				// Source lives in a lower layer: copy its content up. Overlay
+				// layers cannot hard-link across the layer boundary.
+				setNode(p, &layerEntry{kind: entryCopyFrom, link: old})
+			}
+		case changeRename:
+			old := cleanAbs(c.old)
+			src := m.entries[old]
+			// Move the resolved source entry (if created in this layer) to the
+			// destination; otherwise mark the destination as a copy-up of the
+			// parent path via a link-like node handled at emit time.
+			if src != nil && src.kind == entryNode {
+				moved := *src
+				setNode(p, &moved)
+				delete(m.entries, old)
+			} else {
+				// Source lives in a lower layer: copy it up to the destination
+				// and whiteout the source.
+				setNode(p, &layerEntry{kind: entryCopyFrom, link: old})
+			}
+			if !removedHere[old] {
+				m.entries[old] = &layerEntry{kind: entryWhiteout}
+				removedHere[old] = true
+			}
+		}
+	}
+	return m
+}
+
+// mutable returns the entry for p, creating a metadata-only "fromParent" node
+// when the path was not otherwise touched in this layer.
+func (m *layerModel) mutable(p string) *layerEntry {
+	e := m.entries[p]
+	if e == nil {
+		e = &layerEntry{kind: entryNode, fromParent: true}
+		m.entries[p] = e
+	}
+	return e
+}
+
+// removeSubtree drops any entries created in this layer beneath p.
+func (m *layerModel) removeSubtree(p string) {
+	delete(m.entries, p)
+	prefix := p + "/"
+	for k := range m.entries {
+		if strings.HasPrefix(k, prefix) {
+			delete(m.entries, k)
+		}
+	}
+}
+
+// missingAncestors returns the ancestor directories of p that need to be
+// created, ordered top-down (shallowest first). exists reports whether an
+// ancestor is already present.
+func missingAncestors(p string, exists func(string) bool) []string {
+	var missing []string
+	for d := path.Dir(p); d != "/" && d != "."; d = path.Dir(d) {
+		if exists(d) {
+			break
+		}
+		missing = append(missing, d)
+	}
+	// Reverse into top-down order.
+	for i, j := 0, len(missing)-1; i < j; i, j = i+1, j-1 {
+		missing[i], missing[j] = missing[j], missing[i]
+	}
+	return missing
+}
+
+// statParentEntry stats a path (relative or absolute) in the parent view
+// without following a final symlink. It reports false when there is no parent
+// or the path is absent.
+func statParentEntry(parent fs.FS, p string) (fs.FileInfo, bool) {
+	if parent == nil {
+		return nil, false
+	}
+	rel := strings.TrimPrefix(p, "/")
+	var (
+		fi  fs.FileInfo
+		err error
+	)
+	if rl, ok := parent.(fs.ReadLinkFS); ok {
+		fi, err = rl.Lstat(rel)
+	} else {
+		fi, err = fs.Stat(parent, rel)
+	}
+	if err != nil {
+		return nil, false
+	}
+	return fi, true
+}
+
+func readlinkParent(parent fs.FS, rel string) (string, error) {
+	if rl, ok := parent.(fs.ReadLinkFS); ok {
+		return rl.ReadLink(rel)
+	}
+	return "", fmt.Errorf("parent does not support readlink")
+}
+
+// ---------------------------------------------------------------------------
+// Directory sink (overlay upperdir)
+// ---------------------------------------------------------------------------
+
+// dirSink writes entries into an overlay upperdir on disk, using character
+// device whiteouts and opaque xattrs, and copying lower-layer entries up
+// before mutating or referencing them.
+type dirSink struct {
+	dir    string
+	parent fs.FS
+}
+
+func newDirSink(dir string, parent fs.FS) *dirSink {
+	return &dirSink{dir: dir, parent: parent}
+}
+
+func (s *dirSink) target(p string) string {
+	return filepath.Join(s.dir, filepath.FromSlash(strings.TrimPrefix(p, "/")))
+}
+
+func (s *dirSink) ensureParents(p string) error {
+	for _, d := range missingAncestors(p, func(d string) bool {
+		_, err := os.Lstat(s.target(d))
+		return err == nil
+	}) {
+		if err := s.copyUp(d, d); err != nil {
+			return err
+		}
+		if _, err := os.Lstat(s.target(d)); err != nil {
+			if err := os.Mkdir(s.target(d), 0o755); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *dirSink) node(p string, n concreteNode) error {
+	target := s.target(p)
+	switch {
+	case n.mode.IsDir():
+		if err := os.MkdirAll(target, n.mode.Perm()); err != nil {
+			return err
+		}
+		if err := os.Chmod(target, n.mode.Perm()); err != nil {
+			return err
+		}
+		if n.opaque {
+			if err := setOpaque(target); err != nil {
+				return err
+			}
+		}
+	case n.mode&fs.ModeSymlink != 0:
+		if err := os.Symlink(n.target, target); err != nil {
+			return err
+		}
+	default:
+		if err := os.WriteFile(target, n.content, n.mode.Perm()); err != nil {
+			return err
+		}
+		if err := os.Chmod(target, n.mode.Perm()); err != nil {
+			return err
+		}
+	}
+	if n.owned {
+		return os.Lchown(target, n.uid, n.gid)
+	}
+	return nil
+}
+
+func (s *dirSink) whiteout(p string) error { return mknodChar(s.target(p)) }
+func (s *dirSink) link(p, target string) error {
+	return os.Link(s.target(target), s.target(p))
+}
+func (s *dirSink) chown(p string, uid, gid int) error { return os.Lchown(s.target(p), uid, gid) }
+
+func (s *dirSink) copyUp(src, dst string) error {
+	target := s.target(dst)
+	if _, err := os.Lstat(target); err == nil {
+		return nil
+	}
+	fi, ok := statParentEntry(s.parent, src)
+	if !ok {
+		return nil
+	}
+	uid, gid, owned := ownerOf(fi)
+	n := concreteNode{mode: fi.Mode(), uid: uid, gid: gid, owned: owned}
+	switch {
+	case fi.Mode()&fs.ModeSymlink != 0:
+		t, err := readlinkParent(s.parent, strings.TrimPrefix(src, "/"))
+		if err != nil {
+			return err
+		}
+		n.target = t
+	case !fi.IsDir():
+		data, err := fs.ReadFile(s.parent, strings.TrimPrefix(src, "/"))
+		if err != nil {
+			return err
+		}
+		n.content = data
+	}
+	return s.node(dst, n)
+}
+
+// writeNativeDir applies a layer's changes to a native snapshot directory,
+// which already holds a copy of the parent. Because the directory is a real
+// mutable tree, the raw changes are applied sequentially: removals delete,
+// renames move, and links hard-link, all in place.
+func writeNativeDir(dir string, changes []fsChange) error {
+	targetOf := func(p string) string {
+		return filepath.Join(dir, filepath.FromSlash(strings.TrimPrefix(cleanAbs(p), "/")))
+	}
+	for _, c := range changes {
+		target := targetOf(c.path)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		var err error
+		switch c.kind {
+		case changeCreateFile:
+			if err = os.WriteFile(target, c.content, c.mode.Perm()); err == nil {
+				err = os.Chmod(target, c.mode.Perm())
+			}
+		case changeMkdir:
+			if err = os.MkdirAll(target, c.mode.Perm()); err == nil {
+				err = os.Chmod(target, c.mode.Perm())
+			}
+		case changeRemove:
+			err = os.RemoveAll(target)
+		case changeChown:
+			err = os.Lchown(target, c.uid, c.gid)
+		case changeLink:
+			err = os.Link(targetOf(c.old), target)
+		case changeRename:
+			err = os.Rename(targetOf(c.old), target)
+		}
+		if err != nil {
+			return fmt.Errorf("native %s: %w", c.path, err)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot creation via the snapshotter under test
+// ---------------------------------------------------------------------------
+
+// fsCommitNamed prepares an active snapshot under activeKey (on optional
+// parent), applies changes, and commits it under committedName. Callers that
+// need specific snapshot names (Walk, Update, etc.) use this. commitOpt
+// overrides the default gc-root option when provided.
+func fsCommitNamed(ctx context.Context, sn snapshots.Snapshotter, work, activeKey, committedName, parent string, commitOpt ...snapshots.Opt) error {
+	if len(commitOpt) == 0 {
+		commitOpt = []snapshots.Opt{fsOpt}
+	}
+	mounts, err := sn.Prepare(ctx, activeKey, parent, fsOpt)
+	if err != nil {
+		return fmt.Errorf("prepare %s: %w", activeKey, err)
+	}
+	if err := applyLayer(mounts, nil); err != nil {
+		_ = sn.Remove(ctx, activeKey)
+		return fmt.Errorf("apply %s: %w", activeKey, err)
+	}
+	if err := sn.Commit(ctx, committedName, activeKey, commitOpt...); err != nil {
+		return fmt.Errorf("commit %s: %w", committedName, err)
+	}
+	return nil
+}
+
+// fsCreateLayer prepares an active snapshot on top of parent, applies the
+// layer's changes using the strategy that matches the snapshotter, and commits
+// it. It returns the committed snapshot name.
+func fsCreateLayer(ctx context.Context, sn snapshots.Snapshotter, parent, work string, changes []fsChange) (string, error) {
+	name := fmt.Sprintf("fs-%d", randutil.Int())
+	prepare := name + "-prepare"
+
+	mounts, err := sn.Prepare(ctx, prepare, parent, fsOpt)
+	if err != nil {
+		return "", fmt.Errorf("prepare: %w", err)
+	}
+
+	if err := applyLayer(mounts, changes); err != nil {
+		_ = sn.Remove(ctx, prepare)
+		return "", fmt.Errorf("apply layer: %w", err)
+	}
+	if err := sn.Commit(ctx, name, prepare, fsOpt); err != nil {
+		return "", fmt.Errorf("commit: %w", err)
+	}
+	return name, nil
+}
+
+// snapshotTarget classifies an active snapshot's mounts into the write
+// strategy that fits the snapshotter that produced them.
+type snapshotTarget struct {
+	kind        targetKind
+	dir         string // upperdir (overlay) or source dir (native)
+	snapshotDir string // erofs snapshot directory
+}
+
+type targetKind int
+
+const (
+	targetErofs targetKind = iota
+	targetOverlay
+	targetNative
+)
+
+// classifyTarget determines how to write to the active snapshot.
+func classifyTarget(mounts []mount.Mount) (snapshotTarget, error) {
+	if len(mounts) == 0 {
+		return snapshotTarget{}, fmt.Errorf("no mounts to apply to")
+	}
+	last := mounts[len(mounts)-1]
+
+	switch {
+	case last.Type == "bind" || last.Type == "rbind":
+		snapshotDir := filepath.Dir(last.Source)
+		if isErofsSnapshot(snapshotDir) {
+			return snapshotTarget{kind: targetErofs, snapshotDir: snapshotDir}, nil
+		}
+		return snapshotTarget{kind: targetNative, dir: last.Source}, nil
+
+	case last.Type == "overlay":
+		dir, ok := upperdir(last.Options)
+		if !ok {
+			return snapshotTarget{}, fmt.Errorf("overlay mount has no upperdir option")
+		}
+		return snapshotTarget{kind: targetOverlay, dir: dir}, nil
+
+	case strings.HasPrefix(last.Type, "format/") && strings.HasSuffix(last.Type, "overlay"):
+		if snapshotDir, ok := erofsSnapshotDir(last.Options); ok && isErofsSnapshot(snapshotDir) {
+			return snapshotTarget{kind: targetErofs, snapshotDir: snapshotDir}, nil
+		}
+		if dir, ok := upperdir(last.Options); ok && !strings.Contains(dir, "{{") {
+			return snapshotTarget{kind: targetOverlay, dir: dir}, nil
+		}
+		return snapshotTarget{}, fmt.Errorf("unsupported format overlay options: %v", last.Options)
+
+	default:
+		return snapshotTarget{}, fmt.Errorf("unsupported mount type: %s", last.Type)
+	}
+}
+
+// lowerView returns a read-only fs.FS of the parent (lower) layers embedded in
+// an active snapshot's mounts, for copy-up. The parent stack is already part of
+// the active mounts, so instead of preparing a separate parent View we strip
+// the writable upper from the final overlay mount and open what remains. It
+// returns (nil, nil) when the mounts carry no lower layers (e.g. a base layer
+// or the native copy, which needs no copy-up).
+func lowerView(mounts []mount.Mount) (fs.FS, func(), error) {
+	if len(mounts) == 0 {
+		return nil, nil, nil
+	}
+	last := mounts[len(mounts)-1]
+
+	// Only overlay-style mounts embed a separate lower stack. Bind mounts
+	// (native, or an erofs base layer) have no lower to view.
+	isOverlay := last.Type == "overlay" ||
+		(strings.HasPrefix(last.Type, "format/") && strings.HasSuffix(last.Type, "overlay"))
+	if !isOverlay {
+		return nil, nil, nil
+	}
+
+	lower := stripWritableUpper(mounts)
+	if lower == nil {
+		return nil, nil, nil // no lowerdir: nothing to copy up from
+	}
+
+	v, err := fsview.FSMounts(lower)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open lower view: %w", err)
+	}
+	if v == nil {
+		return nil, nil, nil
+	}
+	return v, func() { v.Close() }, nil
+}
+
+// stripWritableUpper returns a copy of mounts with the final overlay mount's
+// writable upperdir and workdir removed, leaving only its lowerdir. It returns
+// nil when the final mount has no lowerdir (no parent layers).
+func stripWritableUpper(mounts []mount.Mount) []mount.Mount {
+	last := mounts[len(mounts)-1]
+
+	var kept []string
+	hasLower := false
+	for _, o := range last.Options {
+		switch {
+		case strings.HasPrefix(o, "upperdir="),
+			strings.HasPrefix(o, "workdir="),
+			strings.HasPrefix(o, "X-containerd.mkdir."):
+			// Drop the writable-upper wiring.
+		case strings.HasPrefix(o, "lowerdir="):
+			hasLower = true
+			kept = append(kept, o)
+		default:
+			kept = append(kept, o)
+		}
+	}
+	if !hasLower {
+		return nil
+	}
+
+	out := make([]mount.Mount, len(mounts))
+	copy(out, mounts)
+	lastCopy := last
+	lastCopy.Options = kept
+	out[len(out)-1] = lastCopy
+	return out
+}
+
+// applyLayer writes changes to the active snapshot as an overlay on top of the
+// parent layers embedded in its own mounts. The parent (lower) view used for
+// copy-up is derived from those mounts rather than a separate View. The erofs
+// and overlay backends share the resolved-layer emitter via a sink; native
+// applies the raw changes directly to its parent copy.
+func applyLayer(mounts []mount.Mount, changes []fsChange) error {
+	tgt, err := classifyTarget(mounts)
+	if err != nil {
+		return err
+	}
+	switch tgt.kind {
+	case targetErofs, targetOverlay:
+		parentView, closeParent, err := lowerView(mounts)
+		if err != nil {
+			return err
+		}
+		if closeParent != nil {
+			defer closeParent()
+		}
+		if tgt.kind == targetErofs {
+			return buildErofsImage(tgt.snapshotDir, func(w *erofs.Writer) error {
+				return emitLayer(newErofsSink(w, parentView), resolveLayer(changes))
+			})
+		}
+		return emitLayer(newDirSink(tgt.dir, parentView), resolveLayer(changes))
+	case targetNative:
+		return writeNativeDir(tgt.dir, changes)
+	}
+	return fmt.Errorf("unhandled target kind")
+}
+
+// buildErofsImage writes the snapshot's layer.erofs using the provided writer
+// callback.
+func buildErofsImage(snapshotDir string, write func(*erofs.Writer) error) error {
+	layerPath := filepath.Join(snapshotDir, "layer.erofs")
+	f, err := os.Create(layerPath)
+	if err != nil {
+		return fmt.Errorf("create layer.erofs: %w", err)
+	}
+	defer f.Close()
+
+	w := erofs.Create(f)
+	if err := write(w); err != nil {
+		return err
+	}
+	return w.Close()
+}
+
+func isErofsSnapshot(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, ".erofslayer"))
+	return err == nil
+}
+
+func upperdir(options []string) (string, bool) {
+	for _, o := range options {
+		if v, ok := strings.CutPrefix(o, "upperdir="); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func erofsSnapshotDir(options []string) (string, bool) {
+	for _, o := range options {
+		if v, ok := strings.CutPrefix(o, "workdir="); ok && !strings.Contains(v, "{{") {
+			return filepath.Dir(v), true
+		}
+		if v, ok := strings.CutPrefix(o, "upperdir="); ok && !strings.Contains(v, "{{") {
+			return filepath.Dir(v), true
+		}
+	}
+	return "", false
+}
+
+// ---------------------------------------------------------------------------
+// Verification driver
+// ---------------------------------------------------------------------------
+
+// fsCheckSnapshots builds a layered snapshot chain with the snapshotter under
+// test and, for each prefix of layers, compares its committed view against an
+// independent canonical EROFS image built directly from the flattened changes.
+// Using a snapshotter-independent reference means the test validates the
+// snapshotter against a known-good state rather than against itself.
+func fsCheckSnapshots(ctx context.Context, sn snapshots.Snapshotter, work string, layers ...[]fsChange) error {
+	parent := ""
+	for i := range layers {
+		layered, err := fsCreateLayer(ctx, sn, parent, work, layers[i])
+		if err != nil {
+			return fmt.Errorf("layer %d: %w", i+1, err)
+		}
+
+		ref, closeRef, err := openFlatReference(work, layers[:i+1])
+		if err != nil {
+			return fmt.Errorf("reference %d: %w", i+1, err)
+		}
+
+		got, closeGot, err := openCommittedView(ctx, sn, layered)
+		if err != nil {
+			closeRef()
+			return err
+		}
+		err = compareFS(got, ref)
+		closeGot()
+		closeRef()
+		if err != nil {
+			return fmt.Errorf("compare at layer %d: %w", i+1, err)
+		}
+		parent = layered
+	}
+	return nil
+}
+
+// openFlatReference builds the canonical flattened filesystem as a standalone
+// EROFS image and opens it read-only. It does not use the snapshotter, so it
+// serves as an independent oracle for comparison.
+func openFlatReference(work string, layers [][]fsChange) (fs.FS, func(), error) {
+	f, err := os.CreateTemp(work, "flat-*.erofs")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create reference image: %w", err)
+	}
+	name := f.Name()
+
+	w := erofs.Create(f)
+	if err := emitFlat(newErofsSink(w, nil), flatten(layers)); err != nil {
+		f.Close()
+		_ = os.Remove(name)
+		return nil, nil, fmt.Errorf("build reference image: %w", err)
+	}
+	if err := w.Close(); err != nil { // serializes the image; does not close f
+		f.Close()
+		_ = os.Remove(name)
+		return nil, nil, fmt.Errorf("finalize reference image: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(name)
+		return nil, nil, fmt.Errorf("close reference image: %w", err)
+	}
+
+	rf, err := os.Open(name)
+	if err != nil {
+		_ = os.Remove(name)
+		return nil, nil, fmt.Errorf("open reference image: %w", err)
+	}
+	efs, err := erofs.Open(rf)
+	if err != nil {
+		rf.Close()
+		_ = os.Remove(name)
+		return nil, nil, fmt.Errorf("read reference image: %w", err)
+	}
+	return efs, func() {
+		rf.Close()
+		_ = os.Remove(name)
+	}, nil
+}
+
+// openCommittedView creates a temporary view of a committed snapshot and opens
+// it as an fs.FS.
+func openCommittedView(ctx context.Context, sn snapshots.Snapshotter, name string) (fs.FS, func(), error) {
+	viewKey := fmt.Sprintf("%s-view-%d", name, randutil.Int())
+	mounts, err := sn.View(ctx, viewKey, name, fsOpt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("view %s: %w", name, err)
+	}
+	v, err := fsview.FSMounts(mounts)
+	if err != nil {
+		_ = sn.Remove(ctx, viewKey)
+		return nil, nil, fmt.Errorf("FSMounts %s: %w", name, err)
+	}
+	if v == nil {
+		_ = sn.Remove(ctx, viewKey)
+		return nil, nil, fmt.Errorf("FSMounts %s returned nil", name)
+	}
+	return v, func() {
+		v.Close()
+		_ = sn.Remove(ctx, viewKey)
+	}, nil
+}
+
+// fsMountsView opens mounts as an fs.FS view, returning a close function.
+func fsMountsView(mounts []mount.Mount) (fs.FS, func() error, error) {
+	v, err := fsview.FSMounts(mounts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if v == nil {
+		return nil, nil, errors.New("FSMounts returned nil")
+	}
+	return v, v.Close, nil
+}
+
+// ---------------------------------------------------------------------------
+// fs.FS comparison
+// ---------------------------------------------------------------------------
+
+// compareFS asserts that two filesystems are structurally identical: same set
+// of paths, and for each path the same mode (type and permission bits),
+// content, symlink target, ownership and xattrs. Modification times are not
+// compared as they are not meaningfully preserved across snapshotter formats.
+func compareFS(got, want fs.FS) error {
+	gotEntries, err := walkFS(got)
+	if err != nil {
+		return fmt.Errorf("walk got: %w", err)
+	}
+	wantEntries, err := walkFS(want)
+	if err != nil {
+		return fmt.Errorf("walk want: %w", err)
+	}
+
+	for p := range wantEntries {
+		if _, ok := gotEntries[p]; !ok {
+			return fmt.Errorf("missing entry %q", p)
+		}
+	}
+	for p := range gotEntries {
+		if _, ok := wantEntries[p]; !ok {
+			return fmt.Errorf("unexpected entry %q", p)
+		}
+	}
+
+	paths := make([]string, 0, len(wantEntries))
+	for p := range wantEntries {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	for _, p := range paths {
+		g, w := gotEntries[p], wantEntries[p]
+		if g.Mode().Type() != w.Mode().Type() {
+			return fmt.Errorf("%s: type %v != %v", p, g.Mode().Type(), w.Mode().Type())
+		}
+		if g.Mode().Perm() != w.Mode().Perm() {
+			return fmt.Errorf("%s: perm %o != %o", p, g.Mode().Perm(), w.Mode().Perm())
+		}
+		if g.Mode().IsRegular() {
+			gd, err := fs.ReadFile(got, p)
+			if err != nil {
+				return fmt.Errorf("%s: read got: %w", p, err)
+			}
+			wd, err := fs.ReadFile(want, p)
+			if err != nil {
+				return fmt.Errorf("%s: read want: %w", p, err)
+			}
+			if string(gd) != string(wd) {
+				return fmt.Errorf("%s: content %q != %q", p, gd, wd)
+			}
+		}
+		if g.Mode()&fs.ModeSymlink != 0 {
+			gt, err := readlink(got, p)
+			if err != nil {
+				return fmt.Errorf("%s: readlink got: %w", p, err)
+			}
+			wt, err := readlink(want, p)
+			if err != nil {
+				return fmt.Errorf("%s: readlink want: %w", p, err)
+			}
+			if gt != wt {
+				return fmt.Errorf("%s: symlink target %q != %q", p, gt, wt)
+			}
+		}
+		if err := compareOwner(p, g, w); err != nil {
+			return err
+		}
+		if err := compareXattrs(p, g, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// walkFS returns a map of every path (excluding ".") in fsys to its
+// FileInfo, without following symlinks.
+func walkFS(fsys fs.FS) (map[string]fs.FileInfo, error) {
+	out := map[string]fs.FileInfo{}
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == "." {
+			return nil
+		}
+		fi, err := lstatFS(fsys, p)
+		if err != nil {
+			return fmt.Errorf("lstat %s: %w", p, err)
+		}
+		out[p] = fi
+		return nil
+	})
+	return out, err
+}
+
+func lstatFS(fsys fs.FS, name string) (fs.FileInfo, error) {
+	if rl, ok := fsys.(fs.ReadLinkFS); ok {
+		return rl.Lstat(name)
+	}
+	return fs.Stat(fsys, name)
+}
+
+func readlink(fsys fs.FS, name string) (string, error) {
+	if rl, ok := fsys.(fs.ReadLinkFS); ok {
+		return rl.ReadLink(name)
+	}
+	return "", fmt.Errorf("filesystem does not support readlink")
+}
+
+// ownerOf extracts UID/GID from a FileInfo produced by an erofs image or a
+// host directory (syscall.Stat_t).
+func ownerOf(fi fs.FileInfo) (uid, gid int, ok bool) {
+	switch st := fi.Sys().(type) {
+	case *erofs.Stat:
+		return int(st.UID), int(st.GID), true
+	case *erofs.WriterStat:
+		return int(st.UID), int(st.GID), true
+	case *syscall.Stat_t:
+		return int(st.Uid), int(st.Gid), true
+	}
+	return 0, 0, false
+}
+
+func compareOwner(p string, g, w fs.FileInfo) error {
+	guid, ggid, gok := ownerOf(g)
+	wuid, wgid, wok := ownerOf(w)
+	if gok != wok {
+		return fmt.Errorf("%s: ownership exposed on one side only (got=%v want=%v)", p, gok, wok)
+	}
+	if !gok {
+		return nil // neither side exposes ownership
+	}
+	if guid != wuid || ggid != wgid {
+		return fmt.Errorf("%s: owner %d:%d != %d:%d", p, guid, ggid, wuid, wgid)
+	}
+	return nil
+}
+
+// xattrsOf returns the extended attributes of fi and whether its FileInfo
+// exposes them. Only erofs-backed views surface xattrs through Sys(); a
+// directory-backed view (syscall.Stat_t) does not, so ok is false there.
+func xattrsOf(fi fs.FileInfo) (map[string]string, bool) {
+	switch st := fi.Sys().(type) {
+	case *erofs.Stat:
+		return st.Xattrs, true
+	case *erofs.WriterStat:
+		return st.Xattrs, true
+	}
+	return nil, false
+}
+
+func compareXattrs(p string, g, w fs.FileInfo) error {
+	gx, gok := xattrsOf(g)
+	wx, wok := xattrsOf(w)
+	// Only compare when both sides expose xattrs. Directory-backed views
+	// (overlay, native) do not surface xattrs through Sys(), so the check is
+	// skipped rather than reported as a mismatch.
+	if !gok || !wok {
+		return nil
+	}
+	gu := userXattrs(gx)
+	wu := userXattrs(wx)
+	if len(gu) != len(wu) {
+		return fmt.Errorf("%s: xattr count %d != %d", p, len(gu), len(wu))
+	}
+	for k, v := range wu {
+		if gu[k] != v {
+			return fmt.Errorf("%s: xattr %q = %q != %q", p, k, gu[k], v)
+		}
+	}
+	return nil
+}
+
+// userXattrs filters out overlay-internal xattrs (e.g. the opaque marker) that
+// are an artifact of layering rather than user-visible metadata.
+func userXattrs(x map[string]string) map[string]string {
+	if len(x) == 0 {
+		return nil
+	}
+	out := map[string]string{}
+	for k, v := range x {
+		if strings.HasPrefix(k, "trusted.overlay.") || strings.HasPrefix(k, "user.overlay.") {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/core/snapshots/testsuite/fs_issues.go
+++ b/core/snapshots/testsuite/fs_issues.go
@@ -1,0 +1,142 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testsuite
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+)
+
+// ---------------------------------------------------------------------------
+// Regression checks for historical layering bugs.
+// ---------------------------------------------------------------------------
+
+// fsCheckLayerFileUpdate updates a single file across layers.
+// See https://github.com/docker/docker/issues/21555
+func fsCheckLayerFileUpdate(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	l1 := []fsChange{
+		fsMkdir("/etc", 0700),
+		fsCreateFile("/etc/hosts", []byte("mydomain 10.0.0.1"), 0644),
+		fsCreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0644),
+	}
+	l2 := []fsChange{
+		fsCreateFile("/etc/hosts", []byte("mydomain 10.0.0.2"), 0644),
+		fsCreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0666),
+		fsMkdir("/root", 0700),
+		fsCreateFile("/root/.bashrc", []byte("PATH=/usr/sbin:/usr/bin"), 0644),
+	}
+
+	// Run repeatedly to catch timestamp-related regressions.
+	var sleepTime time.Duration
+	for range 5 {
+		time.Sleep(sleepTime)
+		if err := fsCheckSnapshots(ctx, sn, work, l1, l2); err != nil {
+			t.Fatalf("check snapshots: %+v", err)
+		}
+		next := time.Now()
+		sleepTime = time.Unix(next.Unix()+1, 0).Sub(next)
+	}
+}
+
+// fsCheckRemoveDirectoryInLowerLayer removes and recreates a directory.
+// See https://github.com/docker/docker/issues/25244
+func fsCheckRemoveDirectoryInLowerLayer(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	l1 := []fsChange{
+		fsMkdir("/lib", 0700),
+		fsCreateFile("/lib/hidden", []byte{}, 0644),
+	}
+	// Removing then recreating /lib hides the lower-layer content beneath it.
+	l2 := []fsChange{
+		fsRemove("/lib"),
+		fsMkdir("/lib", 0700),
+		fsCreateFile("/lib/not-hidden", []byte{}, 0644),
+	}
+	l3 := []fsChange{
+		fsCreateFile("/lib/newfile", []byte{}, 0644),
+	}
+
+	if err := fsCheckSnapshots(ctx, sn, work, l1, l2, l3); err != nil {
+		t.Fatalf("check snapshots: %+v", err)
+	}
+}
+
+// fsCheckChown propagates ownership changes across layers.
+// See https://github.com/docker/docker/issues/20240, 24913, 28391
+func fsCheckChown(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Chown is not supported on Windows")
+	}
+	l1 := []fsChange{
+		fsMkdir("/opt", 0700),
+		fsMkdir("/opt/a", 0700),
+		fsMkdir("/opt/a/b", 0700),
+		fsCreateFile("/opt/a/b/file.txt", []byte("hello"), 0644),
+	}
+	l2 := []fsChange{
+		fsChown("/opt", 1, 1),
+		fsChown("/opt/a", 1, 1),
+		fsChown("/opt/a/b", 1, 1),
+		fsChown("/opt/a/b/file.txt", 1, 1),
+	}
+
+	if err := fsCheckSnapshots(ctx, sn, work, l1, l2); err != nil {
+		t.Fatalf("check snapshots: %+v", err)
+	}
+}
+
+// fsCheckDirectoryPermissionOnCommit tracks directory permissions across layers.
+// See https://github.com/docker/docker/issues/27298
+func fsCheckDirectoryPermissionOnCommit(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Chown is not supported on WCOW")
+	}
+	l1 := []fsChange{
+		fsMkdir("/dir1", 0700),
+		fsMkdir("/dir2", 0700),
+		fsMkdir("/dir3", 0700),
+		fsMkdir("/dir4", 0700),
+		fsCreateFile("/dir4/f1", []byte("..."), 0644),
+		fsMkdir("/dir5", 0700),
+		fsCreateFile("/dir5/f1", []byte("..."), 0644),
+		fsChown("/dir1", 1, 1),
+		fsChown("/dir2", 1, 1),
+		fsChown("/dir3", 1, 1),
+		fsChown("/dir5", 1, 1),
+		fsChown("/dir5/f1", 1, 1),
+	}
+	l2 := []fsChange{
+		fsChown("/dir2", 0, 0),
+		fsRemove("/dir3"),
+		fsChown("/dir4", 1, 1),
+		fsChown("/dir4/f1", 1, 1),
+	}
+	l3 := []fsChange{
+		fsMkdir("/dir3", 0700),
+		fsChown("/dir3", 1, 1),
+		fsRemove("/dir5"),
+		fsMkdir("/dir5", 0700),
+		fsChown("/dir5", 1, 1),
+	}
+
+	if err := fsCheckSnapshots(ctx, sn, work, l1, l2, l3); err != nil {
+		t.Fatalf("check snapshots: %+v", err)
+	}
+}

--- a/core/snapshots/testsuite/fs_linux.go
+++ b/core/snapshots/testsuite/fs_linux.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testsuite
+
+import "golang.org/x/sys/unix"
+
+// mknodChar creates an overlay whiteout: a character device with device
+// number 0. This requires CAP_MKNOD (root).
+func mknodChar(path string) error {
+	return unix.Mknod(path, unix.S_IFCHR|0o000, 0)
+}
+
+// setOpaque marks a directory opaque so overlay hides lower-layer content
+// beneath it. This requires the privilege to set trusted xattrs (root).
+func setOpaque(path string) error {
+	return unix.Setxattr(path, "trusted.overlay.opaque", []byte("y"), 0)
+}

--- a/core/snapshots/testsuite/fs_other.go
+++ b/core/snapshots/testsuite/fs_other.go
@@ -1,0 +1,31 @@
+//go:build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testsuite
+
+import "fmt"
+
+// mknodChar and setOpaque support the overlay upperdir writer, which is only
+// exercised on Linux. On other platforms they are unreachable stubs.
+func mknodChar(path string) error {
+	return fmt.Errorf("overlay whiteouts are only supported on linux")
+}
+
+func setOpaque(path string) error {
+	return fmt.Errorf("overlay opaque dirs are only supported on linux")
+}

--- a/core/snapshots/testsuite/fs_suite.go
+++ b/core/snapshots/testsuite/fs_suite.go
@@ -1,0 +1,165 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package testsuite provides a snapshot test suite that inspects snapshots
+// through the fs.FS interface instead of kernel mounts.
+//
+// SnapshotterFSSuite runs the same logical checks as SnapshotterSuite but:
+//   - Reads committed and view snapshots via fsview.FSMounts as an fs.FS,
+//     never calling mount.All or any mount syscall.
+//   - Describes each layer's changes once, then applies them both as a layered
+//     snapshot and as a flattened snapshot, comparing the two fs.FS views.
+//
+// The suite itself is root-agnostic. The erofs snapshotter runs it rootless on
+// any platform, since layers are built as EROFS images. The overlay and native
+// snapshotters write to real directories and therefore need privileges for
+// operations like chown and whiteout creation; their callers add the
+// appropriate root requirement.
+package testsuite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/containerd/log/logtest"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+)
+
+// fsSuiteConfig holds configuration for the fs.FS test suite.
+type fsSuiteConfig struct {
+	skipTests map[string]bool
+}
+
+// FSSuiteOpt configures SnapshotterFSSuite.
+type FSSuiteOpt func(*fsSuiteConfig)
+
+// FSSuiteSkipTests skips the named tests.
+func FSSuiteSkipTests(names ...string) FSSuiteOpt {
+	return func(o *fsSuiteConfig) {
+		for _, n := range names {
+			o.skipTests[n] = true
+		}
+	}
+}
+
+// SnapshotterFSSuite runs the fs.FS-based snapshot test suite against the
+// snapshotter produced by snapshotterFn. snapshotterFn matches the signature
+// used by SnapshotterSuite so a factory can be shared between both suites.
+func SnapshotterFSSuite(t *testing.T, name string, snapshotterFn SnapshotterFunc, opts ...FSSuiteOpt) {
+	t.Helper()
+
+	// Zero the umask so directory-backed snapshotters (overlay, native) write
+	// the exact permissions requested; the erofs path is unaffected as it sets
+	// modes directly in the image.
+	restore := clearMask()
+	t.Cleanup(restore)
+
+	o := &fsSuiteConfig{skipTests: make(map[string]bool)}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	makeT := func(testName string, fn func(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string)) func(*testing.T) {
+		return func(t *testing.T) {
+			t.Helper()
+			if o.skipTests[testName] {
+				t.Skipf("test %q skipped for snapshotter %q", testName, name)
+			}
+			fsMakeTest(name, snapshotterFn, fn)(t)
+		}
+	}
+
+	t.Run("Basic", makeT("Basic", fsCheckSnapshotterBasic))
+	t.Run("StatActive", makeT("StatActive", fsCheckSnapshotterStatActive))
+	t.Run("StatCommitted", makeT("StatCommitted", fsCheckSnapshotterStatCommitted))
+	t.Run("TransitivityTest", makeT("TransitivityTest", fsCheckSnapshotterTransitivity))
+	t.Run("PrepareViewFailingTest", makeT("PrepareViewFailingTest", fsCheckSnapshotterPrepareView))
+	t.Run("Update", makeT("Update", fsCheckUpdate))
+	t.Run("Remove", makeT("Remove", fsCheckRemove))
+	t.Run("Walk", makeT("Walk", fsCheckWalk))
+
+	t.Run("LayerFileUpdate", makeT("LayerFileUpdate", fsCheckLayerFileUpdate))
+	t.Run("RemoveDirectoryInLowerLayer", makeT("RemoveDirectoryInLowerLayer", fsCheckRemoveDirectoryInLowerLayer))
+	t.Run("Chown", makeT("Chown", fsCheckChown))
+	t.Run("DirectoryPermissionOnCommit", makeT("DirectoryPermissionOnCommit", fsCheckDirectoryPermissionOnCommit))
+	t.Run("RemoveIntermediateSnapshot", makeT("RemoveIntermediateSnapshot", fsCheckRemoveIntermediateSnapshot))
+	t.Run("DeletedFilesInChildSnapshot", makeT("DeletedFilesInChildSnapshot", fsCheckDeletedFilesInChildSnapshot))
+	t.Run("MoveFileFromLowerLayer", makeT("MoveFileFromLowerLayer", fsCheckFileFromLowerLayer))
+
+	t.Run("ViewReadonly", makeT("ViewReadonly", fsCheckSnapshotterViewReadonly))
+
+	t.Run("StatInWalk", makeT("StatInWalk", fsCheckStatInWalk))
+	t.Run("CloseTwice", makeT("CloseTwice", fsCloseTwice))
+	t.Run("RootPermission", makeT("RootPermission", fsCheckRootPermission))
+
+	t.Run("Rename", makeT("Rename", fsCheckRename(name)))
+	t.Run("128Layers", makeT("128Layers", fsCheck128Layers(name)))
+}
+
+// fsMakeTest sets up a temporary root and work directory, constructs the
+// snapshotter, and runs fn. It mirrors makeTest but omits the mount manager.
+func fsMakeTest(
+	snapshotter string,
+	snapshotterFn SnapshotterFunc,
+	fn func(ctx context.Context, t *testing.T, snapshotter snapshots.Snapshotter, work string),
+) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := logtest.WithT(context.Background(), t)
+		ctx = namespaces.WithNamespace(ctx, "fssuite")
+
+		tmpDir, err := os.MkdirTemp("", "fs-suite-"+snapshotter+"-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		root := filepath.Join(tmpDir, "root")
+		if err := os.MkdirAll(root, 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		sn, cleanup, err := snapshotterFn(ctx, root)
+		if err != nil {
+			t.Fatalf("Failed to initialize snapshotter: %+v", err)
+		}
+		defer func() {
+			if cleanup != nil {
+				if err := cleanup(); err != nil {
+					t.Errorf("Cleanup failed: %v", err)
+				}
+			}
+		}()
+
+		work := filepath.Join(tmpDir, "work")
+		if err := os.MkdirAll(work, 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		fn(ctx, t, sn, work)
+	}
+}
+
+// fsOpt is the standard gc-root label option used across the suite.
+var fsOpt = snapshots.WithLabels(map[string]string{
+	"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
+})

--- a/core/snapshots/testsuite/fs_tests.go
+++ b/core/snapshots/testsuite/fs_tests.go
@@ -1,0 +1,765 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testsuite
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/internal/randutil"
+	"github.com/containerd/errdefs"
+)
+
+// ---------------------------------------------------------------------------
+// Basic lifecycle
+// ---------------------------------------------------------------------------
+
+// fsCheckSnapshotterBasic exercises the full lifecycle: create a layer, commit
+// it, stack a second layer, and verify the stacked result matches the
+// flattened result at each step.
+func fsCheckSnapshotterBasic(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	initial := []fsChange{
+		fsCreateFile("/foo", []byte("foo\n"), 0777),
+		fsMkdir("/a", 0755),
+		fsMkdir("/a/b", 0755),
+		fsMkdir("/a/b/c", 0755),
+	}
+	diff := []fsChange{
+		fsCreateFile("/bar", []byte("bar\n"), 0777),
+		fsCreateFile("/foo", []byte("bar\n"), 0777), // overwrite foo
+		fsRemove("/a/b"),
+	}
+
+	if err := fsCheckSnapshots(ctx, sn, work, initial, diff); err != nil {
+		t.Fatalf("check snapshots: %+v", err)
+	}
+
+	// Verify the lifecycle/stat/remove semantics on a concrete chain.
+	c1, err := fsCreateLayer(ctx, sn, "", work, initial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	si, err := sn.Stat(ctx, c1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Empty(t, si.Parent)
+	assert.Equal(t, snapshots.KindCommitted, si.Kind)
+
+	c2, err := fsCreateLayer(ctx, sn, c1, work, diff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	si2, err := sn.Stat(ctx, c2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, c1, si2.Parent)
+	assert.Equal(t, snapshots.KindCommitted, si2.Kind)
+
+	// Removing a parent with a child must fail.
+	err = sn.Remove(ctx, c1)
+	assert.NotNil(t, err)
+	if err != nil {
+		assert.Contains(t, err.Error(), "remove")
+	}
+	assert.Nil(t, sn.Remove(ctx, c2))
+	assert.Nil(t, sn.Remove(ctx, c1))
+}
+
+// ---------------------------------------------------------------------------
+// Stat tests
+// ---------------------------------------------------------------------------
+
+func fsCheckSnapshotterStatActive(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	preparing := filepath.Join(work, "preparing")
+
+	mounts, err := sn.Prepare(ctx, preparing, "", fsOpt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mounts) < 1 {
+		t.Fatal("expected mounts to have entries")
+	}
+	if err := applyLayer(mounts, []fsChange{fsCreateFile("/foo", []byte("foo\n"), 0777)}); err != nil {
+		_ = sn.Remove(ctx, preparing)
+		t.Fatal(err)
+	}
+
+	si, err := sn.Stat(ctx, preparing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, si.Name, preparing)
+	assert.Equal(t, snapshots.KindActive, si.Kind)
+	assert.Equal(t, "", si.Parent)
+}
+
+func fsCheckSnapshotterStatCommitted(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	committed, err := fsCreateLayer(ctx, sn, "", work, []fsChange{fsCreateFile("/foo", []byte("foo\n"), 0777)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	si, err := sn.Stat(ctx, committed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, si.Name, committed)
+	assert.Equal(t, snapshots.KindCommitted, si.Kind)
+	assert.Equal(t, "", si.Parent)
+}
+
+// ---------------------------------------------------------------------------
+// Transitivity
+// ---------------------------------------------------------------------------
+
+func fsCheckSnapshotterTransitivity(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	snapA, err := fsCreateLayer(ctx, sn, "", work, []fsChange{fsCreateFile("/foo", []byte("foo\n"), 0777)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapB, err := fsCreateLayer(ctx, sn, snapA, work, []fsChange{fsCreateFile("/foo", []byte("foo bar\n"), 0777)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	siA, err := sn.Stat(ctx, snapA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	siB, err := sn.Stat(ctx, snapB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	siParentB, err := sn.Stat(ctx, siB.Parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "", siA.Parent)
+	assert.Equal(t, snapA, siB.Parent)
+	assert.Equal(t, "", siParentB.Parent)
+}
+
+// ---------------------------------------------------------------------------
+// Duplicate Prepare/View keys
+// ---------------------------------------------------------------------------
+
+func fsCheckSnapshotterPrepareView(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	snapA, err := fsCreateLayer(ctx, sn, "", work, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newLayer := filepath.Join(work, "newlayer")
+	if _, err = sn.Prepare(ctx, newLayer, snapA, fsOpt); err != nil {
+		t.Fatal(err)
+	}
+	_, err = sn.View(ctx, newLayer, snapA, fsOpt)
+	assert.True(t, err != nil)
+
+	prepLayer := filepath.Join(work, "prepLayer")
+	if _, err = sn.Prepare(ctx, prepLayer, snapA, fsOpt); err != nil {
+		t.Fatal(err)
+	}
+	_, err = sn.Prepare(ctx, prepLayer, snapA, fsOpt)
+	assert.True(t, err != nil)
+
+	viewLayer := filepath.Join(work, "viewLayer")
+	if _, err = sn.View(ctx, viewLayer, snapA, fsOpt); err != nil {
+		t.Fatal(err)
+	}
+	_, err = sn.View(ctx, viewLayer, snapA, fsOpt)
+	assert.True(t, err != nil)
+}
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
+
+func fsCheckUpdate(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	t1 := time.Now().UTC()
+	if err := fsBaseTestSnapshots(ctx, sn, work); err != nil {
+		t.Fatalf("Failed to create base snapshots: %v", err)
+	}
+	t2 := time.Now().UTC()
+
+	testcases := []struct {
+		name   string
+		kind   snapshots.Kind
+		parent string
+	}{
+		{name: "c1", kind: snapshots.KindCommitted},
+		{name: "c2", kind: snapshots.KindCommitted, parent: "c1"},
+		{name: "a1", kind: snapshots.KindActive, parent: "c2"},
+		{name: "a2", kind: snapshots.KindActive},
+		{name: "v1", kind: snapshots.KindView, parent: "c2"},
+		{name: "v2", kind: snapshots.KindView},
+	}
+
+	for _, tc := range testcases {
+		st, err := sn.Stat(ctx, tc.name)
+		if err != nil {
+			t.Fatalf("Failed to stat %s: %v", tc.name, err)
+		}
+		if st.Created.Before(t1) || st.Created.After(t2) {
+			t.Errorf("(%s) wrong created time %s: expected between %s and %s", tc.name, st.Created, t1, t2)
+			continue
+		}
+		if st.Created != st.Updated {
+			t.Errorf("(%s) unexpected updated time %s: expected %s", tc.name, st.Updated, st.Created)
+			continue
+		}
+		if st.Kind != tc.kind {
+			t.Errorf("(%s) unexpected kind %s, expected %s", tc.name, st.Kind, tc.kind)
+			continue
+		}
+		if st.Parent != tc.parent {
+			t.Errorf("(%s) unexpected parent %q, expected %q", tc.name, st.Parent, tc.parent)
+			continue
+		}
+
+		createdAt := st.Created
+		rootTime := time.Now().UTC().Format(time.RFC3339)
+		expectedLabels := map[string]string{
+			"l1":                    "v1",
+			"l2":                    "v2",
+			"l3":                    "v3",
+			"containerd.io/gc.root": rootTime,
+		}
+		st.Parent = "doesnotexist"
+		st.Labels = expectedLabels
+		u1 := time.Now().UTC()
+		st, err = sn.Update(ctx, st)
+		if err != nil {
+			t.Fatalf("Failed to update %s: %v", tc.name, err)
+		}
+		u2 := time.Now().UTC()
+
+		if st.Created != createdAt {
+			t.Errorf("(%s) wrong created time after Update %s: expected %s", tc.name, st.Created, createdAt)
+		}
+		if st.Updated.Before(u1) || st.Updated.After(u2) {
+			t.Errorf("(%s) wrong updated time %s: expected between %s and %s", tc.name, st.Updated, u1, u2)
+		}
+		if st.Kind != tc.kind {
+			t.Errorf("(%s) unexpected kind %s after Update", tc.name, st.Kind)
+		}
+		if st.Parent != tc.parent {
+			t.Errorf("(%s) unexpected parent %q after Update (should be immutable)", tc.name, st.Parent)
+		}
+		assertLabels(t, st.Labels, expectedLabels)
+
+		expectedLabels2 := map[string]string{
+			"l1":                    "updated",
+			"l3":                    "v3",
+			"containerd.io/gc.root": rootTime,
+		}
+		st.Labels = map[string]string{"l1": "updated", "l4": "v4"}
+		st, err = sn.Update(ctx, st, "labels.l1", "labels.l2")
+		if err != nil {
+			t.Fatalf("Failed to update %s: %v", tc.name, err)
+		}
+		assertLabels(t, st.Labels, expectedLabels2)
+
+		expectedLabels3 := map[string]string{
+			"l4":                    "v4",
+			"containerd.io/gc.root": rootTime,
+		}
+		st.Labels = expectedLabels3
+		st, err = sn.Update(ctx, st, "labels")
+		if err != nil {
+			t.Fatalf("Failed to update %s: %v", tc.name, err)
+		}
+		assertLabels(t, st.Labels, expectedLabels3)
+
+		st.Parent = "doesnotexist"
+		st, err = sn.Update(ctx, st, "parent")
+		if err == nil {
+			t.Errorf("Expected error updating with immutable field path")
+		} else if !errdefs.IsInvalidArgument(err) {
+			t.Fatalf("Unexpected error updating %s: %+v", tc.name, err)
+		}
+	}
+}
+
+// fsBaseTestSnapshots creates the base snapshot set used by Update.
+func fsBaseTestSnapshots(ctx context.Context, sn snapshots.Snapshotter, work string) error {
+	if err := fsCommitNamed(ctx, sn, work, "c1-a", "c1", ""); err != nil {
+		return err
+	}
+	if err := fsCommitNamed(ctx, sn, work, "c2-a", "c2", "c1"); err != nil {
+		return err
+	}
+	if _, err := sn.Prepare(ctx, "a1", "c2", fsOpt); err != nil {
+		return err
+	}
+	if _, err := sn.Prepare(ctx, "a2", "", fsOpt); err != nil {
+		return err
+	}
+	if _, err := sn.View(ctx, "v1", "c2", fsOpt); err != nil {
+		return err
+	}
+	if _, err := sn.View(ctx, "v2", "", fsOpt); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Remove
+// ---------------------------------------------------------------------------
+
+func fsCheckRemove(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	if err := fsCommitNamed(ctx, sn, work, "committed-a", "committed-1", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sn.Prepare(ctx, "reuse-1", "committed-1", fsOpt); err != nil {
+		t.Fatal(err)
+	}
+	if err := sn.Remove(ctx, "reuse-1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sn.View(ctx, "reuse-1", "committed-1", fsOpt); err != nil {
+		t.Fatal(err)
+	}
+	if err := sn.Remove(ctx, "reuse-1"); err != nil {
+		t.Fatal(err)
+	}
+	// Prepare reuse-1, remove committed-1 while reuse-1 is active (no parent),
+	// then commit reuse-1 as committed-1. The Prepare/apply/Commit is split
+	// because the removal of committed-1 happens between them.
+	mounts, err := sn.Prepare(ctx, "reuse-1", "", fsOpt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := applyLayer(mounts, nil); err != nil {
+		_ = sn.Remove(ctx, "reuse-1")
+		t.Fatal(err)
+	}
+	if err := sn.Remove(ctx, "committed-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sn.Commit(ctx, "committed-1", "reuse-1", fsOpt); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walk
+// ---------------------------------------------------------------------------
+
+func fsCheckWalk(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	walkOpt := snapshots.WithLabels(map[string]string{
+		"containerd.io/gc.root": "check-walk",
+	})
+	walkLabel1Opt := snapshots.WithLabels(map[string]string{
+		"l":                     "1",
+		"containerd.io/gc.root": "check-walk",
+	})
+
+	if _, err := sn.Prepare(ctx, "a-np", "", walkOpt); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsCommitNamed(ctx, sn, work, "p-tmp", "p", "", walkOpt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sn.Prepare(ctx, "a", "p", walkOpt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sn.View(ctx, "v", "p", walkOpt); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsCommitNamed(ctx, sn, work, "p-wl-tmp", "p-wl", "", walkLabel1Opt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sn.Prepare(ctx, "a-wl", "p-wl", snapshots.WithLabels(map[string]string{
+		"l":                     "2",
+		"containerd.io/gc.root": "check-walk",
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sn.View(ctx, "v-wl", "p-wl", snapshots.WithLabels(map[string]string{
+		"l":                     "3",
+		"containerd.io/gc.root": "check-walk",
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sn.Prepare(ctx, "a-np-wl", "", snapshots.WithLabels(map[string]string{
+		"l":                     "2",
+		"containerd.io/gc.root": "check-walk",
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range []struct {
+		matches []string
+		filters []string
+	}{
+		{
+			matches: []string{"a-np", "p", "a", "v", "p-wl", "a-wl", "v-wl", "a-np-wl"},
+			filters: []string{`labels."containerd.io/gc.root"==check-walk`},
+		},
+		{
+			matches: []string{"a-np", "a", "a-wl", "a-np-wl"},
+			filters: []string{`kind==active,labels."containerd.io/gc.root"==check-walk`},
+		},
+		{
+			matches: []string{"v", "v-wl"},
+			filters: []string{`kind==view,labels."containerd.io/gc.root"==check-walk`},
+		},
+		{
+			matches: []string{"p", "p-wl"},
+			filters: []string{`kind==committed,labels."containerd.io/gc.root"==check-walk`},
+		},
+		{
+			matches: []string{"p", "a-np-wl"},
+			filters: []string{"name==p", "name==a-np-wl"},
+		},
+		{
+			matches: []string{"a-wl"},
+			filters: []string{"name==a-wl,labels.l"},
+		},
+		{
+			matches: []string{"a", "v"},
+			filters: []string{"parent==p"},
+		},
+		{
+			matches: []string{"a", "v", "a-wl", "v-wl"},
+			filters: []string{`parent!="",labels."containerd.io/gc.root"==check-walk`},
+		},
+		{
+			matches: []string{"p-wl", "a-wl", "v-wl", "a-np-wl"},
+			filters: []string{"labels.l"},
+		},
+		{
+			matches: []string{"a-wl", "a-np-wl"},
+			filters: []string{"labels.l==2"},
+		},
+	} {
+		actual := []string{}
+		err := sn.Walk(ctx, func(ctx context.Context, si snapshots.Info) error {
+			actual = append(actual, si.Name)
+			return nil
+		}, tc.filters...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sort.Strings(tc.matches)
+		sort.Strings(actual)
+		if len(actual) != len(tc.matches) {
+			t.Errorf("[%d] size mismatch:\n got %#v\nwant %#v", i, actual, tc.matches)
+			continue
+		}
+		for j := range actual {
+			if actual[j] != tc.matches[j] {
+				t.Errorf("[%d] @%d:\n got %#v\nwant %#v", i, j, actual, tc.matches)
+				break
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// View read-only check
+// ---------------------------------------------------------------------------
+
+func fsCheckSnapshotterViewReadonly(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	committed := filepath.Join(work, "committed")
+	if err := fsCommitNamed(ctx, sn, work, filepath.Join(work, "preparing"), committed, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	view := filepath.Join(work, "view")
+	m, err := sn.View(ctx, view, committed, fsOpt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sn.Remove(ctx, view)
+	defer sn.Remove(ctx, committed)
+
+	hasRO := false
+	for _, mnt := range m {
+		for _, opt := range mnt.Options {
+			if opt == "ro" {
+				hasRO = true
+			}
+		}
+	}
+	if !hasRO {
+		t.Logf("View mounts: %+v", m)
+		t.Error("View mounts should have 'ro' option")
+	}
+
+	// The fs.FS interface is read-only by contract; confirm the view opens.
+	v, closeV, err := fsMountsView(m)
+	if err != nil {
+		t.Fatalf("FSMounts: %+v", err)
+	}
+	defer closeV()
+	root, err := v.Open(".")
+	if err != nil {
+		t.Fatalf("Open root via view: %+v", err)
+	}
+	root.Close()
+}
+
+// ---------------------------------------------------------------------------
+// StatInWalk
+// ---------------------------------------------------------------------------
+
+func fsCheckStatInWalk(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	prefix := "fs-stats-in-walk-"
+	if err := fsCreateNamedSnapshots(ctx, sn, work, prefix); err != nil {
+		t.Fatal(err)
+	}
+
+	err := sn.Walk(ctx, func(ctx context.Context, si snapshots.Info) error {
+		if !strings.HasPrefix(si.Name, prefix) {
+			return nil
+		}
+		si2, err := sn.Stat(ctx, si.Name)
+		if err != nil {
+			return err
+		}
+		return checkInfo(si, si2)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fsCreateNamedSnapshots(ctx context.Context, sn snapshots.Snapshotter, work, ns string) error {
+	c1 := fmt.Sprintf("%sc1", ns)
+	c2 := fmt.Sprintf("%sc2", ns)
+	if err := fsCommitNamed(ctx, sn, work, c1+"-a", c1, ""); err != nil {
+		return err
+	}
+	if err := fsCommitNamed(ctx, sn, work, c2+"-a", c2, c1); err != nil {
+		return err
+	}
+	if _, err := sn.Prepare(ctx, fmt.Sprintf("%sa1", ns), c2, fsOpt); err != nil {
+		return err
+	}
+	if _, err := sn.View(ctx, fmt.Sprintf("%sv1", ns), c2, fsOpt); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// CloseTwice
+// ---------------------------------------------------------------------------
+
+func fsCloseTwice(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	n := fmt.Sprintf("fsCloseTwice-%d", randutil.Int())
+	if err := fsCommitNamed(ctx, sn, work, n+"-prepare", n, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := sn.Remove(ctx, n); err != nil {
+		t.Fatal(err)
+	}
+	if err := sn.Close(); err != nil {
+		t.Fatalf("First close failed: %+v", err)
+	}
+	if err := sn.Close(); err != nil {
+		t.Fatalf("Second close failed: %+v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RootPermission
+// ---------------------------------------------------------------------------
+
+func fsCheckRootPermission(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Filesystem permissions are not supported on Windows")
+	}
+
+	preparing := filepath.Join(work, "preparing")
+	mounts, err := sn.Prepare(ctx, preparing, "", fsOpt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sn.Remove(ctx, preparing)
+
+	v, closeV, err := fsMountsView(mounts)
+	if err != nil {
+		t.Fatalf("FSMounts: %+v", err)
+	}
+	defer closeV()
+
+	f, err := v.Open(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0755 {
+		t.Fatalf("expected root perm 0755, got 0%o", perm)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RemoveIntermediateSnapshot
+// ---------------------------------------------------------------------------
+
+func fsCheckRemoveIntermediateSnapshot(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	base, err := fsCreateLayer(ctx, sn, "", work, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inter, err := fsCreateLayer(ctx, sn, base, work, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	topLayer := filepath.Join(work, "toplayer")
+	if _, err = sn.Prepare(ctx, topLayer, inter, fsOpt); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = sn.Remove(ctx, inter); err == nil {
+		t.Fatal("intermediate layer removal should fail")
+	}
+
+	if err = sn.Remove(ctx, topLayer); err != nil {
+		t.Fatal(err)
+	}
+	if err = sn.Remove(ctx, inter); err != nil {
+		t.Fatal(err)
+	}
+	if err = sn.Remove(ctx, base); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rename (snapshotter-specific behaviour)
+// ---------------------------------------------------------------------------
+
+func fsCheckRename(name string) func(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	return func(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+		l1 := []fsChange{
+			fsMkdir("/dir1", 0700),
+			fsMkdir("/somefiles", 0700),
+			fsCreateFile("/somefiles/f1", []byte("was here first!"), 0644),
+			fsCreateFile("/somefiles/f2", []byte("nothing interesting"), 0644),
+		}
+
+		var l2 []fsChange
+		// Renaming a lower-layer directory needs overlay redirect_dir support,
+		// which the overlay-composed snapshotters lack; skip that one change.
+		switch name {
+		case "overlayfs", "fuse-overlayfs", "erofs":
+		default:
+			l2 = append(l2, fsRename("/dir1", "/dir2"))
+		}
+		l2 = append(l2,
+			fsCreateFile("/somefiles/f1-overwrite", []byte("new content 1"), 0644),
+			fsRename("/somefiles/f1-overwrite", "/somefiles/f1"),
+			fsRename("/somefiles/f2", "/somefiles/f3"),
+		)
+
+		if err := fsCheckSnapshots(ctx, sn, work, l1, l2); err != nil {
+			t.Fatalf("check snapshots: %+v", err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 128 Layers
+// ---------------------------------------------------------------------------
+
+func fsCheck128Layers(name string) func(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	return func(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+		layers := [][]fsChange{{
+			fsCreateFile("/bottom", []byte("way at the bottom\n"), 0777),
+			fsCreateFile("/overwriteme", []byte("FIRST!\n"), 0777),
+			fsMkdir("/addhere", 0755),
+			fsMkdir("/onlyme", 0755),
+			fsCreateFile("/onlyme/bottom", []byte("bye!\n"), 0777),
+		}}
+		for i := 1; i <= 127; i++ {
+			layers = append(layers, []fsChange{
+				fsCreateFile("/overwriteme", []byte(fmt.Sprintf("%d WAS HERE!\n", i)), 0777),
+				fsCreateFile(fmt.Sprintf("/addhere/file-%d", i), []byte("same\n"), 0755),
+				fsRemove("/onlyme"),
+				fsMkdir("/onlyme", 0755),
+				fsCreateFile(fmt.Sprintf("/onlyme/file-%d", i), []byte("only me!\n"), 0777),
+			})
+		}
+
+		if err := fsCheckSnapshots(ctx, sn, work, layers...); err != nil {
+			t.Fatalf("check snapshots: %+v", err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeletedFilesInChildSnapshot
+// ---------------------------------------------------------------------------
+
+func fsCheckDeletedFilesInChildSnapshot(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	l1 := []fsChange{
+		fsCreateFile("/foo", []byte("foo\n"), 0777),
+		fsCreateFile("/foobar", []byte("foobar\n"), 0777),
+	}
+	l2 := []fsChange{fsRemove("/foobar")}
+	var l3 []fsChange
+
+	if err := fsCheckSnapshots(ctx, sn, work, l1, l2, l3); err != nil {
+		t.Fatalf("check snapshots: %+v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MoveFileFromLowerLayer
+// ---------------------------------------------------------------------------
+
+func fsCheckFileFromLowerLayer(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, work string) {
+	l1 := []fsChange{
+		fsMkdir("/dir1", 0700),
+		fsCreateFile("/dir1/f1", []byte("Hello"), 0644),
+		fsMkdir("/dir2", 0700),
+		fsCreateFile("/dir2/f2", []byte("..."), 0644),
+	}
+	l2 := []fsChange{
+		fsMkdir("/dir3", 0700),
+		fsCreateFile("/dir3/f1", []byte("Hello"), 0644),
+		fsRemove("/dir1"),
+		fsLink("/dir2/f2", "/dir3/f2"),
+		fsRemove("/dir2/f2"),
+	}
+
+	if err := fsCheckSnapshots(ctx, sn, work, l1, l2); err != nil {
+		t.Fatalf("check snapshots: %+v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 	github.com/docker/go-metrics v0.0.1
 	github.com/docker/go-units v0.5.0
-	github.com/erofs/go-erofs v0.3.0
+	github.com/erofs/go-erofs v0.3.1-0.20260703080254-f80970c14446
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/certtostore v1.0.6
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/erofs/go-erofs v0.3.0 h1:o/W5ABAA3sHYl97WL93dacKEfeDpJhdFf3c2snAti7I=
-github.com/erofs/go-erofs v0.3.0/go.mod h1:XkSeN9MHszGd4+3gcEjadJLYHCQpWzJ7/8yznzMuzJs=
+github.com/erofs/go-erofs v0.3.1-0.20260703080254-f80970c14446 h1:pi8OYgy2G5Uv8Tf4TjETvv91VVltEzrlRCE6kxCcy8U=
+github.com/erofs/go-erofs v0.3.1-0.20260703080254-f80970c14446/go.mod h1:XkSeN9MHszGd4+3gcEjadJLYHCQpWzJ7/8yznzMuzJs=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/plugins/snapshots/erofs/erofs_fs_test.go
+++ b/plugins/snapshots/erofs/erofs_fs_test.go
@@ -1,0 +1,49 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package erofs contains the erofs snapshotter.
+//
+// This file runs SnapshotterFSSuite against the erofs snapshotter. It builds
+// layers as EROFS images and inspects snapshots through fs.FS, so it needs no
+// kernel mounts, no root, and no Linux-specific features; it runs on all
+// platforms where the snapshotter can be instantiated.
+package erofs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/testsuite"
+
+	// Register the fsview erofs handler so that FSMounts can open erofs images.
+	_ "github.com/containerd/containerd/v2/plugins/mount/fsview/erofs"
+)
+
+// newFSSnapshotter creates an erofs snapshotter for the fs.FS test suite.
+func newFSSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
+	sn, err := NewSnapshotter(root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sn, func() error { return sn.Close() }, nil
+}
+
+// TestErofsFS runs the fs.FS-based snapshot test suite against the erofs
+// snapshotter. No root privileges are required.
+func TestErofsFS(t *testing.T) {
+	testsuite.SnapshotterFSSuite(t, "erofs", newFSSnapshotter)
+}

--- a/plugins/snapshots/native/native_fs_test.go
+++ b/plugins/snapshots/native/native_fs_test.go
@@ -1,0 +1,52 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package native contains the native copy-on-write snapshotter.
+//
+// This file runs SnapshotterFSSuite against the native snapshotter. Each
+// active snapshot is a directory copy of its parent, so layer changes are
+// applied with ordinary filesystem operations and inspected through fs.FS.
+// Ownership changes require privileges, so the test requires root.
+package native
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/testsuite"
+	"github.com/containerd/containerd/v2/pkg/testutil"
+)
+
+// newFSSnapshotter creates a native snapshotter for the fs.FS test suite.
+func newFSSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
+	sn, err := NewSnapshotter(root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sn, func() error { return sn.Close() }, nil
+}
+
+// TestNativeFS runs the fs.FS-based snapshot test suite against the native
+// snapshotter. It requires root for ownership operations.
+func TestNativeFS(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("native snapshotter is only supported on Linux")
+	}
+	testutil.RequiresRoot(t)
+	testsuite.SnapshotterFSSuite(t, "Native", newFSSnapshotter)
+}

--- a/plugins/snapshots/overlay/overlay_fs_test.go
+++ b/plugins/snapshots/overlay/overlay_fs_test.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package overlay contains the overlay snapshotter.
+//
+// This file runs SnapshotterFSSuite against the overlay snapshotter. It writes
+// layers to the overlayfs upperdir directly and inspects snapshots through
+// fs.FS. Overlay whiteouts and ownership changes require privileges, so the
+// test requires root.
+package overlay
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/snapshots/testsuite"
+	"github.com/containerd/containerd/v2/pkg/testutil"
+)
+
+// newFSSnapshotter creates an overlay snapshotter for the fs.FS test suite.
+func newFSSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
+	sn, err := NewSnapshotter(root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sn, func() error { return sn.Close() }, nil
+}
+
+// TestOverlayFS runs the fs.FS-based snapshot test suite against the overlay
+// snapshotter. It requires root for whiteout and ownership operations.
+func TestOverlayFS(t *testing.T) {
+	testutil.RequiresRoot(t)
+	testsuite.SnapshotterFSSuite(t, "overlayfs", newFSSnapshotter)
+}

--- a/vendor/github.com/erofs/go-erofs/erofs.go
+++ b/vendor/github.com/erofs/go-erofs/erofs.go
@@ -97,6 +97,39 @@ type Stat struct {
 	Xattrs      map[string]string
 }
 
+// holeOffset is the sentinel value for DataRange.Offset that marks a hole
+// (a sparse region of zeros) rather than backed device data.
+const holeOffset int64 = -1
+
+// DataRange describes one entry in the complete logical layout of a file's
+// content. A slice of DataRange values returned by [fileInfo.DataRange]
+// covers the file from logical byte 0 to logical byte [fs.FileInfo.Size]-1
+// in order, with no gaps or overlaps.
+//
+// The sum of all Size values in the slice must equal the file size exactly.
+// A slice whose sizes do not sum to the file size is invalid.
+//
+// Each entry is either a data entry or a hole entry:
+//
+//   - A data entry has Offset >= 0. The bytes at [Offset, Offset+Size) in
+//     Device are the file's content verbatim — uncompressed, unreferenced
+//     by transformation.
+//   - A hole entry has Offset == -1. It represents Size bytes of zeros at the
+//     current logical position. Device is ignored for hole entries.
+//
+// Compressed data should not be represented as a DataRange. When a source
+// FS contains compressed files, it should not provide DataRange() []DataRange
+// for those files (or should return nil). In full-image mode CopyFrom will
+// fall back to reading through Open(), which decompresses transparently, and
+// write the decompressed data into the output image. In MetadataOnly mode
+// there is no such fallback: files without DataRange() (or pre-built chunks)
+// are stored as chunk-based inodes with no physical mappings (all holes).
+type DataRange struct {
+	Device uint16 // device index (0 for the device assigned by CopyFrom); ignored for holes
+	Offset int64  // byte offset in the device, or -1 for a hole entry
+	Size   int64  // byte length of this entry
+}
+
 type options struct {
 	extraDevices []io.ReaderAt
 }
@@ -336,7 +369,10 @@ func (img *image) openDirect(ino *inode) io.Reader {
 		if baseOffset%8 != 0 {
 			baseOffset = (baseOffset + 7) & ^int64(7)
 		}
-		needed := int64(nchunks * disk.SizeChunkIndex)
+		needed := int64(nchunks) * int64(disk.SizeChunkIndex)
+		if needed > maxChunkIndexBytes {
+			return nil
+		}
 		idxBuf := make([]byte, needed)
 		if _, err := img.meta.ReadAt(idxBuf, baseOffset); err != nil {
 			return nil
@@ -1047,12 +1083,146 @@ func (b *file) statInfo() (*fileInfo, error) {
 			return nil, err
 		}
 	}
+	// Build data ranges for regular files.
+	// Flat layouts are cheap (no I/O) — compute eagerly.
+	// Chunk-based layout requires a ReadAt on the image; defer until needed.
+	if ino.mode.IsRegular() && ino.size > 0 {
+		if ino.inodeLayout == disk.LayoutChunkBased {
+			// Capture a snapshot of the fields buildChunkDataRanges needs.
+			// We must not capture ino by pointer: the caller may reuse it,
+			// and cached block is released below.
+			inoCopy := *ino
+			inoCopy.cached = nil
+			img := b.img
+			fi.rangesLoader = func() []DataRange {
+				f := &file{img: img}
+				return f.buildChunkDataRanges(&inoCopy)
+			}
+		} else {
+			fi.dataRanges = b.buildDataRanges(ino)
+		}
+	}
 	// Release cached block - stat callers don't need inline data
 	if ino.cached != nil {
 		b.img.putBlock(ino.cached)
 		ino.cached = nil
 	}
 	return fi, nil
+}
+
+// buildDataRanges computes the physical data ranges for a regular file.
+func (b *file) buildDataRanges(ino *inode) []DataRange {
+	blockSize := int64(1 << b.img.sb.BlkSizeBits)
+	switch ino.inodeLayout {
+	case disk.LayoutFlatPlain:
+		dataOffset := int64(ino.inodeData) << b.img.sb.BlkSizeBits
+		return []DataRange{{Device: 0, Offset: dataOffset, Size: ino.size}}
+	case disk.LayoutFlatInline:
+		inodeAddr := b.img.metaStartPos() + int64(ino.nid)*disk.SizeInodeCompact
+		trailingAddr := inodeAddr + ino.flatDataOffset()
+		if ino.size <= blockSize {
+			return []DataRange{{Device: 0, Offset: trailingAddr, Size: ino.size}}
+		}
+		// Multi-block inline: earlier full blocks at dataBlkAddr, last block inline.
+		// headSize is the number of complete blocks before the inline tail, in bytes.
+		// ino.inodeData is the starting block address, not a block count.
+		headSize := ((ino.size - 1) / blockSize) * blockSize
+		tailSize := ino.size - headSize
+		var ranges []DataRange
+		if headSize > 0 {
+			dataOffset := int64(ino.inodeData) << b.img.sb.BlkSizeBits
+			ranges = append(ranges, DataRange{Device: 0, Offset: dataOffset, Size: headSize})
+		}
+		ranges = append(ranges, DataRange{Device: 0, Offset: trailingAddr, Size: tailSize})
+		return ranges
+	case disk.LayoutChunkBased:
+		return b.buildChunkDataRanges(ino)
+	}
+	return nil
+}
+
+// maxChunkIndexBytes is an upper bound on the chunk-index table we will
+// allocate for a single file. 64 MiB covers ~8 M chunks; no real EROFS image
+// should approach this, and it prevents allocation bombs from corrupt images.
+const maxChunkIndexBytes = 64 << 20 // 64 MiB
+
+// buildChunkDataRanges parses chunk indexes into DataRange entries covering
+// the complete logical layout of the file. The returned slice satisfies the
+// DataRange contract: entries are in logical-file order and their sizes sum
+// to ino.size exactly.
+//
+// Null/hole chunks are emitted as DataRange{Offset: -1, Size: ...} entries.
+// Consecutive null chunks coalesce into a single hole entry.
+// Adjacent data chunks that are physically contiguous on the same device
+// merge into one entry. Data chunks never merge across a hole boundary.
+//
+// The final entry (data or hole) has its Size trimmed to the file-tail length
+// so the invariant sum(Size) == ino.size holds precisely.
+func (b *file) buildChunkDataRanges(ino *inode) []DataRange {
+	chunkFmt := uint16(ino.inodeData)
+	if chunkFmt&disk.LayoutChunkFormatIndexes == 0 {
+		return nil
+	}
+	// 48-bit chunk addressing is not yet implemented; the null-chunk sentinel
+	// (blkLo == 0xFFFFFFFF) is only unambiguous in 32-bit address mode.
+	if chunkFmt&disk.LayoutChunkFormat48Bit != 0 {
+		return nil
+	}
+	chunkBits := b.img.sb.BlkSizeBits + uint8(chunkFmt&disk.LayoutChunkFormatBits)
+	nchunks := int((ino.size-1)>>chunkBits) + 1
+	chunkSize := int64(1) << chunkBits
+
+	inodeStart := b.img.metaStartPos() + int64(ino.nid)*disk.SizeInodeCompact
+	baseOffset := inodeStart + ino.flatDataOffset()
+	if baseOffset%8 != 0 {
+		baseOffset = (baseOffset + 7) & ^int64(7)
+	}
+	needed := int64(nchunks) * int64(disk.SizeChunkIndex)
+	if needed > maxChunkIndexBytes {
+		return nil
+	}
+	idxBuf := make([]byte, needed)
+	if _, err := b.img.meta.ReadAt(idxBuf, baseOffset); err != nil {
+		return nil
+	}
+
+	var ranges []DataRange
+	for i := range nchunks {
+		// Size of this logical chunk: full chunkSize for all but the last.
+		size := chunkSize
+		if i == nchunks-1 {
+			size = ino.size - int64(i)*chunkSize
+		}
+
+		off := i * disk.SizeChunkIndex
+		blkLo := binary.LittleEndian.Uint32(idxBuf[off+4 : off+8])
+		if ^blkLo == 0 {
+			// Null/hole chunk: coalesce with a preceding hole if possible.
+			if len(ranges) > 0 && ranges[len(ranges)-1].Offset == holeOffset {
+				ranges[len(ranges)-1].Size += size
+			} else {
+				ranges = append(ranges, DataRange{Offset: holeOffset, Size: size})
+			}
+			continue
+		}
+
+		blkHi := binary.LittleEndian.Uint16(idxBuf[off : off+2])
+		deviceID := binary.LittleEndian.Uint16(idxBuf[off+2:off+4]) & b.img.deviceIDMask
+		phys := (uint64(blkHi) << 32) | uint64(blkLo)
+		byteOffset := int64(phys) << b.img.sb.BlkSizeBits
+
+		// Merge with the previous entry if it is a data range that is
+		// physically contiguous on the same device.
+		if len(ranges) > 0 {
+			prev := &ranges[len(ranges)-1]
+			if prev.Offset != holeOffset && prev.Device == deviceID && prev.Offset+prev.Size == byteOffset {
+				prev.Size += size
+				continue
+			}
+		}
+		ranges = append(ranges, DataRange{Device: deviceID, Offset: byteOffset, Size: size})
+	}
+	return ranges
 }
 
 func (b *file) Stat() (fs.FileInfo, error) {
@@ -1454,12 +1624,21 @@ func (ino *inode) flatDataOffset() int64 {
 //
 //	if u, ok := fi.(interface{ UID() uint32 }); ok { uid = u.UID() }
 type fileInfo struct {
-	name    string
-	size    int64
-	mode    fs.FileMode
-	mtime   uint64
-	mtimeNs uint32
-	stat    *Stat
+	name       string
+	size       int64
+	mode       fs.FileMode
+	mtime      uint64
+	mtimeNs    uint32
+	stat       *Stat
+	dataRanges []DataRange
+
+	// rangesOnce and rangesLoader support lazy computation of data ranges
+	// for chunk-based files (LayoutChunkBased). The loader performs a ReadAt
+	// to parse the chunk index, so it is deferred until the caller actually
+	// calls DataRange(). For flat layouts (FlatPlain, FlatInline), ranges
+	// are computed eagerly at stat time since they require no I/O.
+	rangesOnce   sync.Once
+	rangesLoader func() []DataRange
 }
 
 func (fi *fileInfo) Name() string       { return fi.name }
@@ -1473,6 +1652,18 @@ func (fi *fileInfo) GID() uint32        { return fi.stat.GID }
 func (fi *fileInfo) Ino() uint64        { return uint64(fi.stat.Ino) }
 func (fi *fileInfo) Nlink() uint64      { return uint64(fi.stat.Nlink) }
 func (fi *fileInfo) Rdev() uint64       { return uint64(fi.stat.Rdev) }
+
+// DataRange returns the physical data ranges for this file's uncompressed
+// content. Returns nil for compressed files, directories, symlinks, and
+// other non-regular entries.
+func (fi *fileInfo) DataRange() []DataRange {
+	if fi.rangesLoader != nil {
+		fi.rangesOnce.Do(func() {
+			fi.dataRanges = fi.rangesLoader()
+		})
+	}
+	return fi.dataRanges
+}
 
 // GetAllXattr returns all extended attributes.
 func (fi *fileInfo) GetAllXattr() map[string]string { return fi.stat.Xattrs }

--- a/vendor/github.com/erofs/go-erofs/internal/builder/entry.go
+++ b/vendor/github.com/erofs/go-erofs/internal/builder/entry.go
@@ -19,9 +19,16 @@ type Entry struct {
 	MetadataOnly bool      // chunk-based layout even without chunks
 }
 
+// NullPhysicalBlock is the sentinel value for Chunk.PhysicalBlock that marks
+// a hole (a sparse region of zero bytes). It corresponds to the on-disk
+// EROFS null chunk encoding (StartBlkHi=0xFFFF, StartBlkLo=0xFFFFFFFF).
+const NullPhysicalBlock uint64 = ^uint64(0)
+
 // Chunk maps a range of logical blocks to physical blocks on a device.
+// If PhysicalBlock == NullPhysicalBlock the chunk is a hole: Count logical
+// blocks of zeros with no physical backing. DeviceID is ignored for holes.
 type Chunk struct {
-	PhysicalBlock uint64 // physical block address
+	PhysicalBlock uint64 // physical block address, or NullPhysicalBlock for a hole
 	Count         uint16 // number of contiguous blocks
-	DeviceID      uint16 // 0 = primary, 1+ = extra device
+	DeviceID      uint16 // 0 = primary, 1+ = extra device; ignored for holes
 }

--- a/vendor/github.com/erofs/go-erofs/internal/disk/ftypes.go
+++ b/vendor/github.com/erofs/go-erofs/internal/disk/ftypes.go
@@ -30,7 +30,7 @@ func EroFSFtypeToFileMode(ftype uint8) fs.FileMode {
 	case FileTypeDir:
 		return fs.ModeDir
 	case FileTypeChrdev:
-		return fs.ModeCharDevice
+		return fs.ModeDevice | fs.ModeCharDevice
 	case FileTypeBlkdev:
 		return fs.ModeDevice
 	case FileTypeFifo:
@@ -52,7 +52,7 @@ func EroFSModeToGoFileMode(mode uint16) fs.FileMode {
 	case StatTypeDir:
 		m |= fs.ModeDir
 	case StatTypeChrdev:
-		m |= fs.ModeCharDevice
+		m |= fs.ModeDevice | fs.ModeCharDevice
 	case StatTypeBlkdev:
 		m |= fs.ModeDevice
 	case StatTypeFifo:

--- a/vendor/github.com/erofs/go-erofs/layout.go
+++ b/vendor/github.com/erofs/go-erofs/layout.go
@@ -26,17 +26,27 @@ func (w *erofsWriter) planLayout(root *erofsEntry) {
 	}
 	walk(root)
 
-	w.totalInodes = uint64(len(w.entries))
+	// Secondary hard-link entries share the primary's inode; count only primaries.
+	var inodeCount uint64
+	for _, e := range w.entries {
+		if e.hardLinkPrimary == nil {
+			inodeCount++
+		}
+	}
+	w.totalInodes = inodeCount
 
 	// Block 0 holds: 1024-byte pad + 128-byte superblock + device slot(s) + padding
 	// MetaBlkAddr is set later by write() depending on the on-disk layout.
 
-	// Assign NIDs sequentially.
-	// NID = byte offset from metaStartPos / 32.
-	// Each extended inode is 64 bytes = 2 NID slots.
-	// Trailing data follows and is padded to 32-byte boundary.
+	// Assign NIDs sequentially. NID = byte offset from metaStartPos / 32.
+	// Secondary hard-link entries are skipped here; a second pass copies the
+	// primary's finalized NID to them.
 	currentOff := 0 // byte offset from metaStartPos
 	for _, e := range w.entries {
+		if e.hardLinkPrimary != nil {
+			continue // skip; NID assigned in second pass below
+		}
+
 		e.nid = uint64(currentOff / 32)
 		e.xattrSize = calcXattrSize(e)
 
@@ -132,6 +142,13 @@ func (w *erofsWriter) planLayout(root *erofsEntry) {
 		currentOff += totalInodeSize
 	}
 
+	// Second pass: copy the primary's finalized NID to secondary entries.
+	for _, e := range w.entries {
+		if e.hardLinkPrimary != nil {
+			e.nid = e.hardLinkPrimary.nid
+		}
+	}
+
 	w.rootNid = root.nid
 }
 
@@ -166,29 +183,25 @@ func (w *erofsWriter) calcTrailingSize(e *erofsEntry) int {
 	}
 }
 
-// direntNames returns the sorted list of dirent names for a directory,
-// including "." and "..". EROFS requires dirents within each block to
-// be sorted alphabetically.
-func direntNames(e *erofsEntry) []string {
+// direntDataSize calculates the serialized EROFS dirent data size for a directory.
+// For multi-block directories, this includes inter-block padding.
+func (w *erofsWriter) direntDataSize(e *erofsEntry) int {
+	if len(e.children) == 0 {
+		// Empty dir still needs "." and ".." entries.
+		return 2*disk.SizeDirent + 1 + 2
+	}
+
+	// Build sorted name lengths matching the order writeDirents produces.
+	// "." and ".." are not guaranteed to sort before all real names (any
+	// name with an ASCII value below '.' such as '-' sorts before them).
 	names := make([]string, 0, len(e.children)+2)
 	names = append(names, ".", "..")
 	for _, c := range e.children {
 		names = append(names, c.name)
 	}
 	sort.Strings(names)
-	return names
-}
 
-// direntDataSize calculates the serialized EROFS dirent data size for a directory.
-// For multi-block directories, this includes inter-block padding.
-func (w *erofsWriter) direntDataSize(e *erofsEntry) int {
-	names := direntNames(e)
 	nEntries := len(names)
-	if len(e.children) == 0 {
-		// Empty dir still needs "." and ".." entries
-		return 2*disk.SizeDirent + 1 + 2
-	}
-
 	totalSize := 0
 	i := 0
 	for i < nEntries {
@@ -209,7 +222,7 @@ func (w *erofsWriter) direntDataSize(e *erofsEntry) int {
 			blockUsed = disk.SizeDirent + len(names[i])
 			i++
 		}
-		// Pad non-final blocks to block boundary
+		// Pad non-final blocks to block boundary.
 		if i < nEntries && blockUsed%w.blockSize != 0 {
 			blockUsed = (blockUsed + w.blockSize - 1) & ^(w.blockSize - 1)
 		}

--- a/vendor/github.com/erofs/go-erofs/mkfs.go
+++ b/vendor/github.com/erofs/go-erofs/mkfs.go
@@ -27,6 +27,7 @@ type Writer struct {
 	buildTime    uint64 // from WithBuildTime or buildTimer
 	buildTimeNs  uint32
 	hasBuildTime bool
+	wErr         error               // sticky error: once set, all subsequent ops return it
 	root         *fsEntry            // root directory
 	byPath       map[string]*fsEntry // path → entry (all types)
 
@@ -74,7 +75,7 @@ func Create(out io.WriteSeeker, opts ...CreateOpt) *Writer {
 
 	root := &fsEntry{
 		path: "/",
-		mode: disk.StatTypeDir | 0o755,
+		ino:  &fsInode{mode: disk.StatTypeDir | 0o755},
 	}
 	fsys := &Writer{
 		out:          out,
@@ -85,6 +86,12 @@ func Create(out io.WriteSeeker, opts ...CreateOpt) *Writer {
 		byPath:       map[string]*fsEntry{"/": root},
 		dataFile:     o.dataFile,
 		tempDir:      o.tempDir,
+	}
+
+	if o.blockSize != 0 {
+		if err := fsys.setBlockSize(o.blockSize); err != nil {
+			fsys.wErr = err
+		}
 	}
 
 	if o.dataFile != nil {
@@ -128,6 +135,17 @@ func Merge() CopyOpt {
 
 // --- CreateOpt functions ---
 
+// WithBlockSize sets the filesystem block size. The value must be a power
+// of two between 512 and 64 KiB. When unset the default is 4096.
+// An invalid size causes subsequent Writer operations to return an error.
+// If CopyFrom is called with a source that declares a different block size,
+// CopyFrom returns an error.
+func WithBlockSize(n int) CreateOpt {
+	return func(o *createOptions) {
+		o.blockSize = n
+	}
+}
+
 // WithBuildTime sets the filesystem build timestamp.
 func WithBuildTime(sec uint64, nsec uint32) CreateOpt {
 	return func(o *createOptions) {
@@ -159,6 +177,9 @@ func WithTempDir(dir string) CreateOpt {
 // Create creates a regular file with default mode 0644. The caller must
 // Close the returned File.
 func (fsys *Writer) Create(name string) (*File, error) {
+	if fsys.wErr != nil {
+		return nil, fsys.wErr
+	}
 	name = cleanPath(name)
 	if name == "/" {
 		return nil, fmt.Errorf("mkfs: cannot create file at root")
@@ -169,10 +190,8 @@ func (fsys *Writer) Create(name string) (*File, error) {
 
 	fsys.ensureParent(name)
 
-	e := &fsEntry{
-		path: name,
-		mode: disk.StatTypeReg | 0o644,
-	}
+	ino := &fsInode{mode: disk.StatTypeReg | 0o644}
+	e := &fsEntry{path: name, ino: ino}
 	fsys.addChild(e)
 
 	f := &File{
@@ -182,14 +201,14 @@ func (fsys *Writer) Create(name string) (*File, error) {
 
 	if fsys.dataFile != nil {
 		f.dataStartOff = fsys.dataOff
-		e.dataStartOff = fsys.dataOff
+		ino.dataStartOff = fsys.dataOff
 	} else {
 		if err := fsys.ensureSpool(); err != nil {
 			return nil, err
 		}
 		f.dataStartOff = fsys.spoolOff
-		e.spoolOff = fsys.spoolOff
-		e.dataStartOff = fsys.spoolOff
+		ino.spoolOff = fsys.spoolOff
+		ino.dataStartOff = fsys.spoolOff
 	}
 
 	return f, nil
@@ -198,9 +217,12 @@ func (fsys *Writer) Create(name string) (*File, error) {
 // Mkdir creates a directory. Only permission bits from perm are used;
 // type bits are forced to directory. Mkdir("/", perm) sets root permissions.
 func (fsys *Writer) Mkdir(name string, perm fs.FileMode) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	name = cleanPath(name)
 	if name == "/" {
-		fsys.root.mode = disk.StatTypeDir | uint16(perm.Perm())
+		fsys.root.ino.mode = disk.StatTypeDir | uint16(perm.Perm())
 		return nil
 	}
 	if err := fsys.checkPath(name); err != nil {
@@ -211,7 +233,7 @@ func (fsys *Writer) Mkdir(name string, perm fs.FileMode) error {
 
 	e := &fsEntry{
 		path: name,
-		mode: disk.StatTypeDir | uint16(perm.Perm()),
+		ino:  &fsInode{mode: disk.StatTypeDir | uint16(perm.Perm())},
 	}
 	fsys.addChild(e)
 
@@ -220,6 +242,9 @@ func (fsys *Writer) Mkdir(name string, perm fs.FileMode) error {
 
 // Symlink creates newname as a symbolic link to oldname (mode 0777).
 func (fsys *Writer) Symlink(oldname, newname string) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	newname = cleanPath(newname)
 	if newname == "/" {
 		return fmt.Errorf("mkfs: cannot create symlink at root")
@@ -231,9 +256,8 @@ func (fsys *Writer) Symlink(oldname, newname string) error {
 	fsys.ensureParent(newname)
 
 	e := &fsEntry{
-		path:       newname,
-		mode:       disk.StatTypeSymlink | 0o777,
-		linkTarget: oldname,
+		path: newname,
+		ino:  &fsInode{mode: disk.StatTypeSymlink | 0o777, linkTarget: oldname},
 	}
 	fsys.addChild(e)
 
@@ -243,6 +267,9 @@ func (fsys *Writer) Symlink(oldname, newname string) error {
 // Mknod creates a device, FIFO, or socket. mode must include type bits
 // (e.g. disk.StatTypeChrdev | 0o666).
 func (fsys *Writer) Mknod(name string, mode uint16, rdev uint32) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	name = cleanPath(name)
 	if name == "/" {
 		return fmt.Errorf("mkfs: cannot mknod at root")
@@ -255,8 +282,7 @@ func (fsys *Writer) Mknod(name string, mode uint16, rdev uint32) error {
 
 	e := &fsEntry{
 		path: name,
-		mode: mode,
-		rdev: rdev,
+		ino:  &fsInode{mode: mode, rdev: rdev},
 	}
 	fsys.addChild(e)
 
@@ -267,61 +293,76 @@ func (fsys *Writer) Mknod(name string, mode uint16, rdev uint32) error {
 
 // Chmod sets permission bits on the named path, preserving type bits.
 func (fsys *Writer) Chmod(name string, mode fs.FileMode) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	e, err := fsys.lookup(name)
 	if err != nil {
 		return err
 	}
 	perm := goModeToUnixMode(mode) & 0o7777
-	e.mode = (e.mode & disk.StatTypeMask) | perm
+	e.ino.mode = (e.ino.mode & disk.StatTypeMask) | perm
 	return nil
 }
 
 // Chown sets the owner UID and GID on the named path.
 func (fsys *Writer) Chown(name string, uid, gid int) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	e, err := fsys.lookup(name)
 	if err != nil {
 		return err
 	}
-	e.uid = uint32(uid)
-	e.gid = uint32(gid)
+	e.ino.uid = uint32(uid)
+	e.ino.gid = uint32(gid)
 	return nil
 }
 
 // Chtimes sets the access and modification times on the named path.
 // EROFS only stores mtime; atime is retained for read-back before Close.
 func (fsys *Writer) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	e, err := fsys.lookup(name)
 	if err != nil {
 		return err
 	}
-	e.atime = uint64(atime.Unix())
-	e.atimeNs = uint32(atime.Nanosecond())
-	e.mtime = uint64(mtime.Unix())
-	e.mtimeNs = uint32(mtime.Nanosecond())
+	e.ino.atime = uint64(atime.Unix())
+	e.ino.atimeNs = uint32(atime.Nanosecond())
+	e.ino.mtime = uint64(mtime.Unix())
+	e.ino.mtimeNs = uint32(mtime.Nanosecond())
 	return nil
 }
 
 // Setxattr sets an extended attribute on the named path.
 func (fsys *Writer) Setxattr(name, attr, value string) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	e, err := fsys.lookup(name)
 	if err != nil {
 		return err
 	}
-	if e.xattrs == nil {
-		e.xattrs = make(map[string]string)
+	if e.ino.xattrs == nil {
+		e.ino.xattrs = make(map[string]string)
 	}
-	e.xattrs[attr] = value
+	e.ino.xattrs[attr] = value
 	return nil
 }
 
 // SetNlink overrides the computed link count on the named path.
 func (fsys *Writer) SetNlink(name string, nlink uint32) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	e, err := fsys.lookup(name)
 	if err != nil {
 		return err
 	}
-	e.nlink = nlink
-	e.nlinkSet = true
+	e.ino.nlink = nlink
+	e.ino.nlinkSet = true
 	return nil
 }
 
@@ -332,6 +373,9 @@ func (fsys *Writer) SetNlink(name string, nlink uint32) error {
 // Reads symlink targets via readLinker interface when Entry.LinkTarget is empty.
 // If src implements blockSizer, the image block size is set accordingly.
 func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	// Reset per-CopyFrom state.
 	fsys.copyMetadataOnly = false
 	fsys.copyMerge = false
@@ -435,6 +479,22 @@ func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
 						be = &builder.Entry{}
 					}
 				}
+				// Generate chunks from DataRange if available.
+				if len(be.Chunks) == 0 {
+					if dr, ok := info.(dataRanger); ok {
+						if ranges := dr.DataRange(); len(ranges) > 0 {
+							chunks, err := fsys.chunksFromRanges(ranges, info.Size())
+							if err != nil {
+								return fmt.Errorf("chunksFromRanges %s: %w", p, err)
+							}
+							be.Chunks = chunks
+							// Contiguous: a single non-hole range whose total-size
+							// invariant is satisfied (guaranteed by chunksFromRanges)
+							// means the file is fully covered by one contiguous extent.
+							be.Contiguous = len(ranges) == 1 && ranges[0].Offset != holeOffset
+						}
+					}
+				}
 				return fsys.add(p, &entryFileInfo{info: info, sys: be})
 			}
 			// For EROFS sources, use direct SectionReader (bypasses
@@ -485,11 +545,13 @@ func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
 			}
 		}
 
-		// For directories from plain fs.FS, ensure nlink >= 2.
-		if info.Mode().IsDir() && be == nil {
-			be = entryFromSys(info)
+		// For directories, ensure nlink >= 2.
+		if info.Mode().IsDir() {
 			if be == nil {
-				be = &builder.Entry{Nlink: 2}
+				be = entryFromSys(info)
+				if be == nil {
+					be = &builder.Entry{Nlink: 2}
+				}
 			}
 			if be.Nlink < 2 {
 				be.Nlink = 2
@@ -497,6 +559,12 @@ func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
 			return fsys.add(p, &entryFileInfo{info: info, sys: be})
 		}
 
+		// General case: devices, fifos, sockets, etc.
+		// Wrap in entryFileInfo when be was extracted from Sys()
+		// so that add() sees the metadata.
+		if be != nil {
+			return fsys.add(p, &entryFileInfo{info: info, sys: be})
+		}
 		return fsys.add(p, info)
 	})
 }
@@ -505,6 +573,9 @@ func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
 
 // Close writes the EROFS image. The FS must not be used after Close.
 func (fsys *Writer) Close() error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	if fsys.closed {
 		return fmt.Errorf("mkfs: FS already closed")
 	}
@@ -552,11 +623,13 @@ func (fsys *Writer) Close() error {
 
 // Stat returns file info for the named path. The name is cleaned the same
 // way as other Writer methods (leading slash, no trailing slash).
+//
+// The Writer does not follow symlinks: a path that traverses through a
+// symlink or other non-directory component returns ErrNotDirectory.
 func (fsys *Writer) Stat(name string) (fs.FileInfo, error) {
-	name = cleanPath(name)
-	e, ok := fsys.byPath[name]
-	if !ok {
-		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+	e, err := fsys.resolveEntry("stat", name)
+	if err != nil {
+		return nil, err
 	}
 	return &writerFileInfo{entry: e}, nil
 }
@@ -564,34 +637,104 @@ func (fsys *Writer) Stat(name string) (fs.FileInfo, error) {
 // Open opens the named file for reading. For regular files, the file must
 // have been closed (data finalized) before it can be opened for reading.
 // For directories, the returned file implements fs.ReadDirFile.
+//
+// The Writer does not follow symlinks: a path that traverses through a
+// symlink or other non-directory component returns ErrNotDirectory.
 func (fsys *Writer) Open(name string) (fs.File, error) {
-	name = cleanPath(name)
-	e, ok := fsys.byPath[name]
-	if !ok {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	entry, err := fsys.resolveEntry("open", name)
+	if err != nil {
+		return nil, err
 	}
+	name = cleanPath(name)
+	ino := entry.ino
 
-	typ := e.mode & disk.StatTypeMask
-	switch typ {
+	switch ino.mode & disk.StatTypeMask {
 	case disk.StatTypeDir:
-		return &readDir{fsys: fsys, entry: e}, nil
+		return &readDir{fsys: fsys, entry: entry}, nil
 
 	case disk.StatTypeReg:
-		if !e.fileClosed {
+		if !ino.fileClosed {
 			return nil, &fs.PathError{Op: "open", Path: name, Err: fmt.Errorf("file not yet closed for writing")}
 		}
 		var sr *io.SectionReader
 		if fsys.dataFile != nil {
-			sr = io.NewSectionReader(fsys.dataFile, e.dataStartOff, int64(e.size))
-		} else if fsys.spool != nil && e.size > 0 {
-			sr = io.NewSectionReader(fsys.spool, e.dataStartOff, int64(e.size))
+			sr = io.NewSectionReader(fsys.dataFile, ino.dataStartOff, int64(ino.size))
+		} else if fsys.spool != nil && ino.size > 0 {
+			sr = io.NewSectionReader(fsys.spool, ino.dataStartOff, int64(ino.size))
 		}
-		return &readFile{entry: e, reader: sr}, nil
+		return &readFile{entry: entry, reader: sr}, nil
 
 	default:
 		// Symlinks, devices, etc.: stat-only, no readable data.
-		return &readFile{entry: e}, nil
+		return &readFile{entry: entry}, nil
 	}
+}
+
+// Lstat returns the FileInfo for the named path. Symlinks are stored as their
+// own entries, so the result describes the link itself, never its target.
+// Together with ReadLink this lets the Writer satisfy fs.ReadLinkFS.
+func (fsys *Writer) Lstat(name string) (fs.FileInfo, error) {
+	return fsys.Stat(name)
+}
+
+// ReadLink returns the target of the symlink at name. It returns ErrInvalid
+// if name is not a symlink, ErrNotDirectory if the path traverses a
+// non-directory, or ErrNotExist if it is absent. Targets are readable before
+// the image is finalised with Close.
+func (fsys *Writer) ReadLink(name string) (string, error) {
+	entry, err := fsys.resolveEntry("readlink", name)
+	if err != nil {
+		return "", err
+	}
+	if entry.ino.mode&disk.StatTypeMask != disk.StatTypeSymlink {
+		return "", &fs.PathError{Op: "readlink", Path: cleanPath(name), Err: fs.ErrInvalid}
+	}
+	return entry.ino.linkTarget, nil
+}
+
+// Link creates newname as a hard link to the existing file at oldname.
+// Both names refer to the same fsInode, so the data and metadata (mode, owner,
+// times, xattrs) are shared: a later change through either name is visible
+// through the other. Directories cannot be linked.
+//
+// The shared nlink count is maintained automatically; do not call SetNlink on
+// a hard-linked entry.
+func (fsys *Writer) Link(oldname, newname string) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
+	oldname = cleanPath(oldname)
+	newname = cleanPath(newname)
+	if newname == "/" {
+		return fmt.Errorf("mkfs: cannot link at root")
+	}
+
+	src, err := fsys.resolveEntry("link", oldname)
+	if err != nil {
+		return err
+	}
+	if src.ino.mode&disk.StatTypeMask == disk.StatTypeDir {
+		return &fs.PathError{Op: "link", Path: oldname, Err: ErrIsDirectory}
+	}
+	if err := fsys.checkPath(newname); err != nil {
+		return err
+	}
+	fsys.ensureParent(newname)
+
+	// Increment nlink before the first link is created so that the count
+	// reflects all names, including the original.
+	if src.ino.nlink == 0 {
+		src.ino.nlink = 1 // first time we add a second name
+	}
+	src.ino.nlink++
+
+	// The new entry shares the source fsInode directly.
+	dst := &fsEntry{
+		path: newname,
+		ino:  src.ino,
+	}
+	fsys.addChild(dst)
+	return nil
 }
 
 // --- File methods ---
@@ -645,8 +788,8 @@ func (f *File) Close() error {
 		return fmt.Errorf("mkfs: file already closed")
 	}
 	f.closed = true
-	f.entry.fileClosed = true
-	f.entry.size = uint64(f.written)
+	f.entry.ino.fileClosed = true
+	f.entry.ino.size = uint64(f.written)
 
 	if f.fs.dataFile != nil {
 		return f.closeDataFile()
@@ -657,49 +800,65 @@ func (f *File) Close() error {
 // Chmod sets permission bits on the file, matching os.File.Chmod.
 func (f *File) Chmod(mode fs.FileMode) error {
 	perm := goModeToUnixMode(mode) & 0o7777
-	f.entry.mode = (f.entry.mode & disk.StatTypeMask) | perm
+	f.entry.ino.mode = (f.entry.ino.mode & disk.StatTypeMask) | perm
 	return nil
 }
 
 // Chown sets the owner UID and GID on the file, matching os.File.Chown.
 func (f *File) Chown(uid, gid int) error {
-	f.entry.uid = uint32(uid)
-	f.entry.gid = uint32(gid)
+	f.entry.ino.uid = uint32(uid)
+	f.entry.ino.gid = uint32(gid)
 	return nil
 }
 
 // --- Internal types ---
 
-// fsEntry is the in-memory representation of a filesystem entry held by Writer.
-type fsEntry struct {
-	path       string
-	mode       uint16
-	uid, gid   uint32
-	atime      uint64
-	atimeNs    uint32
-	mtime      uint64
-	mtimeNs    uint32
-	nlink      uint32
-	nlinkSet   bool // true if SetNlink was called
-	size       uint64
-	rdev       uint32
-	xattrs     map[string]string
+// fsInode holds the shared inode payload for a filesystem entry. Every fsEntry
+// owns exactly one *fsInode; hard links share the same *fsInode across multiple
+// fsEntry values. No fsEntry is "primary" — any surviving name can own the
+// on-disk inode during serialization.
+type fsInode struct {
+	mode     uint16
+	uid      uint32
+	gid      uint32
+	atime    uint64
+	atimeNs  uint32
+	mtime    uint64
+	mtimeNs  uint32
+	nlink    uint32
+	nlinkSet bool // true if SetNlink was called; suppresses auto-computation
+	size     uint64
+	rdev     uint32
+	xattrs   map[string]string
+
+	// Symlink target (empty for non-symlinks).
 	linkTarget string
+
+	// Chunk-based layout (metadata-only mode).
 	chunks     []builder.Chunk
-	contiguous bool // data blocks are contiguous; flat-plain is sufficient
+	contiguous bool
+
+	// Data location in spool or external data file.
+	spoolOff     int64
+	dataStartOff int64
+	fileClosed   bool      // true after File.Close()
+	directData   io.Reader // non-nil when data is referenced directly (no spool copy)
+
+	metadataOnly bool // chunk-based layout even when chunks is nil
+}
+
+// fsEntry is the directory-entry view of a file. It carries only the path
+// and tree linkage; all fsInode data (mode, owner, size, data) lives in ino,
+// which is shared among all hard-linked names.
+type fsEntry struct {
+	path string
+	ino  *fsInode
 
 	// Tree structure — maintained during add/remove.
 	parent   *fsEntry
 	children []*fsEntry
 
-	// data location in spool file
-	spoolOff     int64
-	dataStartOff int64     // byte offset where file data begins (spool or data file)
-	fileClosed   bool      // true after File.Close() is called
-	directData   io.Reader // bypasses spool; set by add() for source-provided data
-
-	removed      bool // true if removed by a whiteout in a merge layer
-	metadataOnly bool // from a metadata-only CopyFrom; use chunk-based layout
+	removed bool // true if removed by a whiteout in a merge layer
 }
 
 // createOptions holds the parsed option values for Create.
@@ -707,6 +866,7 @@ type createOptions struct {
 	buildTime    uint64
 	buildTimeNs  uint32
 	hasBuildTime bool
+	blockSize    int      // 0 = use default
 	dataFile     *os.File // external data file for metadata-only mode
 	tempDir      string   // temp directory for spool file
 }
@@ -734,6 +894,21 @@ type deviceBlocker interface {
 // readLinker is an interface for filesystems that support reading symlink targets.
 type readLinker interface {
 	ReadLink(name string) (string, error)
+}
+
+// dataRanger may be implemented by fs.FileInfo to provide the physical
+// location of uncompressed file data in backing devices. CopyFrom checks
+// this via type assertion in metadata-only mode to build chunk indexes
+// without requiring the caller to construct internal chunk types.
+//
+// This interface should only be implemented for files whose device data
+// is stored verbatim (uncompressed). For compressed files, return nil or
+// do not implement the interface. In full-image mode CopyFrom then falls
+// back to reading through Open(), which decompresses transparently. In
+// MetadataOnly mode there is no such fallback: the file is stored as a
+// chunk-based inode with no physical mappings (all holes).
+type dataRanger interface {
+	DataRange() []DataRange
 }
 
 // --- Internal types ---
@@ -765,6 +940,10 @@ type erofsEntry struct {
 
 	// Extended attributes
 	xattrs map[string]string
+
+	// Hard links: non-nil for secondary entries that share an fsInode with primary.
+	// The primary entry gets an on-disk inode; secondary entries borrow its NID.
+	hardLinkPrimary *erofsEntry
 
 	// EROFS layout (assigned during planning)
 	nid           uint64
@@ -817,19 +996,72 @@ func (fi *entryFileInfo) ModTime() time.Time { return fi.info.ModTime() }
 func (fi *entryFileInfo) IsDir() bool        { return fi.info.IsDir() }
 func (fi *entryFileInfo) Sys() any           { return fi.sys }
 
+// WriterStat is returned by Sys() on [fs.FileInfo] values from a [Writer],
+// exposing fsInode metadata before the image is finalised. After [Writer.Close]
+// the image can be reopened with [Open], whose Sys() returns a [Stat].
+type WriterStat struct {
+	Mode    fs.FileMode
+	Size    int64
+	UID     uint32
+	GID     uint32
+	Rdev    uint32
+	Mtime   uint64
+	MtimeNs uint32
+	Nlink   uint32
+	Xattrs  map[string]string
+}
+
 // writerFileInfo implements fs.FileInfo for an fsEntry.
 type writerFileInfo struct {
 	entry *fsEntry
 }
 
-func (fi *writerFileInfo) Name() string      { return path.Base(fi.entry.path) }
-func (fi *writerFileInfo) Size() int64       { return int64(fi.entry.size) }
-func (fi *writerFileInfo) Mode() fs.FileMode { return disk.EroFSModeToGoFileMode(fi.entry.mode) }
-func (fi *writerFileInfo) ModTime() time.Time {
-	return time.Unix(int64(fi.entry.mtime), int64(fi.entry.mtimeNs))
+func (fi *writerFileInfo) Name() string { return path.Base(fi.entry.path) }
+func (fi *writerFileInfo) Size() int64  { return int64(fi.entry.ino.size) }
+func (fi *writerFileInfo) Mode() fs.FileMode {
+	return disk.EroFSModeToGoFileMode(fi.entry.ino.mode)
 }
-func (fi *writerFileInfo) IsDir() bool { return fi.entry.mode&disk.StatTypeMask == disk.StatTypeDir }
-func (fi *writerFileInfo) Sys() any    { return nil }
+func (fi *writerFileInfo) ModTime() time.Time {
+	return time.Unix(int64(fi.entry.ino.mtime), int64(fi.entry.ino.mtimeNs))
+}
+func (fi *writerFileInfo) IsDir() bool {
+	return fi.entry.ino.mode&disk.StatTypeMask == disk.StatTypeDir
+}
+func (fi *writerFileInfo) Sys() any {
+	ino := fi.entry.ino
+	var xattrs map[string]string
+	if len(ino.xattrs) > 0 {
+		xattrs = make(map[string]string, len(ino.xattrs))
+		for k, v := range ino.xattrs {
+			xattrs[k] = v
+		}
+	}
+	return &WriterStat{
+		Mode:    disk.EroFSModeToGoFileMode(ino.mode),
+		Size:    int64(ino.size),
+		UID:     ino.uid,
+		GID:     ino.gid,
+		Rdev:    ino.rdev,
+		Mtime:   ino.mtime,
+		MtimeNs: ino.mtimeNs,
+		Nlink:   inodeNlink(ino),
+		Xattrs:  xattrs,
+	}
+}
+
+// inodeNlink returns the effective nlink for a shared inode.
+func inodeNlink(ino *fsInode) uint32 {
+	if ino.nlinkSet {
+		return ino.nlink
+	}
+	if ino.nlink > 0 {
+		return ino.nlink
+	}
+	if ino.mode&disk.StatTypeMask == disk.StatTypeDir {
+		return 2
+	}
+	return 1
+}
 
 // readFile implements fs.File for reading back a finalized file's data.
 type readFile struct {
@@ -933,9 +1165,11 @@ type dirEntry struct {
 	entry *fsEntry
 }
 
-func (de *dirEntry) Name() string               { return path.Base(de.entry.path) }
-func (de *dirEntry) IsDir() bool                { return de.entry.mode&disk.StatTypeMask == disk.StatTypeDir }
-func (de *dirEntry) Type() fs.FileMode          { return disk.EroFSModeToGoFileMode(de.entry.mode).Type() }
+func (de *dirEntry) Name() string { return path.Base(de.entry.path) }
+func (de *dirEntry) IsDir() bool  { return de.entry.ino.mode&disk.StatTypeMask == disk.StatTypeDir }
+func (de *dirEntry) Type() fs.FileMode {
+	return disk.EroFSModeToGoFileMode(de.entry.ino.mode).Type()
+}
 func (de *dirEntry) Info() (fs.FileInfo, error) { return &writerFileInfo{entry: de.entry}, nil }
 
 // add adds a single entry. Mode and Size come from info; extended metadata
@@ -953,24 +1187,23 @@ func (fsys *Writer) add(p string, info fs.FileInfo) error {
 	}
 
 	if p == "/" {
-		root := fsys.root
-		root.mode = mode
-		root.uid = be.UID
-		root.gid = be.GID
-		root.mtime = be.Mtime
-		root.mtimeNs = be.MtimeNs
+		ino := fsys.root.ino
+		ino.mode = mode
+		ino.uid = be.UID
+		ino.gid = be.GID
+		ino.mtime = be.Mtime
+		ino.mtimeNs = be.MtimeNs
 		if be.Nlink > 0 {
-			root.nlink = be.Nlink
-			root.nlinkSet = true
+			ino.nlink = be.Nlink
+			ino.nlinkSet = true
 		}
-		root.xattrs = be.Xattrs
+		ino.xattrs = be.Xattrs
 		return nil
 	}
 
 	fsys.ensureParent(p)
 
-	fe := &fsEntry{
-		path:       p,
+	ino := &fsInode{
 		mode:       mode,
 		uid:        be.UID,
 		gid:        be.GID,
@@ -984,25 +1217,26 @@ func (fsys *Writer) add(p string, info fs.FileInfo) error {
 		contiguous: be.Contiguous,
 	}
 	if be.Nlink > 0 {
-		fe.nlink = be.Nlink
-		fe.nlinkSet = true
+		ino.nlink = be.Nlink
+		ino.nlinkSet = true
 	}
+	fe := &fsEntry{path: p, ino: ino}
 
 	// Handle duplicate paths (overwrite semantics).
 	if existing, ok := fsys.byPath[p]; ok {
-		// Preserve tree linkage when overwriting.
-		savedParent := existing.parent
-		savedChildren := existing.children
-		*existing = *fe
-		existing.parent = savedParent
-		existing.children = savedChildren
+		// Detach the old fsInode before replacing it so that any hard-linked
+		// names that still reference it get a correct nlink.
+		if existing.ino != ino {
+			unlinkInode(existing.ino)
+		}
+		existing.ino = ino
 		fe = existing
 	} else {
 		fsys.addChild(fe)
 	}
 
 	if fsys.copyMetadataOnly {
-		fe.metadataOnly = true
+		ino.metadataOnly = true
 		// Remap chunk DeviceIDs from source-relative to absolute.
 		// For single-device sources, all chunks use DeviceID=1
 		// and get mapped to copyDeviceID.
@@ -1010,8 +1244,8 @@ func (fsys *Writer) add(p string, info fs.FileInfo) error {
 		// DeviceIDs 1..N that get offset by copyDeviceID-1.
 		if fsys.copyDeviceID > 0 {
 			offset := fsys.copyDeviceID - 1
-			for i := range fe.chunks {
-				fe.chunks[i].DeviceID += offset
+			for i := range ino.chunks {
+				ino.chunks[i].DeviceID += offset
 			}
 		}
 	}
@@ -1022,13 +1256,13 @@ func (fsys *Writer) add(p string, info fs.FileInfo) error {
 		!fsys.copyMetadataOnly
 	if needData {
 		// Data is stored locally; clear any source chunk mappings.
-		fe.chunks = nil
-		fe.contiguous = false
+		ino.chunks = nil
+		ino.contiguous = false
 		if fsys.dataFile != nil {
 			// Data file mode: copy through File for block-aligned padding and chunk recording.
 			f := &File{fs: fsys, entry: fe}
 			f.dataStartOff = fsys.dataOff
-			fe.dataStartOff = fsys.dataOff
+			ino.dataStartOff = fsys.dataOff
 			if _, err := f.ReadFrom(be.Data); err != nil {
 				return err
 			}
@@ -1037,11 +1271,11 @@ func (fsys *Writer) add(p string, info fs.FileInfo) error {
 			}
 		} else {
 			// Spool mode: keep a direct reference to avoid copying.
-			fe.directData = be.Data
-			fe.fileClosed = true
+			ino.directData = be.Data
+			ino.fileClosed = true
 		}
 	} else {
-		fe.fileClosed = true
+		ino.fileClosed = true
 	}
 
 	return nil
@@ -1077,7 +1311,7 @@ func (fsys *Writer) ensureParent(name string) {
 		d := missing[i]
 		e := &fsEntry{
 			path: d,
-			mode: disk.StatTypeDir | 0o755,
+			ino:  &fsInode{mode: disk.StatTypeDir | 0o755},
 		}
 		fsys.addChild(e)
 	}
@@ -1105,7 +1339,8 @@ func (fsys *Writer) remove(p string) {
 	}
 	e.removed = true
 	delete(fsys.byPath, p)
-	if e.mode&disk.StatTypeMask == disk.StatTypeDir {
+	unlinkInode(e.ino)
+	if e.ino.mode&disk.StatTypeMask == disk.StatTypeDir {
 		fsys.removeSubtree(e)
 	}
 }
@@ -1127,10 +1362,19 @@ func (fsys *Writer) removeSubtree(e *fsEntry) {
 		if !c.removed {
 			c.removed = true
 			delete(fsys.byPath, c.path)
-			if c.mode&disk.StatTypeMask == disk.StatTypeDir {
+			unlinkInode(c.ino)
+			if c.ino.mode&disk.StatTypeMask == disk.StatTypeDir {
 				fsys.removeSubtree(c)
 			}
 		}
+	}
+}
+
+// unlinkInode decrements the nlink counter of a shared inode when one of its
+// names is removed, keeping the count consistent with surviving names.
+func unlinkInode(ino *fsInode) {
+	if ino.nlink > 0 {
+		ino.nlink--
 	}
 }
 
@@ -1142,6 +1386,12 @@ func (fsys *Writer) buildErofsTree() *erofsEntry {
 		er *erofsEntry
 	}
 
+	// seen maps a shared *fsInode to the first erofsEntry built for it.
+	// Entries whose fsInode nlink > 1 are hard-linked; the first erofsEntry
+	// seen for that fsInode owns the on-disk inode slot; later ones point
+	// back via hardLinkPrimary and borrow its NID.
+	seen := make(map[*fsInode]*erofsEntry)
+
 	rootEr := fsys.fsToErofs(fsys.root)
 	queue := []pair{{fsys.root, rootEr}}
 
@@ -1152,11 +1402,11 @@ func (fsys *Writer) buildErofsTree() *erofsEntry {
 		// Count child directories for nlink.
 		var childDirs uint32
 		for _, c := range cur.fs.children {
-			if !c.removed && c.mode&disk.StatTypeMask == disk.StatTypeDir {
+			if !c.removed && c.ino.mode&disk.StatTypeMask == disk.StatTypeDir {
 				childDirs++
 			}
 		}
-		if !cur.fs.nlinkSet && cur.fs.mode&disk.StatTypeMask == disk.StatTypeDir {
+		if !cur.fs.ino.nlinkSet && cur.fs.ino.mode&disk.StatTypeMask == disk.StatTypeDir {
 			cur.er.nlink = 2 + childDirs
 		}
 
@@ -1169,8 +1419,20 @@ func (fsys *Writer) buildErofsTree() *erofsEntry {
 				continue
 			}
 			ent := fsys.fsToErofs(c)
+
+			// Hard link: fsInodes shared by more than one surviving name are
+			// tracked in seen. The first erofsEntry for a given fsInode owns
+			// the on-disk inode slot; subsequent ones point back to it.
+			if inodeNlink(c.ino) > 1 {
+				if owner, ok := seen[c.ino]; ok {
+					ent.hardLinkPrimary = owner
+				} else {
+					seen[c.ino] = ent
+				}
+			}
+
 			cur.er.children = append(cur.er.children, ent)
-			if c.mode&disk.StatTypeMask == disk.StatTypeDir {
+			if c.ino.mode&disk.StatTypeMask == disk.StatTypeDir {
 				queue = append(queue, pair{c, ent})
 			}
 		}
@@ -1183,46 +1445,40 @@ func (fsys *Writer) buildErofsTree() *erofsEntry {
 	return rootEr
 }
 
-// fsToErofs converts a single fsEntry to an erofsEntry, resolving data readers.
-func (fsys *Writer) fsToErofs(e *fsEntry) *erofsEntry {
-	var nlink uint32
-	switch {
-	case e.nlinkSet:
-		nlink = e.nlink
-	case e.mode&disk.StatTypeMask == disk.StatTypeDir:
-		nlink = 2 // adjusted by buildErofsTree
-	default:
-		nlink = 1
-	}
+// fsToErofs converts an fsEntry to an erofsEntry.
+// The name/path come from the directory entry; fsInode data comes from ino.
+func (fsys *Writer) fsToErofs(entry *fsEntry) *erofsEntry {
+	ino := entry.ino
+	nlink := inodeNlink(ino)
 
 	var data io.Reader
-	if fsys.dataFile == nil && len(e.chunks) == 0 && !e.metadataOnly &&
-		e.mode&disk.StatTypeMask == disk.StatTypeReg && e.size > 0 {
-		if e.directData != nil {
-			data = e.directData
+	if fsys.dataFile == nil && len(ino.chunks) == 0 && !ino.metadataOnly &&
+		ino.mode&disk.StatTypeMask == disk.StatTypeReg && ino.size > 0 {
+		if ino.directData != nil {
+			data = ino.directData
 		} else if fsys.spool != nil {
-			data = io.NewSectionReader(fsys.spool, e.spoolOff, int64(e.size))
+			data = io.NewSectionReader(fsys.spool, ino.spoolOff, int64(ino.size))
 		}
 	}
 
 	return &erofsEntry{
-		mode:          e.mode,
-		uid:           e.uid,
-		gid:           e.gid,
-		mtime:         e.mtime,
-		mtimeNs:       e.mtimeNs,
+		mode:          ino.mode,
+		uid:           ino.uid,
+		gid:           ino.gid,
+		mtime:         ino.mtime,
+		mtimeNs:       ino.mtimeNs,
 		nlink:         nlink,
-		size:          e.size,
-		rdev:          e.rdev,
-		name:          path.Base(e.path),
-		path:          e.path,
-		symTarget:     e.linkTarget,
-		chunks:        e.chunks,
-		contiguous:    e.contiguous,
-		metadataOnly:  e.metadataOnly,
+		size:          ino.size,
+		rdev:          ino.rdev,
+		name:          path.Base(entry.path),
+		path:          entry.path,
+		symTarget:     ino.linkTarget,
+		chunks:        ino.chunks,
+		contiguous:    ino.contiguous,
+		metadataOnly:  ino.metadataOnly,
 		data:          data,
-		xattrs:        e.xattrs,
-		erofsFileType: modeToFileType(e.mode),
+		xattrs:        ino.xattrs,
+		erofsFileType: modeToFileType(ino.mode),
 	}
 }
 
@@ -1269,6 +1525,95 @@ func (fsys *Writer) zeroPad() []byte {
 	return fsys.padBuf
 }
 
+// chunksFromRanges converts DataRange entries into internal chunk entries.
+// fileSize is the logical size of the file; the sum of all range Sizes must
+// equal fileSize exactly, or an error is returned.
+//
+// The block size used is the Writer's resolved block size. DataRange.Device
+// values are offset by 1 to produce chunk DeviceIDs: DataRange Device 0
+// becomes chunk DeviceID 1 (the first extra device), matching the EROFS
+// convention where DeviceID 0 is the primary image.
+//
+// Validation rules:
+//   - sum(Size) == fileSize; a mismatch is rejected.
+//   - r.Size > 0 for every entry.
+//   - Hole entries (Offset == -1) emit [builder.NullPhysicalBlock] chunks.
+//     Hole Size must be block-aligned for non-final entries; the final entry
+//     may end mid-block to match the file tail.
+//   - For data entries: r.Offset >= 0 and block-aligned; r.Device == 0.
+//   - For non-final data entries: r.Size must be a multiple of blockSize.
+//     The final entry may have a partial last block to match the file tail.
+func (fsys *Writer) chunksFromRanges(ranges []DataRange, fileSize int64) ([]builder.Chunk, error) {
+	blockSize := uint64(fsys.resolveBlockSize())
+
+	// Validate total coverage first.
+	var total int64
+	for _, r := range ranges {
+		total += r.Size
+	}
+	if total != fileSize {
+		return nil, fmt.Errorf("DataRange total size %d does not match file size %d", total, fileSize)
+	}
+
+	last := len(ranges) - 1
+	var chunks []builder.Chunk
+	for i, r := range ranges {
+		if r.Size <= 0 {
+			return nil, fmt.Errorf("DataRange[%d]: non-positive Size %d", i, r.Size)
+		}
+		// Non-final entries must be block-aligned in size; the final entry may
+		// end mid-block to match the file tail.
+		if i < last && uint64(r.Size)%blockSize != 0 {
+			return nil, fmt.Errorf("DataRange[%d]: non-final Size %d is not block-aligned (block size %d)", i, r.Size, blockSize)
+		}
+		if r.Offset == holeOffset {
+			// Hole: emit NullPhysicalBlock chunks covering the hole span.
+			totalBlocks := (uint64(r.Size) + blockSize - 1) / blockSize
+			for totalBlocks > 0 {
+				count := totalBlocks
+				if count > 65535 {
+					count = 65535
+				}
+				chunks = append(chunks, builder.Chunk{
+					PhysicalBlock: builder.NullPhysicalBlock,
+					Count:         uint16(count),
+				})
+				totalBlocks -= count
+			}
+			continue
+		}
+		if r.Offset < 0 {
+			return nil, fmt.Errorf("DataRange[%d]: negative Offset %d", i, r.Offset)
+		}
+		if uint64(r.Offset)%blockSize != 0 {
+			return nil, fmt.Errorf("DataRange[%d]: Offset %d is not block-aligned (block size %d)", i, r.Offset, blockSize)
+		}
+		// Non-EROFS sources register exactly one device via DeviceBlocks();
+		// only Device=0 is valid. Device=0xFFFF would also wrap deviceID to 0
+		// (the primary image), producing an invalid mapping.
+		if r.Device != 0 {
+			return nil, fmt.Errorf("DataRange[%d]: Device %d out of range (source declared one device, only Device=0 is valid)", i, r.Device)
+		}
+		deviceID := r.Device + 1
+		startBlock := uint64(r.Offset) / blockSize
+		totalBlocks := (uint64(r.Size) + blockSize - 1) / blockSize
+		for totalBlocks > 0 {
+			count := totalBlocks
+			if count > 65535 {
+				count = 65535
+			}
+			chunks = append(chunks, builder.Chunk{
+				PhysicalBlock: startBlock,
+				Count:         uint16(count),
+				DeviceID:      deviceID,
+			})
+			startBlock += count
+			totalBlocks -= count
+		}
+	}
+	return chunks, nil
+}
+
 // ensureSpool lazily creates the spool temp file.
 func (fsys *Writer) ensureSpool() error {
 	if fsys.spool != nil {
@@ -1283,13 +1628,41 @@ func (fsys *Writer) ensureSpool() error {
 	return nil
 }
 
+// lookup resolves name to its fsEntry. Callers mutate e.ino to affect the
+// shared fsInode, so changes are visible through all hard-linked names.
 func (fsys *Writer) lookup(name string) (*fsEntry, error) {
+	return fsys.resolveEntry("lookup", name)
+}
+
+// resolveEntry looks up name in byPath. On a miss it calls classifyMiss to
+// distinguish a genuinely absent path (ErrNotExist) from one that traverses
+// through a non-directory component (ErrNotDirectory).
+func (fsys *Writer) resolveEntry(op, name string) (*fsEntry, error) {
 	name = cleanPath(name)
-	e, ok := fsys.byPath[name]
-	if !ok {
-		return nil, fmt.Errorf("mkfs: path not found %q", name)
+	if e, ok := fsys.byPath[name]; ok {
+		return e, nil
 	}
-	return e, nil
+	if err := fsys.classifyMiss(name); err != nil {
+		return nil, &fs.PathError{Op: op, Path: name, Err: err}
+	}
+	return nil, &fs.PathError{Op: op, Path: name, Err: fs.ErrNotExist}
+}
+
+// classifyMiss returns ErrNotDirectory if an existing ancestor of name is not
+// a directory, or nil if the path is simply absent.
+func (fsys *Writer) classifyMiss(name string) error {
+	for dir := path.Dir(name); dir != "/" && dir != "."; dir = path.Dir(dir) {
+		e, ok := fsys.byPath[dir]
+		if !ok {
+			continue
+		}
+		if e.ino.mode&disk.StatTypeMask != disk.StatTypeDir {
+			return ErrNotDirectory
+		}
+		// Nearest existing ancestor is a directory: the path is just absent.
+		return nil
+	}
+	return nil
 }
 
 // closeDataFile pads the data file to a block boundary and records chunks.
@@ -1319,7 +1692,7 @@ func (f *File) closeDataFile() error {
 		if count > 65535 {
 			count = 65535
 		}
-		f.entry.chunks = append(f.entry.chunks, builder.Chunk{
+		f.entry.ino.chunks = append(f.entry.ino.chunks, builder.Chunk{
 			PhysicalBlock: startBlock,
 			Count:         uint16(count),
 			DeviceID:      1,

--- a/vendor/github.com/erofs/go-erofs/mkfs_image.go
+++ b/vendor/github.com/erofs/go-erofs/mkfs_image.go
@@ -198,25 +198,25 @@ func (fsys *Writer) copyFromImage(img *image) error {
 		trailingAddr := inodeAddr + int64(icSize) + int64(xattrSize)
 		typ := mode & disk.StatTypeMask
 
-		// Build fsEntry directly, bypassing builder.Entry + add() overhead.
-		fe := &fsEntry{
-			path:    cur.path,
-			mode:    mode,
-			uid:     uid,
-			gid:     gid,
-			mtime:   mtime,
-			mtimeNs: mtimeNs,
-			size:    size,
-			xattrs:  xattrs,
+		// Build fsInode directly, bypassing builder.Entry + add() overhead.
+		ino := &fsInode{
+			mode:       mode,
+			uid:        uid,
+			gid:        gid,
+			mtime:      mtime,
+			mtimeNs:    mtimeNs,
+			size:       size,
+			xattrs:     xattrs,
+			fileClosed: true,
 		}
 		if nlink > 0 {
-			fe.nlink = nlink
-			fe.nlinkSet = true
+			ino.nlink = nlink
+			ino.nlinkSet = true
 		}
-		fe.fileClosed = true
 		if fsys.copyMetadataOnly {
-			fe.metadataOnly = true
+			ino.metadataOnly = true
 		}
+		fe := &fsEntry{path: cur.path, ino: ino}
 
 		switch typ {
 		case disk.StatTypeDir:
@@ -258,7 +258,7 @@ func (fsys *Writer) copyFromImage(img *image) error {
 					linkData = at(trailingAddr)
 				}
 				if linkData != nil && int(size) <= len(linkData) {
-					fe.linkTarget = string(linkData[:size])
+					ino.linkTarget = string(linkData[:size])
 				}
 			}
 
@@ -270,41 +270,35 @@ func (fsys *Writer) copyFromImage(img *image) error {
 					if chunkAddr%8 != 0 {
 						chunkAddr = (chunkAddr + 7) & ^int64(7)
 					}
-					fe.chunks = fsys.parseChunks(at(chunkAddr), chunkFmt, size, blkBits, img.deviceIDMask)
-					fe.contiguous = true
+					ino.chunks = fsys.parseChunks(at(chunkAddr), chunkFmt, size, blkBits, img.deviceIDMask)
+					ino.contiguous = true
 				}
 			}
 
 		case disk.StatTypeChrdev, disk.StatTypeBlkdev:
-			fe.rdev = disk.RdevFromMode(mode, idata)
+			ino.rdev = disk.RdevFromMode(mode, idata)
 		}
 
 		// Remap chunk DeviceIDs for metadata-only sources.
 		if fsys.copyMetadataOnly && fsys.copyDeviceID > 0 {
 			offset := fsys.copyDeviceID - 1
-			for i := range fe.chunks {
-				fe.chunks[i].DeviceID += offset
+			for i := range ino.chunks {
+				ino.chunks[i].DeviceID += offset
 			}
 		}
 
 		// Register in the tree.
 		if cur.path == "/" {
-			// Update root metadata.
-			fsys.root.mode = fe.mode
-			fsys.root.uid = fe.uid
-			fsys.root.gid = fe.gid
-			fsys.root.mtime = fe.mtime
-			fsys.root.mtimeNs = fe.mtimeNs
-			fsys.root.nlink = fe.nlink
-			fsys.root.nlinkSet = fe.nlinkSet
-			fsys.root.xattrs = fe.xattrs
+			// Update root fsInode.
+			fsys.root.ino = ino
 		} else if existing, ok := fsys.byPath[cur.path]; ok {
-			// Merge overwrites: preserve tree linkage.
-			savedParent := existing.parent
-			savedChildren := existing.children
-			*existing = *fe
-			existing.parent = savedParent
-			existing.children = savedChildren
+			// Merge overwrites: replace fsInode but preserve tree linkage.
+			// Detach the old fsInode so any remaining hard-linked names get a
+			// correct nlink.
+			if existing.ino != ino {
+				unlinkInode(existing.ino)
+			}
+			existing.ino = ino
 		} else {
 			fsys.addChild(fe)
 		}

--- a/vendor/github.com/erofs/go-erofs/writer.go
+++ b/vendor/github.com/erofs/go-erofs/writer.go
@@ -9,11 +9,14 @@ import (
 	"os"
 	"sort"
 
+	"github.com/erofs/go-erofs/internal/builder"
 	"github.com/erofs/go-erofs/internal/disk"
 )
 
-// maxBlockSize is the largest block size we support.
-const maxBlockSize = 1 << 20
+// maxBlockSize is the largest block size we support. EROFS images with
+// larger block sizes are unmountable on common platforms (aarch64 caps
+// page size at 64 KiB) and the reader rejects BlkSizeBits > 16.
+const maxBlockSize = 1 << 16
 
 // onlyWriter wraps an io.Writer to hide io.ReaderFrom so that
 // io.CopyBuffer uses the caller-provided buffer instead of
@@ -113,6 +116,9 @@ func (w *erofsWriter) writeSeekable(out io.WriteSeeker) error {
 func (w *erofsWriter) newMetaBuffer() *bytes.Buffer {
 	totalMetaBytes := 0
 	for _, e := range w.entries {
+		if e.hardLinkPrimary != nil {
+			continue // secondary entries share the primary's on-disk inode
+		}
 		isz := disk.SizeInodeExtended
 		if e.compact {
 			isz = disk.SizeInodeCompact
@@ -138,6 +144,9 @@ func (w *erofsWriter) assignDataBlocks() {
 		// Metadata-first: data blocks come after metadata.
 		totalMetaBytes := 0
 		for _, e := range w.entries {
+			if e.hardLinkPrimary != nil {
+				continue
+			}
 			expectedOff := int(e.nid) * 32
 			sz := inodeCoreSize(e) + e.xattrSize + e.trailingSize
 			if sz%32 != 0 {
@@ -151,6 +160,9 @@ func (w *erofsWriter) assignDataBlocks() {
 		metaBlocks := (totalMetaBytes + w.blockSize - 1) / w.blockSize
 		addr := uint32(w.sbAreaBlocks() + metaBlocks)
 		for _, e := range w.entries {
+			if e.hardLinkPrimary != nil {
+				continue
+			}
 			if ds := w.flatPlainDataSize(e); ds > 0 {
 				e.dataBlkAddr = addr
 				addr += uint32((ds + w.blockSize - 1) / w.blockSize)
@@ -160,6 +172,9 @@ func (w *erofsWriter) assignDataBlocks() {
 		// Data-first: data starts after superblock area.
 		addr := uint32(w.sbAreaBlocks())
 		for _, e := range w.entries {
+			if e.hardLinkPrimary != nil {
+				continue // secondary entries share the primary's data blocks
+			}
 			if ds := w.flatPlainDataSize(e); ds > 0 {
 				e.dataBlkAddr = addr
 				addr += uint32((ds + w.blockSize - 1) / w.blockSize)
@@ -191,6 +206,9 @@ func (w *erofsWriter) sbAreaBlocks() int {
 func (w *erofsWriter) metadataBytes() int {
 	curOff := 0
 	for _, e := range w.entries {
+		if e.hardLinkPrimary != nil {
+			continue // secondary entries have no on-disk inode
+		}
 		expectedOff := int(e.nid) * 32
 		if curOff < expectedOff {
 			curOff = expectedOff
@@ -210,9 +228,12 @@ func (w *erofsWriter) writeBlock0(buf io.Writer) error {
 	totalMetaBytes := w.metadataBytes()
 	metaBlocks := (totalMetaBytes + w.blockSize - 1) / w.blockSize
 
-	// Count data blocks.
+	// Count data blocks (skip secondary hard-link entries).
 	dataBlocks := 0
 	for _, e := range w.entries {
+		if e.hardLinkPrimary != nil {
+			continue
+		}
 		if ds := w.flatPlainDataSize(e); ds > 0 {
 			dataBlocks += (ds + w.blockSize - 1) / w.blockSize
 		}
@@ -280,6 +301,11 @@ func (w *erofsWriter) writeBlock0(buf io.Writer) error {
 func (w *erofsWriter) writeMetadataInodes(buf io.Writer) error {
 	metaStart := 0
 	for _, e := range w.entries {
+		// Secondary hard-link entries share the primary's on-disk inode.
+		if e.hardLinkPrimary != nil {
+			continue
+		}
+
 		expectedOff := int(e.nid) * 32
 		if expectedOff > metaStart {
 			if _, err := buf.Write(w.zeroBuf[:expectedOff-metaStart]); err != nil {
@@ -314,12 +340,18 @@ func (w *erofsWriter) writeMetadataInodes(buf io.Writer) error {
 				}
 				metaStart += e.trailingSize
 			} else if e.layout == disk.LayoutFlatInline && e.size > 0 && e.data != nil {
-				n, err := io.CopyBuffer(onlyWriter{buf}, io.LimitReader(e.data, int64(e.size)), w.copyBuf)
+				// e.data may be an unbounded reader (e.g. directData from CopyFrom);
+				// limit to e.size bytes to prevent overwriting subsequent metadata.
+				expected := int64(e.size)
+				n, err := io.CopyBuffer(onlyWriter{buf}, io.LimitReader(e.data, expected), w.copyBuf)
 				if c, ok := e.data.(io.Closer); ok {
 					_ = c.Close()
 				}
 				if err != nil {
 					return fmt.Errorf("write inline data for %s: %w", e.path, err)
+				}
+				if n != expected {
+					return fmt.Errorf("write inline data for %s: short read: got %d bytes, expected %d", e.path, n, expected)
 				}
 				metaStart += int(n)
 			}
@@ -474,6 +506,8 @@ func (w *erofsWriter) writeChunkIndexes(buf io.Writer, e *erofsEntry) error {
 	if len(e.chunks) > 0 {
 		// Walk source chunks and emit one index per logical chunk.
 		// Source chunks use block-granularity counts; we step by blocksPerChunk.
+		// A chunk with PhysicalBlock == builder.NullPhysicalBlock is a hole:
+		// emit nullIdx entries for its block span.
 		var scratch [disk.SizeChunkIndex]byte
 		ci := 0   // index into source chunks
 		coff := 0 // block offset within current source chunk
@@ -485,12 +519,19 @@ func (w *erofsWriter) writeChunkIndexes(buf io.Writer, e *erofsEntry) error {
 				continue
 			}
 			c := e.chunks[ci]
-			phys := c.PhysicalBlock + uint64(coff)
-			binary.LittleEndian.PutUint16(scratch[0:2], uint16(phys>>32))
-			binary.LittleEndian.PutUint16(scratch[2:4], c.DeviceID)
-			binary.LittleEndian.PutUint32(scratch[4:8], uint32(phys))
-			if _, err := buf.Write(scratch[:]); err != nil {
-				return err
+			if c.PhysicalBlock == builder.NullPhysicalBlock {
+				// Hole chunk: emit a null index entry.
+				if _, err := buf.Write(nullIdx[:]); err != nil {
+					return err
+				}
+			} else {
+				phys := c.PhysicalBlock + uint64(coff)
+				binary.LittleEndian.PutUint16(scratch[0:2], uint16(phys>>32))
+				binary.LittleEndian.PutUint16(scratch[2:4], c.DeviceID)
+				binary.LittleEndian.PutUint32(scratch[4:8], uint32(phys))
+				if _, err := buf.Write(scratch[:]); err != nil {
+					return err
+				}
 			}
 			coff += blocksPerChunk
 			for ci < len(e.chunks) && coff >= int(e.chunks[ci].Count) {
@@ -518,11 +559,14 @@ func (w *erofsWriter) writeDirents(buf io.Writer, e *erofsEntry) (int, error) {
 	}
 
 	// Build the full entry list including "." and ".." then sort
-	// alphabetically. EROFS requires dirents to be sorted within
-	// each block; "." and ".." are not guaranteed to be first.
+	// alphabetically. EROFS requires dirents to be sorted within each block;
+	// "." and ".." are not guaranteed to sort first (filenames with ASCII
+	// values below '.' such as '-' or ',' sort before them).
 	allEnts := make([]direntInfo, 0, len(e.children)+2)
-	allEnts = append(allEnts, direntInfo{".", e.nid, disk.FileTypeDir})
-	allEnts = append(allEnts, direntInfo{"..", e.parentNid, disk.FileTypeDir})
+	allEnts = append(allEnts,
+		direntInfo{".", e.nid, disk.FileTypeDir},
+		direntInfo{"..", e.parentNid, disk.FileTypeDir},
+	)
 	for _, c := range e.children {
 		allEnts = append(allEnts, direntInfo{
 			name:     c.name,
@@ -602,6 +646,9 @@ func (w *erofsWriter) writeDirents(buf io.Writer, e *erofsEntry) (int, error) {
 // writeDataBlocks writes data blocks for flat-plain entries directly to out.
 func (w *erofsWriter) writeDataBlocks(out io.Writer) error {
 	for _, e := range w.entries {
+		if e.hardLinkPrimary != nil {
+			continue // secondary hard-link entries share the primary's data blocks
+		}
 		ds := w.flatPlainDataSize(e)
 		if ds == 0 {
 			continue

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -297,7 +297,7 @@ github.com/docker/go-units
 ## explicit; go 1.13
 github.com/emicklei/go-restful/v3
 github.com/emicklei/go-restful/v3/log
-# github.com/erofs/go-erofs v0.3.0
+# github.com/erofs/go-erofs v0.3.1-0.20260703080254-f80970c14446
 ## explicit; go 1.23
 github.com/erofs/go-erofs
 github.com/erofs/go-erofs/internal/builder


### PR DESCRIPTION
# snapshots/testsuite: fs.FS-based snapshot test suite

Adds `SnapshotterFSSuite`, a mount-free variant of `SnapshotterSuite` that
inspects snapshots through `fs.FS` (via `fsview`) instead of kernel mounts.

## What it does

- Each test defines its layer changes once as `[]fsChange`.
- The snapshotter under test builds a layered snapshot chain.
- An **independent** canonical result is built directly as a standalone EROFS
  image (go-erofs `Writer` → `erofs.Open`), with no snapshotter involvement.
- Each committed layer's view is compared against that reference for equality:
  path set, mode (type + perms), content, symlink target, ownership, and xattrs
  (mtime excluded).

## Backends

- **erofs**: layers built as EROFS images. Rootless, cross-platform.
- **overlay / native**: layers written to the upperdir / copied directory.
  Linux; require root for whiteouts and ownership.

The write strategy is inferred from the active snapshot's own mounts; the
parent (lower) view used for copy-up is derived from those same mounts rather
than a separate `View`.

## Why

- Validates the `fs.FS` interface for snapshot inspection.
- Demonstrates the erofs snapshotter works rootless and cross-platform on any
  host filesystem.
- Compares the snapshotter against a known-good, snapshotter-independent
  baseline rather than against itself.

## Tests

`TestErofsFS` (rootless, all platforms), `TestOverlayFS`, `TestNativeFS`
(Linux, root) run the full suite: 21 subtests each, all passing.
