### PR TITLE
cri: report swap and pod-level IO PSI in CRI stats

### DIFF
--- a/internal/cri/server/container_stats_list.go
+++ b/internal/cri/server/container_stats_list.go
@@ -443,6 +443,8 @@ func (c *criService) linuxContainerMetrics(
 	// IO stats (only has PSI for cgroupv2)
 	cs.Io = c.ioContainerStats(metrics, protobuf.FromTimestamp(stats.Timestamp))
 
+	cs.Swap = c.swapContainerStats(metrics, protobuf.FromTimestamp(stats.Timestamp))
+
 	return containerStats{&cs, pids}, nil
 }
 
@@ -611,4 +613,52 @@ func (c *criService) ioContainerStats(stats cgroupMetrics, timestamp time.Time) 
 		}
 	}
 	return nil
+}
+
+func (c *criService) swapContainerStats(stats cgroupMetrics, timestamp time.Time) *runtime.SwapUsage {
+	switch {
+	case stats.v1 != nil:
+		metrics := stats.v1
+		// cgroupv1 memory.memsw.* accounts memory+swap combined, so the
+		// swap-only values are the memsw values minus the memory values.
+		//
+		// When the memory.memsw.* files are missing (e.g. swap accounting
+		// disabled), stats collected with IgnoreNotExist leave the Swap
+		// entry present but zeroed. A genuinely read memsw limit is never
+		// zero because it must be at least the memory limit, so a zero
+		// limit means swap stats are unavailable rather than zero.
+		if metrics.Memory != nil && metrics.Memory.Swap != nil && metrics.Memory.Swap.Limit > 0 && metrics.Memory.Usage != nil {
+			swapUsage := saturatingSub(metrics.Memory.Swap.Usage, metrics.Memory.Usage.Usage)
+			swap := &runtime.SwapUsage{
+				Timestamp:      timestamp.UnixNano(),
+				SwapUsageBytes: &runtime.UInt64Value{Value: swapUsage},
+			}
+			if !isMemoryUnlimited(metrics.Memory.Swap.Limit) {
+				swapLimit := saturatingSub(metrics.Memory.Swap.Limit, metrics.Memory.Usage.Limit)
+				swap.SwapAvailableBytes = &runtime.UInt64Value{Value: saturatingSub(swapLimit, swapUsage)}
+			}
+			return swap
+		}
+	case stats.v2 != nil:
+		metrics := stats.v2
+		// cgroupv2 memory.swap.* accounts swap only.
+		if metrics.Memory != nil {
+			swap := &runtime.SwapUsage{
+				Timestamp:      timestamp.UnixNano(),
+				SwapUsageBytes: &runtime.UInt64Value{Value: metrics.Memory.SwapUsage},
+			}
+			if !isMemoryUnlimited(metrics.Memory.SwapLimit) {
+				swap.SwapAvailableBytes = &runtime.UInt64Value{Value: saturatingSub(metrics.Memory.SwapLimit, metrics.Memory.SwapUsage)}
+			}
+			return swap
+		}
+	}
+	return nil
+}
+
+func saturatingSub(a, b uint64) uint64 {
+	if a < b {
+		return 0
+	}
+	return a - b
 }

--- a/internal/cri/server/container_stats_list_test.go
+++ b/internal/cri/server/container_stats_list_test.go
@@ -348,6 +348,135 @@ func TestContainerMetricsMemory(t *testing.T) {
 	}
 }
 
