### PR TITLE
core/runtime/v2: bound leaked shim cleanup at load

### DIFF
--- a/core/runtime/v2/shim_load.go
+++ b/core/runtime/v2/shim_load.go
@@ -188,14 +188,21 @@ func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle) error {
 	// containerd/containerd#6860 for further details.
 
 	_, sgetErr := m.sandboxStore.Get(ctx, id)
-	pInfo, pidErr := shim.Pids(ctx)
+	// Bounded for the same reason as the PID call in loadShimTask: this is the
+	// startup path, and an unresponsive shim must not block it. A shim that
+	// misses the deadline is kept registered rather than reaped, see below.
+	pctx, pcancel := timeout.WithContext(ctx, loadTimeout)
+	pInfo, pidErr := shim.Pids(pctx)
+	pcancel()
 	if shouldCleanupShim(sgetErr, pidErr, pInfo) {
 		logEntry := log.G(ctx).WithField("id", id)
 		if pidErr != nil {
 			logEntry = logEntry.WithError(pidErr)
 		}
 		logEntry.Info("cleaning leaked shim process")
-		shim.delete(ctx, false, func(ctx context.Context, id string) {})
+		if err := cleanupLeakedShim(ctx, shim); err != nil {
+			logEntry.WithError(err).Warn("failed to clean leaked shim process")
+		}
 	} else {
 		if pidErr != nil {
 			log.G(ctx).WithField("id", id).WithError(pidErr).Warn("failed to query shim pids, keeping shim registered")
@@ -203,6 +210,37 @@ func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle) error {
 		m.shims.Add(ctx, shim.ShimInstance)
 	}
 	return nil
+}
+
+// cleanupLeakedShim reaps a shim which was loaded from disk but has no task
+// left to manage.
+//
+// The Task.Delete call is bounded, because a leftover shim can keep its socket
+// alive and still never answer it. This runs on the startup path, where an
+// unbounded wait holds an errgroup slot until the process is killed and so
+// stops containerd from ever serving its socket.
+//
+// If the shim does not answer in time it is disconnected instead. Closing the
+// connection runs the regular dead shim cleanup from its on-close callback,
+// which reaps the shim out of band via its delete command and removes the
+// bundle, so a shim that stays unresponsive is not met again on the next start.
+func cleanupLeakedShim(ctx context.Context, shim *shimTask) error {
+	dctx, cancel := timeout.WithContext(context.WithoutCancel(ctx), cleanupTimeout)
+	defer cancel()
+
+	_, err := shim.delete(dctx, false, func(ctx context.Context, id string) {})
+	if err == nil {
+		return nil
+	}
+
+	// dctx is likely expired by now, so the shutdown request gets a deadline of
+	// its own rather than an already cancelled context.
+	if serr := shim.waitShutdown(context.WithoutCancel(ctx)); serr != nil {
+		log.G(ctx).WithField("id", shim.ID()).WithError(serr).Warn("failed to shutdown leaked shim")
+	}
+	shim.Close()
+
+	return err
 }
 
 // shouldCleanupShim determines whether or not a shim is in such a state that

--- a/core/runtime/v2/shim_load_test.go
+++ b/core/runtime/v2/shim_load_test.go
@@ -17,13 +17,19 @@
 package v2
 
 import (
+	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	api "github.com/containerd/containerd/api/runtime/task/v3"
 	"github.com/containerd/errdefs"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	runtimeapi "github.com/containerd/containerd/v2/core/runtime"
+	"github.com/containerd/containerd/v2/pkg/timeout"
 )
 
 func TestShouldCleanupShim(t *testing.T) {
@@ -85,4 +91,87 @@ func TestShouldCleanupShim(t *testing.T) {
 			require.Equal(t, tc.Expected, shouldCleanupShim(tc.SgetErr, tc.PidErr, tc.PInfo))
 		})
 	}
