### PR TITLE
ci: dependabot: group docker/* and codeql action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,10 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    groups:
+      codeql-actions:
+        patterns:
+          - "github/codeql-action/*"
+      docker-actions:
+        patterns:
+          - "docker/*"


### PR DESCRIPTION
relates to;

- https://github.com/containerd/containerd/pull/13846
- https://github.com/containerd/containerd/pull/13845
- https://github.com/containerd/containerd/pull/13843