+func TestContainerMetricsSwap(t *testing.T) {
+	c := newTestCRIService()
+	timestamp := time.Now()
+
+	for _, test := range []struct {
+		desc     string
+		metrics  cgroupMetrics
+		expected *runtime.SwapUsage
+	}{
+		{
+			desc: "v1 metrics - no swap entry",
+			metrics: cgroupMetrics{v1: &v1.Metrics{
+				Memory: &v1.MemoryStat{
+					Usage: &v1.MemoryEntry{
+						Limit: 5000,
+						Usage: 1000,
+					},
+				},
+			}},
+			expected: nil,
+		},
+		{
+			// memory.memsw.* files missing (swap accounting disabled) leave
+			// a zeroed Swap entry when collected with IgnoreNotExist.
+			desc: "v1 metrics - swap accounting disabled, zeroed swap entry",
+			metrics: cgroupMetrics{v1: &v1.Metrics{
+				Memory: &v1.MemoryStat{
+					Usage: &v1.MemoryEntry{
+						Limit: 5000,
+						Usage: 1000,
+					},
+					Swap: &v1.MemoryEntry{},
+				},
+			}},
+			expected: nil,
+		},
+		{
+			desc: "v1 metrics - no swap limit",
+			metrics: cgroupMetrics{v1: &v1.Metrics{
+				Memory: &v1.MemoryStat{
+					Usage: &v1.MemoryEntry{
+						Limit: math.MaxUint64, // no limit
+						Usage: 1000,
+					},
+					Swap: &v1.MemoryEntry{
+						Limit: math.MaxUint64, // no limit
+						Usage: 1300,
+					},
+				},
+			}},
+			expected: &runtime.SwapUsage{
+				Timestamp: timestamp.UnixNano(),
+				// memsw usage minus memory usage
+				SwapUsageBytes: &runtime.UInt64Value{Value: 300},
+			},
+		},
+		{
+			desc: "v1 metrics - swap limit",
+			metrics: cgroupMetrics{v1: &v1.Metrics{
+				Memory: &v1.MemoryStat{
+					Usage: &v1.MemoryEntry{
+						Limit: 5000,
+						Usage: 1000,
+					},
+					Swap: &v1.MemoryEntry{
+						Limit: 7000,
+						Usage: 1300,
+					},
+				},
+			}},
+			expected: &runtime.SwapUsage{
+				Timestamp:      timestamp.UnixNano(),
+				SwapUsageBytes: &runtime.UInt64Value{Value: 300},
+				// (memsw limit - memory limit) - swap usage
+				SwapAvailableBytes: &runtime.UInt64Value{Value: 1700},
+			},
+		},
+		{
+			desc: "v2 metrics - no swap limit",
+			metrics: cgroupMetrics{v2: &v2.Metrics{
+				Memory: &v2.MemoryStat{
+					Usage:     1000,
+					SwapUsage: 150,
+					SwapLimit: math.MaxUint64, // no limit
+				},
+			}},
+			expected: &runtime.SwapUsage{
+				Timestamp:      timestamp.UnixNano(),
+				SwapUsageBytes: &runtime.UInt64Value{Value: 150},
+			},
+		},
+		{
+			desc: "v2 metrics - swap limit",
+			metrics: cgroupMetrics{v2: &v2.Metrics{
+				Memory: &v2.MemoryStat{
+					Usage:     1000,
+					SwapUsage: 150,
+					SwapLimit: 500,
+				},
+			}},
+			expected: &runtime.SwapUsage{
+				Timestamp:          timestamp.UnixNano(),
+				SwapUsageBytes:     &runtime.UInt64Value{Value: 150},
+				SwapAvailableBytes: &runtime.UInt64Value{Value: 350},
+			},
+		},
+		{
+			desc: "v2 metrics - swap disabled with zero limit",
+			metrics: cgroupMetrics{v2: &v2.Metrics{
+				Memory: &v2.MemoryStat{
+					Usage:     1000,
+					SwapUsage: 0,
+					SwapLimit: 0,
+				},
+			}},
+			expected: &runtime.SwapUsage{
+				Timestamp:          timestamp.UnixNano(),
+				SwapUsageBytes:     &runtime.UInt64Value{Value: 0},
+				SwapAvailableBytes: &runtime.UInt64Value{Value: 0},
+			},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			got := c.swapContainerStats(test.metrics, timestamp)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
 func TestListContainerStats(t *testing.T) {
 	if goruntime.GOOS == "darwin" {
 		t.Skip("not implemented on Darwin")

--- a/internal/cri/server/podsandbox/sandbox_stats_linux.go
+++ b/internal/cri/server/podsandbox/sandbox_stats_linux.go
@@ -51,7 +51,10 @@ func (c *Controller) Metrics(ctx context.Context, sandboxID string) (*types.Metr
 		if err != nil {
 			return nil, fmt.Errorf("failed to load sandbox cgroup %q: %w", cgroupPath, err)
 		}
-		stats, err := cg.StatFiltered(cgroupsv2.StatCPU | cgroupsv2.StatMemory)
+		// StatIO is needed so io.pressure (PSI) reaches the pod-level IO
+		// stats in ListPodSandboxStats. StatCPU and StatMemory already
+		// include their pressure files.
+		stats, err := cg.StatFiltered(cgroupsv2.StatCPU | cgroupsv2.StatMemory | cgroupsv2.StatIO)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read sandbox cgroup %q: %w", cgroupPath, err)
 		}

--- a/internal/cri/server/sandbox_stats_linux.go
+++ b/internal/cri/server/sandbox_stats_linux.go
@@ -89,6 +89,9 @@ func (c *criService) podSandboxStats(
 	}
 	podSandboxStats.Linux.Memory = memoryStats
 
+	// IO stats (only has PSI for cgroupv2)
+	podSandboxStats.Linux.Io = c.ioContainerStats(*stats, timestamp)
+
 	if sandbox.NetNSPath != "" {
 		allStats, err := getAllContainerNetIO(ctx, sandbox.NetNSPath)
 		if err != nil {


### PR DESCRIPTION
The CRI stats path never filled `ContainerStats.Swap`. A kubelet running with the `PodAndContainerStatsFromCRI` feature gate therefore reports no container swap, and no pod swap either, because the kubelet aggregates pod swap from container stats. The sandbox metrics path already reads swap from cgroups to emit `container_memory_swap`, so the data was available and just not mapped into the stats response.

This change adds a `swapContainerStats` helper and wires it into `linuxContainerMetrics`:

- cgroup v1: `memory.memsw.*` accounts memory and swap combined, so the swap-only usage is memsw usage minus memory usage, and the swap limit is memsw limit minus memory limit. When the memsw files are missing (swap accounting disabled), stats collected with `IgnoreNotExist` leave a zeroed `Swap` entry. A real memsw limit is never zero, so a zero limit is treated as swap stats unavailable and nothing is reported.
- cgroup v2: `memory.swap.*` accounts swap only and is used directly.

`SwapAvailableBytes` is only set when a real swap limit is configured. This matches the kubelet's cadvisor-based swap accounting (`cadvisorInfoToSwapStats`).

`ListPodSandboxStats` also never set `LinuxPodSandboxStats.Io`, while the per-container path already reported IO pressure (PSI) through the shared `ioContainerStats` helper. The sandbox path now calls the same helper. The pod sandbox cgroup collection also includes `StatIO` now, so `io.pressure` is actually read. `StatCPU` and `StatMemory` already include their pressure files.

Both fixes close gaps in KEP-2371 (kubernetes/enhancements#2371) parity for the `PodAndContainerStatsFromCRI` feature gate, which is targeting beta in Kubernetes 1.37. The kubelet consumes these fields in its strict CRI stats path (`pkg/kubelet/stats/cri_stats_provider.go`, swap aggregation in `addSwapStats` and pod PSI in `addCRIPodIOStats`).

One related issue is left out of scope on purpose. On cgroup v1 the metrics path (`list_pod_sandbox_metrics_linux.go`) emits `container_memory_swap` from the raw `Memory.Swap.Usage` value, which is memsw and therefore includes memory usage. cadvisor subtracts memory usage there. That looks like a separate bug and can be fixed in a follow-up if maintainers agree.

Unit tests cover both cgroup versions, including the memsw arithmetic, the unlimited and zero swap limit cases, and the zeroed swap entry case when swap accounting is disabled.