### PR TITLE
core/runtime/v2: add timeout to shim.delete during loadShims

### DIFF
--- a/core/runtime/v2/shim_load.go
+++ b/core/runtime/v2/shim_load.go
@@ -195,7 +195,9 @@ func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle) error {
 			logEntry = logEntry.WithError(pidErr)
 		}
 		logEntry.Info("cleaning leaked shim process")
-		shim.delete(ctx, false, func(ctx context.Context, id string) {})
+		dctx, cancel := timeout.WithContext(ctx, cleanupTimeout)
+		defer cancel()
+		shim.delete(dctx, false, func(ctx context.Context, id string) {})
 	} else {
 		if pidErr != nil {
 			log.G(ctx).WithField("id", id).WithError(pidErr).Warn("failed to query shim pids, keeping shim registered")


### PR DESCRIPTION
Fixes #13848

when loadShims cleans up abandoned shims during daemon startup, it calls shim.delete() using the daemon's startup context. this context doesn't have a deadline.

if a single leftover shim process never replies to the Delete grpc request (like what happens in #13848), containerd just hangs forever on startup.

this wraps the context with the existing cleanupTimeout (5s) before deleting the shim, ensuring the daemon can recover and continue starting even if a shim is wedged.
