### PR TITLE
pkg/oci: reject out-of-range uid/gid from image user database

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -600,19 +600,14 @@ func WithUser(userstr string) SpecOpts {
 		defer ensureAdditionalGids(s)
 		setProcess(s)
 		s.Process.User.AdditionalGids = nil
-		// While the Linux kernel allows the max UID to be MaxUint32 - 2,
-		// and the OCI Runtime Spec has no definition about the max UID,
-		// the runc implementation is known to require the UID to be <= MaxInt32.
-		//
-		// containerd follows runc's limitation here.
-		//
-		// In future we may relax this limitation to allow MaxUint32 - 2,
-		// or, amend the OCI Runtime Spec to codify the implementation limitation.
+		// The runtime spec models the UID/GID as uint32, and runc accepts
+		// ids up to MaxUint32-1. pkg/oci accepts whatever OCI accepts, and
+		// rejects anything past that bound.
 		const (
 			minUserID  = 0
-			maxUserID  = math.MaxInt32
+			maxUserID  = math.MaxUint32 - 1
 			minGroupID = 0
-			maxGroupID = math.MaxInt32
+			maxGroupID = math.MaxUint32 - 1
 		)
 
 		// For LCOW it's a bit harder to confirm that the user actually exists on the host as a rootfs isn't
@@ -629,7 +624,9 @@ func WithUser(userstr string) SpecOpts {
 		parts := strings.Split(userstr, ":")
 		switch len(parts) {
 		case 1:
-			v, err := strconv.Atoi(parts[0])
+			// Parse into int64 so that ids above MaxInt32 behave the same
+			// on 32-bit platforms, where Atoi would fail with ErrRange.
+			v, err := strconv.ParseInt(parts[0], 10, 64)
 			if err != nil {
 				if errors.Is(err, strconv.ErrRange) {
 					return fmt.Errorf("invalid USER value %q: uid out of range", userstr)
@@ -647,7 +644,7 @@ func WithUser(userstr string) SpecOpts {
 				groupname string
 			)
 			var uid, gid uint32
-			v, err := strconv.Atoi(parts[0])
+			v, err := strconv.ParseInt(parts[0], 10, 64)
 			if err != nil {
 				if errors.Is(err, strconv.ErrRange) {
 					return fmt.Errorf("invalid USER value %q: uid out of range", userstr)
@@ -658,7 +655,7 @@ func WithUser(userstr string) SpecOpts {
 			} else {
 				uid = uint32(v)
 			}
-			v, err = strconv.Atoi(parts[1])
+			v, err = strconv.ParseInt(parts[1], 10, 64)
 			if err != nil {
 				if errors.Is(err, strconv.ErrRange) {
 					return fmt.Errorf("invalid USER value %q: gid out of range", userstr)
@@ -761,7 +758,9 @@ func WithUserID(uid uint32) SpecOpts {
 		s.Process.User.AdditionalGids = nil
 		setUser := func(root fs.FS) error {
 			usr, err := UserFromFS(root, func(u user.User) bool {
-				return u.Uid == int(uid)
+				// Compare at int64 width: uid may exceed MaxInt32, which
+				// int(uid) would overflow on 32-bit platforms.
+				return int64(u.Uid) == int64(uid)
 			})
 			if err != nil {
 				if errors.Is(err, fs.ErrNotExist) || errors.Is(err, ErrNoUsersFound) {
@@ -1010,9 +1009,17 @@ func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 			}
 			var gids []uint32
 			for _, group := range groups {
-				gid, err := strconv.ParseUint(group, 10, 32)
+				// Parse at 64-bit width so that a numeric gid past uint32 is
+				// reported as out of range instead of falling through to the
+				// group-name lookup below.
+				gid, err := strconv.ParseUint(group, 10, 64)
 				if err == nil {
+					if gid > math.MaxUint32-1 {
+						return fmt.Errorf("group %q has gid %d out of range", group, gid)
+					}
 					gids = append(gids, uint32(gid))
+				} else if errors.Is(err, strconv.ErrRange) {
+					return fmt.Errorf("group %q has gid out of range", group)
 				} else {
 					g, ok := groupMap[group]
 					if !ok {
@@ -1020,6 +1027,9 @@ func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 							return fmt.Errorf("unable to find group %s: %w", group, groupErr)
 						}
 						return fmt.Errorf("unable to find group %s", group)
+					}
+					if !validUserID(g.Gid) {
+						return fmt.Errorf("group %q has gid %d out of range", g.Name, g.Gid)
 					}
 					gids = append(gids, uint32(g.Gid))
 				}
@@ -1164,6 +1174,20 @@ func UserFromPath(root string, filter func(user.User) bool) (user.User, error) {
 	return UserFromFS(r.FS(), filter)
 }
 
+// validUserID reports whether id, read from a user database file such as
+// /etc/passwd or /etc/group, fits in a runtime spec UID/GID. pkg/oci accepts
+// whatever OCI accepts, i.e. ids up to MaxUint32-1, so that a larger value
+// read from an image cannot wrap when narrowed to the spec's uint32 field
+// (for example 1<<32 becomes 0, i.e. root).
+//
+// The parser in github.com/moby/sys/user stores ids in an int and discards
+// conversion errors, so on 32-bit platforms an out-of-range id in the file
+// saturates to MaxInt32 before this check runs: it never wraps to 0, but it
+// cannot be detected here either.
+func validUserID(id int) bool {
+	return id >= 0 && int64(id) <= math.MaxUint32-1
+}
+
 // UserFromFS inspects the user object using /etc/passwd in the specified fs.FS.
 // filter can be nil.
 func UserFromFS(root fs.FS, filter func(user.User) bool) (user.User, error) {
@@ -1179,7 +1203,11 @@ func UserFromFS(root fs.FS, filter func(user.User) bool) (user.User, error) {
 	if len(users) == 0 {
 		return user.User{}, ErrNoUsersFound
 	}
-	return users[0], nil
+	u := users[0]
+	if !validUserID(u.Uid) || !validUserID(u.Gid) {
+		return user.User{}, fmt.Errorf("user %q has uid %d / gid %d out of range", u.Name, u.Uid, u.Gid)
+	}
+	return u, nil
 }
 
 // ErrNoGroupsFound can be returned from GIDFromPath
@@ -1212,6 +1240,9 @@ func GIDFromFS(root fs.FS, filter func(user.Group) bool) (gid uint32, err error)
 		return 0, ErrNoGroupsFound
 	}
 	g := groups[0]
+	if !validUserID(g.Gid) {
+		return 0, fmt.Errorf("group %q has gid %d out of range", g.Name, g.Gid)
+	}
 	return uint32(g.Gid), nil
 }
 
@@ -1231,6 +1262,9 @@ func getSupplementalGroupsFromFS(root fs.FS, filter func(user.Group) bool) ([]ui
 	}
 	addlGids := make([]uint32, len(groups))
 	for i, grp := range groups {
+		if !validUserID(grp.Gid) {
+			return []uint32{}, fmt.Errorf("group %q has gid %d out of range", grp.Name, grp.Gid)
+		}
 		addlGids[i] = uint32(grp.Gid)
 	}
 	return addlGids, nil

--- a/pkg/oci/spec_opts_user_bounds_test.go
+++ b/pkg/oci/spec_opts_user_bounds_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"io/fs"
+	"strconv"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -27,6 +28,77 @@ import (
 	"github.com/moby/sys/user"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestUserIDBoundsFromFS asserts that a UID/GID read from an image's
+// /etc/passwd or /etc/group is rejected when it falls outside the range
+// OCI accepts ([0, MaxUint32-1]), instead of wrapping when narrowed to the
+// spec's uint32 fields (for example 1<<32 -> 0, i.e. root).
+func TestUserIDBoundsFromFS(t *testing.T) {
+	t.Parallel()
+
+	// user.User and user.Group store ids in an int, and the parser discards
+	// conversion errors, so on 32-bit platforms an out-of-range id saturates
+	// to MaxInt32 before the bound check can observe it.
+	if strconv.IntSize == 32 {
+		t.Skip("ids parsed from user files saturate to MaxInt32 on 32-bit platforms")
+	}
+
+	// MaxUint32 is the first value past the bound; 1<<32 additionally wraps
+	// to 0 (root) when cast to uint32.
+	overflows := []string{"4294967295", "4294967296"}
+
+	t.Run("passwd uid past bound is rejected", func(t *testing.T) {
+		t.Parallel()
+		for _, overflow := range overflows {
+			fsys := fstest.MapFS{
+				"etc/passwd": &fstest.MapFile{Data: []byte("evil:x:" + overflow + ":10::/:/bin/sh\n"), Mode: 0o644},
+			}
+			_, err := UserFromFS(fsys, func(u user.User) bool { return u.Name == "evil" })
+			assert.ErrorContains(t, err, "out of range", "uid %s", overflow)
+		}
+	})
+
+	t.Run("passwd gid past bound is rejected", func(t *testing.T) {
+		t.Parallel()
+		for _, overflow := range overflows {
+			fsys := fstest.MapFS{
+				"etc/passwd": &fstest.MapFile{Data: []byte("evil:x:10:" + overflow + "::/:/bin/sh\n"), Mode: 0o644},
+			}
+			_, err := UserFromFS(fsys, func(u user.User) bool { return u.Name == "evil" })
+			assert.ErrorContains(t, err, "out of range", "gid %s", overflow)
+		}
+	})
+
+	t.Run("group gid past bound is rejected", func(t *testing.T) {
+		t.Parallel()
+		for _, overflow := range overflows {
+			fsys := fstest.MapFS{
+				"etc/group": &fstest.MapFile{Data: []byte("evil:x:" + overflow + ":\n"), Mode: 0o644},
+			}
+			_, err := GIDFromFS(fsys, func(g user.Group) bool { return g.Name == "evil" })
+			assert.ErrorContains(t, err, "out of range", "gid %s", overflow)
+
+			_, err = getSupplementalGroupsFromFS(fsys, func(g user.Group) bool { return g.Name == "evil" })
+			assert.ErrorContains(t, err, "out of range", "gid %s", overflow)
+		}
+	})
+
+	t.Run("in-range ids are accepted", func(t *testing.T) {
+		t.Parallel()
+		const maxValid = "4294967294" // MaxUint32-1, the largest id OCI accepts
+		fsys := fstest.MapFS{
+			"etc/passwd": &fstest.MapFile{Data: []byte("app:x:" + maxValid + ":" + maxValid + "::/:/bin/sh\n"), Mode: 0o644},
+			"etc/group":  &fstest.MapFile{Data: []byte("app:x:" + maxValid + ":\n"), Mode: 0o644},
+		}
+		usr, err := UserFromFS(fsys, func(u user.User) bool { return u.Name == "app" })
+		assert.NoError(t, err)
+		assert.Equal(t, int64(4294967294), int64(usr.Uid))
+
+		gid, err := GIDFromFS(fsys, func(g user.Group) bool { return g.Name == "app" })
+		assert.NoError(t, err)
+		assert.Equal(t, uint32(4294967294), gid)
+	})
+}
 
 // TestOpenUserFileCapsReads asserts the boundary behavior of the read cap:
 // well below, ending exactly at, and past maxUserFileBytes.

--- a/pkg/oci/spec_opts_user_test.go
+++ b/pkg/oci/spec_opts_user_test.go
@@ -19,6 +19,7 @@ package oci
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/containerd/continuity/fs/fstest"
@@ -87,16 +88,25 @@ guest:x:100:guest
 			expectedGID: 100,
 		},
 		{
-			user: "405:2147483648",
-			err:  "invalid USER value \"405:2147483648\": gid out of range",
+			user:        "405:4294967294",
+			expectedUID: 405,
+			expectedGID: 4294967294,
+		},
+		{
+			user: "405:4294967295",
+			err:  "invalid USER value \"405:4294967295\": gid out of range",
 		},
 		{
 			user: "-1000",
 			err:  "invalid USER value \"-1000\": uid out of range",
 		},
 		{
-			user: "2147483648",
-			err:  "invalid USER value \"2147483648\": uid out of range",
+			user:        "4294967294",
+			expectedUID: 4294967294,
+		},
+		{
+			user: "4294967295",
+			err:  "invalid USER value \"4294967295\": uid out of range",
 		},
 		{
 			user: "999999999999999999999999999999999999",
@@ -313,6 +323,7 @@ func TestWithAppendAdditionalGroups(t *testing.T) {
 	expectedContent := `root:x:0:root
 bin:x:1:root,bin,daemon
 daemon:x:2:root,bin,daemon
+overgrp:x:4294967295:daemon
 `
 	td := t.TempDir()
 	apply := fstest.Apply(
@@ -330,6 +341,7 @@ daemon:x:2:root,bin,daemon
 		groups         []string
 		expected       []uint32
 		err            string
+		skipOn32Bit    bool
 	}{
 		{
 			name:     "no additional gids",
@@ -363,11 +375,42 @@ daemon:x:2:root,bin,daemon
 			err:      "unable to find group unknown",
 			expected: []uint32{0},
 		},
+		{
+			name:     "numeric gid past the OCI bound",
+			groups:   []string{"4294967295"},
+			err:      `group "4294967295" has gid 4294967295 out of range`,
+			expected: []uint32{0},
+		},
+		{
+			name:     "numeric gid past uint32",
+			groups:   []string{"4294967296"},
+			err:      `group "4294967296" has gid 4294967296 out of range`,
+			expected: []uint32{0},
+		},
+		{
+			name:     "numeric gid past uint64",
+			groups:   []string{"99999999999999999999999999"},
+			err:      `group "99999999999999999999999999" has gid out of range`,
+			expected: []uint32{0},
+		},
+		{
+			name:     "group name resolving to gid past the OCI bound",
+			groups:   []string{"overgrp"},
+			err:      `group "overgrp" has gid 4294967295 out of range`,
+			expected: []uint32{0},
+			// The /etc/group parser stores gids in an int and discards
+			// conversion errors, so on 32-bit platforms the gid saturates
+			// to MaxInt32 and cannot be rejected.
+			skipOn32Bit: true,
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
+			if testCase.skipOn32Bit && strconv.IntSize == 32 {
+				t.Skip("gids parsed from /etc/group saturate to MaxInt32 on 32-bit platforms")
+			}
 			s := Spec{
 				Version: specs.Version,
 				Root: &specs.Root{


### PR DESCRIPTION
When the container's USER is given as a name rather than a numeric id, containerd resolves it against the image's /etc/passwd and /etc/group and copies the resulting uid and gid into the runtime spec's uint32 User fields with no range check. An image whose passwd entry maps a name to something like 4294967296 (1<<32) therefore has the value wrap to 0, so a container that should run as an unprivileged account runs as root. I ran into it after adding a passwd entry with a uid just past the 32-bit boundary and seeing the spec come back with UID 0.

The lookup helpers (UserFromFS, GIDFromFS, getSupplementalGroupsFromFS, and the groupname branch of WithAppendAdditionalGroups) now validate the resolved ids against the range OCI accepts, [0, MaxUint32-1], and return an error for anything outside it. Per review, the numeric form of WithUser also moves from its old MaxInt32 cap, which rested on a stale comment claiming runc requires ids to fit in int32, to the same MaxUint32-1 bound, so both paths accept exactly what OCI accepts. Regression tests cover the boundary in both directions: 4294967294 is accepted, 4294967295 and 1<<32 are rejected.