### PR TITLE
core/runtime/v2: Drop checkpointctl module dependency

### DIFF
--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 
-	crmetadata "github.com/checkpoint-restore/checkpointctl/lib"
 	eventstypes "github.com/containerd/containerd/api/events"
 	bootapi "github.com/containerd/containerd/api/runtime/bootstrap/v1"
 	task "github.com/containerd/containerd/api/runtime/task/v3"
@@ -64,6 +63,11 @@ const (
 	loadTimeout     = "io.containerd.timeout.shim.load"
 	cleanupTimeout  = "io.containerd.timeout.shim.cleanup"
 	shutdownTimeout = "io.containerd.timeout.shim.shutdown"
+
+	// rootFsDiffTar is the name of the rootfs diff archive written next to a
+	// checkpoint. It is part of the checkpoint layout produced by CRIU tooling,
+	// so it must stay in sync with github.com/checkpoint-restore/checkpointctl/lib.RootFsDiffTar.
+	rootFsDiffTar = "rootfs-diff.tar"
 )
 
 func init() {
@@ -642,7 +646,7 @@ func (s *shimTask) Create(ctx context.Context, opts runtime.CreateOpts) (runtime
 	if opts.RestoreFromPath {
 		// Unpack rootfs-diff.tar if it exists.
 		// This needs to happen between the 'Create()' from above and before the 'Start()' from below.
-		rootfsDiff := filepath.Join(opts.Checkpoint, "..", crmetadata.RootFsDiffTar)
+		rootfsDiff := filepath.Join(opts.Checkpoint, "..", rootFsDiffTar)
 
 		_, err = os.Stat(rootfsDiff)
 		if err == nil {


### PR DESCRIPTION
The shim imported github.com/checkpoint-restore/checkpointctl/lib for a single string constant.
Consumers that embed only the runtime v2 plugin (and never touch internal/cri) therefore had to vendor the checkpointctl package.

Declare the file name as a local constant instead. checkpointctl still remains a direct requirement here because internal/cri/server uses its types, JSON readers, and annotations, but it is no longer reachable from the runtime v2 import graph.