### PR TITLE
cri: Fix context and error logging when collecting pod sandbox metrics

### DIFF
--- a/internal/cri/server/list_pod_sandbox_metrics_linux.go
+++ b/internal/cri/server/list_pod_sandbox_metrics_linux.go
@@ -106,18 +106,23 @@ func (c *criService) ListPodSandboxMetrics(ctx context.Context, r *runtime.ListP
 				containerMetrics, err := c.collectContainerMetrics(gctx, container, baseLabels)
 				if err != nil {
 					switch {
-					case errdefs.IsUnavailable(err), errdefs.IsNotFound(err):
+					case errdefs.IsNotFound(err):
+						// A completed Kubernetes init container has no task, which is fine.
+						log.G(gctx).WithField("podsandboxid", sandbox.ID).WithField("containerid", container.ID).WithError(err).Debug("skipping container metrics")
+						// Skip this container but keep collecting the rest of the sandbox.
+						continue
+					case errdefs.IsUnavailable(err):
 						log.G(gctx).WithField("podsandboxid", sandbox.ID).WithField("containerid", container.ID).WithError(err).Error("failed to get container metrics, this is likely a transient error")
-						// Don't return error for transient issues, just log and continue
-						return nil
+						// Skip this container but keep collecting the rest of the sandbox.
+						continue
 					case errdefs.IsCanceled(err):
 						log.G(gctx).WithField("podsandboxid", sandbox.ID).WithField("containerid", container.ID).WithError(err).Debug("metrics collection cancelled")
 						// Return the cancellation error to stop other goroutines
 						return err
 					default:
 						log.G(gctx).WithField("podsandboxid", sandbox.ID).WithField("containerid", container.ID).WithError(err).Error("failed to collect container metrics")
-						// Don't return error for individual failures, just log and continue
-						return nil
+						// Skip this container but keep collecting the rest of the sandbox.
+						continue
 					}
 				}
 

--- a/internal/cri/server/list_pod_sandbox_metrics_linux.go
+++ b/internal/cri/server/list_pod_sandbox_metrics_linux.go
@@ -103,7 +103,7 @@ func (c *criService) ListPodSandboxMetrics(ctx context.Context, r *runtime.ListP
 			}
 
 			for _, container := range sandboxContainerMap[sandbox.ID] {
-				containerMetrics, err := c.collectContainerMetrics(ctx, container, baseLabels)
+				containerMetrics, err := c.collectContainerMetrics(gctx, container, baseLabels)
 				if err != nil {
 					switch {
 					case errdefs.IsUnavailable(err), errdefs.IsNotFound(err):

--- a/internal/cri/server/list_pod_sandbox_metrics_linux_test.go
+++ b/internal/cri/server/list_pod_sandbox_metrics_linux_test.go
@@ -1,0 +1,120 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cg2 "github.com/containerd/cgroups/v3/cgroup2/stats"
+	"github.com/containerd/containerd/api/types"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/containers"
+	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
+	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/typeurl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// fakeMetricsContainer implements just enough of containerd.Container for collectContainerMetrics.
+// Non-overridden calls to embedded-interface methods panic.
+type fakeMetricsContainer struct {
+	containerd.Container
+	task    containerd.Task
+	taskErr error
+}
+
+func (c *fakeMetricsContainer) Task(context.Context, cio.Attach) (containerd.Task, error) {
+	if c.taskErr != nil {
+		return nil, c.taskErr
+	}
+	return c.task, nil
+}
+
+func (c *fakeMetricsContainer) Info(context.Context, ...containerd.InfoOpts) (containers.Container, error) {
+	return containers.Container{}, errors.New("not implemented")
+}
+
+type fakeMetricsTask struct {
+	containerd.Task
+	metrics *types.Metric
+}
+
+func (t *fakeMetricsTask) Metrics(context.Context) (*types.Metric, error) {
+	return t.metrics, nil
+}
+
+func (t *fakeMetricsTask) Spec(context.Context) (*oci.Spec, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (t *fakeMetricsTask) Pids(context.Context) ([]containerd.ProcessInfo, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestListPodSandboxMetrics(t *testing.T) {
+	c := newTestCRIService()
+
+	require.NoError(t, c.sandboxStore.Add(sandboxstore.NewSandbox(
+		sandboxstore.Metadata{
+			ID: "s1",
+			Config: &runtime.PodSandboxConfig{
+				Metadata: &runtime.PodSandboxMetadata{Name: "sandbox", Namespace: "ns"},
+			},
+		},
+		sandboxstore.Status{State: sandboxstore.StateReady},
+	)))
+
+	metricsData, err := typeurl.MarshalAnyToProto(&cg2.Metrics{CPU: &cg2.CPUStat{UsageUsec: 100}})
+	require.NoError(t, err)
+
+	newContainer := func(id string, container containerd.Container) containerstore.Container {
+		internalContainer, err := containerstore.NewContainer(
+			containerstore.Metadata{
+				ID:        id,
+				SandboxID: "s1",
+				Config: &runtime.ContainerConfig{
+					Metadata: &runtime.ContainerMetadata{Name: id},
+					Image:    &runtime.ImageSpec{UserSpecifiedImage: "test-image"},
+				},
+			},
+			containerstore.WithFakeStatus(containerstore.Status{}),
+			containerstore.WithContainer(container),
+		)
+		require.NoError(t, err)
+		return internalContainer
+	}
+
+	require.NoError(t, c.containerStore.Add(newContainer("running", &fakeMetricsContainer{
+		task: &fakeMetricsTask{metrics: &types.Metric{Data: metricsData}},
+	})))
+
+	resp, err := c.ListPodSandboxMetrics(t.Context(), &runtime.ListPodSandboxMetricsRequest{})
+	require.NoError(t, err)
+
+	require.Len(t, resp.PodMetrics, 1)
+	podMetrics := resp.PodMetrics[0]
+	assert.Equal(t, "s1", podMetrics.PodSandboxId)
+	require.Len(t, podMetrics.ContainerMetrics, 1)
+	assert.Equal(t, "running", podMetrics.ContainerMetrics[0].ContainerId)
+	assert.NotEmpty(t, podMetrics.ContainerMetrics[0].Metrics)
+}

--- a/internal/cri/server/list_pod_sandbox_metrics_linux_test.go
+++ b/internal/cri/server/list_pod_sandbox_metrics_linux_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	cg2 "github.com/containerd/cgroups/v3/cgroup2/stats"
@@ -29,6 +30,7 @@ import (
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,6 +106,9 @@ func TestListPodSandboxMetrics(t *testing.T) {
 		return internalContainer
 	}
 
+	require.NoError(t, c.containerStore.Add(newContainer("terminated-kubernetes-init-container", &fakeMetricsContainer{
+		taskErr: fmt.Errorf("no running task found: %w", errdefs.ErrNotFound),
+	})))
 	require.NoError(t, c.containerStore.Add(newContainer("running", &fakeMetricsContainer{
 		task: &fakeMetricsTask{metrics: &types.Metric{Data: metricsData}},
 	})))


### PR DESCRIPTION
Stop logging `NotFound` errors for containers without a running task at the error level. Log this case at the debug level, as this is the expected, regular and permanent state of terminated Kubernetes init containers. Add a test for `ListPodSandboxMetrics`, covering the happy path and a terminated init container.

Also use the errgroup's context when collecting container metrics. They are collected in a goroutine that's part of an errgroup. However, the `collectContainerMetrics` call used the errgroup's parent context instead, so any errors in the sibling goroutines did not properly cancel it.

Related:

* #13896
* #13532 (KEP-2371)
* https://github.com/k0sproject/k0s/issues/7830#issuecomment-4981893560