### PR TITLE
internal/oom: Fix memory leak by removing watcher from map on Stop

### DIFF
--- a/internal/oom/watcher.go
+++ b/internal/oom/watcher.go
@@ -80,10 +80,11 @@ func (ows *oomWatchers) Add(cid string, pid int, fn EventFunc) (retErr error) {
 
 func (ows *oomWatchers) Stop(cid string) error {
 	ows.mu.Lock()
-	w, exist := ows.watchers[cid]
+	w := ows.watchers[cid]
+	delete(ows.watchers, cid)
 	ows.mu.Unlock()
 
-	if !exist {
+	if w == nil {
 		return nil
 	}
 	return w.stop()

--- a/internal/oom/watcher_test.go
+++ b/internal/oom/watcher_test.go
@@ -99,3 +99,35 @@ func skipIfBinaryUnavailable(t *testing.T, binaryName string) {
 func toPtr[T comparable](v T) *T {
 	return &v
 }
+
+func TestWatcherStopRemovesFromMap(t *testing.T) {
+	testutil.RequiresRoot(t)
+
+	skipIfCgroupUnavailable(t)
+
+	group := fmt.Sprintf("/%s", t.Name())
+	mgr, err := cgroupsv2.NewManager(defaultCgroup2Path, group, &cgroupsv2.Resources{})
+	require.NoError(t, err)
+
+	// A dummy process to get a valid pid and cgroup
+	cmd := exec.Command("sleep", "10000")
+	require.NoError(t, cmd.Start())
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}()
+
+	require.NoError(t, mgr.AddProc(uint64(cmd.Process.Pid)))
+
+	watchers := New()
+	containerID := "test-stop-removes"
+
+	fn := func(cid string) {}
+
+	require.NoError(t, watchers.Add(containerID, cmd.Process.Pid, fn))
+	require.NoError(t, watchers.Stop(containerID))
+
+	// Should be able to add again with the same containerID
+	require.NoError(t, watchers.Add(containerID, cmd.Process.Pid, fn))
+	require.NoError(t, watchers.Stop(containerID))
+}


### PR DESCRIPTION
- Fixes #13853

The `oomWatchers.Stop` method stopped the watcher but never removed it from the `watchers` map. Because `Add` is the only writer and nothing ever deletes from the map, `*watcher` entries accumulated for the lifetime of the shim process. This resulted in an unbounded memory leak.

Furthermore, this prevented the same container ID from ever being watched again if it was re-created, silently dropping OOM monitoring.

This commit modifies `Stop` to `delete(ows.watchers, cid)`, ensuring the watcher is released and the container ID is freed. It also adds a unit test in `watcher_test.go` to ensure `Stop` successfully allows a watcher to be re-added under the same container ID.

```release-note
Fix memory leak in OOM watcher map when stopping container monitoring
```
