### PR TITLE
ctr: dedupe CRI image aliases in images list by default

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -30,6 +30,8 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
+	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
 	"github.com/urfave/cli/v2"
 )
 
@@ -59,22 +61,35 @@ var Command = &cli.Command{
 }
 
 var listCommand = &cli.Command{
-	Name:        "list",
-	Aliases:     []string{"ls"},
-	Usage:       "List images known to containerd",
-	ArgsUsage:   "[flags] [<filter>, ...]",
-	Description: "list images registered with containerd",
+	Name:      "list",
+	Aliases:   []string{"ls"},
+	Usage:     "List images known to containerd",
+	ArgsUsage: "[flags] [<filter>, ...]",
+	Description: `List images registered with containerd.
+
+By default, when multiple names point at the same image target digest (common
+in the k8s.io namespace after CRI pulls, which store repo:tag, repo@digest, and
+a digest-only image ID), only the tagged name(s) are shown. Use --all to print
+every reference.
+
+This is a display filter only; metadata in the image store is unchanged.`,
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "quiet",
 			Aliases: []string{"q"},
 			Usage:   "Print only the image refs",
 		},
+		&cli.BoolFlag{
+			Name:    "all",
+			Aliases: []string{"a"},
+			Usage:   "Show all references, including digest-only and repo@digest aliases (e.g. CRI k8s.io duplicates)",
+		},
 	},
 	Action: func(cliContext *cli.Context) error {
 		var (
 			filters = cliContext.Args().Slice()
 			quiet   = cliContext.Bool("quiet")
+			all     = cliContext.Bool("all")
 		)
 		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
@@ -89,6 +104,7 @@ var listCommand = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("failed to list images: %w", err)
 		}
