### PR TITLE
Support warm image cache for erofs snapshotter

### DIFF
--- a/cmd/ctr/commands/images/build_erofs_cache.go
+++ b/cmd/ctr/commands/images/build_erofs_cache.go
@@ -33,6 +33,7 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/converter/erofs"
+	"github.com/containerd/containerd/v2/internal/dmverity"
 	"github.com/containerd/containerd/v2/internal/erofsutils"
 )
 
@@ -41,10 +42,15 @@ var buildErofsCacheCommand = &cli.Command{
 	Usage:     "Build an erofs layer content cache from an image's layers",
 	ArgsUsage: "[flags] <image_ref> <cache_dir>",
 	Description: `Convert each layer of an already-pulled image into a directory of
-diffID-keyed erofs blobs (<cache_dir>/<algorithm>/<hex>.erofs) for the erofs
+diffID-keyed erofs blobs (<cache_dir>/<algorithm>/<xx>/<hex>.erofs, where <xx> is
+the first two characters of <hex>) for the erofs
 snapshotter's layer_content_cache. Layers are read from the content store; no
 converted image is produced. The directory can then be synced to the read-only
-location the fleet mounts. Requires mkfs.erofs.`,
+location the fleet mounts. Requires mkfs.erofs.
+
+Pass --dmverity to also generate a dm-verity hash tree and .dmverity sidecar for
+each blob (Linux only); this is required when the snapshotter runs with
+dmverity_mode=on, which rejects cache hits that lack a sidecar.`,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "compressors",
@@ -57,6 +63,10 @@ location the fleet mounts. Requires mkfs.erofs.`,
 		&cli.StringFlag{
 			Name:  "platform",
 			Usage: "Cache layers for a specific platform (default: host platform)",
+		},
+		&cli.BoolFlag{
+			Name:  "dmverity",
+			Usage: "Generate a dm-verity hash tree and .dmverity sidecar for each blob (Linux only)",
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
@@ -94,9 +104,9 @@ location the fleet mounts. Requires mkfs.erofs.`,
 			return err
 		}
 
-		if err := buildCache(ctx, client.ContentStore(), img.Target, platform, cacheDir, opts...); err != nil {
+		if err := buildCache(ctx, client.ContentStore(), img.Target, platform, cacheDir, cliContext.Bool("dmverity"), opts...); err != nil {
 			if errdefs.IsNotFound(err) {
-				return fmt.Errorf("%w; fetch the image content first, e.g. `ctr content fetch %s`", err, ref)
+				return fmt.Errorf("fetch the image content first, e.g. `ctr content fetch %s`: %w", ref, err)
 			}
 			return err
 		}
@@ -111,9 +121,9 @@ location the fleet mounts. Requires mkfs.erofs.`,
 // the cache can be populated from an already-pulled image and then synced to the
 // read-only location the fleet mounts. Because the key is the source layer's
 // diffID, it matches what the runtime looks up when pulling the original image,
-// and layers shared across images converge on one blob. dm-verity sidecars are
-// not produced here (the converter does no dm-verity formatting).
-func buildCache(ctx context.Context, cs content.Store, image ocispec.Descriptor, platform platforms.MatchComparer, cacheDir string, opts ...erofs.ConvertOpt) error {
+// and layers shared across images converge on one blob. When withDmverity is set
+// a dm-verity hash tree and .dmverity sidecar are also produced per blob.
+func buildCache(ctx context.Context, cs content.Store, image ocispec.Descriptor, platform platforms.MatchComparer, cacheDir string, withDmverity bool, opts ...erofs.ConvertOpt) error {
 	manifest, err := images.Manifest(ctx, cs, image, platform)
 	if err != nil {
 		return fmt.Errorf("failed to resolve manifest: %w", err)
@@ -123,7 +133,7 @@ func buildCache(ctx context.Context, cs content.Store, image ocispec.Descriptor,
 		if !images.IsLayerType(layer.MediaType) || erofsutils.IsErofsMediaType(layer.MediaType) || images.IsNonDistributable(layer.MediaType) {
 			continue
 		}
-		if err := buildLayer(ctx, cs, layer, cacheDir, opts...); err != nil {
+		if err := buildLayer(ctx, cs, layer, cacheDir, withDmverity, opts...); err != nil {
 			// Preserve errdefs.IsNotFound so callers can add context-appropriate
 			// remediation (e.g. ctr suggesting `ctr content fetch`).
 			if errdefs.IsNotFound(err) {
@@ -138,8 +148,9 @@ func buildCache(ctx context.Context, cs content.Store, image ocispec.Descriptor,
 // buildLayer converts one layer into a temp file inside cacheDir, then
 // atomically renames it to its diffID-keyed name (same filesystem, so no extra
 // copy and no reliance on TMPDIR). An existing entry is overwritten, keeping the
-// operation idempotent across re-runs and shared layers.
-func buildLayer(ctx context.Context, cs content.Store, layer ocispec.Descriptor, cacheDir string, opts ...erofs.ConvertOpt) (retErr error) {
+// operation idempotent across re-runs and shared layers. When withDmverity is
+// set the blob is dm-verity formatted and its sidecar is moved into place too.
+func buildLayer(ctx context.Context, cs content.Store, layer ocispec.Descriptor, cacheDir string, withDmverity bool, opts ...erofs.ConvertOpt) (retErr error) {
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
 		return err
 	}
@@ -152,6 +163,7 @@ func buildLayer(ctx context.Context, cs content.Store, layer ocispec.Descriptor,
 	defer func() {
 		if retErr != nil {
 			os.Remove(tmpPath)
+			os.Remove(dmverity.MetadataPath(tmpPath))
 		}
 	}()
 
@@ -160,15 +172,62 @@ func buildLayer(ctx context.Context, cs content.Store, layer ocispec.Descriptor,
 		return err
 	}
 
+	if withDmverity {
+		// Appends the hash tree to the blob and writes tmpPath's .dmverity sidecar.
+		if err := dmverity.FormatLayer(ctx, tmpPath, nil); err != nil {
+			return err
+		}
+	}
+
 	// os.CreateTemp makes the file 0600; widen it so other users (e.g. a
 	// rootless containerd) can read the shared cache.
 	if err := os.Chmod(tmpPath, 0644); err != nil {
 		return err
 	}
 
-	dest := filepath.Join(cacheDir, diffID.Algorithm().String(), diffID.Encoded()+".erofs")
-	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+	dest := erofsutils.CacheBlobPath(cacheDir, diffID)
+	destDir := filepath.Dir(dest)
+	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return err
 	}
-	return os.Rename(tmpPath, dest)
+
+	// fsync the temp files before renaming so a crash right after the rename can't
+	// leave a zero-length or torn cache entry. A missing sidecar (dm-verity
+	// disabled) is skipped.
+	for _, p := range []string{tmpPath, dmverity.MetadataPath(tmpPath)} {
+		if err := fsync(p); err != nil {
+			return err
+		}
+	}
+
+	// Move the sidecar into place before the blob: the snapshotter keys on the
+	// blob's presence, so the sidecar must already exist when the blob appears.
+	if withDmverity {
+		if err := os.Rename(dmverity.MetadataPath(tmpPath), dmverity.MetadataPath(dest)); err != nil {
+			return err
+		}
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		return err
+	}
+
+	// fsync the directory so the renames themselves survive a crash.
+	return fsync(destDir)
+}
+
+// fsync flushes the file (or directory) at path to disk. A path that does not
+// exist is treated as a no-op so callers can fsync an optional sidecar.
+func fsync(path string) error {
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
 }

--- a/cmd/ctr/commands/images/build_erofs_cache.go
+++ b/cmd/ctr/commands/images/build_erofs_cache.go
@@ -1,0 +1,174 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli/v2"
+
+	"github.com/containerd/containerd/v2/cmd/ctr/commands"
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/images/converter/erofs"
+	"github.com/containerd/containerd/v2/internal/erofsutils"
+)
+
+var buildErofsCacheCommand = &cli.Command{
+	Name:      "build-erofs-cache",
+	Usage:     "Build an erofs layer content cache from an image's layers",
+	ArgsUsage: "[flags] <image_ref> <cache_dir>",
+	Description: `Convert each layer of an already-pulled image into a directory of
+diffID-keyed erofs blobs (<cache_dir>/<algorithm>/<hex>.erofs) for the erofs
+snapshotter's layer_content_cache. Layers are read from the content store; no
+converted image is produced. The directory can then be synced to the read-only
+location the fleet mounts. Requires mkfs.erofs.`,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "compressors",
+			Usage: "EROFS per-block compression algorithm(s), e.g. 'lz4', 'deflate', 'zstd'; empty means uncompressed",
+		},
+		&cli.StringFlag{
+			Name:  "mkfs-options",
+			Usage: "Extra mkfs.erofs options (e.g. '-Efragments,dedupe')",
+		},
+		&cli.StringFlag{
+			Name:  "platform",
+			Usage: "Cache layers for a specific platform (default: host platform)",
+		},
+	},
+	Action: func(cliContext *cli.Context) error {
+		ref := cliContext.Args().Get(0)
+		cacheDir := cliContext.Args().Get(1)
+		if ref == "" || cacheDir == "" {
+			return errors.New("image ref and cache dir must be specified")
+		}
+
+		platform := platforms.DefaultStrict()
+		if p := cliContext.String("platform"); p != "" {
+			parsed, err := platforms.Parse(p)
+			if err != nil {
+				return fmt.Errorf("invalid platform %q: %w", p, err)
+			}
+			platform = platforms.Only(parsed)
+		}
+
+		var opts []erofs.ConvertOpt
+		if c := cliContext.String("compressors"); c != "" {
+			opts = append(opts, erofs.WithCompressors(c))
+		}
+		if m := cliContext.String("mkfs-options"); m != "" {
+			opts = append(opts, erofs.WithMkfsOptions(strings.Fields(m)))
+		}
+
+		client, ctx, cancel, err := commands.NewClient(cliContext)
+		if err != nil {
+			return err
+		}
+		defer cancel()
+
+		img, err := client.ImageService().Get(ctx, ref)
+		if err != nil {
+			return err
+		}
+
+		if err := buildCache(ctx, client.ContentStore(), img.Target, platform, cacheDir, opts...); err != nil {
+			if errdefs.IsNotFound(err) {
+				return fmt.Errorf("%w; fetch the image content first, e.g. `ctr content fetch %s`", err, ref)
+			}
+			return err
+		}
+		fmt.Fprintln(cliContext.App.Writer, cacheDir)
+		return nil
+	},
+}
+
+// buildCache converts each layer of image (for the given platform) into the
+// erofs layer content cache at cacheDir, keyed by the layer's diffID. It reads
+// layers straight from the content store — no converted image is produced — so
+// the cache can be populated from an already-pulled image and then synced to the
+// read-only location the fleet mounts. Because the key is the source layer's
+// diffID, it matches what the runtime looks up when pulling the original image,
+// and layers shared across images converge on one blob. dm-verity sidecars are
+// not produced here (the converter does no dm-verity formatting).
+func buildCache(ctx context.Context, cs content.Store, image ocispec.Descriptor, platform platforms.MatchComparer, cacheDir string, opts ...erofs.ConvertOpt) error {
+	manifest, err := images.Manifest(ctx, cs, image, platform)
+	if err != nil {
+		return fmt.Errorf("failed to resolve manifest: %w", err)
+	}
+
+	for _, layer := range manifest.Layers {
+		if !images.IsLayerType(layer.MediaType) || erofsutils.IsErofsMediaType(layer.MediaType) || images.IsNonDistributable(layer.MediaType) {
+			continue
+		}
+		if err := buildLayer(ctx, cs, layer, cacheDir, opts...); err != nil {
+			// Preserve errdefs.IsNotFound so callers can add context-appropriate
+			// remediation (e.g. ctr suggesting `ctr content fetch`).
+			if errdefs.IsNotFound(err) {
+				return fmt.Errorf("layer %s is not in the content store: %w", layer.Digest, err)
+			}
+			return fmt.Errorf("failed to cache layer %s: %w", layer.Digest, err)
+		}
+	}
+	return nil
+}
+
+// buildLayer converts one layer into a temp file inside cacheDir, then
+// atomically renames it to its diffID-keyed name (same filesystem, so no extra
+// copy and no reliance on TMPDIR). An existing entry is overwritten, keeping the
+// operation idempotent across re-runs and shared layers.
+func buildLayer(ctx context.Context, cs content.Store, layer ocispec.Descriptor, cacheDir string, opts ...erofs.ConvertOpt) (retErr error) {
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(cacheDir, ".build-*.erofs")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	tmp.Close()
+	defer func() {
+		if retErr != nil {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	diffID, err := erofs.ConvertLayerToErofs(ctx, cs, layer, tmpPath, opts...)
+	if err != nil {
+		return err
+	}
+
+	// os.CreateTemp makes the file 0600; widen it so other users (e.g. a
+	// rootless containerd) can read the shared cache.
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		return err
+	}
+
+	dest := filepath.Join(cacheDir, diffID.Algorithm().String(), diffID.Encoded()+".erofs")
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, dest)
+}

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -53,6 +53,7 @@ var Command = &cli.Command{
 		tagCommand,
 		setLabelsCommand,
 		convertCommand,
+		buildErofsCacheCommand,
 		usageCommand,
 	},
 }

--- a/core/images/converter/erofs/erofs.go
+++ b/core/images/converter/erofs/erofs.go
@@ -204,7 +204,10 @@ func ConvertLayerToErofs(ctx context.Context, cs content.Store, desc ocispec.Des
 	mkfsArgs = append(mkfsArgs, copts.mkfsExtraOpts...)
 	mkfsArgs = erofsutils.AddDefaultMkfsOpts(mkfsArgs)
 
-	u := uuid.NewSHA1(uuid.NameSpaceURL, []byte("erofs:blobs/"+desc.Digest))
+	// Derive the erofs UUID from the uncompressed digest (diffID) so the blob is a
+	// deterministic function of the layer content, independent of how the source
+	// was compressed. This is also the key the layer content cache uses.
+	u := uuid.NewSHA1(uuid.NameSpaceURL, []byte("erofs:blobs/"+uncompressedDesc.Digest))
 	if err := erofsutils.ConvertTarErofs(ctx, sr, outPath, u.String(), mkfsArgs); err != nil {
 		return "", fmt.Errorf("failed to convert to EROFS: %w", err)
 	}

--- a/core/images/converter/erofs/erofs.go
+++ b/core/images/converter/erofs/erofs.go
@@ -81,19 +81,6 @@ func LayerConvertFunc(opts ...ConvertOpt) converter.ConvertFunc {
 			return nil, nil
 		}
 
-		uncompressedDesc := &desc
-		if !uncompress.IsUncompressedType(desc.MediaType) {
-			var err error
-			uncompressedDesc, err = uncompress.LayerConvertFunc(ctx, cs, desc)
-			if err != nil {
-				return nil, err
-			}
-			if uncompressedDesc == nil {
-				return nil, fmt.Errorf("unexpectedly got the same blob after decompression (%s, %q)", desc.Digest, desc.MediaType)
-			}
-			log.G(ctx).Debugf("uncompressed %s into %s", desc.Digest, uncompressedDesc.Digest)
-		}
-
 		info, err := cs.Info(ctx, desc.Digest)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get content info: %w", err)
@@ -103,14 +90,6 @@ func LayerConvertFunc(opts ...ConvertOpt) converter.ConvertFunc {
 		if labelz == nil {
 			labelz = make(map[string]string)
 		}
-
-		ra, err := cs.ReaderAt(ctx, *uncompressedDesc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get reader: %w", err)
-		}
-		defer ra.Close()
-
-		sr := io.NewSectionReader(ra, 0, uncompressedDesc.Size)
 
 		blob, err := os.CreateTemp("", "layer-*.erofs")
 		if err != nil {
@@ -125,21 +104,9 @@ func LayerConvertFunc(opts ...ConvertOpt) converter.ConvertFunc {
 			}
 		}()
 
-		var mkfsArgs []string
-		if convertOpts.compressors != "" {
-			compressionArg := "-z" + convertOpts.compressors
-			mkfsArgs = append(mkfsArgs, compressionArg)
-			mkfsArgs = append(mkfsArgs, []string{"-C", "65536"}...)
+		if _, err := ConvertLayerToErofs(ctx, cs, desc, blobPath, opts...); err != nil {
+			return nil, err
 		}
-		mkfsArgs = append(mkfsArgs, convertOpts.mkfsExtraOpts...)
-
-		mkfsArgs = erofsutils.AddDefaultMkfsOpts(mkfsArgs)
-
-		u := uuid.NewSHA1(uuid.NameSpaceURL, []byte("erofs:blobs/"+desc.Digest))
-		if err := erofsutils.ConvertTarErofs(ctx, sr, blobPath, u.String(), mkfsArgs); err != nil {
-			return nil, fmt.Errorf("failed to convert to EROFS: %w", err)
-		}
-		log.G(ctx).Debugf("converted %s to EROFS", desc.Digest)
 
 		erofsFile, err := os.Open(blobPath)
 		if err != nil {
@@ -197,6 +164,52 @@ func LayerConvertFunc(opts ...ConvertOpt) converter.ConvertFunc {
 		newDesc.Size = cInfo.Size
 		return &newDesc, nil
 	}
+}
+
+// ConvertLayerToErofs converts a single OCI layer blob (desc) into a
+// directly-mountable erofs image written to outPath, and returns the layer's
+// uncompressed digest (diffID). It is the shared conversion step behind both
+// LayerConvertFunc (which then stores the blob in the content store) and
+// BuildLayerCache (which stores it in the layer content cache).
+func ConvertLayerToErofs(ctx context.Context, cs content.Store, desc ocispec.Descriptor, outPath string, opts ...ConvertOpt) (digest.Digest, error) {
+	var copts convertOptions
+	for _, opt := range opts {
+		opt(&copts)
+	}
+
+	uncompressedDesc := &desc
+	if !uncompress.IsUncompressedType(desc.MediaType) {
+		var err error
+		uncompressedDesc, err = uncompress.LayerConvertFunc(ctx, cs, desc)
+		if err != nil {
+			return "", err
+		}
+		if uncompressedDesc == nil {
+			return "", fmt.Errorf("unexpectedly got the same blob after decompression (%s, %q)", desc.Digest, desc.MediaType)
+		}
+		log.G(ctx).Debugf("uncompressed %s into %s", desc.Digest, uncompressedDesc.Digest)
+	}
+
+	ra, err := cs.ReaderAt(ctx, *uncompressedDesc)
+	if err != nil {
+		return "", fmt.Errorf("failed to get reader: %w", err)
+	}
+	defer ra.Close()
+	sr := io.NewSectionReader(ra, 0, uncompressedDesc.Size)
+
+	var mkfsArgs []string
+	if copts.compressors != "" {
+		mkfsArgs = append(mkfsArgs, "-z"+copts.compressors, "-C", "65536")
+	}
+	mkfsArgs = append(mkfsArgs, copts.mkfsExtraOpts...)
+	mkfsArgs = erofsutils.AddDefaultMkfsOpts(mkfsArgs)
+
+	u := uuid.NewSHA1(uuid.NameSpaceURL, []byte("erofs:blobs/"+desc.Digest))
+	if err := erofsutils.ConvertTarErofs(ctx, sr, outPath, u.String(), mkfsArgs); err != nil {
+		return "", fmt.Errorf("failed to convert to EROFS: %w", err)
+	}
+	log.G(ctx).Debugf("converted %s to EROFS", desc.Digest)
+	return uncompressedDesc.Digest, nil
 }
 
 func UpdateManifestPlatform(ctx context.Context, cs content.Store, originalDesc, convertedDesc ocispec.Descriptor) (*ocispec.Descriptor, error) {

--- a/core/metadata/snapshot.go
+++ b/core/metadata/snapshot.go
@@ -39,7 +39,6 @@ import (
 
 const (
 	inheritedLabelsPrefix = "containerd.io/snapshot/"
-	labelSnapshotRef      = "containerd.io/snapshot.ref"
 )
 
 type snapshotter struct {
@@ -316,7 +315,7 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 	}
 
 	var (
-		target  = base.Labels[labelSnapshotRef]
+		target  = base.Labels[snapshots.LabelSnapshotRef]
 		bparent string
 		bkey    string
 		bopts   = []snapshots.Opt{
@@ -388,10 +387,10 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 	if errdefs.IsAlreadyExists(err) {
 		if target != "" {
 			var tinfo *snapshots.Info
-			filter := fmt.Sprintf(`labels."containerd.io/snapshot.ref"==%s,parent==%q`, target, bparent)
+			filter := fmt.Sprintf(`labels.%q==%s,parent==%q`, snapshots.LabelSnapshotRef, target, bparent)
 			if err := s.Snapshotter.Walk(ctx, func(ctx context.Context, i snapshots.Info) error {
 				if tinfo == nil && i.Kind == snapshots.KindCommitted {
-					if i.Labels["containerd.io/snapshot.ref"] != target {
+					if i.Labels[snapshots.LabelSnapshotRef] != target {
 						// Walk did not respect filter
 						return nil
 					}

--- a/core/metadata/snapshot_test.go
+++ b/core/metadata/snapshot_test.go
@@ -70,7 +70,7 @@ func TestSnapshotterWithRef(t *testing.T) {
 	key1 := "test1"
 	test1opt := snapshots.WithLabels(
 		map[string]string{
-			labelSnapshotRef: key1,
+			snapshots.LabelSnapshotRef: key1,
 		},
 	)
 
@@ -113,7 +113,7 @@ func TestSnapshotterWithRef(t *testing.T) {
 	key2 := "test2"
 	test2opt := snapshots.WithLabels(
 		map[string]string{
-			labelSnapshotRef: key2,
+			snapshots.LabelSnapshotRef: key2,
 		},
 	)
 
@@ -340,7 +340,7 @@ func (s *tmpSnapshotter) create(ctx context.Context, key, parent string, kind sn
 	base.Name = key
 	base.Kind = kind
 
-	target := base.Labels[labelSnapshotRef]
+	target := base.Labels[snapshots.LabelSnapshotRef]
 	if target != "" {
 		for _, name := range s.targets[target] {
 			if s.snapshots[name].Parent == parent {
@@ -399,7 +399,7 @@ func (s *tmpSnapshotter) Commit(ctx context.Context, name, key string, opts ...s
 	s.snapshots[name] = base
 	delete(s.snapshots, key)
 
-	if target := base.Labels[labelSnapshotRef]; target != "" {
+	if target := base.Labels[snapshots.LabelSnapshotRef]; target != "" {
 		s.targets[target] = append(s.targets[target], name)
 	}
 

--- a/core/snapshots/snapshotter.go
+++ b/core/snapshots/snapshotter.go
@@ -33,7 +33,17 @@ const (
 	// UnpackKeyFormat is the format for the snapshotter keys used for extraction
 	UnpackKeyFormat       = UnpackKeyPrefix + "-%s %s"
 	inheritedLabelsPrefix = "containerd.io/snapshot/"
-	labelSnapshotRef      = "containerd.io/snapshot.ref"
+
+	// LabelSnapshotRef is set by the unpacker on the extraction Prepare to
+	// the target chainID. A snapshotter that already has the layer commits a
+	// snapshot named after this value and returns ErrAlreadyExists, which
+	// makes the unpacker skip fetching and applying the layer (the remote
+	// snapshot protocol). It is inherited by FilterInheritedLabels.
+	LabelSnapshotRef = "containerd.io/snapshot.ref"
+
+	// LabelSnapshotDiffID is set by the unpacker on the extraction Prepare to
+	// the uncompressed digest (diffID) of the layer being unpacked.
+	LabelSnapshotDiffID = "containerd.io/snapshot/diff-id"
 
 	// LabelSnapshotUIDMapping is the label used for UID mappings
 	LabelSnapshotUIDMapping = "containerd.io/snapshot/uidmapping"
@@ -397,7 +407,7 @@ func FilterInheritedLabels(labels map[string]string) map[string]string {
 
 	filtered := make(map[string]string)
 	for k, v := range labels {
-		if k == labelSnapshotRef || strings.HasPrefix(k, inheritedLabelsPrefix) {
+		if k == LabelSnapshotRef || strings.HasPrefix(k, inheritedLabelsPrefix) {
 			filtered[k] = v
 		}
 	}

--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -49,9 +49,7 @@ import (
 )
 
 const (
-	labelSnapshotRef    = "containerd.io/snapshot.ref"
 	labelSnapshotParent = "containerd.io/snapshot/parent-chain-id"
-	labelSnapshotDiffID = "containerd.io/snapshot/diff-id"
 	unpackSpanPrefix    = "pkg.unpack.unpacker"
 )
 
@@ -397,8 +395,8 @@ func (u *Unpacker) unpack(
 		if snapshotLabels == nil {
 			snapshotLabels = make(map[string]string)
 		}
-		snapshotLabels[labelSnapshotRef] = chainID
-		snapshotLabels[labelSnapshotDiffID] = diffIDs[i].String()
+		snapshotLabels[snapshots.LabelSnapshotRef] = chainID
+		snapshotLabels[snapshots.LabelSnapshotDiffID] = diffIDs[i].String()
 		if i > 0 {
 			snapshotLabels[labelSnapshotParent] = chainIDs[i-1].String()
 		}

--- a/internal/dmverity/dmverity_linux.go
+++ b/internal/dmverity/dmverity_linux.go
@@ -17,10 +17,16 @@
 package dmverity
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
+	"github.com/containerd/log"
+	"github.com/google/uuid"
+
 	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/pkg/atomicfile"
 	"github.com/containerd/go-dmverity/pkg/utils"
 	"github.com/containerd/go-dmverity/pkg/verity"
 )
@@ -109,6 +115,111 @@ func Format(dataDevice, hashDevice string, opts *DmverityOptions) (string, error
 	}
 
 	return fmt.Sprintf("%x", rootDigest), nil
+}
+
+// FormatLayer appends a dm-verity hash tree to the erofs layer blob at
+// layerBlobPath (growing the file in place) and writes the "<blob>.dmverity"
+// sidecar holding the resulting root hash and superblock offset. It is a no-op
+// if the sidecar already exists. A nil opts uses DefaultDmverityOptions.
+func FormatLayer(ctx context.Context, layerBlobPath string, opts *DmverityOptions) error {
+	metadataPath := MetadataPath(layerBlobPath)
+	if _, err := os.Stat(metadataPath); err == nil {
+		log.G(ctx).WithField("path", layerBlobPath).Debug("Layer already formatted with dm-verity, skipping")
+		return nil
+	}
+
+	if opts == nil {
+		opts = DefaultDmverityOptions()
+	} else {
+		clone := *opts
+		opts = &clone
+	}
+
+	fileInfo, err := os.Stat(layerBlobPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat layer blob: %w", err)
+	}
+
+	blockSize := int64(opts.DataBlockSize)
+	fileSize := fileInfo.Size()
+
+	// dm-verity requires the hash area to start at a block-aligned offset
+	dataBlocks := (fileSize + blockSize - 1) / blockSize
+	hashOffset := uint64(dataBlocks * blockSize)
+
+	opts.HashOffset = hashOffset
+	opts.DataBlocks = uint64(dataBlocks)
+
+	hashTreeSize, err := verity.GetHashTreeSize(&verity.Params{
+		HashName:      opts.HashAlgorithm,
+		DataBlockSize: opts.DataBlockSize,
+		HashBlockSize: opts.HashBlockSize,
+		DataBlocks:    opts.DataBlocks,
+		HashType:      opts.HashType,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to calculate hash tree size: %w", err)
+	}
+
+	// In superblock mode, Format() stores the superblock at hashOffset and the hash tree after it
+	superblockSize := uint64(0)
+	if !opts.NoSuperblock {
+		superblockSize = utils.AlignUp(uint64(verity.SuperblockSize), uint64(opts.HashBlockSize))
+	}
+	requiredSize := hashOffset + superblockSize + hashTreeSize
+	if err := os.Truncate(layerBlobPath, int64(requiredSize)); err != nil {
+		return fmt.Errorf("failed to pre-allocate space for hash tree: %w", err)
+	}
+
+	// Generate a random UUID for the superblock (required for superblock mode).
+	// The library's ReadSuperblock() validates that UUID is not nil/empty.
+	if opts.UUID == "" {
+		u, err := uuid.NewRandom()
+		if err != nil {
+			return fmt.Errorf("failed to generate superblock UUID: %w", err)
+		}
+		opts.UUID = u.String()
+	}
+
+	rootHash, err := Format(layerBlobPath, layerBlobPath, opts)
+	if err != nil {
+		return fmt.Errorf("failed to format dm-verity: %w", err)
+	}
+
+	// Save the ORIGINAL hashOffset (where the superblock is located), not the
+	// post-Format offset (which points past the superblock). Open() needs the
+	// superblock location to read device parameters.
+	metadata := DmverityMetadata{
+		RootHash:   rootHash,
+		HashOffset: hashOffset,
+	}
+	metadataBytes, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal dm-verity metadata: %w", err)
+	}
+	// Write the sidecar atomically (temp file, synced, renamed) so a reader never
+	// observes a partially written .dmverity.
+	f, err := atomicfile.New(metadataPath, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create dm-verity metadata file: %w", err)
+	}
+	if _, err := f.Write(metadataBytes); err != nil {
+		f.Cancel()
+		return fmt.Errorf("failed to write dm-verity metadata: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to write dm-verity metadata: %w", err)
+	}
+
+	log.G(ctx).WithFields(log.Fields{
+		"path":       layerBlobPath,
+		"size":       fileSize,
+		"blockSize":  opts.DataBlockSize,
+		"hashOffset": hashOffset,
+		"rootHash":   rootHash,
+	}).Debug("Successfully formatted dm-verity layer")
+
+	return nil
 }
 
 // Open creates a read-only device-mapper target for transparent integrity verification.

--- a/internal/dmverity/dmverity_other.go
+++ b/internal/dmverity/dmverity_other.go
@@ -18,7 +18,10 @@
 
 package dmverity
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 var errUnsupported = fmt.Errorf("dmverity is only supported on Linux systems")
 
@@ -28,6 +31,10 @@ func IsSupported() (bool, error) {
 
 func Format(_ string, _ string, _ *DmverityOptions) (string, error) {
 	return "", errUnsupported
+}
+
+func FormatLayer(_ context.Context, _ string, _ *DmverityOptions) error {
+	return errUnsupported
 }
 
 func Open(_ string, _ string, _ string, _ string, _ uint64, _ *DmverityOptions) (string, error) {

--- a/internal/erofsutils/mount.go
+++ b/internal/erofsutils/mount.go
@@ -29,9 +29,21 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/opencontainers/go-digest"
 
 	"github.com/containerd/containerd/v2/core/mount"
 )
+
+// CacheBlobPath returns the layer content cache path for a diffID, following the
+// <dir>/<algo>/<xx>/<hex>.erofs layout, where <xx> is the first two characters of
+// the encoded digest. The extra prefix directory shards blobs so no single
+// directory grows unwieldy for a large cache. It is the single source of the
+// layout, shared by the cache producer (ctr build-erofs-cache) and the erofs
+// snapshotter that reads it, so the two never drift.
+func CacheBlobPath(dir string, diffID digest.Digest) string {
+	enc := diffID.Encoded()
+	return filepath.Join(dir, diffID.Algorithm().String(), enc[:2], enc+".erofs")
+}
 
 // IsErofsMediaType returns true if the media type is an EROFS layer type.
 func IsErofsMediaType(mt string) bool {

--- a/internal/erofsutils/mount_test.go
+++ b/internal/erofsutils/mount_test.go
@@ -1,0 +1,37 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofsutils
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheBlobPath(t *testing.T) {
+	diffID := digest.FromString("hello")
+	enc := diffID.Encoded()
+
+	got := CacheBlobPath("/cache", diffID)
+
+	// <dir>/<algo>/<xx>/<hex>.erofs, where <xx> is the first two hex characters.
+	want := filepath.Join("/cache", "sha256", enc[:2], enc+".erofs")
+	assert.Equal(t, want, got)
+	assert.Equal(t, enc[:2], filepath.Base(filepath.Dir(got)), "blob must live under a 2-char prefix dir")
+}

--- a/plugins/diff/erofs/dmverity_linux.go
+++ b/plugins/diff/erofs/dmverity_linux.go
@@ -20,14 +20,6 @@ package erofs
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"os"
-
-	"github.com/containerd/go-dmverity/pkg/utils"
-	"github.com/containerd/go-dmverity/pkg/verity"
-	"github.com/containerd/log"
-	"github.com/google/uuid"
 
 	"github.com/containerd/containerd/v2/internal/dmverity"
 )
@@ -53,84 +45,8 @@ func (s *erofsDiff) getDmverityOptions() *dmverity.DmverityOptions {
 	return opts
 }
 
-// formatDmverityLayer formats an EROFS layer with dm-verity hash tree
+// formatDmverityLayer formats an EROFS layer with a dm-verity hash tree using
+// the differ's configured options.
 func (s *erofsDiff) formatDmverityLayer(ctx context.Context, layerBlobPath string) error {
-	metadataPath := dmverity.MetadataPath(layerBlobPath)
-	if _, err := os.Stat(metadataPath); err == nil {
-		log.G(ctx).WithField("path", layerBlobPath).Debug("Layer already formatted with dm-verity, skipping")
-		return nil
-	}
-
-	fileInfo, err := os.Stat(layerBlobPath)
-	if err != nil {
-		return fmt.Errorf("failed to stat layer blob: %w", err)
-	}
-
-	opts := s.getDmverityOptions()
-	blockSize := int64(opts.DataBlockSize)
-	fileSize := fileInfo.Size()
-
-	// dm-verity requires the hash area to start at a block-aligned offset
-	dataBlocks := (fileSize + blockSize - 1) / blockSize
-	hashOffset := uint64(dataBlocks * blockSize)
-
-	opts.HashOffset = hashOffset
-	opts.DataBlocks = uint64(dataBlocks)
-
-	hashTreeSize, err := verity.GetHashTreeSize(&verity.Params{
-		HashName:      opts.HashAlgorithm,
-		DataBlockSize: opts.DataBlockSize,
-		HashBlockSize: opts.HashBlockSize,
-		DataBlocks:    opts.DataBlocks,
-		HashType:      opts.HashType,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to calculate hash tree size: %w", err)
-	}
-
-	// In superblock mode, Format() stores the superblock at hashOffset and the hash tree after it
-	superblockSize := uint64(0)
-	if !opts.NoSuperblock {
-		superblockSize = utils.AlignUp(uint64(verity.SuperblockSize), uint64(opts.HashBlockSize))
-	}
-	requiredSize := hashOffset + superblockSize + hashTreeSize
-	if err := os.Truncate(layerBlobPath, int64(requiredSize)); err != nil {
-		return fmt.Errorf("failed to pre-allocate space for hash tree: %w", err)
-	}
-
-	// Generate a random UUID for the superblock (required for superblock mode)
-	// The library's ReadSuperblock() validates that UUID is not nil/empty
-	if opts.UUID == "" {
-		opts.UUID = uuid.New().String()
-	}
-
-	rootHash, err := dmverity.Format(layerBlobPath, layerBlobPath, opts)
-	if err != nil {
-		return fmt.Errorf("failed to format dm-verity: %w", err)
-	}
-
-	// Important: Save the ORIGINAL hashOffset (where superblock is located),
-	// not result.HashOffset (which points to where the hash tree starts after the superblock).
-	// Open() needs the superblock location to read device parameters.
-	metadata := dmverity.DmverityMetadata{
-		RootHash:   rootHash,
-		HashOffset: hashOffset,
-	}
-	metadataBytes, err := json.MarshalIndent(metadata, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal dm-verity metadata: %w", err)
-	}
-	if err := os.WriteFile(metadataPath, metadataBytes, 0644); err != nil {
-		return fmt.Errorf("failed to write dm-verity metadata: %w", err)
-	}
-
-	log.G(ctx).WithFields(log.Fields{
-		"path":       layerBlobPath,
-		"size":       fileSize,
-		"blockSize":  opts.DataBlockSize,
-		"hashOffset": hashOffset,
-		"rootHash":   rootHash,
-	}).Info("Successfully formatted dm-verity layer")
-
-	return nil
+	return dmverity.FormatLayer(ctx, layerBlobPath, s.getDmverityOptions())
 }

--- a/plugins/snapshots/erofs/erofs.go
+++ b/plugins/snapshots/erofs/erofs.go
@@ -18,6 +18,7 @@ package erofs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,11 +28,13 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/opencontainers/go-digest"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
 	"github.com/containerd/containerd/v2/internal/dmverity"
+	"github.com/containerd/containerd/v2/internal/erofsutils"
 	"github.com/containerd/containerd/v2/internal/fsverity"
 	"github.com/containerd/containerd/v2/internal/userns"
 )
@@ -49,6 +52,12 @@ type SnapshotterConfig struct {
 	remapIDs    bool
 	// dmverityMode controls dm-verity behavior: "auto" (use if .dmverity exists), "on" (require .dmverity), "off" (disable)
 	dmverityMode string
+	// layerContentCache is a directory of pre-converted, diffID-keyed erofs
+	// layer blobs. When set and an unpacked layer's blob is present, the
+	// snapshotter commits the layer immediately (symlinking the blob) and
+	// returns ErrAlreadyExists, skipping the download and tar->erofs
+	// conversion. Empty disables the feature.
+	layerContentCache string
 }
 
 // Opt is an option to configure the erofs snapshotter
@@ -96,6 +105,16 @@ func WithRemapIDs() Opt {
 	}
 }
 
+// WithLayerContentCache configures a read-only directory of pre-converted,
+// diffID-keyed erofs layer blobs that the snapshotter sources layers from on
+// pull instead of downloading and converting them. See the layerContentCache
+// field for details.
+func WithLayerContentCache(path string) Opt {
+	return func(config *SnapshotterConfig) {
+		config.layerContentCache = path
+	}
+}
+
 type MetaStore interface {
 	TransactionContext(ctx context.Context, writable bool) (context.Context, storage.Transactor, error)
 	WithTransaction(ctx context.Context, writable bool, fn storage.TransactionCallback) error
@@ -103,15 +122,16 @@ type MetaStore interface {
 }
 
 type snapshotter struct {
-	root            string
-	ms              *storage.MetaStore
-	ovlOptions      []string
-	enableFsverity  bool
-	setImmutable    bool
-	defaultWritable int64
-	blockMode       bool
-	remapIDs        bool
-	dmverityMode    string
+	root              string
+	ms                MetaStore
+	ovlOptions        []string
+	enableFsverity    bool
+	setImmutable      bool
+	defaultWritable   int64
+	blockMode         bool
+	remapIDs          bool
+	dmverityMode      string
+	layerContentCache string
 }
 
 // NewSnapshotter returns a Snapshotter which uses EROFS+OverlayFS. The layers
@@ -153,6 +173,20 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		}
 	}
 
+	// Cache blobs may live on a read-only mount the snapshotter can't modify, so
+	// fsverity and IMMUTABLE_FL can't be applied to them. Be explicit about this to
+	// the user instead of ignoring them silently (they're bypassed because cache
+	// hits commit during Prepare and skip Commit); dm-verity is the cache's
+	// integrity mechanism.
+	if config.layerContentCache != "" {
+		if config.enableFsverity {
+			return nil, fmt.Errorf("enable_fsverity is incompatible with layer_content_cache; use dm-verity for cache integrity")
+		}
+		if config.setImmutable {
+			return nil, fmt.Errorf("set_immutable is incompatible with layer_content_cache")
+		}
+	}
+
 	// Check fsverity support if enabled
 	if config.enableFsverity {
 		// TODO: Call specific function here
@@ -169,6 +203,24 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		return nil, fmt.Errorf("setting IMMUTABLE_FL is only supported on Linux")
 	}
 
+	// Resolve the cache dir to an absolute path so materialized layer blobs are
+	// absolute symlinks, independent of the process working directory, and verify
+	// it exists and is a directory so misconfiguration fails fast at startup.
+	if config.layerContentCache != "" {
+		abs, err := filepath.Abs(config.layerContentCache)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve layer_content_cache path %q: %w", config.layerContentCache, err)
+		}
+		fi, err := os.Stat(abs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to access layer_content_cache %q: %w", abs, err)
+		}
+		if !fi.IsDir() {
+			return nil, fmt.Errorf("layer_content_cache %q is not a directory", abs)
+		}
+		config.layerContentCache = abs
+	}
+
 	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"))
 	if err != nil {
 		return nil, err
@@ -179,15 +231,16 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 	}
 
 	return &snapshotter{
-		root:            root,
-		ms:              ms,
-		ovlOptions:      config.ovlOptions,
-		enableFsverity:  config.enableFsverity,
-		setImmutable:    config.setImmutable,
-		defaultWritable: config.defaultSize,
-		blockMode:       config.defaultSize > 0,
-		remapIDs:        config.remapIDs,
-		dmverityMode:    config.dmverityMode,
+		root:              root,
+		ms:                ms,
+		ovlOptions:        config.ovlOptions,
+		enableFsverity:    config.enableFsverity,
+		setImmutable:      config.setImmutable,
+		defaultWritable:   config.defaultSize,
+		blockMode:         config.defaultSize > 0,
+		remapIDs:          config.remapIDs,
+		dmverityMode:      config.dmverityMode,
+		layerContentCache: config.layerContentCache,
 	}, nil
 }
 
@@ -245,7 +298,7 @@ func (s *snapshotter) lowerPath(id string) (string, error) {
 	return layerBlob, nil
 }
 
-func (s *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
+func (s *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind, entry *cacheEntry) (string, error) {
 	td, err := os.MkdirTemp(snapshotDir, "new-")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
@@ -264,6 +317,26 @@ func (s *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 		// prepared as an EROFS layer by the EROFS snapshotter.
 		if err := os.WriteFile(filepath.Join(td, ".erofslayer"), []byte{}, 0644); err != nil {
 			return td, err
+		}
+	}
+
+	// Layer content cache hit: stage the pre-converted blob as a symlink so the
+	// caller's rename publishes a ready committed layer.
+	if entry != nil {
+		layerBlob := filepath.Join(td, "layer.erofs")
+		if err := os.Symlink(entry.blob, layerBlob); err != nil {
+			return td, fmt.Errorf("failed to symlink cached layer blob: %w", err)
+		}
+		// Copy the dm-verity sidecar alongside the blob (unless dm-verity is off,
+		// when it's never consumed) so mount-time metadata resolution and the
+		// pinned root hash match locally-converted layers. A missing sidecar is
+		// fine except with dmverity_mode "on", which requires it.
+		if s.dmverityMode != "off" {
+			if err := fs.CopyFile(dmverity.MetadataPath(layerBlob), dmverity.MetadataPath(entry.blob)); err != nil {
+				if s.dmverityMode == "on" || !errors.Is(err, os.ErrNotExist) {
+					return td, fmt.Errorf("failed to copy dm-verity sidecar: %w", err)
+				}
+			}
 		}
 	}
 
@@ -503,6 +576,12 @@ func (s *snapshotter) mounts(snap storage.Snapshot, info snapshots.Info) ([]moun
 	}), nil
 }
 
+// createSnapshot creates an active (or view) snapshot and returns its mounts.
+// On an image-layer extraction whose diffID blob is in the layer content cache,
+// it instead stages the cached blob and commits the snapshot as the target
+// chainID in the same transaction, then returns ErrAlreadyExists (the
+// remote-snapshot signal that makes the unpacker skip the layer download and
+// conversion).
 func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ []mount.Mount, err error) {
 	var (
 		snap     storage.Snapshot
@@ -510,8 +589,21 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		info     snapshots.Info
 	)
 
+	// Only image-layer extractions (active snapshots) can be served from the
+	// layer content cache; View and container-rootfs Prepares get a nil entry and
+	// fall through to the normal path.
+	var entry *cacheEntry
+	if kind == snapshots.KindActive {
+		entry = s.lookupCache(ctx, opts...)
+	}
+
+	// committed is set only once the cached layer is committed and we deliberately
+	// return ErrAlreadyExists; the committed dir must then be kept. Any real error
+	// (including an unexpected AlreadyExists from CreateSnapshot) leaves it false
+	// so the staged td/path is reclaimed.
+	var committed bool
 	defer func() {
-		if err != nil {
+		if err != nil && !committed {
 			if td != "" {
 				if err1 := os.RemoveAll(td); err1 != nil {
 					log.G(ctx).WithError(err1).Warn("failed to cleanup temp snapshot directory")
@@ -527,7 +619,7 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 	}()
 
 	snapshotDir := filepath.Join(s.root, "snapshots")
-	td, err = s.prepareDirectory(ctx, snapshotDir, kind)
+	td, err = s.prepareDirectory(ctx, snapshotDir, kind, entry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create prepare snapshot dir: %w", err)
 	}
@@ -598,9 +690,32 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 			return fmt.Errorf("failed to rename: %w", err)
 		}
 		td = ""
+
+		// Commit the cached layer straight away as the target chainID. CommitActive
+		// replaces labels with those from opts (which carry snapshot.ref), which the
+		// metadata layer's Walk filter needs to resolve the backend target.
+		if entry != nil {
+			if _, err = storage.CommitActive(ctx, key, entry.target, snapshots.Usage{}, opts...); err != nil {
+				return fmt.Errorf("unable to commit active snapshot: %w", err)
+			}
+		}
 		return nil
 	}); err != nil {
 		return nil, err
+	}
+
+	// Cache hit committed successfully: signal the unpacker via ErrAlreadyExists to
+	// skip the layer download and conversion. (A concurrent pull that already
+	// committed the same target returned a plain AlreadyExists error above, which
+	// the metadata layer resolves the same way.)
+	if entry != nil {
+		log.G(ctx).WithFields(log.Fields{
+			"key":     key,
+			"chainID": entry.target,
+			"blob":    entry.blob,
+		}).Debug("layer content cache hit, committed cached erofs blob")
+		committed = true
+		return nil, errdefs.ErrAlreadyExists
 	}
 
 	return s.mounts(snap, info)
@@ -608,6 +723,63 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 
 func (s *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
 	return s.createSnapshot(ctx, snapshots.KindActive, key, parent, opts)
+}
+
+// cacheEntry describes a resolved layer content cache entry: the target chainID
+// to commit as and the absolute path of the cached blob to symlink (any
+// dm-verity sidecar is derived from blob via dmverity.MetadataPath).
+type cacheEntry struct {
+	target string
+	blob   string
+}
+
+// cacheBlobPath returns the expected path of the cached erofs blob for a diffID.
+func (s *snapshotter) cacheBlobPath(diffID digest.Digest) string {
+	return erofsutils.CacheBlobPath(s.layerContentCache, diffID)
+}
+
+// lookupCache resolves the layer content cache entry that can serve the layer
+// being prepared, or nil on a miss. It gates on: the cache being configured, the
+// Prepare being an image-layer extraction (carries the snapshot.ref and diff-id
+// labels), and the diffID blob being present. Misses (cache disabled,
+// non-extraction Prepare, missing entries, unreadable cache dirs such as a FUSE
+// mount being down, malformed labels) all return nil so pulls keep working. The
+// dm-verity sidecar is handled when the blob is materialized (prepareDirectory).
+func (s *snapshotter) lookupCache(ctx context.Context, opts ...snapshots.Opt) *cacheEntry {
+	if s.layerContentCache == "" {
+		return nil
+	}
+
+	var base snapshots.Info
+	for _, opt := range opts {
+		if err := opt(&base); err != nil {
+			return nil
+		}
+	}
+
+	target := base.Labels[snapshots.LabelSnapshotRef]
+	diffIDStr := base.Labels[snapshots.LabelSnapshotDiffID]
+	if target == "" || diffIDStr == "" {
+		// Not an image-layer extraction, or no diffID to key on.
+		return nil
+	}
+	diffID, err := digest.Parse(diffIDStr)
+	if err != nil {
+		log.G(ctx).WithError(err).WithField("diffID", diffIDStr).
+			Warn("erofs layer cache: invalid diff-id label, treating as cache miss")
+		return nil
+	}
+
+	blob := s.cacheBlobPath(diffID)
+	if _, err := os.Stat(blob); err != nil {
+		if !os.IsNotExist(err) {
+			log.G(ctx).WithError(err).WithField("blob", blob).
+				Warn("erofs layer cache: failed to stat cache blob, treating as cache miss")
+		}
+		return nil
+	}
+
+	return &cacheEntry{target: target, blob: blob}
 }
 
 func (s *snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
@@ -798,10 +970,20 @@ func (s *snapshotter) Remove(ctx context.Context, key string) (err error) {
 
 		// The layer blob is only persisted for committed snapshots.
 		if info.Kind == snapshots.KindCommitted {
-			// Clear IMMUTABLE_FL before removal, since this flag avoids it.
-			err = setImmutable(s.layerBlobPath(id), false)
-			if err != nil && !errdefs.IsNotImplemented(err) {
-				return fmt.Errorf("failed to clear IMMUTABLE_FL: %w", err)
+			layerBlob := s.layerBlobPath(id)
+			// A cache-hit snapshot's blob is a symlink into the operator-owned
+			// cache dir. Skip clearing IMMUTABLE_FL: setImmutable's os.Open would
+			// follow the link and ioctl the cache entry (which we don't own), and
+			// cache blobs were never made immutable by us in the first place.
+			// os.RemoveAll below unlinks the symlink without following it.
+			if fi, lerr := os.Lstat(layerBlob); lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
+				log.G(ctx).WithField("id", id).Trace("erofs layer cache: skipping IMMUTABLE_FL clear for symlinked cache blob")
+			} else {
+				// Clear IMMUTABLE_FL before removal, since this flag avoids it.
+				err = setImmutable(layerBlob, false)
+				if err != nil && !errdefs.IsNotImplemented(err) {
+					return fmt.Errorf("failed to clear IMMUTABLE_FL: %w", err)
+				}
 			}
 		}
 		_, _, err = storage.Remove(ctx, key)

--- a/plugins/snapshots/erofs/erofs_linux_test.go
+++ b/plugins/snapshots/erofs/erofs_linux_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
@@ -816,5 +817,260 @@ func TestMountFsMeta(t *testing.T) {
 			"device=" + s.layerBlobPath("p2"),
 			"device=" + s.layerBlobPath("p1"),
 		}, m.Options)
+	})
+}
+
+// --- layer content cache tests ---
+
+const (
+	cacheTestDiffID  = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+	cacheTestChainID = "sha256:0000000000000000000000000000000000000000000000000000000000000002"
+)
+
+// requireErofs skips a test unless the erofs kernel filesystem is available,
+// which NewSnapshotter requires. The layer content cache tests don't mount, so
+// they need neither root nor mkfs.erofs.
+func requireErofs(t *testing.T) {
+	t.Helper()
+	if !FindErofs() {
+		t.Skip("check for erofs kernel support failed, skipping test")
+	}
+}
+
+// writeCacheBlob writes a fake erofs blob into cacheDir keyed by diffID and
+// returns its absolute path. The bytes need not be a valid erofs image: the
+// snapshotter only symlinks the blob, so these tests exercise the
+// Prepare/Commit/Remove logic rather than mounting.
+func writeCacheBlob(t *testing.T, cacheDir string, diffID digest.Digest, data []byte) string {
+	t.Helper()
+	blob := erofsutils.CacheBlobPath(cacheDir, diffID)
+	require.NoError(t, os.MkdirAll(filepath.Dir(blob), 0755))
+	require.NoError(t, os.WriteFile(blob, data, 0644))
+	return blob
+}
+
+// extractionOpt builds the snapshot options the unpacker attaches to an
+// image-layer extraction Prepare (the snapshot.ref target and the diffID).
+func extractionOpt(target string, diffID digest.Digest) snapshots.Opt {
+	return snapshots.WithLabels(map[string]string{
+		snapshots.LabelSnapshotRef:    target,
+		snapshots.LabelSnapshotDiffID: diffID.String(),
+	})
+}
+
+// snapshotID returns the backend snapshot ID for key.
+func snapshotID(t *testing.T, ctx context.Context, s *snapshotter, key string) string {
+	t.Helper()
+	var id string
+	require.NoError(t, s.ms.WithTransaction(ctx, false, func(ctx context.Context) error {
+		var err error
+		id, _, _, err = storage.GetInfo(ctx, key)
+		return err
+	}))
+	return id
+}
+
+// newCacheSnapshotter creates an erofs snapshotter rooted in a temp dir with the
+// given options, skipping the test if erofs is unavailable and registering the
+// snapshotter's cleanup.
+func newCacheSnapshotter(t *testing.T, opts ...Opt) *snapshotter {
+	t.Helper()
+	requireErofs(t)
+	sn, err := NewSnapshotter(t.TempDir(), opts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { sn.Close() })
+	return sn.(*snapshotter)
+}
+
+// prepareCacheHit runs an extraction Prepare for target/diffID and asserts it was
+// served from the cache (committed and signaled via ErrAlreadyExists, no mounts).
+func prepareCacheHit(t *testing.T, ctx context.Context, s *snapshotter, target string, diffID digest.Digest) {
+	t.Helper()
+	mounts, err := s.Prepare(ctx, "extract-1 "+target, "", extractionOpt(target, diffID))
+	require.ErrorIs(t, err, errdefs.ErrAlreadyExists, "cache hit must signal the remote-snapshot protocol")
+	assert.Nil(t, mounts, "a cache hit returns no mounts")
+}
+
+// TestCacheHit covers the happy path: an extraction Prepare whose diffID blob is
+// in the cache commits the target chainID (right kind, parent, and snapshot.ref
+// label), symlinks the blob, and returns ErrAlreadyExists.
+func TestCacheHit(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+
+	cacheDir := t.TempDir()
+	diffID := digest.Digest(cacheTestDiffID)
+	blob := writeCacheBlob(t, cacheDir, diffID, []byte("fake erofs blob"))
+
+	s := newCacheSnapshotter(t, WithLayerContentCache(cacheDir))
+
+	target := cacheTestChainID
+	prepareCacheHit(t, ctx, s, target, diffID)
+
+	// The target chainID is committed, with the parent and snapshot.ref label the
+	// metadata layer's Walk filter needs to resolve the backend target.
+	info, err := s.Stat(ctx, target)
+	require.NoError(t, err, "committed snapshot must exist under the target chainID")
+	assert.Equal(t, snapshots.KindCommitted, info.Kind)
+	assert.Equal(t, "", info.Parent)
+	assert.Equal(t, target, info.Labels[snapshots.LabelSnapshotRef])
+
+	// layer.erofs is an absolute symlink into the operator-owned cache blob.
+	link := s.layerBlobPath(snapshotID(t, ctx, s, target))
+	fi, err := os.Lstat(link)
+	require.NoError(t, err)
+	assert.NotZero(t, fi.Mode()&os.ModeSymlink, "layer.erofs should be a symlink")
+	dst, err := os.Readlink(link)
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(dst), "symlink target should be absolute")
+	assert.Equal(t, blob, dst)
+}
+
+// TestCacheSidecar covers a hit in the default "auto" dm-verity mode where the
+// cache entry has a sidecar: it must be copied into the snapshot dir as a plain
+// regular file (not symlinked).
+func TestCacheSidecar(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+
+	cacheDir := t.TempDir()
+	diffID := digest.Digest(cacheTestDiffID)
+	blob := writeCacheBlob(t, cacheDir, diffID, []byte("fake erofs blob"))
+	require.NoError(t, os.WriteFile(dmverity.MetadataPath(blob), []byte(testDmverityMetadata), 0644))
+
+	// dmverity_mode defaults to "auto": use the sidecar if present.
+	s := newCacheSnapshotter(t, WithLayerContentCache(cacheDir))
+
+	target := cacheTestChainID
+	prepareCacheHit(t, ctx, s, target, diffID)
+
+	// The sidecar is copied in as a plain regular file (not a symlink) so mount-time
+	// metadata resolution is independent of the cache filesystem.
+	sidecar := dmverity.MetadataPath(s.layerBlobPath(snapshotID(t, ctx, s, target)))
+	fi, err := os.Lstat(sidecar)
+	require.NoError(t, err, "sidecar should be copied into the snapshot dir")
+	assert.Zero(t, fi.Mode()&os.ModeSymlink, "sidecar should be a regular file, not a symlink")
+	data, err := os.ReadFile(sidecar)
+	require.NoError(t, err)
+	assert.Equal(t, testDmverityMetadata, string(data))
+}
+
+// TestCacheMiss covers the cases that must NOT be served from the cache and
+// instead create a normal active snapshot: cache disabled, blob absent, a
+// label-less (container-rootfs) Prepare, and a View (which the KindActive gate
+// excludes even with matching labels and a cached blob).
+func TestCacheMiss(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	diffID := digest.Digest(cacheTestDiffID)
+	target := cacheTestChainID
+
+	// Each case must leave the extraction as a normal active snapshot: mounts are
+	// returned and the target chainID is not committed.
+	assertFellThrough := func(t *testing.T, s *snapshotter, mounts []mount.Mount, err error) {
+		t.Helper()
+		require.NoError(t, err)
+		assert.NotEmpty(t, mounts, "a miss must return normal active-snapshot mounts")
+		_, err = s.Stat(ctx, target)
+		assert.Error(t, err, "target chainID must not be committed on a miss")
+	}
+
+	t.Run("cache disabled", func(t *testing.T) {
+		s := newCacheSnapshotter(t) // no cache configured
+		mounts, err := s.Prepare(ctx, "extract-1 "+target, "", extractionOpt(target, diffID))
+		assertFellThrough(t, s, mounts, err)
+	})
+
+	t.Run("blob absent", func(t *testing.T) {
+		s := newCacheSnapshotter(t, WithLayerContentCache(t.TempDir()))
+		mounts, err := s.Prepare(ctx, "extract-1 "+target, "", extractionOpt(target, diffID))
+		assertFellThrough(t, s, mounts, err)
+	})
+
+	t.Run("no extraction labels", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		writeCacheBlob(t, cacheDir, diffID, []byte("blob"))
+		s := newCacheSnapshotter(t, WithLayerContentCache(cacheDir))
+		// A container-rootfs Prepare carries no snapshot.ref/diff-id labels.
+		mounts, err := s.Prepare(ctx, "container-rootfs", "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, mounts)
+	})
+
+	t.Run("view is never short-circuited", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		writeCacheBlob(t, cacheDir, diffID, []byte("blob"))
+		s := newCacheSnapshotter(t, WithLayerContentCache(cacheDir))
+		// Even with matching labels and a cached blob, a View must not commit.
+		mounts, err := s.View(ctx, "view-1", "", extractionOpt(target, diffID))
+		assertFellThrough(t, s, mounts, err)
+	})
+}
+
+// TestCacheRemove covers removal of a cache-hit snapshot: it succeeds (the
+// setImmutable guard skips the symlink), removes the snapshot dir/symlink, and
+// leaves the operator-owned cache blob and sidecar untouched.
+func TestCacheRemove(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+
+	cacheDir := t.TempDir()
+	diffID := digest.Digest(cacheTestDiffID)
+	blob := writeCacheBlob(t, cacheDir, diffID, []byte("fake erofs blob"))
+	sidecar := dmverity.MetadataPath(blob)
+	require.NoError(t, os.WriteFile(sidecar, []byte(testDmverityMetadata), 0644))
+
+	s := newCacheSnapshotter(t, WithLayerContentCache(cacheDir))
+
+	target := cacheTestChainID
+	prepareCacheHit(t, ctx, s, target, diffID)
+
+	snapDir := filepath.Dir(s.layerBlobPath(snapshotID(t, ctx, s, target)))
+
+	// Remove must succeed (the symlinked blob is skipped by the setImmutable guard,
+	// which would otherwise follow the link and ioctl the operator-owned blob).
+	require.NoError(t, s.Remove(ctx, target))
+
+	// The snapshot dir (and its symlink) is gone, but the cache is untouched.
+	_, err := os.Stat(snapDir)
+	assert.True(t, os.IsNotExist(err), "snapshot dir should be removed")
+	_, err = os.Stat(blob)
+	require.NoError(t, err, "cache blob must be untouched by Remove")
+	_, err = os.Stat(sidecar)
+	require.NoError(t, err, "cache sidecar must be untouched by Remove")
+}
+
+// TestCacheDmverity covers dmverity_mode="on": a cache entry with a sidecar is
+// committed (and the sidecar copied), while an entry missing its required
+// sidecar is a hard error (not a hit, nothing committed).
+func TestCacheDmverity(t *testing.T) {
+	if supported, err := dmverity.IsSupported(); err != nil || !supported {
+		t.Skip("dm-verity is not supported on this system")
+	}
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	diffID := digest.Digest(cacheTestDiffID)
+	target := cacheTestChainID
+
+	t.Run("with sidecar commits and copies it", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		blob := writeCacheBlob(t, cacheDir, diffID, []byte("fake erofs blob"))
+		require.NoError(t, os.WriteFile(dmverity.MetadataPath(blob), []byte(testDmverityMetadata), 0644))
+
+		s := newCacheSnapshotter(t, WithLayerContentCache(cacheDir), WithDmverityMode("on"))
+		prepareCacheHit(t, ctx, s, target, diffID)
+
+		_, err := os.Stat(dmverity.MetadataPath(s.layerBlobPath(snapshotID(t, ctx, s, target))))
+		require.NoError(t, err, "sidecar must be present for a dmverity_mode=on hit")
+	})
+
+	t.Run("without sidecar fails the pull", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		writeCacheBlob(t, cacheDir, diffID, []byte("fake erofs blob")) // no sidecar
+
+		s := newCacheSnapshotter(t, WithLayerContentCache(cacheDir), WithDmverityMode("on"))
+
+		// dmverity_mode=on requires a sidecar; a cache entry without one is a hard
+		// error rather than a silent fallback.
+		_, err := s.Prepare(ctx, "extract-1 "+target, "", extractionOpt(target, diffID))
+		require.Error(t, err)
+		assert.False(t, errdefs.IsAlreadyExists(err), "missing sidecar must not be treated as a hit")
+		_, err = s.Stat(ctx, target)
+		assert.Error(t, err, "no snapshot should be committed on failure")
 	})
 }

--- a/plugins/snapshots/erofs/plugin/plugin.go
+++ b/plugins/snapshots/erofs/plugin/plugin.go
@@ -55,6 +55,11 @@ type Config struct {
 	// DmverityMode controls dm-verity behavior: "auto" (use if available), "on" (require), "off" (disable)
 	// Linux only
 	DmverityMode string `toml:"dmverity_mode"`
+
+	// LayerContentCache is a directory of pre-converted, diffID-keyed erofs
+	// layer blobs. When set, layers already present in the cache are committed
+	// without being downloaded or converted. Empty disables the feature.
+	LayerContentCache string `toml:"layer_content_cache"`
 }
 
 func init() {
@@ -100,6 +105,10 @@ func init() {
 				opts = append(opts, erofs.WithDmverityMode(config.DmverityMode))
 			}
 
+			if config.LayerContentCache != "" {
+				opts = append(opts, erofs.WithLayerContentCache(config.LayerContentCache))
+			}
+
 			// Don't bother supporting overlay's slow_chown, only RemapIDs
 			ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaOnlyRemapIDs)
 			if ok, err := supportsIDMappedMounts(); err == nil && ok {
@@ -108,7 +117,19 @@ func init() {
 			}
 
 			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
-			ic.Meta.Capabilities = append(ic.Meta.Capabilities, "rebase")
+			// The "rebase" capability lets the unpacker unpack layers in parallel
+			// via a deferred commit: Prepare receives no parent and the real parent
+			// is applied at Commit time. The layer content cache is incompatible
+			// with that — it commits the layer during Prepare (returning
+			// ErrAlreadyExists), when the parent is not yet known in parallel mode,
+			// so the committed layer would be parentless and the chain would break.
+			// With the cache enabled we therefore unpack sequentially. Cache hits
+			// skip the download and conversion anyway, but a cache *miss* is then
+			// slower than a cold pull on an uncached node.
+			// TODO: keep "rebase" and defer the cache commit so misses stay parallel.
+			if config.LayerContentCache == "" {
+				ic.Meta.Capabilities = append(ic.Meta.Capabilities, "rebase")
+			}
 			return erofs.NewSnapshotter(root, opts...)
 		},
 	})


### PR DESCRIPTION
A common technique to speed up cold container launches is to prefetch image
content onto the node:

- https://aws.amazon.com/blogs/containers/start-pods-faster-by-prefetching-images/
- https://docs.cloud.google.com/artifact-registry/docs/prewarm-images
- https://aws.amazon.com/blogs/containers/reduce-container-startup-time-on-amazon-eks-with-bottlerocket-data-volume/
- https://blogs.oracle.com/cloud-infrastructure/optimize-container-start-time-with-oci-storage

Two approaches are common:

- Bake the content into containerd's content store at OS image build time.
- Mount cached content from external/remote storage and have the
  snapshotter consume it.

The OS image must be re-baked whenever the set of prefetched
containers changes, coupling the bake pipeline to container images.

The second approach is hard to combine with erofs today. To keep container
writes local you'd either need a writable cache mount — which then can't be
shared read-only across nodes — or you'd layer the read-only cache under an
overlay that routes writes elsewhere. The overlay route doesn't work with erofs,
because of nested-overlay constraints:

- erofs can't mount blobs that live under an overlay directly, so every layer
  falls back to a loop device
- The container's own writable overlay can't be stacked on top of another
  overlay and the two would conflict.

This PR proposes a `layer_content_cache` option to the erofs snapshotter: a path to a
RO directory of pre-converted, diffID-keyed erofs layer blobs (`<dir>/<algorithm>/<hex>.erofs`).

- The directory is operator-owned — used as RO mount from
  external storage. containerd never writes to it.
- On a cache hit the snapshotter commits the layer by symlinking the cached blob
  and returns `ErrAlreadyExists`, so the pull skips both the layer download and
  the on-the-fly tar→erofs conversion — i.e. it acts as a remote snapshotter.
  A miss transparently falls back to the normal download+convert path.
- As a side effect: because the key is the layer's diffID, blobs are deduplicated
  across images that share layers, independent of chain position (a similar approach was
  proposed for overlayfs in https://github.com/containerd/containerd/issues/13307)

`ctr images` gains `build-erofs-cache <img> <dir>` to create erofs blobs from content store.

```
ctr images build-erofs-cache "$IMG" /mnt/erofs-cache
```

The converted image itself is discarded; only the cache blobs are kept (and can
then be synced to shared storage). Keying by the source layer's diffID means the
cache is consumed when the fleet pulls the original image.

containerd config:

```toml
[plugins.'io.containerd.snapshotter.v1.erofs']
  layer_content_cache = '/mnt/erofs-cache'
```

This way containerd can start with literally empty state directory and
still launch containers blazingly fast with erofs!

```release-note
Support warm image cache for erofs snapshotter
```