### PR TITLE
pkg/sys: add actionable hint to socket dir permission errors

### DIFF
--- a/pkg/sys/socket_unix.go
+++ b/pkg/sys/socket_unix.go
@@ -19,6 +19,7 @@
 package sys
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -73,6 +74,9 @@ func mkdirAs(path string, uid, gid int) error {
 	}
 
 	if err := os.MkdirAll(path, 0770); err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return fmt.Errorf("%w (the configured socket address points at a directory that requires root, which is the hardcoded default for the grpc and ttrpc plugins; if running containerd as a non-root user, configure a writable address for the grpc, ttrpc, and debug plugins)", err)
+		}
 		return err
 	}
 

--- a/pkg/sys/socket_unix.go
+++ b/pkg/sys/socket_unix.go
@@ -70,15 +70,27 @@ func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
 
 func mkdirAs(path string, uid, gid int) error {
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		if errors.Is(err, os.ErrPermission) {
+			return wrapSocketDirPermissionErr(err)
+		}
 		return err
 	}
 
 	if err := os.MkdirAll(path, 0770); err != nil {
 		if errors.Is(err, os.ErrPermission) {
-			return fmt.Errorf("%w (the configured socket address points at a directory that requires root, which is the hardcoded default for the grpc and ttrpc plugins; if running containerd as a non-root user, configure a writable address for the grpc, ttrpc, and debug plugins)", err)
+			return wrapSocketDirPermissionErr(err)
 		}
 		return err
 	}
 
 	return os.Chown(path, uid, gid)
+}
+
+// wrapSocketDirPermissionErr adds a hint to a permission-denied error
+// encountered while stat-ing or creating a socket directory. The grpc and
+// ttrpc server plugins carry their own hardcoded default socket address, so
+// a user who only overrides one of root/state/[grpc] address can still hit
+// this on the others.
+func wrapSocketDirPermissionErr(err error) error {
+	return fmt.Errorf("%w (the configured socket address points at a directory that is not writable/accessible by the current user, which is the hardcoded default for the grpc and ttrpc plugins; if running containerd as a non-root user, configure a writable address for the grpc, ttrpc, and debug plugins)", err)
 }

--- a/pkg/sys/socket_unix.go
+++ b/pkg/sys/socket_unix.go
@@ -87,10 +87,12 @@ func mkdirAs(path string, uid, gid int) error {
 }
 
 // wrapSocketDirPermissionErr adds a hint to a permission-denied error
-// encountered while stat-ing or creating a socket directory. The grpc and
-// ttrpc server plugins carry their own hardcoded default socket address, so
-// a user who only overrides one of root/state/[grpc] address can still hit
-// this on the others.
+// encountered while stat-ing or creating a socket directory. This directory
+// is derived from a plugin's configured socket address, and the grpc and
+// ttrpc server plugins carry their own hardcoded default for that address,
+// so a user who only overrides one of root/state/[grpc] address can still
+// hit this on the others (including the debug plugin, if its address is
+// configured to a similarly unwritable path).
 func wrapSocketDirPermissionErr(err error) error {
-	return fmt.Errorf("%w (the configured socket address points at a directory that is not writable/accessible by the current user, which is the hardcoded default for the grpc and ttrpc plugins; if running containerd as a non-root user, configure a writable address for the grpc, ttrpc, and debug plugins)", err)
+	return fmt.Errorf("%w (the configured socket address points at a directory that is not writable/accessible by the current user; if running containerd as a non-root user, configure a writable address for the grpc, ttrpc, and debug plugins, whose addresses may otherwise default to or be set to a directory that requires root)", err)
 }

--- a/pkg/sys/socket_unix_test.go
+++ b/pkg/sys/socket_unix_test.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMkdirAsPermissionErrorIncludesHint(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("test requires a non-root user to observe a permission error")
+	}
+
+	parent := t.TempDir()
+	require.NoError(t, os.Chmod(parent, 0500))
+
+	err := mkdirAs(filepath.Join(parent, "child"), os.Geteuid(), os.Getegid())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrPermission))
+	assert.Contains(t, err.Error(), "non-root user")
+}

--- a/pkg/sys/socket_unix_test.go
+++ b/pkg/sys/socket_unix_test.go
@@ -41,3 +41,20 @@ func TestMkdirAsPermissionErrorIncludesHint(t *testing.T) {
 	assert.True(t, errors.Is(err, os.ErrPermission))
 	assert.Contains(t, err.Error(), "non-root user")
 }
+
+func TestMkdirAsStatPermissionErrorIncludesHint(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("test requires a non-root user to observe a permission error")
+	}
+
+	parent := t.TempDir()
+	target := filepath.Join(parent, "child")
+	require.NoError(t, os.Mkdir(target, 0770))
+	require.NoError(t, os.Chmod(parent, 0000))
+	t.Cleanup(func() { _ = os.Chmod(parent, 0700) })
+
+	err := mkdirAs(target, os.Geteuid(), os.Getegid())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrPermission))
+	assert.Contains(t, err.Error(), "non-root user")
+}


### PR DESCRIPTION
Motivation:
On macOS (and other non-root deployments), containerd can fail at
startup with a bare "mkdir /var/run/containerd: permission denied"
even when root, state, and [grpc] address are all set to custom,
writable paths (containerd/containerd#12444). This happens because
the grpc and ttrpc server plugins each carry their own hardcoded
default socket address under /var/run (or /run), independent of the
configured root/state/[grpc] address. A user who only overrides
[grpc] address still hits the hardcoded ttrpc default (or a
misconfigured debug address), and the resulting permission-denied
error gives no indication of what to change.

Approach:
This does not change any default address. Doing so would require a
way to distinguish "address left at its hardcoded default" from "user
explicitly set this value" at plugin config-decode time, which the
current plugin config model does not support, and is a larger,
design-level change than fits a surgical fix.

Instead, pkg/sys.mkdirAs — the single chokepoint used by the grpc,
ttrpc, and debug server plugins via GetLocalListener — now wraps a
permission-denied error from creating the socket directory with a
hint identifying the grpc/ttrpc hardcoded default and telling the
user to configure a writable address for the grpc, ttrpc, and debug
plugins. This is a diagnostics-only change: the exact command from
the issue will still fail on a non-root user with an unwritable
default state dir, but the error now explains why and what to do,
instead of a bare "permission denied".

Validation:
  go build ./...
  go test ./pkg/sys/... -v
Added TestMkdirAsPermissionErrorIncludesHint, which reproduces a
non-root permission-denied mkdir (via a 0500 parent dir) and asserts
the wrapped error still satisfies errors.Is(err, os.ErrPermission) and
includes the new hint text. Both commands pass on darwin/arm64.

Updates #12444

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
