### PR TITLE
[release/2.1] Add deferred call to ShutdownSandbox to avoid leaks

### DIFF
--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -293,6 +293,16 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, fmt.Errorf("failed to start sandbox %q: %w", id, err)
 	}
 
+	// Shutdown the sandbox if we fail before adding it to store.
+	rollbackSandbox := true
+	defer func() {
+		if retErr != nil && rollbackSandbox {
+			deferCtx, deferCancel := util.DeferContext()
+			defer deferCancel()
+			cleanupErr = c.sandboxService.ShutdownSandbox(deferCtx, sandbox.Sandboxer, id)
+		}
+	}()
+
 	if ctrl.Address != "" {
 		sandbox.Endpoint = sandboxstore.Endpoint{
 			Version: ctrl.Version,
@@ -349,6 +359,8 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err := c.sandboxStore.Add(sandbox); err != nil {
 		return nil, fmt.Errorf("failed to add sandbox %+v into store: %w", sandbox, err)
 	}
+	// We no longer need to stop sandbox with a cleanup defer since it is in the store.
+	rollbackSandbox = false
 
 	// Send CONTAINER_CREATED event with both ContainerId and SandboxId equal to SandboxId.
 	// Note that this has to be done after sandboxStore.Add() because we need to get


### PR DESCRIPTION
Clean cherry-pick of #13399 (via the release/2.2 backport #13640, commit ba7605ee) to release/2.1.

Fixes #13609 on the 2.1 branch: when RunPodSandbox fails after StartSandbox has persisted the sandbox record (e.g. an NRI hook rejection), the record is never cleaned up. Retries of the same pod then accumulate records sharing one sandbox name, and the next containerd restart exits fatally in CRI recovery with `failed to reserve sandbox name ... name is reserved for ...`, leaving the node unusable until manual intervention.

We hit this in production on v2.1.7 (GKE): an NRI plugin rejected RunPodSandbox ~94 times for one pod, and a later routine containerd restart crash-looped both affected nodes.

The patch applies cleanly; `go build`/`go vet`/`go test ./internal/cri/server/` pass.

Made with [Cursor](https://cursor.com)