+}
+
+// hangingTaskClient is a task client for a shim which answers every request
+// except Delete, which is silently dropped and never replied to. This mirrors
+// the reported production failure, where the leftover shims kept serving other
+// requests and only the task teardown request went unanswered.
+//
+// Embedding the interface leaves every other method nil, so an unexpected call
+// panics instead of silently passing.
+type hangingTaskClient struct {
+	TaskServiceClient
+
+	deleteCalled   atomic.Bool
+	shutdownCalled atomic.Bool
+	// shutdownCtxLive records whether Shutdown was handed a context which had
+	// not already expired.
+	shutdownCtxLive atomic.Bool
+}
+
+func (c *hangingTaskClient) Delete(ctx context.Context, _ *api.DeleteRequest) (*api.DeleteResponse, error) {
+	c.deleteCalled.Store(true)
+	// A ttrpc call only gives up once the caller's context is done, so an
+	// unbounded context blocks here forever.
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (c *hangingTaskClient) Shutdown(ctx context.Context, _ *api.ShutdownRequest) (*emptypb.Empty, error) {
+	c.shutdownCtxLive.Store(ctx.Err() == nil)
+	c.shutdownCalled.Store(true)
+	return &emptypb.Empty{}, nil
+}
+
+type fakeShimInstance struct {
+	ShimInstance
+
+	id          string
+	closeCalled atomic.Bool
+}
+
+func (f *fakeShimInstance) ID() string                   { return f.id }
+func (f *fakeShimInstance) Endpoint() (string, int)      { return "ttrpc+unix://fake.sock", 3 }
+func (f *fakeShimInstance) Delete(context.Context) error { return nil }
+
+func (f *fakeShimInstance) Close() error {
+	f.closeCalled.Store(true)
+	return nil
+}
+
+// TestCleanupLeakedShimDoesNotHang covers the startup hang reported in #13848.
+// loadShims loads bundles through an errgroup limited to GOMAXPROCS, so a
+// cleanup which never returns holds its slot forever and eg.Wait never
+// completes: containerd never creates its socket, systemd kills it on the
+// start timeout, and the next start hits the very same shim again.
+func TestCleanupLeakedShimDoesNotHang(t *testing.T) {
+	const shortTimeout = 100 * time.Millisecond
+
+	orig := timeout.Get(cleanupTimeout)
+	timeout.Set(cleanupTimeout, shortTimeout)
+	t.Cleanup(func() { timeout.Set(cleanupTimeout, orig) })
+
+	client := &hangingTaskClient{}
+	instance := &fakeShimInstance{id: "leaked-shim"}
+	shim := &shimTask{ShimInstance: instance, task: client}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cleanupLeakedShim(context.Background(), shim)
+	}()
+
+	select {
+	case err := <-done:
+		// Note that the error is not comparable to context.DeadlineExceeded:
+		// errgrpc.ToNative rewrites it into an opaque error of its own.
+		require.Error(t, err, "cleaning up an unresponsive shim should report failure")
+	case <-time.After(10 * shortTimeout):
+		t.Fatal("cleanupLeakedShim never returned: loadShims would hang forever at startup")
+	}
+
+	require.True(t, client.deleteCalled.Load(), "Task.Delete should have been attempted")
+	require.True(t, client.shutdownCalled.Load(), "shim should be shut down after Task.Delete timed out")
+	require.True(t, client.shutdownCtxLive.Load(), "forced shutdown needs a context which has not already expired")
+	require.True(t, instance.closeCalled.Load(), "shim connection should be closed after Task.Delete timed out")
 }


### PR DESCRIPTION
## Problem

`loadShims` walks every leftover bundle in the state dir, loads them through an `errgroup` limited to `runtime.GOMAXPROCS(0)`, and ends with `eg.Wait()`. For a bundle whose task is gone, `loadShim` reaps the shim with:

```go
shim.delete(ctx, false, func(ctx context.Context, id string) {})
```

`ctx` here carries no deadline, and `shimTask.delete` starts with a `Task.Delete` RPC. A leftover shim that keeps its socket alive and simply never answers that one request parks the goroutine forever, so its errgroup slot is never released and `eg.Wait()` never returns.

That happens before the daemon serves its socket, so the failure is not "one container is stuck", it is "containerd never finishes starting":

- no socket, `ctr version` hangs, node goes `NotReady`, CRI is down;
- the supervisor kills the daemon on its start timeout and restarts it;
- the restart re-reads the same bundle from disk and hangs in exactly the same place.

Nothing in the loop removes the blocker, so the node cannot leave it by itself — the reporter saw 412, 457 and 636+ identical restarts, and raising `TimeoutStartSec` to 900s did not help. Clearing `/run/containerd/*` by hand recovers the node only until the next restart rebuilds the same state.

`Fixes #13848`

## Root cause

The evidence that this is a missing deadline rather than a slow shim is inside the same file. `loadShimTask` deliberately bounds its own probe of the very same shim:

```go
ctx, cancel := timeout.WithContext(ctx, loadTimeout)
defer cancel()

if _, err := s.PID(ctx); err != nil {
```

So the load path already assumes a shim may not answer — the cleanup path next to it just never got the same treatment. This also matches the reporter's minimal reproduction: a relay that passed every request through and dropped **only** the task teardown request was enough to wedge start-up, while a fully unresponsive shim (`kill -STOP`) recovered in ~10s, because that one is caught by the bounded `PID` call.

