### PR TITLE
ci: compile and install libpathrs for install-runc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,7 +425,7 @@ jobs:
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y gperf dmsetup strace xfsprogs
+          sudo apt-get install -y gperf dmsetup strace xfsprogs lld
           script/setup/install-seccomp
           script/setup/install-runc
           script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')

--- a/.github/workflows/node-e2e.yml
+++ b/.github/workflows/node-e2e.yml
@@ -60,7 +60,7 @@ jobs:
           # Disable swap to allow kubelet to start.
           sudo swapoff -a
           sudo apt-get update
-          sudo apt-get install -y gperf build-essential pkg-config
+          sudo apt-get install -y gperf build-essential pkg-config lld
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -41,8 +41,13 @@ FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang
 
 # Install runc
 FROM golang AS runc
+# cargo, lld and xz-utils are needed to build libpathrs, which runc 1.5+
+# links against
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    cargo \
     libseccomp-dev \
+    lld \
+    xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 COPY script/setup/runc-version script/setup/install-runc ./

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -38,7 +38,13 @@ function install_runc() {
 	git clone "${RUNC_REPO}" "${TMPROOT}"/runc
 	pushd "${TMPROOT}"/runc
 	git checkout "${RUNC_VERSION}"
-	env -u VERSION make BUILDTAGS='seccomp' runc
+
+	# runc 1.5+ enables libpathrs by default. Build and install it so runc can
+	# link against it.
+  script/build-libpathrs.sh 0.2.5 /usr/local/lib
+  #export PKG_CONFIG_PATH="${TMPROOT}/libpathrs/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+
+	env -u VERSION make runc
 	$SUDO make install
 	popd
 }

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -38,7 +38,29 @@ function install_runc() {
 	git clone "${RUNC_REPO}" "${TMPROOT}"/runc
 	pushd "${TMPROOT}"/runc
 	git checkout "${RUNC_VERSION}"
-	env -u VERSION make BUILDTAGS='seccomp' runc
+
+	# runc 1.5+ links against libpathrs by default. The version is
+	# pinned by the runc revision that is checked out.
+	local libpathrs_version
+	libpathrs_version="$(sed -n 's/^ARG LIBPATHRS_VERSION=//p' Dockerfile | head -n1)"
+	: "${libpathrs_version:?could not determine libpathrs version from runc Dockerfile}"
+
+	# Install into /usr the same way runc's CI does.
+	# Ref: https://github.com/opencontainers/runc/blob/a7f0be5861d3013d240cfe0b1c31fc409151bf83/.github/workflows/test.yml#L98-L101
+	# DESTDIR is cleared just for this call, because the runc build finds
+	# libpathrs through pkg-config, which only looks under /usr.
+	$SUDO ${SUDO:+-E} env -u DESTDIR "PATH=${PATH}" script/build-libpathrs.sh "${libpathrs_version}" /usr
+
+	# The .so also has to be in the staged DESTDIR tree so runc can load it
+	# at runtime once the tree is unpacked.
+	if [ -n "${DESTDIR:-}" ]; then
+		local libdir
+		libdir="$(pkg-config --variable=libdir pathrs)"
+		$SUDO install -d "${DESTDIR}${libdir}"
+		$SUDO cp -a "${libdir}"/libpathrs.so* "${DESTDIR}${libdir}"/
+	fi
+
+	env -u VERSION make runc
 	$SUDO make install
 	popd
 }

--- a/script/vm/provision.sh
+++ b/script/vm/provision.sh
@@ -44,6 +44,7 @@ export PATH="/usr/local/go/bin:${GOPATH}/bin:/usr/local/bin:/usr/local/sbin:${PA
 dnf -y makecache --refresh
 # shellcheck disable=SC2086
 dnf -y install \
+	cargo \
 	container-selinux \
 	curl \
 	gcc \
@@ -51,9 +52,11 @@ dnf -y install \
 	iptables \
 	libseccomp-devel \
 	libselinux-devel \
+	lld \
 	lsof \
 	make \
 	strace \
+	wget \
 	which \
 	"kernel-modules-extra-$(uname -r)" \
 	${INSTALL_PACKAGES}


### PR DESCRIPTION
- runc 1.5 makes libathrs default while compiling. For ci , while installing runc, install libpathrs and compile runc 