### PR TITLE
Fix flaky CI on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,14 @@ jobs:
           git checkout "${CRITOOLS_VERSION}"
           make critest
 
+      # Docker creates the "nat" HNS network that install-cni-windows needs, but
+      # on windows-2022 it intermittently fails to start. Start it explicitly.
+      # https://github.com/actions/runner-images/issues/13729#issuecomment-4183956802
+      - name: Ensure Docker is running
+        shell: powershell
+        run: |
+          Start-Service -Name "docker"
+
       - run: script/setup/install-cni-windows
 
       - env:

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -2773,27 +2773,18 @@ func TestContainerPTY(t *testing.T) {
 
 	<-statusC
 
+	// Wait for all IO copy operations to complete before inspecting buf.
+	// Otherwise there is a race between the IO copy goroutine writing to buf
+	// and the read below, which is flaky on Windows named pipes. Wait must be
+	// called before Delete, which cancels the IO.
+	task.IO().Wait()
+
 	if _, err := task.Delete(ctx); err != nil {
 		t.Fatal(err)
 	}
 
-	tries := 1
-	if runtime.GOOS == "windows" {
-		// TODO: Fix flakiness on Window by checking for race in writing to buffer
-		tries += 2
-	}
-
-	for {
-		out := buf.String()
-		if strings.ContainsAny(fmt.Sprintf("%#q", out), `\x00`) {
-			break
-
-		}
-		tries--
-		if tries == 0 {
-			t.Fatal(`expected \x00 in output`)
-		}
-		t.Logf("output %#q does not contain \\x00, trying again", out)
-		time.Sleep(time.Millisecond)
+	out := buf.String()
+	if !strings.ContainsAny(fmt.Sprintf("%#q", out), `\x00`) {
+		t.Fatalf(`expected \x00 in output, got %#q`, out)
 	}
 }


### PR DESCRIPTION
Fix flaky Windows tests:

- Fix `hcnCreateNetwork failed in Win32: Element not found` - [1](https://github.com/containerd/containerd/actions/runs/29885392691/job/88815094810), [2](https://github.com/containerd/containerd/actions/runs/29837993805/job/88660185091), [3](https://github.com/containerd/containerd/actions/runs/29879829228/job/88798333354)
- Fix `output `` does not contain \x00` - [1](https://github.com/containerd/containerd/actions/runs/29887527318/job/88821511853?pr=13827)
