### PR TITLE
internal/oom: remove container from map on Stop

### DIFF
--- a/internal/oom/watcher.go
+++ b/internal/oom/watcher.go
@@ -81,6 +81,9 @@ func (ows *oomWatchers) Add(cid string, pid int, fn EventFunc) (retErr error) {
 func (ows *oomWatchers) Stop(cid string) error {
 	ows.mu.Lock()
 	w, exist := ows.watchers[cid]
+	if exist {
+		delete(ows.watchers, cid)
+	}
 	ows.mu.Unlock()
 
 	if !exist {

--- a/internal/oom/watcher.go
+++ b/internal/oom/watcher.go
@@ -81,15 +81,21 @@ func (ows *oomWatchers) Add(cid string, pid int, fn EventFunc) (retErr error) {
 func (ows *oomWatchers) Stop(cid string) error {
 	ows.mu.Lock()
 	w, exist := ows.watchers[cid]
-	if exist {
-		delete(ows.watchers, cid)
-	}
 	ows.mu.Unlock()
 
 	if !exist {
 		return nil
 	}
-	return w.stop()
+
+	err := w.stop()
+
+	ows.mu.Lock()
+	if ows.watchers[cid] == w {
+		delete(ows.watchers, cid)
+	}
+	ows.mu.Unlock()
+
+	return err
 }
 
 type watcher struct {

--- a/internal/oom/watcher_test.go
+++ b/internal/oom/watcher_test.go
@@ -109,7 +109,7 @@ func TestStopRemovesWatcher(t *testing.T) {
 	require.NoError(t, err)
 	defer mgr.Delete()
 
-	sleepCmd := exec.Command("sleep", "infinity")
+	sleepCmd := exec.Command("sleep", "3600")
 	require.NoError(t, sleepCmd.Start())
 	defer func() {
 		sleepCmd.Process.Kill()

--- a/internal/oom/watcher_test.go
+++ b/internal/oom/watcher_test.go
@@ -103,6 +103,7 @@ func skipIfBinaryUnavailable(t *testing.T, binaryName string) {
 func TestStopRemovesWatcher(t *testing.T) {
 	testutil.RequiresRoot(t)
 	skipIfCgroupUnavailable(t)
+	skipIfBinaryUnavailable(t, "sleep")
 
 	group := fmt.Sprintf("/%s", t.Name())
 	mgr, err := cgroupsv2.NewManager(defaultCgroup2Path, group, &cgroupsv2.Resources{})

--- a/internal/oom/watcher_test.go
+++ b/internal/oom/watcher_test.go
@@ -96,6 +96,42 @@ func skipIfBinaryUnavailable(t *testing.T, binaryName string) {
 	}
 }
 
+// TestStopRemovesWatcher verifies that Stop removes the container ID from the
+// internal map so the same ID can be re-added after a stop. This is the
+// Kubernetes restart scenario: the shim process is reused across container
+// restarts, so the same container ID will be passed to Add again.
+func TestStopRemovesWatcher(t *testing.T) {
+	testutil.RequiresRoot(t)
+	skipIfCgroupUnavailable(t)
+
+	group := fmt.Sprintf("/%s", t.Name())
+	mgr, err := cgroupsv2.NewManager(defaultCgroup2Path, group, &cgroupsv2.Resources{})
+	require.NoError(t, err)
+	defer mgr.Delete()
+
+	sleepCmd := exec.Command("sleep", "infinity")
+	require.NoError(t, sleepCmd.Start())
+	defer func() {
+		sleepCmd.Process.Kill()
+		sleepCmd.Wait()
+	}()
+
+	require.NoError(t, mgr.AddProc(uint64(sleepCmd.Process.Pid)))
+
+	watchers := New()
+	containerID := "restart-test"
+
+	require.NoError(t, watchers.Add(containerID, sleepCmd.Process.Pid, func(string) {}))
+	require.NoError(t, watchers.Stop(containerID))
+
+	// After Stop, the same container ID must be re-addable.
+	// Before the fix this returned errdefs.ErrAlreadyExists.
+	err = watchers.Add(containerID, sleepCmd.Process.Pid, func(string) {})
+	require.NoError(t, err, "re-adding container after Stop should succeed")
+
+	require.NoError(t, watchers.Stop(containerID))
+}
+
 func toPtr[T comparable](v T) *T {
 	return &v
 }


### PR DESCRIPTION
## Problem
`oomWatchers.Stop` shuts down the watcher goroutine and closes the file descriptor but never removes the container ID from the internal map.

This causes two problems:
- Dead entries accumulate in the map for the lifetime of the shim process, leaking memory proportional to containers stopped.
- When Kubernetes restarts a container under the same ID (same shim, new process), `Add` finds the stale entry and returns `ErrAlreadyExists`. The container runs without OOM monitoring and Kubernetes is never notified of any OOM kills silently.

## Fix
Deleted the map entry inside the same lock before releasing it and calling `w.stop()`.

## Test
Added `TestStopRemovesWatcher` -- starts a process, adds it, stops it, then adds it again with the same container ID. Before this fix that second Add would fail with `ErrAlreadyExists`.