### PR TITLE
Raise stale bot limits

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -37,6 +37,13 @@ jobs:
           exempt-all-issue-milestones: true
           exempt-all-pr-milestones: true
 
+          # How many items to process per run, default is 30, which is not
+          # enough to process the whole backlog. This number should strike the
+          # right balance: too high value might cause rate limits.
+          operations-per-run: 150
+          # Process the oldest items first.
+          ascending: true
+
           # Messages
           stale-issue-message: >
             This issue has not been updated in 12 months and is now marked as stale.


### PR DESCRIPTION
Increase the number of operations stale bot allowed to do during a single run.
Default is 30, which is not enough to process our backlog.
Also start from oldest items first, which makes more sense for stale issues/PRs.