The neighbouring `shim.Pids(ctx)` probe, which decides whether the shim is reapable, is unbounded for the same reason.

## Fix

`shimTask.delete` is already called under a deadline elsewhere in this package — `task_manager.go` does exactly this when a task fails to be created:

```go
dctx, cancel := timeout.WithContext(context.WithoutCancel(ctx), cleanupTimeout)
defer cancel()
_, errShim := shimTask.delete(dctx, sandboxed, func(context.Context, string) {})
```

This change applies the same treatment on the load path, using the existing `io.containerd.timeout.shim.cleanup` key (5s default, already tunable through `[timeouts]` in `config.toml`, so no new configuration is introduced). The `Pids` probe is bounded with the existing `io.containerd.timeout.shim.load` key, matching the `PID` call it sits beside.

## State after a timeout

The interesting part is what is left behind when the deadline hits, since the bundle must not be orphaned while its shim is still alive.

On timeout `shimTask.delete` returns early, before it reaches `waitShutdown` and `ShimInstance.Delete`, so the cleanup has to be finished explicitly. This change sends a `Shutdown` on a **fresh** deadline (`shim.waitShutdown`, `shutdownTimeout`) rather than the exhausted one, then closes the connection.

Closing is what makes the state converge, and it reuses machinery that is already there: the connection was created in `loadShim` with `ttrpc.WithOnClose(onClose)`, and that callback is the existing dead-shim path — `cleanupAfterDeadShim` → `binary.Delete`, which runs the shim's own `delete` command (reaping the runtime container), calls `bundle.Delete()`, publishes `TaskExit`/`TaskDelete`, and drops the shim from the manager. `cleanupAfterDeadShim` is itself already bounded by `cleanupTimeout`.

So the end state matches the success path — bundle gone, shim reaped, events published — and, importantly for the loop in the report, an unresponsive shim is **not** met again on the next start. If a shim ignores `Task.Delete`, `Shutdown` *and* its own `delete` command, the process can still survive; that is strictly better than today, where start-up never completes at all.

Worth flagging separately: `errgrpc.ToNative` rewrites `context.DeadlineExceeded` into an opaque `errdefs.customMessage`, so `errdefs.IsDeadlineExceeded` returns **false** for the error `shimTask.delete` returns on timeout. That makes the conditional context refresh in `task_manager.go` ineffective for the deadline case it was written for, and it hands `shimTask.Shutdown` an already-expired context. I did not touch it here to keep this change scoped to the reported hang, but I am happy to send a follow-up. It is also why this change refreshes the context unconditionally instead of copying that check.

## Testing

`shim_load_test.go` gains a fake shim whose `Task.Delete` is never answered — it blocks until the caller's context is done, which is what a ttrpc call does when the server stays silent. Every other method is left nil via an embedded interface, so an unexpected call panics rather than passing quietly. `cleanupTimeout` is shortened for the test and restored afterwards.

Before (the goroutine never returns, so the test reports the hang instead of hanging the suite):

```
$ go test ./core/runtime/v2/ -run TestCleanupLeakedShimDoesNotHang -count=1 -race -v
=== RUN   TestCleanupLeakedShimDoesNotHang
    shim_load_test.go:170: cleanupLeakedShim never returned: loadShims would hang forever at startup
--- FAIL: TestCleanupLeakedShimDoesNotHang (1.00s)
FAIL
FAIL	github.com/containerd/containerd/v2/core/runtime/v2	1.703s
FAIL
```

After:

```
$ go test ./core/runtime/v2/ -run TestCleanupLeakedShimDoesNotHang -count=1 -race -v
=== RUN   TestCleanupLeakedShimDoesNotHang
time="..." level=error msg="failed to delete task" error="context deadline exceeded" id=leaked-shim
--- PASS: TestCleanupLeakedShimDoesNotHang (0.10s)
PASS
ok  	github.com/containerd/containerd/v2/core/runtime/v2	1.716s
```

The test also asserts that the forced `Shutdown` receives a context that has not already expired, and that the connection is closed so the dead-shim cleanup described above actually runs.

Full package, plus a cross-compile check for the linux-only files in this package (I am on darwin):

```
$ go test ./core/runtime/v2/... -count=1 -race
ok  	github.com/containerd/containerd/v2/core/runtime/v2	1.827s

$ go build ./...
$ GOOS=linux go vet ./core/runtime/v2/...
$ gofmt -l core/runtime/v2/
```

The reporter's own end-to-end reproduction (a relay dropping only `Task.Delete`, then restarting containerd) is the real integration check for this and needs a node; I could not run that here.
