### PR TITLE
[release/2.0] ci: bound Go fuzzing by execution count

### DIFF
--- a/script/go-test-fuzz.sh
+++ b/script/go-test-fuzz.sh
@@ -14,16 +14,18 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-# Running Go 1.18's fuzzing for 30 seconds each. While this would be too
+# Running Go's fuzzing for 50,000 executions. While this would be too
 # short to actually find issues, we want to make sure that these fuzzing
-# tests are not fundamentally broken.
+# tests are not fundamentally broken. Using an execution limit rather than a
+# duration also avoids spurious failures when a duration expires
+# (https://go.dev/issue/75804).
 
 set -euo pipefail
 
-fuzztime=30s
+fuzzlimit=50000x
 pkgs=$(git grep 'func Fuzz.*testing\.F' | grep -o '.*\/' | sort | uniq)
 
 for pkg in $pkgs
 do
-    go test -fuzz=. ./$pkg -fuzztime=$fuzztime
+    go test -fuzz=. ./$pkg -fuzztime=$fuzzlimit
 done


### PR DESCRIPTION
Go can report context deadline exceeded when a duration-based fuzz limit expires (https://go.dev/issue/75804).

Use a 50,000-execution limit based on the roughly 47,000 executions FuzzImageStore completed in 30 seconds in CI. This keeps work stable across runners and avoids the duration issue.

Assisted-by: Codex
(cherry picked from commit c1b9b78f473f2936fb5d3f06b147d0a01f7a12dc)