### PR TITLE
pkg/oci: resolve rootfs symlinks for user lookup

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1830,16 +1830,11 @@ func WithWindowsNetworkNamespace(ns string) SpecOpts {
 	}
 }
 
-// readLinker defines the ReadLink method locally.
-// We keep this shim to ensure compatibility with build environments where
-// the standard library's fs.ReadLinkFS interface is not yet available or recognized.
-type readLinker interface {
-	ReadLink(name string) (string, error)
-}
-
 // openUserFile attempts to open a file within the root fs.
-// It handles cases where the file is an absolute symlink (e.g., NixOS /etc/passwd -> /nix/store/...),
-// which triggers "path escapes from parent" errors in Go 1.24+ due to stricter os.DirFS validation.
+// It handles cases where the path contains symlinks (e.g., NixOS
+// /etc/passwd -> /nix/store/...). os.Root-backed filesystems reject
+// absolute symlinks, so when the direct open fails the path is resolved
+// within the root via resolveInRootFS and the open is retried.
 //
 // The returned file rejects non-regular sources and returns an error if more
 // than maxUserFileBytes are read from it.
@@ -1849,32 +1844,21 @@ func openUserFile(root fs.FS, name string) (fs.File, error) {
 		return wrapUserFile(f, name)
 	}
 
-	// Check if the FS implements our local ReadLink interface.
-	// We use a local interface instead of fs.ReadLinkFS to avoid strict dependency
-	// issues in some build environments.
-	if lfs, ok := root.(readLinker); ok {
-		if target, lerr := lfs.ReadLink(name); lerr == nil {
-			// Use filepath.IsAbs to handle platform-agnostic absolute path checks
-			if filepath.IsAbs(target) {
-				// Re-anchor the absolute path to the root.
-				// e.g. /nix/store/... becomes nix/store/... (relative to root fs)
-				// We use filepath.Rel to safely strip the leading separator.
-				rel, rerr := filepath.Rel(string(filepath.Separator), target)
-				if rerr == nil {
-					// filepath.Rel might return OS-specific separators (backslashes on Windows).
-					// fs.Open strictly expects forward slashes, so we convert it.
-					f, oerr := root.Open(filepath.ToSlash(rel))
-					if oerr != nil {
-						return nil, oerr
-					}
-					return wrapUserFile(f, name)
-				}
-			}
-		}
+	lfs, ok := root.(fs.ReadLinkFS)
+	if !ok {
+		return nil, err
 	}
 
-	// Return the original error if we couldn't resolve it
-	return nil, err
+	resolvedName, err := resolveInRootFS(lfs, name)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err = root.Open(resolvedName)
+	if err != nil {
+		return nil, err
+	}
+	return wrapUserFile(f, name)
 }
 
 // maxUserFileBytes caps how much data is read from any user-database file

