### PR TITLE
docs: correct default for [debug] address

### DIFF
--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -69,7 +69,7 @@ defaults when its configuration block is omitted. Contains properties:
 : Section to enable and configure a debug socket listener. In version 4, use the
 server plugin **io.containerd.server.v1.debug** instead. Contains properties:
 
-- **address** (Default: "/run/containerd/debug.sock")
+- **address** (Default: "") Debug endpoint does not listen by default
 - **uid** (Default: 0)
 - **gid** (Default: 0)
 - **level** (Default: "info") sets the debug log level. Supported levels are:


### PR DESCRIPTION
The debug server plugin returns ErrSkipPlugin when its address is empty and the default configuration emitted by 'containerd config default' sets the address to an empty string.
