### PR TITLE
overlay: don't override a configured index mount option

### DIFF
--- a/plugins/snapshots/overlay/overlay.go
+++ b/plugins/snapshots/overlay/overlay.go
@@ -147,7 +147,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		return nil, err
 	}
 
-	if !hasOption(config.mountOptions, "userxattr", false) {
+	if !hasOption(config.mountOptions, "userxattr") {
 		// figure out whether "userxattr" option is recognized by the kernel && needed
 		userxattr, err := overlayutils.NeedsUserXAttr(root)
 		if err != nil {
@@ -158,7 +158,9 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		}
 	}
 
-	if !hasOption(config.mountOptions, "index", false) && supportsIndex() {
+	// Mount options are last-wins in the kernel, so appending "index=off"
+	// after a configured "index=on" would silently override it.
+	if !hasOption(config.mountOptions, "index") && supportsIndex() {
 		config.mountOptions = append(config.mountOptions, "index=off")
 	}
 
@@ -173,13 +175,14 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 	}, nil
 }
 
-func hasOption(options []string, key string, hasValue bool) bool {
+// hasOption reports whether the "key" option is present in options, either
+// as a bare flag ("userxattr") or in "key=value" form ("index=on").
+func hasOption(options []string, key string) bool {
 	for _, option := range options {
-		if hasValue {
-			if strings.HasPrefix(option, key) && len(option) > len(key) && option[len(key)] == '=' {
-				return true
-			}
-		} else if option == key {
+		if option == key {
+			return true
+		}
+		if optionKey, _, ok := strings.Cut(option, "="); ok && optionKey == key {
 			return true
 		}
 	}

--- a/plugins/snapshots/overlay/overlay_test.go
+++ b/plugins/snapshots/overlay/overlay_test.go
@@ -48,6 +48,29 @@ func newSnapshotterWithOpts(opts ...Opt) testsuite.SnapshotterFunc {
 	}
 }
 
+// NewSnapshotter must not auto-append "index=off" when the configuration
+// already carries an index option: mount options are last-wins in the
+// kernel, so the appended "index=off" would silently override a configured
+// "index=on" — and combined with "nfs_export=on" it makes every overlay
+// mount fail with EINVAL (nfs_export=on conflicts with an explicit
+// index=off).
+func TestOverlayConfiguredIndexNotOverridden(t *testing.T) {
+	if !supportsIndex() {
+		t.Skip("kernel does not expose the overlay index parameter")
+	}
+	sn, err := NewSnapshotter(t.TempDir(), WithMountOptions([]string{"index=on", "nfs_export=on"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sn.Close()
+	options := sn.(*snapshotter).options
+	for _, opt := range options {
+		if opt == "index=off" {
+			t.Fatalf("configured index option overridden by auto-appended index=off (options: %v)", options)
+		}
+	}
+}
+
 func TestOverlay(t *testing.T) {
 	testutil.RequiresRoot(t)
 	optTestCases := map[string][]Opt{


### PR DESCRIPTION
The overlay snapshotter auto-appends `index=off` to its mount options unless the user configuration already carries an index option — but the guard can never fire:

```go
if !hasOption(config.mountOptions, "index", false) && supportsIndex() {
    config.mountOptions = append(config.mountOptions, "index=off")
}
```

`hasOption(..., hasValue=false)` compares each option against the literal string `"index"`. The index option is always valued (`index=on` / `index=off`), so no valid configuration ever matches, and `index=off` is appended unconditionally whenever `/sys/module/overlay/parameters/index` exists.

Mount options are last-wins in the kernel, so a configured `index=on` is silently overridden. The practical casualty is NFS export of overlay mounts: configuring

```toml
[plugins."io.containerd.snapshotter.v1.overlayfs"]
  mount_options = ["index=on", "nfs_export=on"]
```

produces `index=on,nfs_export=on,index=off` on every snapshot mount, which the kernel rejects with EINVAL — `nfs_export=on` conflicts with an explicit `index=off` (`fs/overlayfs/params.c`, "conflicting options: nfs_export=on,index=off"). The first casualty is image unpack:

```
failed to mount /tmp/containerd-mount2856290739: ...
data: "workdir=...,upperdir=...,lowerdir=...,index=on,nfs_export=on,index=off", err: invalid argument
```

(Reproduced on containerd 2.2.5 / kernel 6.12 with dockerd 29.6.1 using the containerd image store; the code is unchanged on main.)

This changes the check to `hasValue=true` (prefix `index=` match, the same helper the valued form exists for), so a configured index option suppresses the auto-append. The neighboring `userxattr` check keeps `hasValue=false`, which is correct for a bare flag option.

Also adds a regression test asserting that a snapshotter configured with `WithMountOptions([]string{"index=on", "nfs_export=on"})` does not end up with `index=off` in its options.

```release-note
Avoid overriding user-configured index mount option in overlayfs snapshotter
```