+		imageList = filterImageListForDisplay(imageList, all)
 		if quiet {
 			for _, image := range imageList {
 				fmt.Println(image.Name)
@@ -141,6 +157,64 @@ var listCommand = &cli.Command{
 
 		return tw.Flush()
 	},
+}
+
+// filterImageListForDisplay reduces CRI-style duplicate refs for list output.
+// When all is false and multiple names share the same target digest, only
+// tagged references (name:tag) are kept for that digest. If a digest group has
+// no tagged name, every reference in the group is kept so digest-only images
+// remain visible. When all is true, the list is returned unchanged.
+func filterImageListForDisplay(imageList []images.Image, all bool) []images.Image {
+	if all || len(imageList) == 0 {
+		return imageList
+	}
+
+	type group struct {
+		images []images.Image
+		// first index in the original list, for stable ordering by first appearance
+		order int
+	}
+	byDigest := make(map[digest.Digest]*group)
+	var order []digest.Digest
+
+	for i, img := range imageList {
+		d := img.Target.Digest
+		g, ok := byDigest[d]
+		if !ok {
+			g = &group{order: i}
+			byDigest[d] = g
+			order = append(order, d)
+		}
+		g.images = append(g.images, img)
+	}
+
+	// Preserve original relative order of digests and of images within a group.
+	out := make([]images.Image, 0, len(imageList))
+	for _, d := range order {
+		g := byDigest[d]
+		var tagged []images.Image
+		for _, img := range g.images {
+			if isTaggedImageName(img.Name) {
+				tagged = append(tagged, img)
+			}
+		}
+		if len(tagged) > 0 {
+			out = append(out, tagged...)
+		} else {
+			out = append(out, g.images...)
+		}
+	}
+	return out
+}
+
+func isTaggedImageName(name string) bool {
+	parsed, err := reference.ParseAnyReference(name)
+	if err != nil {
+		// Keep names we cannot parse so nothing unexpected disappears.
+		return true
+	}
+	_, ok := parsed.(reference.Tagged)
+	return ok
 }
 
 var setLabelsCommand = &cli.Command{

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -172,17 +172,15 @@ func filterImageListForDisplay(imageList []images.Image, all bool) []images.Imag
 
 	type group struct {
 		images []images.Image
-		// first index in the original list, for stable ordering by first appearance
-		order int
 	}
 	byDigest := make(map[digest.Digest]*group)
 	var order []digest.Digest
 
-	for i, img := range imageList {
+	for _, img := range imageList {
 		d := img.Target.Digest
 		g, ok := byDigest[d]
 		if !ok {
-			g = &group{order: i}
+			g = &group{}
 			byDigest[d] = g
 			order = append(order, d)
 		}
@@ -211,8 +209,9 @@ func filterImageListForDisplay(imageList []images.Image, all bool) []images.Imag
 func isTaggedImageName(name string) bool {
 	parsed, err := reference.ParseAnyReference(name)
 	if err != nil {
-		// Keep names we cannot parse so nothing unexpected disappears.
-		return true
+		// Unparseable refs are not treated as tags, so they cannot alone
+		// trigger the "prefer tags" path for a digest group.
+		return false
 	}
 	_, ok := parsed.(reference.Tagged)
 	return ok

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -31,6 +31,8 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
+	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
 	"github.com/urfave/cli/v3"
 )
 
@@ -60,22 +62,35 @@ var Command = &cli.Command{
 }
 
 var listCommand = &cli.Command{
-	Name:        "list",
-	Aliases:     []string{"ls"},
-	Usage:       "List images known to containerd",
-	ArgsUsage:   "[flags] [<filter>, ...]",
-	Description: "list images registered with containerd",
+	Name:      "list",
+	Aliases:   []string{"ls"},
+	Usage:     "List images known to containerd",
+	ArgsUsage: "[flags] [<filter>, ...]",
+	Description: `List images registered with containerd.
+
+By default, when multiple names point at the same image target digest (common
+in the k8s.io namespace after CRI pulls, which store repo:tag, repo@digest, and
+a digest-only image ID), only the tagged name(s) are shown. Use --all to print
+every reference.
+
+This is a display filter only; metadata in the image store is unchanged.`,
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "quiet",
 			Aliases: []string{"q"},
 			Usage:   "Print only the image refs",
 		},
+		&cli.BoolFlag{
+			Name:    "all",
+			Aliases: []string{"a"},
+			Usage:   "Show all references, including digest-only and repo@digest aliases (e.g. CRI k8s.io duplicates)",
+		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		var (
 			filters = cmd.Args().Slice()
 			quiet   = cmd.Bool("quiet")
+			all     = cmd.Bool("all")
 		)
 		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
@@ -90,6 +105,7 @@ var listCommand = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("failed to list images: %w", err)
 		}
+		imageList = filterImageListForDisplay(imageList, all)
 		if quiet {
 			for _, image := range imageList {
 				fmt.Println(image.Name)
@@ -142,6 +158,64 @@ var listCommand = &cli.Command{
 
 		return tw.Flush()
 	},
+}
+
+// filterImageListForDisplay reduces CRI-style duplicate refs for list output.
+// When all is false and multiple names share the same target digest, only
+// tagged references (name:tag) are kept for that digest. If a digest group has
+// no tagged name, every reference in the group is kept so digest-only images
+// remain visible. When all is true, the list is returned unchanged.
+func filterImageListForDisplay(imageList []images.Image, all bool) []images.Image {
+	if all || len(imageList) == 0 {
+		return imageList
+	}
+
+	type group struct {
+		images []images.Image
+		// first index in the original list, for stable ordering by first appearance
+		order int
+	}
+	byDigest := make(map[digest.Digest]*group)
+	var order []digest.Digest
+
+	for i, img := range imageList {
+		d := img.Target.Digest
+		g, ok := byDigest[d]
+		if !ok {
+			g = &group{order: i}
+			byDigest[d] = g
+			order = append(order, d)
+		}
+		g.images = append(g.images, img)
+	}
+
+	// Preserve original relative order of digests and of images within a group.
+	out := make([]images.Image, 0, len(imageList))
+	for _, d := range order {
+		g := byDigest[d]
+		var tagged []images.Image
+		for _, img := range g.images {
+			if isTaggedImageName(img.Name) {
+				tagged = append(tagged, img)
+			}
+		}
+		if len(tagged) > 0 {
+			out = append(out, tagged...)
+		} else {
+			out = append(out, g.images...)
+		}
+	}
+	return out
+}
+
+func isTaggedImageName(name string) bool {
+	parsed, err := reference.ParseAnyReference(name)
+	if err != nil {
+		// Keep names we cannot parse so nothing unexpected disappears.
+		return true
+	}
+	_, ok := parsed.(reference.Tagged)
+	return ok
 }
 
 var setLabelsCommand = &cli.Command{

--- a/cmd/ctr/commands/images/list_filter_test.go
+++ b/cmd/ctr/commands/images/list_filter_test.go
@@ -1,0 +1,112 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestFilterImageListForDisplay(t *testing.T) {
+	d1 := digest.FromString("target-1")
+	d2 := digest.FromString("target-2")
+	target1 := ocispec.Descriptor{Digest: d1, MediaType: ocispec.MediaTypeImageManifest}
+	target2 := ocispec.Descriptor{Digest: d2, MediaType: ocispec.MediaTypeImageManifest}
+
+	// CRI-style triple for one image (k8s.io namespace after pull).
+	criTriple := []images.Image{
+		{Name: "docker.io/library/centos:7", Target: target1},
+		{Name: "docker.io/library/centos@" + d1.String(), Target: target1},
+		{Name: d1.String(), Target: target1},
+	}
+
+	t.Run("default hides CRI aliases when tag exists", func(t *testing.T) {
+		got := filterImageListForDisplay(criTriple, false)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ref, got %d: %#v", len(got), names(got))
+		}
+		if got[0].Name != "docker.io/library/centos:7" {
+			t.Fatalf("expected tagged ref, got %q", got[0].Name)
+		}
+	})
+
+	t.Run("all keeps every reference", func(t *testing.T) {
+		got := filterImageListForDisplay(criTriple, true)
+		if len(got) != 3 {
+			t.Fatalf("expected 3 refs, got %d: %#v", len(got), names(got))
+		}
+	})
+
+	t.Run("digest-only images remain visible", func(t *testing.T) {
+		list := []images.Image{
+			{Name: d2.String(), Target: target2},
+			{Name: "registry.example.com/app@" + d2.String(), Target: target2},
+		}
+		got := filterImageListForDisplay(list, false)
+		if len(got) != 2 {
+			t.Fatalf("expected both non-tagged refs, got %d: %#v", len(got), names(got))
+		}
+	})
+
+	t.Run("multiple tags for same digest are all kept", func(t *testing.T) {
+		list := []images.Image{
+			{Name: "docker.io/library/alpine:3.18", Target: target1},
+			{Name: "docker.io/library/alpine:latest", Target: target1},
+			{Name: "docker.io/library/alpine@" + d1.String(), Target: target1},
+		}
+		got := filterImageListForDisplay(list, false)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 tags, got %d: %#v", len(got), names(got))
+		}
+		want := map[string]bool{
+			"docker.io/library/alpine:3.18":   true,
+			"docker.io/library/alpine:latest": true,
+		}
+		for _, img := range got {
+			if !want[img.Name] {
+				t.Fatalf("unexpected name %q", img.Name)
+			}
+		}
+	})
+
+	t.Run("preserves order across digests", func(t *testing.T) {
+		list := []images.Image{
+			{Name: "docker.io/library/centos:7", Target: target1},
+			{Name: d1.String(), Target: target1},
+			{Name: "docker.io/library/alpine:latest", Target: target2},
+			{Name: d2.String(), Target: target2},
+		}
+		got := filterImageListForDisplay(list, false)
+		if len(got) != 2 {
+			t.Fatalf("expected 2, got %d: %#v", len(got), names(got))
+		}
+		if got[0].Name != "docker.io/library/centos:7" || got[1].Name != "docker.io/library/alpine:latest" {
+			t.Fatalf("unexpected order: %#v", names(got))
+		}
+	})
+}
+
+func names(list []images.Image) []string {
+	out := make([]string, len(list))
+	for i, img := range list {
+		out[i] = img.Name
+	}
+	return out
+}

--- a/cmd/ctr/commands/images/list_filter_test.go
+++ b/cmd/ctr/commands/images/list_filter_test.go
@@ -101,6 +101,19 @@ func TestFilterImageListForDisplay(t *testing.T) {
 			t.Fatalf("unexpected order: %#v", names(got))
 		}
 	})
+
+	t.Run("unparseable name does not hide other refs in digest group", func(t *testing.T) {
+		// Unparseable ref alone must not count as a "tag" and drop the
+		// digest-only sibling for the same target.
+		list := []images.Image{
+			{Name: "not a valid image reference!!!", Target: target1},
+			{Name: d1.String(), Target: target1},
+		}
+		got := filterImageListForDisplay(list, false)
+		if len(got) != 2 {
+			t.Fatalf("expected both refs kept, got %d: %#v", len(got), names(got))
+		}
+	})
 }
 
 func names(list []images.Image) []string {


### PR DESCRIPTION
## Problem

Fixes #11000 (related: #8421, #10090, #10303, #10328).

CRI writes three image names into the containerd metadata store for each pull (`repo:tag`, `repo@digest`, and a digest-only config/image ID). That is intentional for CRI's own image store, but `ctr -n k8s.io images ls` lists every name, so operators see three rows for one image.

```
$ ctr -n k8s.io i ls
REF                                      ... DIGEST
docker.io/library/centos:7               ... sha256:be65...
docker.io/library/centos@sha256:be65...  ... sha256:be65...
sha256:eeb6ee3f44bd...                   ... sha256:be65...
```

## Design (display-only, minimal UX)

**Prefer filtering at list time over changing CRI create behavior.**

| Approach | Pros | Cons |
| --- | --- | --- |
| **A. Display filter in `ctr images list` (this PR)** | No metadata / CRI semantics change; safe for scripts that still know exact names; matches docker-like "show tags by default" | Must use `--all` to see aliases; nerdctl not covered |
| B. Stop CRI from creating repo@digest / imageID names | True uniqueness in meta.db | High risk: CRI, GC, pinned images, and other tools may depend on those names; needs broader design |
| C. Dedupe only by digest (one row total) | Cleanest table | Hides multiple tags that legitimately share a digest |

This PR implements **A**, as sketched in the issue.

### Behavior

- **Default:** For each target digest, if any name is a **tagged** ref (`name:tag`), only tagged refs are printed. CRI's `repo@digest` and bare digest ID rows are hidden when a tag exists.
- **No tagged name:** All refs for that digest are still shown (digest-only images are not dropped).
- **`--all` / `-a`:** Previous behavior — print every reference.
- Metadata store, delete, pull, and CRI are **unchanged**. Deleting still requires the exact name (or multiple deletes) as today; fixing delete-by-ID is a separate problem.

### Why not filter only on `io.cri-containerd.image=managed`?

A pure "tagged only" filter (as in the issue snippet) would hide legitimate digests that were never tagged. Grouping by target digest and preferring tags when present avoids that.

## Code

- `cmd/ctr/commands/images/images.go` — `--all` flag + `filterImageListForDisplay`
- `cmd/ctr/commands/images/list_filter_test.go` — unit tests for CRI triple, multi-tag, digest-only, ordering

## Test

```
go test ./cmd/ctr/commands/images/ -run TestFilterImageListForDisplay
```

## Notes for maintainers

Happy to adjust defaults if preferred:

1. Default stays full list; opt-in `--dedupe` instead of opt-out `--all`
2. Also collapse multi-tag digests to a single row (not done here)
3. Document-only note in `docs/namespaces.md` without code change

Open to discussion if approach B (CRI create) is preferred long-term; this PR is intentionally the small, reversible UX fix.