### PR TITLE
pkg/archive: fix symlink-follow race in lchmod

### DIFF
--- a/pkg/archive/tar_freebsd.go
+++ b/pkg/archive/tar_freebsd.go
@@ -38,7 +38,7 @@ func lsetxattrCreate(link string, attr string, data []byte) error {
 }
 
 func lchmod(path string, mode os.FileMode) error {
-	err := unix.Fchmodat(unix.AT_FDCWD, path, uint32(mode), unix.AT_SYMLINK_NOFOLLOW)
+	err := unix.Fchmodat(unix.AT_FDCWD, path, syscallMode(mode), unix.AT_SYMLINK_NOFOLLOW)
 	if err != nil {
 		err = &os.PathError{Op: "lchmod", Path: path, Err: err}
 	}

--- a/pkg/archive/tar_linux.go
+++ b/pkg/archive/tar_linux.go
@@ -1,0 +1,56 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import (
+	"os"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// openParentFlags opens the parent directory handle used by lchmod. O_PATH
+// only needs search permission on the directory, which is all the lstat and
+// chmod by name it replaced needed as well; a regular O_RDONLY open would also
+// require read permission and fail on e.g. a 0300 directory when not running
+// as root.
+const openParentFlags = unix.O_PATH | unix.O_DIRECTORY | unix.O_CLOEXEC
+
+// lchmodFallback changes the mode of base, relative to dirfd, when Fchmodat
+// cannot honor AT_SYMLINK_NOFOLLOW: on kernels before 6.6, which lack
+// fchmodat2, and on any kernel when base is a symlink.
+//
+// It pins base with an O_PATH|O_NOFOLLOW descriptor and, unless that is a
+// symlink, applies the mode through the descriptor's /proc/self/fd entry, the
+// same emulation glibc and musl use. The mode lands on the inode that was
+// checked, so base cannot be swapped for a symlink in between.
+func lchmodFallback(dirfd int, base string, mode os.FileMode) error {
+	fd, err := unix.Openat(dirfd, base, unix.O_PATH|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(fd)
+
+	var st unix.Stat_t
+	if err := unix.Fstat(fd, &st); err != nil {
+		return err
+	}
+	if st.Mode&unix.S_IFMT == unix.S_IFLNK {
+		return nil
+	}
+	return unix.Chmod("/proc/self/fd/"+strconv.Itoa(fd), syscallMode(mode))
+}

--- a/pkg/archive/tar_linux_test.go
+++ b/pkg/archive/tar_linux_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/containerd/log/logtest"
+	"golang.org/x/sys/unix"
 )
 
 func TestOverlayApply(t *testing.T) {
@@ -168,4 +170,75 @@ func (d overlayDiffApplier) Apply(ctx context.Context, a fstest.Applier) (string
 	oc.mounted = true
 
 	return oc.merged, nil, nil
+}
+
+func TestLchmodRestrictiveParent(t *testing.T) {
+	// The parent handle is opened with O_PATH, so lchmod only needs search
+	// permission on the directory, as the lstat and chmod by name it replaced
+	// did. Only an unprivileged run can tell the difference; root gets
+	// through either way.
+	dir := filepath.Join(t.TempDir(), "dir")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, "file")
+	if err := os.WriteFile(p, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o300); err != nil {
+		t.Fatal(err)
+	}
+	// Restore read permission so the TempDir cleanup can list it.
+	t.Cleanup(func() { os.Chmod(dir, 0o700) })
+
+	if err := lchmod(p, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Lstat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0o640 {
+		t.Fatalf("mode = %o, want 0640", got)
+	}
+}
+
+func TestLchmodFallback(t *testing.T) {
+	// Kernels with fchmodat2 only reach the fallback for symlinks, so call it
+	// directly to cover both the symlink and the regular file case.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "link")); err != nil {
+		t.Fatal(err)
+	}
+	dirfd, err := unix.Open(dir, openParentFlags, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(dirfd)
+
+	if err := lchmodFallback(dirfd, "link", 0o777); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Lstat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Fatalf("symlink target mode changed to %o, want 0600", got)
+	}
+
+	want := os.FileMode(0o640) | os.ModeSetuid
+	if err := lchmodFallback(dirfd, "target", want); err != nil {
+		t.Fatal(err)
+	}
+	if fi, err = os.Lstat(target); err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode() & (os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky); got != want {
+		t.Fatalf("mode = %o, want %o", got, want)
+	}
 }

--- a/pkg/archive/tar_mostunix.go
+++ b/pkg/archive/tar_mostunix.go
@@ -19,7 +19,9 @@
 package archive
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
@@ -39,16 +41,48 @@ func lsetxattrCreate(link string, attr string, data []byte) error {
 	return err
 }
 
-// lchmod checks for symlink and changes the mode if not a symlink
+// lchmod changes the mode of path without following it when path is a symlink.
+//
+// It opens a handle to path's parent directory and operates on the base name
+// relative to that handle, so the directory components of path are resolved
+// once and cannot be redirected afterwards. The chmod itself uses Fchmodat
+// with AT_SYMLINK_NOFOLLOW so it never follows a terminal symlink, matching
+// the freebsd build.
+//
+// On Linux the flag needs fchmodat2 (kernel 6.6+): on older kernels the
+// x/sys/unix wrapper translates the fchmodat2 ENOSYS into EOPNOTSUPP, and
+// kernels that do have it return EOPNOTSUPP when path itself is a symlink,
+// since symlinks have no modes of their own on Linux. Both cases fall back to
+// an fstatat-guarded chmod relative to the same directory handle. That
+// fallback is not atomic: the base name can still be swapped for a symlink
+// between the fstatat and the chmod, so pre-6.6 Linux kernels keep a narrow
+// window on the final component. Other unixes support the flag natively and
+// never take the fallback.
 func lchmod(path string, mode os.FileMode) error {
-	fi, err := os.Lstat(path)
+	parent, err := os.Open(filepath.Dir(path))
 	if err != nil {
-		return err
+		return &os.PathError{Op: "lchmod", Path: path, Err: err}
+	}
+	defer parent.Close()
+
+	base := filepath.Base(path)
+	dirfd := int(parent.Fd())
+
+	err = unix.Fchmodat(dirfd, base, syscallMode(mode), unix.AT_SYMLINK_NOFOLLOW)
+	switch {
+	case err == nil:
+		return nil
+	case !errors.Is(err, unix.EOPNOTSUPP):
+		return &os.PathError{Op: "lchmod", Path: path, Err: err}
 	}
 
-	if fi.Mode()&os.ModeSymlink == 0 {
-		if err := os.Chmod(path, mode); err != nil {
-			return err
+	var st unix.Stat_t
+	if err := unix.Fstatat(dirfd, base, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return &os.PathError{Op: "lchmod", Path: path, Err: err}
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFLNK {
+		if err := unix.Fchmodat(dirfd, base, syscallMode(mode), 0); err != nil {
+			return &os.PathError{Op: "lchmod", Path: path, Err: err}
 		}
 	}
 	return nil

--- a/pkg/archive/tar_mostunix.go
+++ b/pkg/archive/tar_mostunix.go
@@ -19,7 +19,9 @@
 package archive
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
@@ -39,17 +41,35 @@ func lsetxattrCreate(link string, attr string, data []byte) error {
 	return err
 }
 
-// lchmod checks for symlink and changes the mode if not a symlink
+// lchmod changes the mode of path without following it when path is a symlink.
+//
+// It opens a handle to path's parent directory and operates on the base name
+// relative to that handle, so the directory components of path are resolved
+// once and cannot be redirected afterwards. The chmod itself uses Fchmodat
+// with AT_SYMLINK_NOFOLLOW so it never follows a terminal symlink, matching
+// the freebsd build.
+//
+// Fchmodat reports EOPNOTSUPP when it cannot honor the flag. On Linux that is
+// the case on kernels before 6.6, which lack fchmodat2 (the x/sys/unix wrapper
+// translates the ENOSYS), and on any kernel when path itself is a symlink,
+// since symlinks have no mode of their own there. Other unixes implement the
+// flag natively, but some of them, Solaris for one, still report it for a
+// symlink. All of these go through the platform-specific lchmodFallback,
+// which leaves symlinks alone.
 func lchmod(path string, mode os.FileMode) error {
-	fi, err := os.Lstat(path)
+	dirfd, err := unix.Open(filepath.Dir(path), openParentFlags, 0)
 	if err != nil {
-		return err
+		return &os.PathError{Op: "lchmod", Path: path, Err: err}
 	}
+	defer unix.Close(dirfd)
 
-	if fi.Mode()&os.ModeSymlink == 0 {
-		if err := os.Chmod(path, mode); err != nil {
-			return err
-		}
+	base := filepath.Base(path)
+	err = unix.Fchmodat(dirfd, base, syscallMode(mode), unix.AT_SYMLINK_NOFOLLOW)
+	if errors.Is(err, unix.EOPNOTSUPP) {
+		err = lchmodFallback(dirfd, base, mode)
+	}
+	if err != nil {
+		return &os.PathError{Op: "lchmod", Path: path, Err: err}
 	}
 	return nil
 }

--- a/pkg/archive/tar_unix.go
+++ b/pkg/archive/tar_unix.go
@@ -39,6 +39,23 @@ func chmodTarEntry(perm os.FileMode) os.FileMode {
 	return perm
 }
 
+// syscallMode returns the Unix permission bits (including the setuid, setgid
+// and sticky bits) for an os.FileMode, matching the translation os.Chmod does
+// internally before calling the kernel.
+func syscallMode(i os.FileMode) (o uint32) {
+	o |= uint32(i.Perm())
+	if i&os.ModeSetuid != 0 {
+		o |= unix.S_ISUID
+	}
+	if i&os.ModeSetgid != 0 {
+		o |= unix.S_ISGID
+	}
+	if i&os.ModeSticky != 0 {
+		o |= unix.S_ISVTX
+	}
+	return o
+}
+
 func setHeaderForSpecialDevice(hdr *tar.Header, name string, fi os.FileInfo) error {
 	// Devmajor and Devminor are only needed for special devices.
 

--- a/pkg/archive/tar_unix_other.go
+++ b/pkg/archive/tar_unix_other.go
@@ -1,0 +1,47 @@
+//go:build !windows && !freebsd && !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openParentFlags opens the parent directory handle used by lchmod. These
+// platforms have no search-only open flag in x/sys/unix, so like os.Root this
+// needs read permission on the directory.
+const openParentFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC
+
+// lchmodFallback changes the mode of base, relative to dirfd, when Fchmodat
+// reports EOPNOTSUPP for AT_SYMLINK_NOFOLLOW. These platforms implement the
+// flag natively, so that only happens where a symlink's mode cannot be
+// changed (Solaris is one), and the symlink is simply left alone. Anything
+// else is chmod'ed by name after an fstatat check, which is not atomic, but
+// in practice this path is not reached for non-symlinks.
+func lchmodFallback(dirfd int, base string, mode os.FileMode) error {
+	var st unix.Stat_t
+	if err := unix.Fstatat(dirfd, base, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return err
+	}
+	if st.Mode&unix.S_IFMT == unix.S_IFLNK {
+		return nil
+	}
+	return unix.Fchmodat(dirfd, base, syscallMode(mode), 0)
+}

--- a/pkg/archive/tar_unix_test.go
+++ b/pkg/archive/tar_unix_test.go
@@ -22,6 +22,7 @@ import (
 	"archive/tar"
 	"errors"
 	"math"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -48,5 +49,52 @@ func TestHandleTarTypeBlockCharFifoDeviceRange(t *testing.T) {
 				t.Fatalf("expected errInvalidArchive for %d:%d, got %v", tc.devmajor, tc.devminor, err)
 			}
 		})
+	}
+}
+
+func TestLchmodPreservesSpecialBits(t *testing.T) {
+	// A directory rather than a regular file: FreeBSD rejects setting the
+	// sticky bit on non-directories for unprivileged callers with EFTYPE.
+	p := filepath.Join(t.TempDir(), "dir")
+	if err := os.Mkdir(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	want := os.FileMode(0o750) | os.ModeSetuid | os.ModeSticky
+	if err := lchmod(p, want); err != nil {
+		t.Fatal(err)
+	}
+
+	fi, err := os.Lstat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fi.Mode() & (os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky)
+	if got != want {
+		t.Fatalf("mode = %o, want %o", got, want)
+	}
+}
+
+func TestLchmodDoesNotFollowSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := lchmod(link, 0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	fi, err := os.Lstat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Fatalf("symlink target mode changed to %o, want 0600", got)
 	}
 }


### PR DESCRIPTION
When containerd applies an image layer, createTarFile sets each entry's permissions through lchmod, which is meant to skip symlinks so the mode change never lands on a link target. On the Linux build it did that by calling os.Lstat first and then os.Chmod by name only when the entry was not a symlink. os.Chmod follows symlinks, so the lstat result was only advisory: if path is replaced with a symlink after the lstat but before the chmod, the mode (including any setuid or setgid bit from the untrusted header) is applied to whatever the link points at, outside the layer root. I noticed it while looking at the recently fixed openFile chmod race, since the freebsd build here already sidesteps the same problem with Fchmodat and AT_SYMLINK_NOFOLLOW.

lchmod now opens a handle to the parent directory and chmods the base name relative to it with AT_SYMLINK_NOFOLLOW, so the directory components are resolved once and the chmod never follows a terminal symlink. On Linux the parent is opened with O_PATH, so only search permission on it is needed, same as the lstat and chmod it replaced. Kernels without fchmodat2 (before 6.6) take a fallback that pins the entry with an O_PATH|O_NOFOLLOW descriptor and applies the mode through /proc/self/fd, the glibc/musl emulation that moby/go-archive#45 also settled on, so the fallback has no window either. A small syscallMode helper keeps the setuid, setgid and sticky bits intact, matching what os.Chmod did before, and the freebsd build goes through it as well.