### PR TITLE
pkg/archive: reject out-of-range owner IDs in layer headers

### DIFF
--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -327,6 +328,19 @@ func applyNaive(ctx context.Context, root string, r io.Reader, options ApplyOpti
 	return size, nil
 }
 
+// validateHeaderIDs rejects owner IDs that do not fit in the uint32 range the
+// chown syscalls accept. Uid and Gid come from the (untrusted) tar header as
+// int, but lchown/chown truncate anything wider than 32 bits, so a header owner
+// at or above 2^32 would land the file on a different owner than declared (for
+// example 0x100000000 becomes 0, i.e. root).
+func validateHeaderIDs(hdr *tar.Header) error {
+	if hdr.Uid < 0 || int64(hdr.Uid) > math.MaxUint32 ||
+		hdr.Gid < 0 || int64(hdr.Gid) > math.MaxUint32 {
+		return fmt.Errorf("owner %d:%d for %q out of range: %w", hdr.Uid, hdr.Gid, hdr.Name, errInvalidArchive)
+	}
+	return nil
+}
+
 func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header, reader io.Reader, noSameOwner bool) error {
 	// hdr.Mode is in linux format, which we can use for syscalls,
 	// but for os.Foo() calls we need the mode converted to os.FileMode,
@@ -394,6 +408,9 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 	}
 
 	if !noSameOwner {
+		if err := validateHeaderIDs(hdr); err != nil {
+			return err
+		}
 		if err := os.Lchown(path, hdr.Uid, hdr.Gid); err != nil {
 			err = fmt.Errorf("failed to Lchown %q for UID %d, GID %d: %w", path, hdr.Uid, hdr.Gid, err)
 			if errors.Is(err, syscall.EINVAL) && userns.RunningInUserNS() {

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -347,6 +347,14 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
 	hdrInfo := hdr.FileInfo()
 
+	// Reject an out-of-range owner before creating anything, so an invalid
+	// header fails without leaving a partially extracted entry behind.
+	if !noSameOwner {
+		if err := validateHeaderIDs(hdr); err != nil {
+			return err
+		}
+	}
+
 	switch hdr.Typeflag {
 	case tar.TypeDir:
 		// Create directory unless it exists as a directory already.
@@ -408,9 +416,6 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 	}
 
 	if !noSameOwner {
-		if err := validateHeaderIDs(hdr); err != nil {
-			return err
-		}
 		if err := os.Lchown(path, hdr.Uid, hdr.Gid); err != nil {
 			err = fmt.Errorf("failed to Lchown %q for UID %d, GID %d: %w", path, hdr.Uid, hdr.Gid, err)
 			if errors.Is(err, syscall.EINVAL) && userns.RunningInUserNS() {

--- a/pkg/archive/tar_opts_linux.go
+++ b/pkg/archive/tar_opts_linux.go
@@ -41,6 +41,9 @@ func OverlayConvertWhiteout(hdr *tar.Header, path string) (bool, error) {
 		originalBase := base[len(whiteoutPrefix):]
 		originalPath := filepath.Join(dir, originalBase)
 
+		if err := validateHeaderIDs(hdr); err != nil {
+			return false, err
+		}
 		if err := unix.Mknod(originalPath, unix.S_IFCHR, 0); err != nil {
 			return false, err
 		}

--- a/pkg/archive/tar_unix_test.go
+++ b/pkg/archive/tar_unix_test.go
@@ -50,3 +50,35 @@ func TestHandleTarTypeBlockCharFifoDeviceRange(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateHeaderIDs(t *testing.T) {
+	type ownerCase struct {
+		name     string
+		uid, gid int64
+	}
+	cases := []ownerCase{
+		{"negative uid", -1, 0},
+		{"negative gid", 0, -1},
+	}
+	// Owner IDs at or above 2^32 only fit in Header.Uid/Gid (int) on 64-bit
+	// platforms, so guard those cases to keep this test building on 32-bit.
+	if math.MaxInt > math.MaxUint32 {
+		cases = append(cases,
+			ownerCase{"uid above uint32", math.MaxUint32 + 1, 0},
+			ownerCase{"gid above uint32", 0, math.MaxUint32 + 1},
+		)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hdr := &tar.Header{Name: "x", Uid: int(tc.uid), Gid: int(tc.gid)}
+			if err := validateHeaderIDs(hdr); !errors.Is(err, errInvalidArchive) {
+				t.Fatalf("expected errInvalidArchive for %d:%d, got %v", tc.uid, tc.gid, err)
+			}
+		})
+	}
+
+	// An in-range owner must still be accepted.
+	if err := validateHeaderIDs(&tar.Header{Name: "x", Uid: 65534, Gid: 65534}); err != nil {
+		t.Fatalf("unexpected error for in-range owner: %v", err)
+	}
+}


### PR DESCRIPTION
createTarFile and OverlayConvertWhiteout pass hdr.Uid and hdr.Gid straight from a layer's tar header into lchown/chown, which take uint32, so an owner ID at or above 2^32 is silently truncated. A crafted layer that declares uid 0x100000000 for a file ends up chowning it to 0 (root) rather than the value the header states. Range-check both IDs against the uint32 range before the chown and reject the entry otherwise, matching the guard the block/char/fifo device path already uses.