### PR TITLE
pkg/epoch: reject negative SOURCE_DATE_EPOCH values

### DIFF
--- a/pkg/epoch/epoch.go
+++ b/pkg/epoch/epoch.go
@@ -52,6 +52,9 @@ func ParseSourceDateEpoch(sourceDateEpoch string) (*time.Time, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid value: %w", err)
 	}
+	if i64 < 0 {
+		return nil, fmt.Errorf("invalid value: %q must be non-negative", sourceDateEpoch)
+	}
 	unix := time.Unix(i64, 0).UTC()
 	return &unix, nil
 }

--- a/pkg/epoch/epoch_test.go
+++ b/pkg/epoch/epoch_test.go
@@ -81,4 +81,20 @@ func TestSourceDateEpoch(t *testing.T) {
 		require.ErrorContains(t, err, "invalid value:")
 		require.Nil(t, vp)
 	})
+
+	t.Run("WithNegativeSourceDateEpoch", func(t *testing.T) {
+		// SOURCE_DATE_EPOCH is defined as a non-negative number of seconds
+		// since the Unix epoch, so a negative value is not well-formatted.
+		// See https://reproducible-builds.org/docs/source-date-epoch/
+		const negativeValue = "-1"
+		t.Setenv(SourceDateEpochEnv, negativeValue)
+
+		vp, err := SourceDateEpoch()
+		require.ErrorContains(t, err, "invalid SOURCE_DATE_EPOCH value")
+		require.Nil(t, vp)
+
+		vp, err = ParseSourceDateEpoch(negativeValue)
+		require.ErrorContains(t, err, "invalid value:")
+		require.Nil(t, vp)
+	})
 }


### PR DESCRIPTION
`ParseSourceDateEpoch` uses `strconv.ParseInt`, which accepts a leading sign, so a negative `SOURCE_DATE_EPOCH` (e.g. `-1`) is silently accepted and returns a pre-1970 timestamp with a `nil` error. That contradicts both the function's own godoc ("returns an error if ... not well-formatted") and the [reproducible-builds spec](https://reproducible-builds.org/docs/source-date-epoch/), where `SOURCE_DATE_EPOCH` is a non-negative number of seconds since the Unix epoch.

This rejects negative values with an error and adds a regression test. The existing `WithInvalidSourceDateEpoch` case only covered a non-numeric string (`"foo"`), so the negative case was untested.
