### PR TITLE
core/unpack: don't honor id-mapping labels from image annotations

### DIFF
--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -298,6 +298,24 @@ type unpackStatus struct {
 	startAt time.Time
 }
 
+// layerSnapshotLabels builds the snapshot labels for a layer's extraction
+// Prepare from the image layer descriptor annotations. Those annotations come
+// from the (untrusted) image manifest, so it drops the id-mapping labels: a
+// snapshotter honors containerd.io/snapshot/uidmapping and .../gidmapping by
+// chowning the extracted layer to the mapped host uid/gid during Prepare, and
+// that ownership must be set by the runtime (client.WithRemapperLabels), not
+// carried in image content. The remaining inherited labels (e.g. the remote
+// snapshotter labels) are left untouched.
+func layerSnapshotLabels(annotations map[string]string) map[string]string {
+	labels := snapshots.FilterInheritedLabels(annotations)
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	delete(labels, snapshots.LabelSnapshotUIDMapping)
+	delete(labels, snapshots.LabelSnapshotGIDMapping)
+	return labels
+}
+
 func (u *Unpacker) unpack(
 	h images.Handler,
 	config ocispec.Descriptor,
@@ -390,11 +408,9 @@ func (u *Unpacker) unpack(
 			}
 		}()
 
-		// inherits annotations which are provided as snapshot labels.
-		snapshotLabels := snapshots.FilterInheritedLabels(desc.Annotations)
-		if snapshotLabels == nil {
-			snapshotLabels = make(map[string]string)
-		}
+		// inherits annotations which are provided as snapshot labels, minus the
+		// id-mapping labels (see layerSnapshotLabels).
+		snapshotLabels := layerSnapshotLabels(desc.Annotations)
 		snapshotLabels[snapshots.LabelSnapshotRef] = chainID
 		snapshotLabels[snapshots.LabelSnapshotDiffID] = diffIDs[i].String()
 		if i > 0 {

--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -298,14 +298,10 @@ type unpackStatus struct {
 	startAt time.Time
 }
 
-// layerSnapshotLabels builds the snapshot labels for a layer's extraction
-// Prepare from the image layer descriptor annotations. Those annotations come
-// from the (untrusted) image manifest, so it drops the id-mapping labels: a
-// snapshotter honors containerd.io/snapshot/uidmapping and .../gidmapping by
-// chowning the extracted layer to the mapped host uid/gid during Prepare, and
-// that ownership must be set by the runtime (client.WithRemapperLabels), not
-// carried in image content. The remaining inherited labels (e.g. the remote
-// snapshotter labels) are left untouched.
+// layerSnapshotLabels filters out containerd.io/snapshot/uidmapping and
+// .../gidmapping annotations from the (untrusted) image manifest to prevent
+// snapshotters from incorrectly chowning the extracted layer to the supplied
+// mapped host uid/gid.
 func layerSnapshotLabels(annotations map[string]string) map[string]string {
 	labels := snapshots.FilterInheritedLabels(annotations)
 	if labels == nil {
@@ -408,8 +404,7 @@ func (u *Unpacker) unpack(
 			}
 		}()
 
-		// inherits annotations which are provided as snapshot labels, minus the
-		// id-mapping labels (see layerSnapshotLabels).
+		// inherits a filtered set of annotations which are provided as snapshot labels
 		snapshotLabels := layerSnapshotLabels(desc.Annotations)
 		snapshotLabels[snapshots.LabelSnapshotRef] = chainID
 		snapshotLabels[snapshots.LabelSnapshotDiffID] = diffIDs[i].String()

--- a/core/unpack/unpacker_test.go
+++ b/core/unpack/unpacker_test.go
@@ -105,6 +105,32 @@ func BenchmarkUnpackWithChainIDs(b *testing.B) {
 	}
 }
 
+func TestLayerSnapshotLabels(t *testing.T) {
+	// Layer annotations come from the (untrusted) image manifest. The id-mapping
+	// labels drive a host-side chown of the extracted layer in the snapshotter's
+	// Prepare, so they must not be honored when they originate from image content;
+	// other inherited snapshot labels must still be passed through.
+	got := layerSnapshotLabels(map[string]string{
+		snapshots.LabelSnapshotUIDMapping: "0:1000:1",
+		snapshots.LabelSnapshotGIDMapping: "0:1000:1",
+		"containerd.io/snapshot/remote":   "keep",
+		"unrelated":                       "drop",
+	})
+
+	if _, ok := got[snapshots.LabelSnapshotUIDMapping]; ok {
+		t.Errorf("uid mapping label from image annotations must be dropped, got %q", got[snapshots.LabelSnapshotUIDMapping])
+	}
+	if _, ok := got[snapshots.LabelSnapshotGIDMapping]; ok {
+		t.Errorf("gid mapping label from image annotations must be dropped, got %q", got[snapshots.LabelSnapshotGIDMapping])
+	}
+	if got["containerd.io/snapshot/remote"] != "keep" {
+		t.Errorf("inherited snapshot label must be preserved, got %q", got["containerd.io/snapshot/remote"])
+	}
+	if _, ok := got["unrelated"]; ok {
+		t.Error("non-snapshot annotation must not be inherited")
+	}
+}
+
 func TestBindToOverlay(t *testing.T) {
 	testCases := []struct {
 		name   string

--- a/core/unpack/unpacker_test.go
+++ b/core/unpack/unpacker_test.go
@@ -108,8 +108,7 @@ func BenchmarkUnpackWithChainIDs(b *testing.B) {
 func TestLayerSnapshotLabels(t *testing.T) {
 	// Layer annotations come from the (untrusted) image manifest. The id-mapping
 	// labels drive a host-side chown of the extracted layer in the snapshotter's
-	// Prepare, so they must not be honored when they originate from image content;
-	// other inherited snapshot labels must still be passed through.
+	// Prepare, so they must be filtered out.
 	got := layerSnapshotLabels(map[string]string{
 		snapshots.LabelSnapshotUIDMapping: "0:1000:1",
 		snapshots.LabelSnapshotGIDMapping: "0:1000:1",


### PR DESCRIPTION
The unpacker turns each image layer descriptor's annotations into snapshot labels and hands them to the snapshotter's Prepare, and FilterInheritedLabels keeps every containerd.io/snapshot/ key, so it also keeps containerd.io/snapshot/uidmapping and .../gidmapping. The overlay and erofs snapshotters act on those in Prepare by chowning the extracted layer's fs directory to the mapped host uid/gid, and that branch runs whenever the label is present, independent of the snapshotter's remapIDs setting. Layer annotations come straight from the image manifest, so a crafted image can put the mapping labels on a layer and make containerd chown the committed layer directory to an arbitrary host uid/gid during an ordinary pull, with no user-namespace setup involved. Because the committed directory is a shared, reused rootfs lowerdir, that ownership sticks and follows every container built on the layer. I ran into it while tracing where these labels are produced: the id maps are meant to reach the snapshotter from the runtime via WithRemapperLabels at container-prepare time, not from image content. The fix drops only the two id-mapping labels in the unpacker, so the annotation inheritance that remote snapshotters depend on stays intact while image content can no longer reach that chown.