### PR TITLE
metadata: bound snapshotter Remove during garbage collection

### DIFF
--- a/core/metadata/snapshot.go
+++ b/core/metadata/snapshot.go
@@ -18,6 +18,7 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -31,6 +32,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	bolt "go.etcd.io/bbolt"
@@ -41,6 +43,19 @@ const (
 	inheritedLabelsPrefix = "containerd.io/snapshot/"
 	labelSnapshotRef      = "containerd.io/snapshot.ref"
 )
+
+// snapshotRemoveTimeout bounds each Snapshotter.Remove during garbage
+// collection, which holds the snapshotter write lock: an unresponsive
+// snapshotter (e.g. a hung proxy plugin RPC) would otherwise block all
+// snapshot operations forever. On timeout the rest of the pass is abandoned;
+// remaining snapshots stay orphaned and are retried on the next GC pass.
+const snapshotRemoveTimeout = "io.containerd.timeout.snapshot.remove"
+
+func init() {
+	timeout.Set(snapshotRemoveTimeout, 5*time.Minute)
+}
+
+var errGCRemoveTimeout = errors.New("snapshot removal timed out during garbage collection")
 
 type snapshotter struct {
 	snapshots.Snapshotter
@@ -861,11 +876,14 @@ func validateSnapshot(info *snapshots.Info) error {
 
 // garbageCollect removes all snapshots that are no longer used.
 func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, err error) {
+	var abandoned bool
 	s.l.Lock()
 	t1 := time.Now()
 	defer func() {
 		s.l.Unlock()
-		if err == nil {
+		// Skip Cleanup after an abandoned pass: the snapshotter just failed to
+		// answer a bounded Remove, so an unbounded Cleanup RPC would hang GC.
+		if err == nil && !abandoned {
 			if c, ok := s.Snapshotter.(snapshots.Cleaner); ok {
 				err = c.Cleanup(ctx)
 				if errdefs.IsNotImplemented(err) {
@@ -934,6 +952,11 @@ func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, err 
 
 	for _, node := range roots {
 		if err := s.pruneBranch(ctx, node); err != nil {
+			if errors.Is(err, errGCRemoveTimeout) {
+				// Bounded abandon: skipped snapshots are retried next pass.
+				abandoned = true
+				break
+			}
 			return 0, err
 		}
 	}
@@ -990,7 +1013,15 @@ func (s *snapshotter) pruneBranch(ctx context.Context, node *treeNode) error {
 
 	if node.remove {
 		logger := log.G(ctx).WithField("snapshotter", s.name)
-		if err := s.Snapshotter.Remove(ctx, node.info.Name); err != nil {
+		removeCtx, cancel := timeout.WithContext(ctx, snapshotRemoveTimeout)
+		err := s.Snapshotter.Remove(removeCtx, node.info.Name)
+		removeTimedOut := errors.Is(removeCtx.Err(), context.DeadlineExceeded)
+		cancel()
+		if err != nil {
+			if removeTimedOut {
+				logger.WithError(err).WithField("key", node.info.Name).Warn("snapshot removal timed out, abandoning garbage collection pass")
+				return errGCRemoveTimeout
+			}
 			if !errdefs.IsFailedPrecondition(err) {
 				return err
 			}

--- a/core/metadata/snapshot.go
+++ b/core/metadata/snapshot.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	bolt "go.etcd.io/bbolt"
@@ -40,6 +41,20 @@ import (
 const (
 	inheritedLabelsPrefix = "containerd.io/snapshot/"
 )
+
+// gcSnapshotterRemoveTimeoutKey bounds each Snapshotter.Remove during garbage
+// collection, which holds the snapshotter write lock: an unresponsive
+// snapshotter (e.g. a hung proxy plugin RPC) would otherwise block all
+// snapshot operations forever. On timeout the rest of the pass is abandoned;
+// remaining snapshots stay orphaned and are retried on the next GC pass.
+const (
+	gcSnapshotterRemoveTimeoutKey     = "io.containerd.timeout.gc.snapshotter.remove"
+	defaultGCSnapshotterRemoveTimeout = 30 * time.Minute
+)
+
+func init() {
+	timeout.Set(gcSnapshotterRemoveTimeoutKey, defaultGCSnapshotterRemoveTimeout)
+}
 
 type snapshotter struct {
 	snapshots.Snapshotter
@@ -989,7 +1004,10 @@ func (s *snapshotter) pruneBranch(ctx context.Context, node *treeNode) error {
 
 	if node.remove {
 		logger := log.G(ctx).WithField("snapshotter", s.name)
-		if err := s.Snapshotter.Remove(ctx, node.info.Name); err != nil {
+		removeCtx, cancel := timeout.WithContext(ctx, gcSnapshotterRemoveTimeoutKey)
+		err := s.Snapshotter.Remove(removeCtx, node.info.Name)
+		cancel()
+		if err != nil {
 			if !errdefs.IsFailedPrecondition(err) {
 				return err
 			}

--- a/core/metadata/snapshot_test.go
+++ b/core/metadata/snapshot_test.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/errdefs"
 )
 
@@ -456,4 +458,103 @@ func (s *tmpSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...
 
 func (s *tmpSnapshotter) Close() error {
 	return nil
+}
+
+type hangingRemoveSnapshotter struct {
+	snapshots.Snapshotter
+	removes  atomic.Int32
+	cleanups atomic.Int32
+}
+
+func (s *hangingRemoveSnapshotter) Remove(ctx context.Context, key string) error {
+	s.removes.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// Cleanup makes the wrapper a snapshots.Cleaner so the test can assert GC does
+// not call it after abandoning a pass. This stub returns immediately; a real
+// wedged snapshotter would hang here just like it does in Remove.
+func (s *hangingRemoveSnapshotter) Cleanup(ctx context.Context) error {
+	s.cleanups.Add(1)
+	return nil
+}
+
+func TestGarbageCollectHangingRemove(t *testing.T) {
+	ctx, bdb := testEnv(t)
+
+	sn := &hangingRemoveSnapshotter{Snapshotter: NewTmpSnapshotter()}
+	db := NewDB(bdb, nil, map[string]snapshots.Snapshotter{"tmp": sn})
+	if err := db.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Orphan snapshots: exist in the backend but not in metadata, so GC removes them.
+	for _, key := range []string{"orphan-1", "orphan-2"} {
+		if _, err := sn.Snapshotter.Prepare(ctx, key, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	prev := timeout.Get(snapshotRemoveTimeout)
+	timeout.Set(snapshotRemoveTimeout, 100*time.Millisecond)
+	t.Cleanup(func() { timeout.Set(snapshotRemoveTimeout, prev) })
+
+	msn := db.Snapshotter("tmp").(*snapshotter)
+	done := make(chan error, 1)
+	go func() {
+		_, err := msn.garbageCollect(ctx)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("garbageCollect returned error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("garbageCollect hung on unresponsive snapshotter Remove")
+	}
+
+	// The pass is abandoned after the first timed-out removal.
+	if n := sn.removes.Load(); n != 1 {
+		t.Fatalf("expected 1 remove attempt before abandoning the pass, got %d", n)
+	}
+	// Cleanup must be skipped after an abandoned pass: the snapshotter just
+	// failed to answer a bounded Remove, and Cleanup has no bound.
+	if n := sn.cleanups.Load(); n != 0 {
+		t.Fatalf("expected no Cleanup call after abandoned pass, got %d", n)
+	}
+	// Skipped snapshots stay orphaned for the next GC pass.
+	for _, key := range []string{"orphan-1", "orphan-2"} {
+		if _, err := sn.Snapshotter.Stat(ctx, key); err != nil {
+			t.Fatalf("orphan %q should survive for the next GC pass: %v", key, err)
+		}
+	}
+}
+
+type failingRemoveSnapshotter struct {
+	snapshots.Snapshotter
+}
+
+func (s *failingRemoveSnapshotter) Remove(ctx context.Context, key string) error {
+	return errdefs.ErrFailedPrecondition
+}
+
+func TestGarbageCollectFailedPreconditionRemove(t *testing.T) {
+	ctx, bdb := testEnv(t)
+
+	sn := &failingRemoveSnapshotter{Snapshotter: NewTmpSnapshotter()}
+	db := NewDB(bdb, nil, map[string]snapshots.Snapshotter{"tmp": sn})
+	if err := db.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sn.Snapshotter.Prepare(ctx, "orphan", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	msn := db.Snapshotter("tmp").(*snapshotter)
+	if _, err := msn.garbageCollect(ctx); err != nil {
+		t.Fatalf("FailedPrecondition on Remove must not fail garbage collection: %v", err)
+	}
 }

--- a/core/metadata/snapshot_test.go
+++ b/core/metadata/snapshot_test.go
@@ -18,11 +18,14 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/containerd/containerd/v2/core/leases"
@@ -456,4 +459,95 @@ func (s *tmpSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...
 
 func (s *tmpSnapshotter) Close() error {
 	return nil
+}
+
+type hangingRemoveSnapshotter struct {
+	snapshots.Snapshotter
+	removes  atomic.Int32
+	cleanups atomic.Int32
+}
+
+func (s *hangingRemoveSnapshotter) Remove(ctx context.Context, key string) error {
+	s.removes.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// Cleanup makes the wrapper a snapshots.Cleaner so the test can assert GC does
+// not call it after abandoning a pass. This stub returns immediately; a real
+// wedged snapshotter would hang here just like it does in Remove.
+func (s *hangingRemoveSnapshotter) Cleanup(ctx context.Context) error {
+	s.cleanups.Add(1)
+	return nil
+}
+
+func TestGarbageCollectHangingRemove(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, bdb := testEnv(t)
+
+		sn := &hangingRemoveSnapshotter{Snapshotter: NewTmpSnapshotter()}
+		db := NewDB(bdb, nil, map[string]snapshots.Snapshotter{"tmp": sn})
+		if err := db.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		// Orphan snapshots: exist in the backend but not in metadata, so GC removes them.
+		for _, key := range []string{"orphan-1", "orphan-2"} {
+			if _, err := sn.Snapshotter.Prepare(ctx, key, ""); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// The fake clock reaches the removal deadline as soon as Remove blocks,
+		// so this runs against the real default instead of a shortened one. An
+		// unbounded Remove would deadlock the bubble rather than pass.
+		msn := db.Snapshotter("tmp").(*snapshotter)
+		_, err := msn.garbageCollect(ctx)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected the bounded Remove to fail with DeadlineExceeded, got %v", err)
+		}
+
+		// The pass is abandoned after the first timed-out removal.
+		if n := sn.removes.Load(); n != 1 {
+			t.Fatalf("expected 1 remove attempt before abandoning the pass, got %d", n)
+		}
+		// Cleanup must be skipped after an abandoned pass: the snapshotter just
+		// failed to answer a bounded Remove, and Cleanup has no bound.
+		if n := sn.cleanups.Load(); n != 0 {
+			t.Fatalf("expected no Cleanup call after abandoned pass, got %d", n)
+		}
+		// Skipped snapshots stay orphaned for the next GC pass.
+		for _, key := range []string{"orphan-1", "orphan-2"} {
+			if _, err := sn.Snapshotter.Stat(ctx, key); err != nil {
+				t.Fatalf("orphan %q should survive for the next GC pass: %v", key, err)
+			}
+		}
+	})
+}
+
+type failingRemoveSnapshotter struct {
+	snapshots.Snapshotter
+}
+
+func (s *failingRemoveSnapshotter) Remove(ctx context.Context, key string) error {
+	return errdefs.ErrFailedPrecondition
+}
+
+func TestGarbageCollectFailedPreconditionRemove(t *testing.T) {
+	ctx, bdb := testEnv(t)
+
+	sn := &failingRemoveSnapshotter{Snapshotter: NewTmpSnapshotter()}
+	db := NewDB(bdb, nil, map[string]snapshots.Snapshotter{"tmp": sn})
+	if err := db.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sn.Snapshotter.Prepare(ctx, "orphan", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	msn := db.Snapshotter("tmp").(*snapshotter)
+	if _, err := msn.garbageCollect(ctx); err != nil {
+		t.Fatalf("FailedPrecondition on Remove must not fail garbage collection: %v", err)
+	}
 }

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -178,6 +178,7 @@ documentation.
   "io.containerd.timeout.shim.cleanup" = "5s"
   "io.containerd.timeout.shim.load" = "5s"
   "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.snapshot.remove" = "5m"
   "io.containerd.timeout.task.state" = "2s" -->
 
 **imports**

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -178,6 +178,7 @@ documentation.
   "io.containerd.timeout.shim.cleanup" = "5s"
   "io.containerd.timeout.shim.load" = "5s"
   "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.gc.snapshotter.remove" = "30m"
   "io.containerd.timeout.task.state" = "2s" -->
 
 **imports**


### PR DESCRIPTION
Fixes #13798

**Problem**

During snapshot GC, `cleanupSnapshotter` calls the snapshotter's `Remove` while holding the metadata store write lock, with no deadline (it even strips the caller's cancellation). If the snapshotter never answers, the lock is held forever. Every snapshot operation on the node queues behind it, including CRI `RunPodSandbox`, so no new container can start. Nothing on the readiness path takes this lock, so the node keeps reporting Ready the whole time.

```mermaid
flowchart TD
    K[kubelet] -->|Ready probe| S["CRI Status()"]
    K -->|RunPodSandbox| P[snapshot Prepare]
    S --> OK["returns OK - never takes the lock"]
    P --> L{{metadata store write lock}}
    GC[snapshot GC] -->|holds| L
    GC -->|"Remove() - no deadline"| SOCI[soci snapshotter<br/>out of fds, never answers]
    L -.->|blocked behind GC| P
```

We hit this in production: our soci snapshotter ran out of file descriptors and stopped answering, the GC's `Remove` parked in `waitOnHeader`, and the node could not start a single pod for 4.5 hours while showing Ready. Goroutine dumps are in the issue. The fd leak was a soci bug (fixed upstream in awslabs/soci-snapshotter#2043), but any proxy snapshotter that stalls reproduces this: one stuck RPC should not brick the node.

**Fix**

Bound each GC-path `Remove` with a `pkg/timeout` key (`io.containerd.timeout.snapshot.remove`, default 30m), the same pattern as shim cleanup and bolt open timeouts.

On the first timed-out `Remove` the rest of the pass is abandoned, so a wedged snapshotter costs one timeout per GC cycle instead of one per orphan. Skipped snapshots stay orphaned and are retried next pass. The deferred `Cleanup` call is skipped in that case too, since it is an unbounded RPC to the same snapshotter that just failed to answer.

**Not in this PR**

`Walk` runs under the same lock and is also unbounded. Left out to keep this change small; can follow up.
