### PR TITLE
reference: reject `..` path components that rewrite the host

### DIFF
--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"net/url"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/containerd/containerd/v2/internal/lazyregexp"
@@ -111,6 +112,14 @@ func Parse(s string) (Spec, error) {
 			object = object[1:]
 		}
 		u.Path = u.Path[:idx[0]]
+	}
+
+	// A ".." element in the path would let the path.Join below climb past
+	// the host and repoint the reference at a different registry, e.g.
+	// "example.com/../other/image" resolves to "other/image". Valid
+	// references never contain one.
+	if slices.Contains(strings.Split(u.Path, "/"), "..") {
+		return Spec{}, ErrInvalid
 	}
 
 	return Spec{

--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -157,6 +157,21 @@ func TestReferenceParser(t *testing.T) {
 			Digest:   "sha512:fffffff",
 			Err:      ErrInvalid,
 		},
+		{
+			Name:  "DotDotRewritesHost",
+			Input: "example.com/../other/image:latest",
+			Err:   ErrInvalid,
+		},
+		{
+			Name:  "EncodedDotDotRewritesHost",
+			Input: "example.com/%2e%2e/other/image:latest",
+			Err:   ErrInvalid,
+		},
+		{
+			Name:  "DotDotComponentInPath",
+			Input: "example.com/library/../image:latest",
+			Err:   ErrInvalid,
+		},
 	} {
 		t.Run(testcase.Name, func(t *testing.T) {
 			ref, err := Parse(testcase.Input)


### PR DESCRIPTION
reference.Parse builds the locator with path.Join(u.Host, u.Path), which cleans the result and lets a `..` element climb past the host. `example.com/../other/image` parses to a locator of `other/image`, so Hostname() returns `other` and the docker resolver, the auth scope, and the distribution-source label all follow the reference to a different registry than the one that was written (url.Parse decodes `%2e%2e`, so the percent-encoded form behaves the same). The CRI pull path runs references through distribution/reference first, which rejects these, but the transfer service and client.Pull hand the reference straight to the resolver.

Reject any reference whose path carries a `..` component. Keeping the check in Parse means every consumer of a Spec stays on the host that was actually written rather than each re-validating, and since valid references never contain `..` this only turns previously-misrouted input into an error.