### PR TITLE
core/mount/manager: improve TestMkdirHandler failure messages

### DIFF
--- a/core/mount/manager/mkdir_linux_test.go
+++ b/core/mount/manager/mkdir_linux_test.go
@@ -77,14 +77,14 @@ func TestMkdirHandler(t *testing.T) {
 		t.Fatalf("expected directory")
 	}
 	if fi.Mode().Perm() != testmode {
-		t.Fatalf("expected mode 0775 got %o", fi.Mode().Perm())
+		t.Fatalf("expected mode %04o got %04o", testmode, fi.Mode().Perm())
 	}
 	sys := fi.Sys().(*syscall.Stat_t)
 	if int(sys.Uid) != luid {
-		t.Fatalf("expected uid 1000 got %d", sys.Uid)
+		t.Fatalf("expected uid %d got %d", luid, sys.Uid)
 	}
 	if int(sys.Gid) != lgid {
-		t.Fatalf("expected gid 1000 got %d", sys.Gid)
+		t.Fatalf("expected gid %d got %d", lgid, sys.Gid)
 	}
 
 	m.Options = append(m.Options, fmt.Sprintf("X-containerd.mkdir.path=%s", filepath.Join(td, "notinroot")))


### PR DESCRIPTION
## Summary

Improve `TestMkdirHandler` assertion messages to report the actual expected values.

## Changes

- Use `testmode` when reporting the expected permission.
- Use `luid` when reporting the expected UID.
- Use `lgid` when reporting the expected GID.

## Motivation

While debugging a local test failure, I noticed that the assertion messages use hardcoded values (`0775`, `1000`) even though the test compares against variables (`testmode`, `luid`, and `lgid`).

Reporting the actual expected values makes test failures easier to understand and avoids confusion during debugging.

This change only improves test diagnostics and does not modify runtime behavior.