### PR TITLE
Use ScrubLogs by default on Windows

### DIFF
--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -39,6 +39,10 @@ var platformRunFlags = []cli.Flag{
 		Name:  "isolated",
 		Usage: "Run the container with vm isolation",
 	},
+	&cli.BoolFlag{
+		Name:  "scrub-logs",
+		Usage: "Scrub sensitive information from the shim logs (Windows only)",
+	},
 }
 
 // NewContainer creates a new container
@@ -176,9 +180,14 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 	runtime := cliContext.String("runtime")
 	var runtimeOpts any
 	if runtime == "io.containerd.runhcs.v1" {
-		runtimeOpts = &options.Options{
+		opts := &options.Options{
 			Debug: cliContext.Bool("debug"),
 		}
+		if cliContext.IsSet("scrub-logs") {
+			scrubLogs := cliContext.Bool("scrub-logs")
+			opts.ScrubLogs = &scrubLogs
+		}
+		runtimeOpts = opts
 	}
 	cOpts = append(cOpts, containerd.WithRuntime(runtime, runtimeOpts))
 

--- a/internal/cri/config/config_windows.go
+++ b/internal/cri/config/config_windows.go
@@ -59,6 +59,13 @@ func DefaultRuntimeConfig() RuntimeConfig {
 				"runhcs-wcow-process": {
 					Type:                 "io.containerd.runhcs.v1",
 					ContainerAnnotations: []string{"io.microsoft.container.*"},
+					// Full set of Windows shim options:
+					// https://pkg.go.dev/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options#Options
+					Options: map[string]any{
+						// ScrubLogs enables removing environment variables and other potentially sensitive information
+						// from logs
+						"ScrubLogs": true,
+					},
 				},
 				"runhcs-wcow-hypervisor": {
 					Type:                 "io.containerd.runhcs.v1",
@@ -67,6 +74,9 @@ func DefaultRuntimeConfig() RuntimeConfig {
 					// Full set of Windows shim options:
 					// https://pkg.go.dev/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options#Options
 					Options: map[string]any{
+						// ScrubLogs enables removing environment variables and other potentially sensitive information
+						// from logs
+						"ScrubLogs": true,
 						// SandboxIsolation specifies the isolation level of the sandbox.
 						// PROCESS (0) and HYPERVISOR (1) are the valid options.
 						"SandboxIsolation": 1,


### PR DESCRIPTION
Ensure the change from https://github.com/microsoft/hcsshim/pull/2725 is explicitly set here, so we can backport the configuration default without having to upgrade the rest of hcsshim.

```release-note
Enable log scrubbing by default on Windows
```