### PR TITLE
shim_load: Log error when failing to load

### DIFF
--- a/core/runtime/v2/shim_load.go
+++ b/core/runtime/v2/shim_load.go
@@ -189,7 +189,7 @@ func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle) error {
 	_, sgetErr := m.sandboxStore.Get(ctx, id)
 	pInfo, pidErr := shim.Pids(ctx)
 	if sgetErr != nil && errors.Is(sgetErr, errdefs.ErrNotFound) && (len(pInfo) == 0 || errors.Is(pidErr, errdefs.ErrNotFound)) {
-		log.G(ctx).WithField("id", id).Info("cleaning leaked shim process")
+		log.G(ctx).WithField("id", id).WithError(pidErr).Info("cleaning leaked shim process")
 		// We are unable to get Pids from the shim and it's not a sandbox
 		// shim. We should clean it up her.
 		// No need to do anything for removeTask since we never added this shim.


### PR DESCRIPTION
This simplifies debugging a lot. i.e. now you can see this error if you hit it:

    start-kubelet-containerd.sh[3601505]: {"error":" unable to get all container pids: readdirent /sys/fs/cgroup/kubepods.slice/kubepods-pod0be77e0a_037c_4209_b3cd_7d0cc20b4b57.slice/cri-containerd-c83c746184c42fbeb6fdd60f3679d068d9fde6692f8cf555394e7cabda90c54c.scope/churn.13.52: no such file or directory\n","id":"c83c746184c42fbeb6fdd60f3679d068d9fde6692f8cf555394e7cabda90c54c","level":"info","msg":"cleaning leaked shim process","namespace":"k8s.io","time":"2026-07-13T22:01:41.816709962Z"}

Link: https://github.com/containerd/containerd/issues/13784