--- a/pkg/oci/spec_test.go
+++ b/pkg/oci/spec_test.go
@@ -19,9 +19,7 @@ package oci
 import (
 	"context"
 	"io"
-	"io/fs"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -32,6 +30,7 @@ import (
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/moby/sys/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateSpec(t *testing.T) {
@@ -338,104 +337,145 @@ func TestWithPrivileged(t *testing.T) {
 	}
 }
 
-func TestOpenUserFile_AbsoluteSymlink(t *testing.T) {
+func TestOpenUserFile_Symlink(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("absolute symlink handling is only supported on non-Windows platforms")
+		t.Skip("symlink handling is only supported on non-Windows platforms")
 	}
 
 	expectedContent := []byte("root:x:0:0:root:/root:/bin/bash" + t.Name())
 
-	root := t.TempDir()
-	// Use 'continuity' library to create a directory structure simulating NixOS
-	if err := fstest.Apply(
-		fstest.CreateDir("/etc", 0o755),
-		fstest.CreateDir("/nix/store/abcd", 0o755),
-		fstest.CreateFile("/nix/store/abcd/passwd", expectedContent, 0o644),
-		// /etc/passwd -> /nix/store/abcd/passwd (absolute symlink)
-		fstest.Symlink("/nix/store/abcd/passwd", "/etc/passwd"),
-	).Apply(root); err != nil {
-		t.Fatal(err)
+	for _, tc := range []struct {
+		name    string
+		initOps []fstest.Applier
+	}{
+		{
+			name: "absolute symlink - v1",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/etc", 0o755),
+				fstest.CreateDir("/nix/store/abcd", 0o755),
+				fstest.CreateFile("/nix/store/abcd/passwd", expectedContent, 0o644),
+				// /etc/passwd -> /nix/store/abcd/passwd (absolute symlink)
+				fstest.Symlink("/nix/store/abcd/passwd", "/etc/passwd"),
+			},
+		},
+		{
+			name: "absolute symlink - v2",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/system/etc", 0o755),
+				fstest.CreateFile("/system/etc/passwd", expectedContent, 0o644),
+				// /etc -> /system/etc (absolute symlink)
+				fstest.Symlink("/system/etc", "/etc"),
+			},
+		},
+		{
+			name: "relative symlink - v1",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/system/etc", 0o755),
+				fstest.CreateFile("/system/etc/passwd", expectedContent, 0o644),
+				fstest.Symlink("../system/etc", "/etc"),
+			},
+		},
+		{
+			name: "relative symlink - v2",
+			initOps: []fstest.Applier{
+				fstest.CreateFile("/passwd", expectedContent, 0o644),
+				fstest.Symlink("..", "/etc"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rootDir := t.TempDir()
+
+			err := fstest.Apply(tc.initOps...).Apply(rootDir)
+			require.NoError(t, err)
+
+			rootFS, err := os.OpenRoot(rootDir)
+			require.NoError(t, err)
+			defer rootFS.Close()
+
+			f, err := openUserFile(rootFS.FS(), "etc/passwd")
+			require.NoError(t, err)
+
+			defer f.Close()
+
+			content, err := io.ReadAll(f)
+			require.NoError(t, err)
+
+			require.Equal(t, string(expectedContent), string(content))
+		})
 	}
 
-	rootFS := os.DirFS(root)
-
-	// Ensure the FS implements the ReadLink interface.
-	// If the native os.DirFS doesn't implement it (depending on Go version),
-	// wrap it in our readLinkFS helper.
-	if _, ok := rootFS.(readLinker); !ok {
-		t.Logf("os.DirFS does not implement ReadLink; wrapping to use ReadLink")
-		rootFS = readLinkFS{root: root, fs: rootFS}
-	}
-
-	f, err := openUserFile(rootFS, "etc/passwd")
-	if err != nil {
-		t.Fatalf("openUserFile failed on absolute symlink: %v", err)
-	}
-	defer f.Close()
-
-	content, err := io.ReadAll(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != string(expectedContent) {
-		t.Errorf("expected content %q, got %q", string(expectedContent), string(content))
-	}
 }
 
-func TestGroupLookup_AbsoluteSymlink(t *testing.T) {
+func TestGroupLookup_Symlink(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("absolute symlink handling is only supported on non-Windows platforms")
+		t.Skip("symlink handling is only supported on non-Windows platforms")
 	}
 
 	expectedContent := []byte("dummygroup:x:1001:paulo\n")
 
-	root := t.TempDir()
-	if err := fstest.Apply(
-		fstest.CreateDir("/etc", 0o755),
-		fstest.CreateDir("/nix/store/abcd", 0o755),
-		fstest.CreateFile("/nix/store/abcd/group", expectedContent, 0o644),
-		fstest.Symlink("/nix/store/abcd/group", "/etc/group"),
-	).Apply(root); err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range []struct {
+		name    string
+		initOps []fstest.Applier
+	}{
+		{
+			name: "absolute symlink - v1",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/etc", 0o755),
+				fstest.CreateDir("/nix/store/abcd", 0o755),
+				fstest.CreateFile("/nix/store/abcd/group", expectedContent, 0o644),
+				fstest.Symlink("/nix/store/abcd/group", "/etc/group"),
+			},
+		},
+		{
+			name: "absolute symlink - v2",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/system/etc", 0o755),
+				fstest.CreateFile("/system/etc/group", expectedContent, 0o644),
+				fstest.Symlink("/system/etc", "/etc"),
+			},
+		},
+		{
+			name: "relative symlink - v1",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/system/etc", 0o755),
+				fstest.CreateFile("/system/etc/group", expectedContent, 0o644),
+				fstest.Symlink("../system/etc", "/etc"),
+			},
+		},
+		{
+			name: "relative symlink - v2",
+			initOps: []fstest.Applier{
+				fstest.CreateFile("group", expectedContent, 0o644),
+				fstest.Symlink("..", "/etc"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rootDir := t.TempDir()
 
-	rootFS := os.DirFS(root)
-	if _, ok := rootFS.(readLinker); !ok {
-		rootFS = readLinkFS{root: root, fs: rootFS}
-	}
+			err := fstest.Apply(tc.initOps...).Apply(rootDir)
+			require.NoError(t, err)
 
-	gid, err := GIDFromFS(rootFS, func(g user.Group) bool {
-		return g.Name == "dummygroup"
-	})
-	if err != nil {
-		t.Fatalf("GIDFromFS failed on absolute symlink: %v", err)
-	}
-	if gid != 1001 {
-		t.Errorf("expected GID 1001, got %d", gid)
-	}
+			rootFS, err := os.OpenRoot(rootDir)
+			require.NoError(t, err)
+			defer rootFS.Close()
 
-	gids, err := getSupplementalGroupsFromFS(rootFS, func(g user.Group) bool {
-		return g.Name == "dummygroup"
-	})
-	if err != nil {
-		t.Fatalf("getSupplementalGroupsFromFS failed on absolute symlink: %v", err)
+			gid, err := GIDFromFS(rootFS.FS(), func(g user.Group) bool {
+				return g.Name == "dummygroup"
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, uint32(1001), gid)
+
+			gids, err := getSupplementalGroupsFromFS(rootFS.FS(), func(g user.Group) bool {
+				return g.Name == "dummygroup"
+			})
+			require.NoError(t, err)
+
+			if len(gids) != 1 || gids[0] != 1001 {
+				t.Errorf("expected supplemental GIDs [1001], got %v", gids)
+			}
+		})
 	}
-	if len(gids) != 1 || gids[0] != 1001 {
-		t.Errorf("expected supplemental GIDs [1001], got %v", gids)
-	}
-}
-
-// Helpers for testing ReadLink support
-type readLinkFS struct {
-	root string
-	fs   fs.FS
-}
-
-func (r readLinkFS) Open(name string) (fs.File, error) {
-	return r.fs.Open(name)
-}
-
-func (r readLinkFS) ReadLink(name string) (string, error) {
-	// Force link reading using the actual path on disk
-	return os.Readlink(filepath.Join(r.root, filepath.FromSlash(name)))
 }

--- a/pkg/oci/utils_unix.go
+++ b/pkg/oci/utils_unix.go
@@ -21,8 +21,11 @@ package oci
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 
 	"github.com/moby/sys/userns"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -182,4 +185,121 @@ func DeviceFromPath(path string) (*specs.LinuxDevice, error) {
 		UID:      &stat.Uid,
 		GID:      &stat.Gid,
 	}, nil
+}
+
+// resolveInRootFS resolves name within rootFS, following symbolic links while
+// treating rootFS as the filesystem root. It returns the canonical path
+// relative to rootFS.
+//
+// ReadLink is expected to return a bounded target. Linux rejects symlink
+// targets of PATH_MAX (4096) bytes or more when creating them. Together with
+// the 40-link limit, this bounds the work during resolution. However, a
+// synthetic fs.ReadLinkFS can return an arbitrarily large target and make the
+// resolution expensive. See the "Length limit" section of path_resolution(7).
+func resolveInRootFS(rootFs fs.ReadLinkFS, name string) (string, error) {
+	if len(name) == 0 {
+		return "", &fs.PathError{
+			Op:   "resolve",
+			Path: name,
+			Err:  syscall.ENOENT,
+		}
+	}
+
+	// In Linux 4.2, the kernel's pathname-resolution code was reworked to
+	// eliminate the use of recursion, so that the only limit that remains
+	// is the maximum of 40 resolutions for the entire pathname.
+	//
+	// https://man7.org/linux/man-pages/man7/path_resolution.7.html
+	const symloopMax = 40
+	followed := 0
+
+	seq := "/"
+
+	pendings := splitPathComponents(name)
+	candidates := make([]string, 0, len(pendings))
+	for len(pendings) > 0 {
+		part := pendings[0]
+		pendings = pendings[1:]
+
+		if part == "." {
+			continue
+		}
+
+		if part == ".." {
+			if len(candidates) > 0 {
+				candidates = candidates[:len(candidates)-1]
+			}
+			continue
+		}
+
+		candidates = append(candidates, part)
+
+		resolved := strings.Join(candidates, seq)
+
+		info, err := rootFs.Lstat(resolved)
+		if err != nil {
+			return "", err
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			followed++
+
+			if followed > symloopMax {
+				return "", &fs.PathError{
+					Op:   "resolve",
+					Path: resolved,
+					Err:  syscall.ELOOP,
+				}
+			}
+
+			// target can't be empty in real filesystem because
+			// linux kernel doesn't allow to create empty symbolic
+			// link. However, synthetic fs.FS can do that.
+			target, err := rootFs.ReadLink(resolved)
+			if err != nil {
+				return "", err
+			}
+
+			if filepath.IsAbs(target) {
+				candidates = candidates[:0]
+			} else {
+				candidates = candidates[:len(candidates)-1]
+			}
+
+			pendings = append(splitPathComponents(target), pendings...)
+			continue
+		}
+
+		if !info.IsDir() && len(pendings) > 0 {
+			return "", &fs.PathError{
+				Op:   "resolve",
+				Path: resolved,
+				Err:  syscall.ENOTDIR,
+			}
+		}
+	}
+
+	resolvedName := strings.Join(candidates, seq)
+	if resolvedName == "" {
+		resolvedName = "."
+	}
+	return resolvedName, nil
+}
+
+// splitPathComponents returns path components in string slice format and appends
+// "." as last one if origin name contains trailing slash. With trailing dot
+// component, the path resolution can verify if name is directory or not.
+func splitPathComponents(name string) []string {
+	res := make([]string, 0, 8)
+	for part := range strings.SplitSeq(name, "/") {
+		if part == "" {
+			continue
+		}
+		res = append(res, part)
+	}
+
+	if len(name) > 0 && name[len(name)-1] == '/' {
+		res = append(res, ".")
+	}
+	return res
 }

--- a/pkg/oci/utils_unix_test.go
+++ b/pkg/oci/utils_unix_test.go
@@ -24,10 +24,13 @@ import (
 	"io/fs"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 
+	"github.com/containerd/continuity/fs/fstest"
 	"github.com/moby/sys/userns"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func cleanupTest() {
@@ -163,5 +166,270 @@ func TestHostDevicesAllValid(t *testing.T) {
 		default:
 			t.Errorf("device entry %+v has unexpected type %v", device, device.Type)
 		}
+	}
+}
+
+func TestSplitPathComponents(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty path",
+			input: "",
+			want:  []string{},
+		},
+		{
+			name:  "single component",
+			input: "passwd",
+			want:  []string{"passwd"},
+		},
+		{
+			name:  "relative path",
+			input: "etc/passwd",
+			want:  []string{"etc", "passwd"},
+		},
+		{
+			name:  "absolute path",
+			input: "/etc/passwd",
+			want:  []string{"etc", "passwd"},
+		},
+		{
+			name:  "repeated separators",
+			input: "//a///b//c",
+			want:  []string{"a", "b", "c"},
+		},
+		{
+			name:  "dot components are preserved",
+			input: "a/./link/../real",
+			want:  []string{"a", ".", "link", "..", "real"},
+		},
+		{
+			name:  "trailing separator splits as dot",
+			input: "a/b/",
+			want:  []string{"a", "b", "."},
+		},
+		{
+			name:  "root path",
+			input: "/",
+			want:  []string{"."},
+		},
+		{
+			name:  "only separators",
+			input: "///",
+			want:  []string{"."},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, splitPathComponents(tc.input))
+		})
+	}
+}
+
+func TestResolveInRootFS(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		initOps  []fstest.Applier
+		original string
+		expected string
+		err      string
+	}{
+		{
+			name: "no symlink",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir/a/b", 0o755),
+				fstest.CreateFile("/dir/a/b/c", nil, 0o644),
+			},
+			original: "/dir/a/b/c",
+			expected: "dir/a/b/c",
+		},
+		{
+			name: "symlink deadloop - v1",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.Symlink("b", "/dir/a"),
+				fstest.Symlink("c", "/dir/b"),
+				fstest.Symlink("a", "/dir/c"),
+			},
+			original: "/dir/a",
+			err:      "too many levels of symbolic links",
+		},
+		{
+			name: "symlink deadloop - v2",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.Symlink("/dir/b", "/dir/a"),
+				fstest.Symlink("/dir/c", "/dir/b"),
+				fstest.Symlink("/dir/a", "/dir/c"),
+			},
+			original: "/dir/a",
+			err:      "too many levels of symbolic links",
+		},
+		{
+			name: "symlink deadloop - v3",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.Symlink("loop", "/dir/loop"),
+			},
+			original: "/dir/loop",
+			err:      "too many levels of symbolic links",
+		},
+		{
+			name: "symlink deadloop - v4",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.Symlink("loop/..", "/dir/loop"),
+			},
+			original: "/dir/loop",
+			err:      "too many levels of symbolic links",
+		},
+		{
+			name: "symlink target component is too long",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.Symlink(strings.Repeat("a", 256), "/dir/link"),
+			},
+			original: "/dir/link",
+			err:      "file name too long",
+		},
+		{
+			name: "41 levels of symbolic links",
+			initOps: func() []fstest.Applier {
+				res := []fstest.Applier{
+					fstest.CreateDir("/dir", 0o755),
+					fstest.CreateFile("/dir/empty", nil, 0o644),
+					fstest.Symlink("/dir/empty", "/dir/link1"),
+				}
+
+				for i := range 40 {
+					res = append(res, fstest.Symlink(
+						fmt.Sprintf("link%d", i+1),
+						fmt.Sprintf("/dir/link%d", i+2)),
+					)
+				}
+				return res
+			}(),
+			original: "/dir/link41",
+			err:      "too many levels of symbolic links",
+		},
+		{
+			name: "try to escape root",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.CreateDir("/real", 0o755),
+				fstest.CreateFile("/real/empty", nil, 0o644),
+				fstest.Symlink("../../../../../../real", "/dir/link"),
+			},
+			original: "/dir/link/empty",
+			expected: "real/empty",
+		},
+		{
+			name: "unfold symlink",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.CreateDir("/dir/l1", 0o755),
+				fstest.CreateDir("/dir/l1/l2", 0o755),
+				fstest.CreateFile("/dir/l1/empty", nil, 0o644),
+				fstest.Symlink("l1/l2", "/dir/link"),
+			},
+			original: "/dir/link/../empty",
+			expected: "dir/l1/empty",
+		},
+		{
+			name: "not empty",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+			},
+			original: "./../.././.",
+			expected: ".",
+		},
+		{
+			name: "respect trailing slash - v1",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+			},
+			original: "./../.././dir/",
+			expected: "dir",
+		},
+		{
+			name: "respect trailing slash - v2",
+			initOps: []fstest.Applier{
+				fstest.CreateFile("/fake-dir", nil, 0o644),
+			},
+			original: "./../.././fake-dir/",
+			err:      "not a directory",
+		},
+		{
+			name:     "respect trailing slash - v3",
+			initOps:  []fstest.Applier{},
+			original: "/",
+			expected: ".",
+		},
+		{
+			name: "respect trailing slash - v4",
+			initOps: []fstest.Applier{
+				fstest.CreateFile("/f", nil, 0o644),
+				fstest.Symlink("f", "/link"),
+			},
+			original: "link/",
+			err:      "not a directory",
+		},
+		{
+			// The symlink target's own trailing slash requires the
+			// final entity to be a directory.
+			name: "respect trailing slash - v5",
+			initOps: []fstest.Applier{
+				fstest.CreateFile("/f", nil, 0o644),
+				fstest.Symlink("f/", "/link"),
+			},
+			original: "link",
+			err:      "not a directory",
+		},
+		{
+			// The trailing-slash requirement is sticky across
+			// chained symlinks.
+			name: "respect trailing slash - v6",
+			initOps: []fstest.Applier{
+				fstest.CreateFile("/f", nil, 0o644),
+				fstest.Symlink("link2/", "/link1"),
+				fstest.Symlink("f", "/link2"),
+			},
+			original: "link1",
+			err:      "not a directory",
+		},
+		{
+			name:     "empty path",
+			initOps:  []fstest.Applier{},
+			original: "",
+			err:      "no such file or directory",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rootDir := t.TempDir()
+
+			err := fstest.Apply(tc.initOps...).Apply(rootDir)
+			require.NoError(t, err)
+
+			rootFS, err := os.OpenRoot(rootDir)
+			require.NoError(t, err)
+			defer rootFS.Close()
+
+			got, err := resolveInRootFS(rootFS.FS().(fs.ReadLinkFS), tc.original)
+			if tc.err != "" {
+				t.Logf("received %v", err)
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+
+			assert.True(t, fs.ValidPath(got))
+
+			fd, err := rootFS.FS().Open(got)
+			require.NoError(t, err)
+			fd.Close()
+		})
 	}
 }

