### PR TITLE
oom: bound the wait for a watcher to stop

### DIFF
--- a/internal/oom/watcher.go
+++ b/internal/oom/watcher.go
@@ -24,10 +24,24 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/containerd/errdefs"
 	"golang.org/x/sys/unix"
 )
+
+// stopTimeout bounds how long stop waits for a watcher goroutine to drain once
+// its event FD has been closed.
+//
+// The wait itself is wanted: it lets a last OOM event be delivered before the
+// caller publishes the task exit. It must not be unbounded, though. stop runs
+// on the shim's only exit-processing goroutine, while the goroutine it waits
+// for can be parked reading the container's cgroup files or forwarding an
+// event, and neither is guaranteed to come back promptly while a device is
+// being torn down. Draining is sub-millisecond on a healthy system, so this
+// only ever trips when something is already wrong, and there losing the last
+// OOM event is far cheaper than never publishing a task exit at all.
+const stopTimeout = 2 * time.Second
 
 func New() Interface {
 	return &oomWatchers{
@@ -145,6 +159,14 @@ func (w *watcher) stop() error {
 	if errors.Is(cerr, os.ErrClosed) {
 		cerr = nil
 	}
-	werr := <-w.errCh
-	return errors.Join(cerr, werr)
+
+	timer := time.NewTimer(stopTimeout)
+	defer timer.Stop()
+
+	select {
+	case werr := <-w.errCh:
+		return errors.Join(cerr, werr)
+	case <-timer.C:
+		return errors.Join(cerr, fmt.Errorf("timed out after %v waiting for the oom watcher of %s to stop", stopTimeout, w.cid))
+	}
 }

--- a/internal/oom/watcher_test.go
+++ b/internal/oom/watcher_test.go
@@ -19,7 +19,9 @@
 package oom
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"sync/atomic"
 	"testing"
@@ -81,6 +83,61 @@ func TestWatcher(t *testing.T) {
 	}, 30*time.Second, time.Second, "should receive oom event (%v)", oomKills.Load())
 
 	require.NoError(t, watchers.Stop(containerID))
+}
+
+// newTestWatcher builds a watcher without starting its goroutine, so a test
+// controls exactly if and when errCh is resolved.
+func newTestWatcher(t *testing.T, cid string) *watcher {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		r.Close()
+		w.Close()
+	})
+
+	return &watcher{
+		cid:     cid,
+		eventFD: r,
+		errCh:   make(chan error, 1),
+	}
+}
+
+// TestWatcherStopDoesNotBlockForever covers the shim wedge reported in #13814.
+// The shim calls Stop from handleProcessExit before it publishes TaskExit, on
+// its single processExits goroutine, so a watcher goroutine which never comes
+// back used to stop that shim from ever publishing another task exit: clients
+// waiting on the task, the container IO fifos and the CRI exit monitors then
+// all leak, and the shim is orphaned with its container already gone.
+func TestWatcherStopDoesNotBlockForever(t *testing.T) {
+	// errCh is never written to and never closed, which is how a watcher
+	// goroutine parked in a read of the container's cgroup files looks to stop.
+	w := newTestWatcher(t, "stuck-container")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.stop()
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorContains(t, err, "timed out")
+	case <-time.After(stopTimeout + 30*time.Second):
+		t.Fatal("watcher.stop never returned: the shim would stop publishing task exits")
+	}
+}
+
+// TestWatcherStopReportsWatcherError makes sure bounding the wait did not stop
+// stop from reporting what the watcher goroutine actually failed with.
+func TestWatcherStopReportsWatcherError(t *testing.T) {
+	w := newTestWatcher(t, "failed-container")
+
+	watcherErr := errors.New("read memory.events: boom")
+	w.errCh <- watcherErr
+	close(w.errCh)
+
+	require.ErrorIs(t, w.stop(), watcherErr)
 }
 
 func skipIfCgroupUnavailable(t *testing.T) {


### PR DESCRIPTION
## Problem

Reported in #13814 as a v2.2.5 → v2.3.2 regression: after a pod with a VFIO/IOMMU passthrough device is deleted, its shim is orphaned — the container is reaped and the sandbox is gone from `crictl pods`, but the shim process is still alive and the task exit is never delivered. containerd itself stays responsive, yet the node stops creating new sandboxes while still reporting `Ready`, and only a runtime restart clears it.

The reporter's `SIGUSR1` dumps show that as a large, permanent goroutine leak — roughly two thirds to four fifths of all goroutines stuck for ~47h, matching the last runtime restart, clustered exactly where an undelivered task exit would leave them:

```
43  core/runtime/v2.loadShim.func3                    [IO wait]
41  client.(*task).Wait.func1                         [select]
38  internal/cri/io.(*ContainerIO).Pipe               [IO wait]
25  internal/cri/server.(*criService).startContainerExitMonitor.func1
14  ...podsandbox.(*Controller).RecoverContainer.func2
```

 - Fixes #13814

## Root cause

The regression is `handleProcessExit` in `cmd/containerd-shim-runc-v2/task/service.go`. On v2.2.5 the exit was published immediately:

```go
func (s *service) handleProcessExit(e runcC.Exit, c *runc.Container, p process.Process) {
	p.SetExited(e.Status)
	s.send(&eventstypes.TaskExit{...})
```

On 2.3.x an unbounded wait sits in front of that `send`. It arrived in `8ac7e3c0` ("cmd/containerd-shim-runc-v2: use experimental OOM package") from #12714, "Update OOMKilled event handling", merged 2026-01-07 — in 2.3.x, not in 2.2.5, which matches the reported version boundary:

```go
	p.SetExited(e.Status)
	_, isInit := p.(*process.Init)
	if isInit {
		if err := s.cg2oom.Stop(c.ID); err != nil {   // <-- waits, with no bound
			...
		}
	}
	s.send(&eventstypes.TaskExit{...})
```

`Stop` ends in `internal/oom`:

```go
func (w *watcher) stop() error {
	cerr := w.eventFD.Close()
	...
	werr := <-w.errCh          // only resolved when the watcher goroutine returns
	return errors.Join(cerr, werr)
}
```

so publishing a task exit is made to depend on another goroutine returning. That goroutine, before it closes `errCh`, both reads the container's cgroup files (`memory.events`) and can call `eventFn` → `publisher.Publish`. Neither is guaranteed to come back promptly while a device is being torn down, which fits the VFIO/IOMMU trigger.

Two things turn that into a permanently wedged node rather than a slow exit:

- **It runs on the shim's only exit goroutine.** `processExits` is a single `for e := range s.ec` loop that calls the handlers inline, and for an init process with no running execs `handleInitExit` calls `handleProcessExit` directly on it. So the stall stops *every* subsequent exit for that shim, not just this one.
- **Nothing retries.** The exit is never published, so `task.Wait`, the IO fifos and the CRI exit monitors never return — and on restart `RecoverContainer` re-attaches and gets stuck again, which is why the dumps show `RecoverContainer` goroutines too.

I could not pin down which syscall the watcher goroutine ultimately parks in (the reporter could not dump an orphaned shim, since its log target is already deleted). That is worth saying plainly — but it does not change what needs fixing: the dependency is unbounded by construction, and any stall in it costs the shim all of its exit events.

## Fix

Bound the wait in `watcher.stop()` and report a timeout instead of blocking forever.

The wait is deliberately kept rather than removed. Closing the event FD makes the watcher do one final `memory.events` check, so waiting is what lets a last `TaskOOM` be delivered *before* `TaskExit` — the ordering #12714 set out to fix. Draining is sub-millisecond on a healthy system, so the bound only trips when something is already wrong, and there losing the last OOM annotation is far cheaper than never publishing a task exit.

### Alternative considered

The obvious smaller change is to move `s.cg2oom.Stop()` after `s.send(TaskExit)`, restoring 2.2.x ordering. I did not do that, for two reasons:

- it would give up #12714's ordering guarantee for *every* container, not just stalled ones, so a real OOM kill could report its exit before (or without) its OOM event;
- it would not actually unwedge the shim. `Stop` would still run unbounded on the `processExits` goroutine right after the `send`, so this container's exit would get through and every later exit on that shim would still be lost.

Bounding fixes both. Happy to switch if maintainers prefer the ordering change, or to take the timeout as a `context.Context` argument on `Interface.Stop` instead of a package constant — there is exactly one production caller, so either is cheap. `2s` is a starting point, not a considered SLO; say the word if you want a different value.

Also worth flagging, but left alone here: `oomWatchers.Stop` never deletes the watcher from its map, so every exited container leaves an entry behind. Unrelated to this hang, so I did not fold it in.

## Testing

`internal/oom/watcher_test.go` gets a watcher whose goroutine never resolves `errCh` — which is what a goroutine parked in a cgroup read looks like from `stop`'s side — and asserts `stop` still returns. A second test asserts the watcher's own error is still propagated, so bounding the wait did not swallow it. Neither needs root or cgroups, unlike the existing `TestWatcher`.

This package is `//go:build linux` and I am on darwin, so I ran the tests through `go test -overlay`, substituting darwin stubs for the inotify/cgroup-v2 symbols in `utils.go` (and the one inotify constant `start()` uses). `stop()` itself and both tests are the real code, unmodified — the stubs are not on the path either test takes. Repo tree untouched; the overlay files live outside it.

Before, against `stop()` as it is on main:

```
$ go test -overlay=... ./internal/oom/ -run TestWatcherStop -count=1 -race -v
=== RUN   TestWatcherStopDoesNotBlockForever
    watcher_test.go:71: watcher.stop never returned: the shim would stop publishing task exits
--- FAIL: TestWatcherStopDoesNotBlockForever (32.00s)
=== RUN   TestWatcherStopReportsWatcherError
--- PASS: TestWatcherStopReportsWatcherError (0.00s)
FAIL
```

After:

```
=== RUN   TestWatcherStopDoesNotBlockForever
--- PASS: TestWatcherStopDoesNotBlockForever (2.00s)
=== RUN   TestWatcherStopReportsWatcherError
--- PASS: TestWatcherStopReportsWatcherError (0.00s)
ok  	github.com/containerd/containerd/v2/internal/oom	3.632s
```

Native linux checks, since the overlay run is not the real build:

```
$ gofmt -l internal/oom/
$ GOOS=linux go vet ./internal/oom/... ./cmd/containerd-shim-runc-v2/...
$ GOOS=linux go test -c -o /dev/null ./internal/oom/     # test binary builds
$ GOOS=linux go build ./...
```

I have not run the pre-existing `TestWatcher`, which needs root and cgroup v2. The end-to-end behaviour (deleting a VFIO passthrough pod and watching the shim exit cleanly) needs the reporter's hardware and cannot be covered here either.

This does not overlap #13635, which touches `start()` in the same file for a different issue.
