### PR TITLE
pkg/shim: prevent windows zombie shims by closing stdin on context cancel

### DIFF
--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -274,7 +274,19 @@ func run(ctx context.Context, manager Shim, config Config) error {
 		// We try reading stdin twice: first for the new boot API, then runc Options.
 		// The stdin pipe is not seekable, so this should be read into memory first.
 		// Protect against unbounded memory consumption with a limit (e.g., 10MB).
+		readDone := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				// Forcefully break the blocking io.ReadAll if the daemon disconnects
+				os.Stdin.Close()
+			case <-readDone:
+				// Read completed successfully, exit the monitor
+			}
+		}()
+
 		input, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+		close(readDone)
 		if err != nil {
 			return fmt.Errorf("failed to read stdin: %w", err)
 		}


### PR DESCRIPTION
pkg/shim: prevent windows zombie shims by closing stdin on context cancel

When the containerd daemon restarts or exits unexpectedly on Windows, the 
named pipe write handles may be inherited or fail to immediately broadcast 
an EOF. Because io.ReadAll does not natively respect context.Context, 
the runhcs shim blocks indefinitely waiting for data, leaking the process 
and blocking network ports.

This introduces a background monitor that explicitly closes os.Stdin 
if the parent context is canceled. This forcefully aborts the blocking 
I/O read, allowing the shim to detect the daemon disconnection and 
terminate gracefully.

Signed-off-by: Harshal Patel <hp842484@gmail.com>