--- a/pkg/oci/utils_unix_test.go
+++ b/pkg/oci/utils_unix_test.go
@@ -24,10 +24,13 @@ import (
 	"io/fs"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 
+	"github.com/containerd/continuity/fs/fstest"
 	"github.com/moby/sys/userns"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func cleanupTest() {
@@ -163,5 +166,290 @@ func TestHostDevicesAllValid(t *testing.T) {
 		default:
 			t.Errorf("device entry %+v has unexpected type %v", device, device.Type)
 		}
+	}
+}
+
+func TestSplitPathComponents(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty path",
+			input: "",
+			want:  []string{},
+		},
+		{
+			name:  "single component",
+			input: "passwd",
+			want:  []string{"passwd"},
+		},
+		{
+			name:  "relative path",
+			input: "etc/passwd",
+			want:  []string{"etc", "passwd"},
+		},
+		{
+			name:  "absolute path",
+			input: "/etc/passwd",
+			want:  []string{"etc", "passwd"},
+		},
+		{
+			name:  "repeated separators",
+			input: "//a///b//c",
+			want:  []string{"a", "b", "c"},
+		},
+		{
+			name:  "dot components are preserved",
+			input: "a/./link/../real",
+			want:  []string{"a", ".", "link", "..", "real"},
+		},
+		{
+			name:  "trailing separator splits as dot",
+			input: "a/b/",
+			want:  []string{"a", "b", "."},
+		},
+		{
+			name:  "root path",
+			input: "/",
+			want:  []string{"."},
+		},
+		{
+			name:  "only separators",
+			input: "///",
+			want:  []string{"."},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, splitPathComponents(tc.input))
+		})
+	}
+}
+
+func TestResolveInRootFS(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		initOps  []fstest.Applier
+		original string
+		expected string
+		err      string
+	}{
+		{
+			name: "no symlink",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir/a/b", 0o755),
+				fstest.CreateFile("/dir/a/b/c", nil, 0o644),
+			},
+			original: "/dir/a/b/c",
+			expected: "dir/a/b/c",
+		},
+		{
+			name: "symlink deadloop - v1",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.Symlink("b", "/dir/a"),
+				fstest.Symlink("c", "/dir/b"),
+				fstest.Symlink("a", "/dir/c"),
+			},
+			original: "/dir/a",
+			err:      "too many levels of symbolic links",
+		},
+		{
+			name: "symlink deadloop - v2",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.Symlink("/dir/b", "/dir/a"),
+				fstest.Symlink("/dir/c", "/dir/b"),
+				fstest.Symlink("/dir/a", "/dir/c"),
+			},
+			original: "/dir/a",
+			err:      "too many levels of symbolic links",
+		},
+		{
+			name: "symlink deadloop - v3",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.Symlink("loop", "/dir/loop"),
+			},
+			original: "/dir/loop",
+			err:      "too many levels of symbolic links",
+		},
+		{
+			name: "symlink deadloop - v4",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.Symlink("loop/..", "/dir/loop"),
+			},
+			original: "/dir/loop",
+			err:      "too many levels of symbolic links",
+		},
+		{
+			name: "symlink target component is too long",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.Symlink(strings.Repeat("a", 256), "/dir/link"),
+			},
+			original: "/dir/link",
+			err:      "file name too long",
+		},
+		{
+			name: "40 levels of symbolic links",
+			initOps: func() []fstest.Applier {
+				res := []fstest.Applier{
+					fstest.CreateDir("/dir", 0o755),
+					fstest.CreateFile("/dir/empty", nil, 0o644),
+					fstest.Symlink("/dir/empty", "/dir/link1"),
+				}
+
+				for i := range 39 {
+					res = append(res, fstest.Symlink(
+						fmt.Sprintf("link%d", i+1),
+						fmt.Sprintf("/dir/link%d", i+2)),
+					)
+				}
+				return res
+			}(),
+			original: "/dir/link40",
+			expected: "dir/empty",
+		},
+		{
+			name: "41 levels of symbolic links",
+			initOps: func() []fstest.Applier {
+				res := []fstest.Applier{
+					fstest.CreateDir("/dir", 0o755),
+					fstest.CreateFile("/dir/empty", nil, 0o644),
+					fstest.Symlink("/dir/empty", "/dir/link1"),
+				}
+
+				for i := range 40 {
+					res = append(res, fstest.Symlink(
+						fmt.Sprintf("link%d", i+1),
+						fmt.Sprintf("/dir/link%d", i+2)),
+					)
+				}
+				return res
+			}(),
+			original: "/dir/link41",
+			err:      "too many levels of symbolic links",
+		},
+		{
+			name: "try to escape root",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.CreateDir("/real", 0o755),
+				fstest.CreateFile("/real/empty", nil, 0o644),
+				fstest.Symlink("../../../../../../real", "/dir/link"),
+			},
+			original: "/dir/link/empty",
+			expected: "real/empty",
+		},
+		{
+			name: "unfold symlink",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+				fstest.CreateDir("/dir/l1", 0o755),
+				fstest.CreateDir("/dir/l1/l2", 0o755),
+				fstest.CreateFile("/dir/l1/empty", nil, 0o644),
+				fstest.Symlink("l1/l2", "/dir/link"),
+			},
+			original: "/dir/link/../empty",
+			expected: "dir/l1/empty",
+		},
+		{
+			name: "not empty",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+			},
+			original: "./../.././.",
+			expected: ".",
+		},
+		{
+			name: "respect trailing slash - v1",
+			initOps: []fstest.Applier{
+				fstest.CreateDir("/dir", 0o755),
+			},
+			original: "./../.././dir/",
+			expected: "dir",
+		},
+		{
+			name: "respect trailing slash - v2",
+			initOps: []fstest.Applier{
+				fstest.CreateFile("/fake-dir", nil, 0o644),
+			},
+			original: "./../.././fake-dir/",
+			err:      "not a directory",
+		},
+		{
+			name:     "respect trailing slash - v3",
+			initOps:  []fstest.Applier{},
+			original: "/",
+			expected: ".",
+		},
+		{
+			name: "respect trailing slash - v4",
+			initOps: []fstest.Applier{
+				fstest.CreateFile("/f", nil, 0o644),
+				fstest.Symlink("f", "/link"),
+			},
+			original: "link/",
+			err:      "not a directory",
+		},
+		{
+			// The symlink target's own trailing slash requires the
+			// final entity to be a directory.
+			name: "respect trailing slash - v5",
+			initOps: []fstest.Applier{
+				fstest.CreateFile("/f", nil, 0o644),
+				fstest.Symlink("f/", "/link"),
+			},
+			original: "link",
+			err:      "not a directory",
+		},
+		{
+			// The trailing-slash requirement is sticky across
+			// chained symlinks.
+			name: "respect trailing slash - v6",
+			initOps: []fstest.Applier{
+				fstest.CreateFile("/f", nil, 0o644),
+				fstest.Symlink("link2/", "/link1"),
+				fstest.Symlink("f", "/link2"),
+			},
+			original: "link1",
+			err:      "not a directory",
+		},
+		{
+			name:     "empty path",
+			initOps:  []fstest.Applier{},
+			original: "",
+			err:      "no such file or directory",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rootDir := t.TempDir()
+
+			err := fstest.Apply(tc.initOps...).Apply(rootDir)
+			require.NoError(t, err)
+
+			rootFS, err := os.OpenRoot(rootDir)
+			require.NoError(t, err)
+			defer rootFS.Close()
+
+			got, err := resolveInRootFS(rootFS.FS().(fs.ReadLinkFS), tc.original)
+			if tc.err != "" {
+				t.Logf("received %v", err)
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+
+			assert.True(t, fs.ValidPath(got))
+
+			fd, err := rootFS.FS().Open(got)
+			require.NoError(t, err)
+			fd.Close()
+		})
 	}
 }

--- a/pkg/oci/utils_windows.go
+++ b/pkg/oci/utils_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package oci
+
+import "io/fs"
+
+func resolveInRootFS(_ fs.ReadLinkFS, name string) (string, error) {
+	return name, nil
+}


### PR DESCRIPTION
Some rootfs may use symlinks for /etc/passwd and /etc/group. For example,
NixOS uses absolute symlinks to files in /nix/store. os.Root is not used
because [it rejects absolute symlinks][2].

The previous code only handled a symlink on the final path. Add a helper to
resolve symlinks in every path component with fs.ReadLinkFS. Absolute symlinks
are resolved from the rootfs, and the final path is still opened with fs.FS.

When tracing a path through symbolic links, the maximum number of links that
can be followed is [40][1].

[1]: <https://man7.org/linux/man-pages/man7/path_resolution.7.html>
[2]: <https://github.com/golang/go/issues/67002#issuecomment-2284659595>


Provides an alternative to #13383
Fixes: https://github.com/containerd/containerd/issues/13382

cc @jasonjoo2010

```release-note
Fix user and group lookup failures in container rootfs containing symlinked /etc/passwd or /etc/group
```
