### PR TITLE
Prepare release notes for v2.4.0-beta.0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -49,6 +49,7 @@ Eric Lin <linxiulei@gmail.com> <exlin@google.com>
 Eric Ren <renzhen.rz@linux.alibaba.com> <renzhen@linux.alibaba.com>
 Eric Ren <renzhen.rz@linux.alibaba.com> <renzhen.rz@alibaba-linux.com>
 Eric Ren <renzhen.rz@linux.alibaba.com> <renzhen.rz@alibaba-inc.com>
+Esteban Ginez <esteban.ginez@docker.com> <175813+eginez@users.noreply.github.com>
 Fabian Hoffmann <extern.fabian.hoffmann@cariad.technology>
 Fabian Hoffmann <extern.fabian.hoffmann@cariad.technology> <35104465+FabHof@users.noreply.github.com>
 Fabiano Fidêncio <fidencio@redhat.com> <fabiano.fidencio@intel.com>
@@ -114,6 +115,7 @@ Kohei Tokunaga <ktokunaga.mail@gmail.com>
 Krasi Georgiev <krasi.root@gmail.com> <krasi@vip-consult.solutions>
 Lantao Liu <lantaol@google.com>
 Lantao Liu <lantaol@google.com> <taotaotheripper@gmail.com>
+Laura Lorenz <lauralorenz@google.com>
 lengrongfu <1275177125@qq.com>
 Li Yuxuan <liyuxuan04@baidu.com> <darfux@163.com>
 Lifubang <lifubang@aliyun.com> <lifubang@acmcoder.com>

--- a/releases/v2.4.0-beta.toml
+++ b/releases/v2.4.0-beta.toml
@@ -1,0 +1,37 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "v2.3.0"
+
+pre_release = true
+
+preface = """\
+containerd 2.4 is a regular (non-LTS) release with a shorter support window,
+intended for users who want to adopt new features sooner. As the release
+following the 2.3 LTS, it is the point in the release cycle where previously
+deprecated features may be removed, so this release may include breaking
+changes; check the notes below and clear any deprecation warnings from your
+current version before upgrading.
+
+Users prioritizing stability and a longer support lifecycle should stay on the
+2.3 LTS release.
+
+This is a beta release and some functionality is still under development.
+"""
+
+postface = """\
+### Which file should I download?
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.35 (Ubuntu 22.04).
+* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on Linux distributions that do not use glibc >= 2.35. Not position-independent.
+
+In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
+and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.
+
+See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.3.0+unknown"
+	Version = "2.4.0-beta+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes

----

containerd 2.4.0-beta.0

Welcome to the v2.4.0-beta.0 release of containerd!  
*This is a pre-release of containerd*

containerd 2.4 is a regular (non-LTS) release with a shorter support window,
intended for users who want to adopt new features sooner. As the release
following the 2.3 LTS, it is the point in the release cycle where previously
deprecated features may be removed, so this release may include breaking
changes; check the notes below and clear any deprecation warnings from your
current version before upgrading.

Users prioritizing stability and a longer support lifecycle should stay on the
2.3 LTS release.

This is a beta release and some functionality is still under development.

### Highlights

* **Support warm image cache for erofs snapshotter** ([#13813](https://github.com/containerd/containerd/pull/13813))

#### Container Runtime Interface (CRI)

* **Introspect OCI runtime features for non-runc runtimes** ([#13504](https://github.com/containerd/containerd/pull/13504))

#### Image Distribution

* **Use klauspost/compress/gzip for decode** ([#13560](https://github.com/containerd/containerd/pull/13560))

#### Image Storage

* **Add forward References to the GC collection context** ([#13634](https://github.com/containerd/containerd/pull/13634))

#### Snapshotters

* **Add max size label for snapshots** ([#13520](https://github.com/containerd/containerd/pull/13520))

#### Deprecations

* **Fix sandbox task API endpoints for non-runc runtimes** ([#13360](https://github.com/containerd/containerd/pull/13360))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Maksym Pavlenko
* Samuel Karp
* Akihiro Suda
* Derek McGowan
* Sebastiaan van Stijn
* Wei Fu
* Chris Henzie
* Mike Brown
* Paweł Gronowski
* Brian Goff
* Jordan Liggitt
* Austin Vazquez
* Kazuyoshi Kato
* Phil Estes
* Sergey Kanzhelev
* ningmingxiao
* Ahmet Alp Balkan
* Akhil Mohan
* Esteban Ginez
* Laura Lorenz
* Maksim An
* Abhishek Bhunia
* Alan Grosskurth
* Albin Kerouanton
* Alex Lyn
* Aman Raj
* Amir Alavi
* Amit Barve
* Andrew Halaney
* AprilNEA
* Arjun Yogidas
* Ayato Tokubi
* Aysha Afrah Ziya
* Ben Cressey
* Chris Crone
* Craig Gumbley
* Daniel De Graaf
* Davanum Srinivas
* Dr. Jan-Philip Gehrcke
* Gao Xiang
* Henry Wang
* Kir Kolyshkin
* Kohei Tokunaga
* LEI WANG
* Mikhail Dmitrichenko
* Paco Xu
* SaloniRathi
* ayush-panta
* crawfordxx
* cshung
* s3onghyun
* 归寂
* 徐晓伟

### Changes
<details><summary>319 commits</summary>
<p>

  * [`1759e9ff7`](https://github.com/containerd/containerd/commit/1759e9ff7204ddef656f4418e4bec847469692d5) Prepare release notes for v2.4.0-beta.0
* build(deps): bump github.com/fsnotify/fsnotify from 1.9.0 to 1.10.1 ([#13343](https://github.com/containerd/containerd/pull/13343))
  * [`b1085e19b`](https://github.com/containerd/containerd/commit/b1085e19b75310d2b480b07a83d99939b2941b98) build(deps): bump github.com/fsnotify/fsnotify from 1.9.0 to 1.10.1
* cri: add streaming RPCs ([#13187](https://github.com/containerd/containerd/pull/13187))
  * [`47c7085d2`](https://github.com/containerd/containerd/commit/47c7085d222160d8d944ef55251c963d62036e03) cri: add streaming RPCs
* Handle []byte envvar value for CRI ([#13453](https://github.com/containerd/containerd/pull/13453))
  * [`b824ddc0b`](https://github.com/containerd/containerd/commit/b824ddc0b5bc882ce0bad8564fc28c64e67458ab) Handle []byte envvar value
  * [`78abbfb7f`](https://github.com/containerd/containerd/commit/78abbfb7f7c0459ffe5ee81ae2f2740b9de591ad) update to v0.36.x kubernetes dependencies
* build(deps): bump github.com/erofs/go-erofs from 0.3.0 to 0.3.1 ([#13820](https://github.com/containerd/containerd/pull/13820))
  * [`6e4c6acc0`](https://github.com/containerd/containerd/commit/6e4c6acc0dc4b81b25f5008ec20e8ed6bc4cac5f) build(deps): bump github.com/erofs/go-erofs from 0.3.0 to 0.3.1
* shim_load: Consider shim leaked only if we can't find pids ([#13790](https://github.com/containerd/containerd/pull/13790))
  * [`54a5a606c`](https://github.com/containerd/containerd/commit/54a5a606cb8438cafe483507c8dbeedcfc963e8b) shim_load: Consider shim leaked only if we can't find pids
* Fix flaky CI on windows ([#13827](https://github.com/containerd/containerd/pull/13827))
  * [`dd654ecca`](https://github.com/containerd/containerd/commit/dd654ecca04082541f953062f8008fa3e78d9ee7) Fix does not contain \x00 on windows
  * [`5c620e984`](https://github.com/containerd/containerd/commit/5c620e984fdae621e910e74454dac2124f6a9903) Fix NET/network CI failure on Windows
* build: bump github.com/containerd/nri ([#13812](https://github.com/containerd/containerd/pull/13812))
  * [`5d35f9ef9`](https://github.com/containerd/containerd/commit/5d35f9ef9774e64f012c801c12af6e5c2ff2d729) build: bump github.com/containerd/nri
* build(deps): bump golang.org/x/net from 0.51.0 to 0.55.0 in /api ([#13819](https://github.com/containerd/containerd/pull/13819))
  * [`52c5f1f64`](https://github.com/containerd/containerd/commit/52c5f1f64e2184af56f3550940db29ccdb94e576) build(deps): bump golang.org/x/net from 0.51.0 to 0.55.0 in /api
* docs: correct default for [debug] address ([#13821](https://github.com/containerd/containerd/pull/13821))
  * [`1a7d78e0b`](https://github.com/containerd/containerd/commit/1a7d78e0b9bbd5a756d316acf592ec619f506231) docs: correct default for [debug] address
* Support warm image cache for erofs snapshotter ([#13813](https://github.com/containerd/containerd/pull/13813))
  * [`82a47efe9`](https://github.com/containerd/containerd/commit/82a47efe92a079b0cd9837a2e2a5fb1b6822e5c8) Support dmverity
  * [`f52e748f1`](https://github.com/containerd/containerd/commit/f52e748f164d0a90fdea9effd1bcb90df9f64336) ctr: add build-erofs-cache to populate the erofs layer cache
  * [`728093bdc`](https://github.com/containerd/containerd/commit/728093bdca8837673ed43eb17821a53c28d9ee80) snapshots/erofs: source pre-converted layers from a content cache
* docs: add threat model and triage guide ([#12942](https://github.com/containerd/containerd/pull/12942))
  * [`3a3eddcbf`](https://github.com/containerd/containerd/commit/3a3eddcbf99b741dda7b0b8aad1059cab6a251a6) docs: add threat model and triage guide
* build(deps): bump golang.org/x/mod from 0.37.0 to 0.38.0 in the golang-x group ([#13806](https://github.com/containerd/containerd/pull/13806))
  * [`9ead7c087`](https://github.com/containerd/containerd/commit/9ead7c087df39b1d07f0e24e28e76a8172d0fdf5) build(deps): bump golang.org/x/mod in the golang-x group
* build(deps): bump actions/attest-build-provenance from 4.1.0 to 4.1.1 ([#13688](https://github.com/containerd/containerd/pull/13688))
  * [`43866c6a3`](https://github.com/containerd/containerd/commit/43866c6a3f8d311196ccd9e3131c06257dbc6103) build(deps): bump actions/attest-build-provenance from 4.1.0 to 4.1.1
* fsmount: Fix selinux mount parameter parsing ([#13754](https://github.com/containerd/containerd/pull/13754))
  * [`dd2bcfc64`](https://github.com/containerd/containerd/commit/dd2bcfc6438e51ca8eae7f72543fcfd7034cdd39) fsmount: Fix selinux mount parameter parsing
* build(deps): bump github/codeql-action/upload-sarif from 4.36.2 to 4.37.0 ([#13810](https://github.com/containerd/containerd/pull/13810))
  * [`624c8e85b`](https://github.com/containerd/containerd/commit/624c8e85bdf66985038097ec4e1a2539e3bf4055) build(deps): bump github/codeql-action/upload-sarif
* build(deps): bump docker/setup-buildx-action from 4.1.0 to 4.2.0 ([#13765](https://github.com/containerd/containerd/pull/13765))
  * [`51355849a`](https://github.com/containerd/containerd/commit/51355849a7299cadb066c8f42ad7987035429229) build(deps): bump docker/setup-buildx-action from 4.1.0 to 4.2.0
* build(deps): bump docker/login-action from 4.2.0 to 4.4.0 ([#13772](https://github.com/containerd/containerd/pull/13772))
  * [`a9bb893ec`](https://github.com/containerd/containerd/commit/a9bb893ecbefc861a66ce614d02a1ad35c3265ad) build(deps): bump docker/login-action from 4.2.0 to 4.4.0
* build(deps): bump github.com/pelletier/go-toml/v2 from 2.4.2 to 2.4.3 ([#13807](https://github.com/containerd/containerd/pull/13807))
  * [`10e0d68a9`](https://github.com/containerd/containerd/commit/10e0d68a948f1dcee27992e922bb1e0f98e9ba59) build(deps): bump github.com/pelletier/go-toml/v2 from 2.4.2 to 2.4.3
* build(deps): bump actions/stale from 10.3.0 to 10.4.0 ([#13811](https://github.com/containerd/containerd/pull/13811))
  * [`a4b1e9a44`](https://github.com/containerd/containerd/commit/a4b1e9a44b319b68b4339411445ccf4af0b0d708) build(deps): bump actions/stale from 10.3.0 to 10.4.0
* README: remove Go Report Card badge ([#13741](https://github.com/containerd/containerd/pull/13741))
  * [`5de7b675c`](https://github.com/containerd/containerd/commit/5de7b675c652181b2476ea3d7f8e6c51a82cfef2) README: remove Go Report Card badge
* overlay: don't override a configured index mount option ([#13805](https://github.com/containerd/containerd/pull/13805))
  * [`5e25f36e5`](https://github.com/containerd/containerd/commit/5e25f36e5e23fdd759cbc87fb3dad61e7742da10) overlay: don't override a configured index mount option
* core/mount/manager: improve TestMkdirHandler failure messages ([#13800](https://github.com/containerd/containerd/pull/13800))
  * [`807fbc13d`](https://github.com/containerd/containerd/commit/807fbc13dcff3ecf77e0b9add9d575146e8256d3) core/mount/manager: improve TestMkdirHandler failure messages
* core/runtime/v2: Preserve protobuf shim response bytes ([#13801](https://github.com/containerd/containerd/pull/13801))
  * [`dac4ea43f`](https://github.com/containerd/containerd/commit/dac4ea43f366561df1931ef4a4b4cd7fd27f80c5) core/runtime/v2: Preserve protobuf shim response bytes
* Run CI against dev branches ([#13748](https://github.com/containerd/containerd/pull/13748))
  * [`6c438b047`](https://github.com/containerd/containerd/commit/6c438b0479adfe31c1b2e3420e905c858c4eac6b) Run CI against dev branches
* Raise stale bot limits ([#13780](https://github.com/containerd/containerd/pull/13780))
  * [`12f6a4d58`](https://github.com/containerd/containerd/commit/12f6a4d585448729e3101906087e08b31a33d26b) Raise stale bot limits
* pkg/archive: reject out-of-range device numbers in layer headers ([#13792](https://github.com/containerd/containerd/pull/13792))
  * [`0205398ac`](https://github.com/containerd/containerd/commit/0205398ac25d256ca90f76f4981e57e0dfb5a3aa) pkg/archive: reject out-of-range device numbers in layer headers
* blockcim config and plugin initialization changes ([#13469](https://github.com/containerd/containerd/pull/13469))
  * [`5ae5d993e`](https://github.com/containerd/containerd/commit/5ae5d993e6edeffb94ef18a7f2270d805d1725e3) use IsBlockCimWriteSupported for block CIM plugin init checks
  * [`8fbeab28d`](https://github.com/containerd/containerd/commit/8fbeab28d263a3a0bbea4bbe398e449725f11015) Fix incorrect default config value for block CIM snapshotter
* update runc to v1.5.1 ([#13791](https://github.com/containerd/containerd/pull/13791))
  * [`21efcf19a`](https://github.com/containerd/containerd/commit/21efcf19a402cc15a45a00a94321c8e463a0d5e9) update runc to v1.5.1
* ci: bound Go fuzzing by execution count ([#13757](https://github.com/containerd/containerd/pull/13757))
  * [`c1b9b78f4`](https://github.com/containerd/containerd/commit/c1b9b78f473f2936fb5d3f06b147d0a01f7a12dc) ci: bound Go fuzzing by execution count
* Introspect OCI runtime features for non-runc runtimes ([#13504](https://github.com/containerd/containerd/pull/13504))
  * [`fd7819bcb`](https://github.com/containerd/containerd/commit/fd7819bcb7d5fa60d2e05861b64eed758840020f) fix(cri): introspect OCI runtime features for non-runc runtimes
* build(deps): bump github.com/klauspost/compress from 1.18.6 to 1.19.0 ([#13768](https://github.com/containerd/containerd/pull/13768))
  * [`61a70e7ef`](https://github.com/containerd/containerd/commit/61a70e7ef2d1fa611065fff1fdfd83505bb0f87a) build(deps): bump github.com/klauspost/compress from 1.18.6 to 1.19.0
* build(deps): bump the golang-x group across 1 directory with 2 updates ([#13766](https://github.com/containerd/containerd/pull/13766))
  * [`d5657dbf6`](https://github.com/containerd/containerd/commit/d5657dbf64242a74ce463e30119ecbf31130538e) build(deps): bump the golang-x group across 1 directory with 2 updates
* build(deps): bump google.golang.org/grpc from 1.81.1 to 1.82.0 ([#13767](https://github.com/containerd/containerd/pull/13767))
  * [`bfae6f351`](https://github.com/containerd/containerd/commit/bfae6f35131f6c40a48001aa3af4d534b89dbe25) build(deps): bump google.golang.org/grpc from 1.81.1 to 1.82.0
* build(deps): bump github.com/containerd/ttrpc to v1.2.9 ([#13740](https://github.com/containerd/containerd/pull/13740))
  * [`658a1c78b`](https://github.com/containerd/containerd/commit/658a1c78b52e25002c9c26a504055c8d3af09ea3) build(deps): bump github.com/containerd/ttrpc to v1.2.9
* CI: migrate Vagrant to Lima ([#13728](https://github.com/containerd/containerd/pull/13728))
  * [`a42b09aaa`](https://github.com/containerd/containerd/commit/a42b09aaa6719d5956b72fd6a2c6c164970bece2) CI: migrate Vagrant to Lima
* RELEASES.md: mark 2.1 EOL and update latest 1.7/2.0/2.1/2.2/2.3 tags ([#13739](https://github.com/containerd/containerd/pull/13739))
  * [`617944bab`](https://github.com/containerd/containerd/commit/617944babe00b8d7df7db31fca7b3bd913bd6e0b) RELEASES.md: mark 2.1 EOL and update latest 1.7/2.0/2.1/2.2/2.3 tags
* remotes: surface OCI error body in registry 4xx responses ([#13547](https://github.com/containerd/containerd/pull/13547))
  * [`5c66703ee`](https://github.com/containerd/containerd/commit/5c66703ee37a122f813f9cd1cb37c792e9f7097c) remotes: surface OCI error body on HEAD 403 via GET fallback
* Disable checkpoint restore codepath when CRIU is not installed ([#13664](https://github.com/containerd/containerd/pull/13664))
  * [`81350a5d9`](https://github.com/containerd/containerd/commit/81350a5d9a7a4299ed88ce188062badc986b9e6c) github/workflows: install criu in node-e2e
  * [`06495733b`](https://github.com/containerd/containerd/commit/06495733b2c3b21433ec6e5d6e2e329726e3a181) cri: add enable_criu configuration option
  * [`186397511`](https://github.com/containerd/containerd/commit/186397511b62120b4b99157005268339be84e796) cri: validate CRIU availability and version early
* Update go to 1.26.5 ([#13725](https://github.com/containerd/containerd/pull/13725))
  * [`2b017f12b`](https://github.com/containerd/containerd/commit/2b017f12b5759e0298d13eb9c072ab652a7bf516) Update go to 1.26.5
* feat: add loong64 (LoongArch) build support ([#13642](https://github.com/containerd/containerd/pull/13642))
  * [`48c841fe2`](https://github.com/containerd/containerd/commit/48c841fe2d17d76619e81760e842b825c7f13b95) feat: add loong64 (LoongArch) build support
* Add dockerfile for the whiteout-test test image ([#13704](https://github.com/containerd/containerd/pull/13704))
  * [`cb3c0f066`](https://github.com/containerd/containerd/commit/cb3c0f0665266c3929f0bd0086d23bc653bacd56) Add dockerfile for the whiteout-test test image
* build(deps): bump actions/cache from 5.0.5 to 6.1.0 ([#13687](https://github.com/containerd/containerd/pull/13687))
  * [`ee7e56cac`](https://github.com/containerd/containerd/commit/ee7e56cac79aff6970b56931582fe87f9baa5da3) build(deps): bump actions/cache from 5.0.5 to 6.1.0
* *: disable bbolt stat usage ([#13721](https://github.com/containerd/containerd/pull/13721))
  * [`0b7466980`](https://github.com/containerd/containerd/commit/0b7466980e90aec50e497b05a0a7ebc937395cd5) *: disable bbolt stat usage
* build(deps): bump github.com/pelletier/go-toml/v2 from 2.4.1 to 2.4.2 ([#13672](https://github.com/containerd/containerd/pull/13672))
  * [`fb80dbbf9`](https://github.com/containerd/containerd/commit/fb80dbbf9419e3bb15fb04590d865a5c8b23dd86) build(deps): bump github.com/pelletier/go-toml/v2 from 2.4.1 to 2.4.2
* pkg/kernelversion: fix linting and sync with upstream ([#13701](https://github.com/containerd/containerd/pull/13701))
  * [`296f917d5`](https://github.com/containerd/containerd/commit/296f917d5da0eaae4c12037240faa2d40b14a84d) pkg/kernelversion: update links to upstream source
  * [`c45f91198`](https://github.com/containerd/containerd/commit/c45f911980ca2e7582333898f28bc1086c09d3fd) pkg/kernelversion: simplify code with sync.OnceValues
  * [`5e3e05aec`](https://github.com/containerd/containerd/commit/5e3e05aec7f54689f588166ee6bf790427a19e15) pkg/kernelversion: fix minor linting issues
  * [`762b89cee`](https://github.com/containerd/containerd/commit/762b89ceebbea1fa58c68c24c748f268fcfbb08f) pkg/kernelversion: use unix.ByteSliceToString for utsname fields
* Update stale PR policy ([#13716](https://github.com/containerd/containerd/pull/13716))
  * [`4f9bae677`](https://github.com/containerd/containerd/commit/4f9bae6776084facc8e3de384d0abd50731f0700) Update stale PR policy
* ci: pin fog-json to resolve gem conflict ([#13707](https://github.com/containerd/containerd/pull/13707))
  * [`84112c78c`](https://github.com/containerd/containerd/commit/84112c78c1f70e5f115ea777f0e878f59e1074d0) ci: pin fog-json to resolve gem conflict
* cri: auto-add prefix for pause image ([#13513](https://github.com/containerd/containerd/pull/13513))
  * [`c7d4057d4`](https://github.com/containerd/containerd/commit/c7d4057d47dd8c8187e6c145d254e0db201c9198) cri: auto-add prefix for pause image
* gha: pin remaining actions and apply hardening from zizmor ([#13597](https://github.com/containerd/containerd/pull/13597))
  * [`0f1830782`](https://github.com/containerd/containerd/commit/0f18307820499e8ef91b8bdb23fc25f0b12ee49a) gha: quote some values
  * [`0274924d7`](https://github.com/containerd/containerd/commit/0274924d743e94f9efc802f8fc054e68e4049076) gha: remove uses of "read-all" permissions
  * [`072a34d64`](https://github.com/containerd/containerd/commit/072a34d64804081aa4694732b3edfdfce4009f4f) gha: suppress zizmor warning for intentionally un-pinned workflows
  * [`9f0bb640c`](https://github.com/containerd/containerd/commit/9f0bb640ce2f8775a3ad0f1383dfcaef82f8b6fb) gha: apply zizmor fixes
  * [`8722c4631`](https://github.com/containerd/containerd/commit/8722c4631378261544e2e69d78b978e170a477df) gha: buf-breaking: pin actions by sha
* shim: allow specifying runc's --parent-path during checkpointing ([#13699](https://github.com/containerd/containerd/pull/13699))
  * [`ea0ed51e2`](https://github.com/containerd/containerd/commit/ea0ed51e2101448874215c0de945197a1cafdea4) shim: allow specifying runc's --parent-path during checkpointing
* Fix nil pointer dereference in NRI GetIPs ([#13683](https://github.com/containerd/containerd/pull/13683))
  * [`c2dae310a`](https://github.com/containerd/containerd/commit/c2dae310af03dec3654ecbf8a0b846e86372766d) Fix nil pointer dereference in NRI GetIPs
* Set SystemTemp env var to config temp on Windows ([#13667](https://github.com/containerd/containerd/pull/13667))
  * [`faff4d66b`](https://github.com/containerd/containerd/commit/faff4d66ba60734cf309d442266cb9a1d061e8a8) Set SystemTemp env var to config temp on Windows
* update runhcs to v0.15.0-rc.3 ([#13691](https://github.com/containerd/containerd/pull/13691))
  * [`7c9c25d64`](https://github.com/containerd/containerd/commit/7c9c25d649c5521daed619d5462a1d3ef347b1bc) update runhcs to v0.15.0-rc.3
* build(deps): bump github.com/Microsoft/hcsshim from 0.15.0-rc.1 to 0.15.0-rc.3 ([#13690](https://github.com/containerd/containerd/pull/13690))
  * [`d763407d4`](https://github.com/containerd/containerd/commit/d763407d4aba357cfd3cd42ccc5d1ec19bf7a3bb) build(deps): bump github.com/Microsoft/hcsshim
* Use klauspost/compress/gzip for decode ([#13560](https://github.com/containerd/containerd/pull/13560))
  * [`d8f13bf4c`](https://github.com/containerd/containerd/commit/d8f13bf4cce8b8a99ae61457cb574696fcf475e5) pkg/archive/compression: use klauspost/compress/gzip for decode
* cri: route sandbox stats through Controller.Metrics ([#13312](https://github.com/containerd/containerd/pull/13312))
  * [`749d8fbe4`](https://github.com/containerd/containerd/commit/749d8fbe45e2217089e07a1aa5d084a4f03968cf) Use metric timestamp for sandbox stats samples
  * [`e8dbd24ac`](https://github.com/containerd/containerd/commit/e8dbd24ac5a83f9d19c4d076013c9862e5374edf) cri: route stats collector's sandbox path through Controller.Metrics
  * [`309aaba2a`](https://github.com/containerd/containerd/commit/309aaba2a5396b42992ae52e9b68ebd00e972b4d) cri: route sandbox stats through Controller.Metrics
* docs: point runtime to updated errdefs pkg ([#13410](https://github.com/containerd/containerd/pull/13410))
  * [`668e0681a`](https://github.com/containerd/containerd/commit/668e0681a437d1da8339b468a3048669e9efb88c) docs: point runtime to updated errdefs pkg
* : increase fuzz test time to 60s ([#13677](https://github.com/containerd/containerd/pull/13677))
  * [`2121a44ce`](https://github.com/containerd/containerd/commit/2121a44ce7feaf1821b0b2a51a02b9ab3d93e56f) Increase fuzz timeout to 60s
* build(deps): bump github.com/moby/sys/user from 0.4.0 to 0.4.1 in the moby-sys group across 1 directory ([#13670](https://github.com/containerd/containerd/pull/13670))
  * [`6079844da`](https://github.com/containerd/containerd/commit/6079844dae04c8ac9de6d4cd34e1d395ddeab13e) build(deps): bump github.com/moby/sys/user
* snapshots/devmapper: avoid nil status deref after mkfs failure ([#13633](https://github.com/containerd/containerd/pull/13633))
  * [`5e38aadc5`](https://github.com/containerd/containerd/commit/5e38aadc536518dfe3de789c20024a9aba48f96b) snapshots/devmapper: avoid nil status deref after mkfs failure
* pkg/archive: remove redundant github.com/moby/sys/sequential dependency ([#13675](https://github.com/containerd/containerd/pull/13675))
  * [`35f753cc4`](https://github.com/containerd/containerd/commit/35f753cc4431b2c69f84a30ac62988810f37ff0a) pkg/archive: remove redundant github.com/moby/sys/sequential dependency
* pkg/oci: update TestOpenUserFileCapsReads to use newlined data ([#13674](https://github.com/containerd/containerd/pull/13674))
  * [`7a7aebfcb`](https://github.com/containerd/containerd/commit/7a7aebfcbf6d3ce24d7b50eb2d7f9676b26c91d5) pkg/oci: update TestOpenUserFileCapsReads to use newlined data
* cri: exclude cached layer bytes from image_pulling_throughput_mibps ([#13245](https://github.com/containerd/containerd/pull/13245))
  * [`16ff70b86`](https://github.com/containerd/containerd/commit/16ff70b8614592cb379dccfb0376c54cbe0e147d) cri: add image_pulling_throughput_mibps and deprecate image_pulling_throughput
  * [`1755053a7`](https://github.com/containerd/containerd/commit/1755053a786fd7f027e52ead3734e3966d502cb4) cri: exclude cached layer bytes from image_pulling_throughput
* RELEASES: document platform support policy ([#13655](https://github.com/containerd/containerd/pull/13655))
  * [`d0b381949`](https://github.com/containerd/containerd/commit/d0b381949517c2ecd4e2b94a60450279e9aeb016) RELEASES: document platform support policy
* update runc to v1.5.0 ([#13673](https://github.com/containerd/containerd/pull/13673))
  * [`8f2bbc77a`](https://github.com/containerd/containerd/commit/8f2bbc77a416d7034855527f4633eb388037e08c) update runc to v1.5.0
* fix snapshotter variable check in ContainerWithCheckpoint ([#13482](https://github.com/containerd/containerd/pull/13482))
  * [`57fca66a6`](https://github.com/containerd/containerd/commit/57fca66a602440bfb42b61ec8b23c9c5da73c055) [Bugfix] fix snapshotter variable check in ContainerWithCheckpoint
* build(deps): bump actions/checkout from 6 to 7 ([#13648](https://github.com/containerd/containerd/pull/13648))
  * [`38aaa269c`](https://github.com/containerd/containerd/commit/38aaa269c7f7457e5ab551fc22278ea984fe091e) build(deps): bump actions/checkout from 6 to 7
* cri: fix duplicated image env vars on checkpoint import ([#13623](https://github.com/containerd/containerd/pull/13623))
  * [`6a677e0fd`](https://github.com/containerd/containerd/commit/6a677e0fd61fa0200a4aa5ba57c6c200433ee7d2) cri: fix duplicated image env vars on checkpoint import
* cri: reject CreateContainer when sandbox is not running ([#13654](https://github.com/containerd/containerd/pull/13654))
  * [`ae30a5cad`](https://github.com/containerd/containerd/commit/ae30a5cad24925d2aec232d31fb390aa2c77d1ff) cri: reject CreateContainer when sandbox is not running
* build(deps): bump github.com/mdlayher/vsock from 1.2.1 to 1.3.0 ([#13493](https://github.com/containerd/containerd/pull/13493))
  * [`3fdb9abca`](https://github.com/containerd/containerd/commit/3fdb9abcabab47168fb2acd6e516dac78675d5eb) build(deps): bump github.com/mdlayher/vsock from 1.2.1 to 1.3.0
* build(deps): bump github.com/intel/goresctrl from 0.12.0 to 0.13.0 ([#13527](https://github.com/containerd/containerd/pull/13527))
  * [`787bb3da6`](https://github.com/containerd/containerd/commit/787bb3da649b1a676fc6ba0fcf73fe797a0c0a41) build(deps): bump github.com/intel/goresctrl from 0.12.0 to 0.13.0
* oci: use path.Join to fill CgroupsPath ([#13661](https://github.com/containerd/containerd/pull/13661))
  * [`51e3a8f4a`](https://github.com/containerd/containerd/commit/51e3a8f4ab30363239cce0de9f4aaf3927b82887) oci: use path.Join to fill CgroupsPath
* build(deps): bump github.com/moby/sys/sequential from 0.6.0 to 0.7.0 in the moby-sys group across 1 directory ([#13557](https://github.com/containerd/containerd/pull/13557))
  * [`ef32a6c8a`](https://github.com/containerd/containerd/commit/ef32a6c8ac68ec43c05a95aaac6eb118cacf5937) build(deps): bump github.com/moby/sys/sequential
* Register tracing log hook before signal handling ([#13411](https://github.com/containerd/containerd/pull/13411))
  * [`125c15bcd`](https://github.com/containerd/containerd/commit/125c15bcd09972d754284693f26857517ef9869c) Register tracing log hook before signal handling
* content: handle sharing violations on Windows ([#13329](https://github.com/containerd/containerd/pull/13329))
  * [`a26143af1`](https://github.com/containerd/containerd/commit/a26143af1e314668ff7875c3893fc48b52b4f50f) content: handle sharing violations on Windows
* update runhcs to v0.15.0-rc.2 ([#13659](https://github.com/containerd/containerd/pull/13659))
  * [`ceee91ff5`](https://github.com/containerd/containerd/commit/ceee91ff5a8e161330d367cb038025d10560c88f) update runhcs to v0.15.0-rc.2
* build(deps): bump go.etcd.io/bbolt from 1.4.3 to 1.5.0 ([#13649](https://github.com/containerd/containerd/pull/13649))
  * [`7f3f8fffd`](https://github.com/containerd/containerd/commit/7f3f8fffdd743b93450ada2fb50742131d4c6bc5) build(deps): bump go.etcd.io/bbolt from 1.4.3 to 1.5.0
* cri: don't leak the new mount if mutateImageMount() fails ([#13656](https://github.com/containerd/containerd/pull/13656))
  * [`a88ce40fd`](https://github.com/containerd/containerd/commit/a88ce40fd12e50de3c9252a88e79ba1cd3c51131) cri: don't leak the new mount if mutateImageMount() fails
* build(deps): bump softprops/action-gh-release from 3.0.0 to 3.0.1 ([#13650](https://github.com/containerd/containerd/pull/13650))
  * [`d568ae9cb`](https://github.com/containerd/containerd/commit/d568ae9cb5b435bec0666dddbbb9ffbdfbefd98e) build(deps): bump softprops/action-gh-release from 3.0.0 to 3.0.1
* build(deps): bump github.com/pelletier/go-toml/v2 from 2.3.1 to 2.4.1 ([#13651](https://github.com/containerd/containerd/pull/13651))
  * [`f407302ba`](https://github.com/containerd/containerd/commit/f407302bab3d993a508236805e196936a06f42b3) build(deps): bump github.com/pelletier/go-toml/v2 from 2.3.1 to 2.4.1
* docs: fix duplicated word in NRI guide ([#13618](https://github.com/containerd/containerd/pull/13618))
  * [`59ccb0029`](https://github.com/containerd/containerd/commit/59ccb0029ba1e279c79f8870f316174861fe487c) docs: fix duplicated word in NRI guide
* Add forward References to the GC collection context ([#13634](https://github.com/containerd/containerd/pull/13634))
  * [`4be39f13f`](https://github.com/containerd/containerd/commit/4be39f13f4545ae42117a033c2c4ec68442f7985) core/metadata: add forward References to the GC collection context
* integration: add http trace for debug ([#13518](https://github.com/containerd/containerd/pull/13518))
  * [`3d80ce288`](https://github.com/containerd/containerd/commit/3d80ce2881f6b24bc289a5e9fd00a57e2452208b) integration: add http trace for debug
* test: fix flaky image timestamp check on coarse clocks ([#13588](https://github.com/containerd/containerd/pull/13588))
  * [`e5e219088`](https://github.com/containerd/containerd/commit/e5e219088632e67d1024e647fd9e9820619d3a1d) test: fix flaky image timestamp check on coarse clocks
* core/content/proxy: Convert reader errors to native errdefs ([#13585](https://github.com/containerd/containerd/pull/13585))
  * [`d58c2c1aa`](https://github.com/containerd/containerd/commit/d58c2c1aa4ddc2bd8bb27875e189cceaa64c4c80) core/content/proxy: Convert reader errors to native errdefs
* Patches ([#13626](https://github.com/containerd/containerd/pull/13626))
  * [`a0086cfce`](https://github.com/containerd/containerd/commit/a0086cfceec8efcb17c64f6a3d03dbac0e59fd42) Merge commit from fork
  * [`861ffc109`](https://github.com/containerd/containerd/commit/861ffc1097685f9ecf13adaa381aca5fdf7ef0b4) cri: filter CDI annotations on checkpoint restore
  * [`432a7af29`](https://github.com/containerd/containerd/commit/432a7af29942e0c7c8817a019d89aac4c0b32218) Merge commit from fork
  * [`0c0918fa8`](https://github.com/containerd/containerd/commit/0c0918fa8fb4d997f889a3d811603995a3a2b68a) cri: do not re-tag restored checkpoints
  * [`3977106b5`](https://github.com/containerd/containerd/commit/3977106b535137b1345279599ff80565b9542c66) Merge commit from fork
  * [`8196411f2`](https://github.com/containerd/containerd/commit/8196411f24065533093be4c7ad874c23b06178f3) cri: make checkpoint restore robust to unexpected archive content
  * [`5a91c9958`](https://github.com/containerd/containerd/commit/5a91c99584d9c7a4718d76944bbbfaee845dc1a8) Merge commit from fork
  * [`7b05ec421`](https://github.com/containerd/containerd/commit/7b05ec421d0a07b33964c74145b6bf5dff58f476) Bound user-database file reads in openUserFile
  * [`a834385de`](https://github.com/containerd/containerd/commit/a834385de9eec8445afbfc6f4283919e08e1b413) Merge commit from fork
  * [`0ec1af4ca`](https://github.com/containerd/containerd/commit/0ec1af4cae1256d18719ca892bf66340499e8050) Do not propagate reserved labels from image configs
* erofs: align default mkfs block size across platforms ([#13624](https://github.com/containerd/containerd/pull/13624))
  * [`773d3517d`](https://github.com/containerd/containerd/commit/773d3517ddfca4c03881ac0164a4ea9eaf7a1fe7) erofs: align default mkfs block size across platforms
* fix(shim/windows): retry on winio.ErrTimeout in awaitPipeReady ([#13536](https://github.com/containerd/containerd/pull/13536))
  * [`be3fcf33e`](https://github.com/containerd/containerd/commit/be3fcf33e81e5991ed239f9116f6482d571e50fd) fix(shim/windows): retry on winio.ErrTimeout in awaitPipeReady
* vendor: golang.org/x/crypto v0.53.0 ([#13600](https://github.com/containerd/containerd/pull/13600))
  * [`9838a323e`](https://github.com/containerd/containerd/commit/9838a323ed8b310643a7a36dc758270676ed59c0) vendor: golang.org/x/crypto v0.53.0
* update runc binary to v1.4.3 ([#13590](https://github.com/containerd/containerd/pull/13590))
  * [`ebef5893c`](https://github.com/containerd/containerd/commit/ebef5893ccd74b7ffe8de855666cffdc9df5278b) update runc binary to v1.4.3
* core/proxy: Convert stream proxy errors to native errdefs ([#13586](https://github.com/containerd/containerd/pull/13586))
  * [`d3c143e8b`](https://github.com/containerd/containerd/commit/d3c143e8b4904e22485b2c9e94b4d7b2db5eb07f) core/proxy: Convert stream proxy errors to native errdefs
* build(deps): bump the golang-x group with 3 updates ([#13556](https://github.com/containerd/containerd/pull/13556))
  * [`719088fba`](https://github.com/containerd/containerd/commit/719088fbaa3248cda723765fa3c7a33841170b17) build(deps): bump the golang-x group with 3 updates
* resolver: retry on transient network errors ([#13323](https://github.com/containerd/containerd/pull/13323))
  * [`20af2e324`](https://github.com/containerd/containerd/commit/20af2e324a5fab7e1fed9b17ef0dbb42ecdc4596) resolver: retry on transient network errors
* update go to 1.26.4 ([#13575](https://github.com/containerd/containerd/pull/13575))
  * [`3c37ceee4`](https://github.com/containerd/containerd/commit/3c37ceee46acd9d9557e88c5b6c9b282f09cd708) update go to 1.26.4
* Update to current setup-go version ([#13516](https://github.com/containerd/containerd/pull/13516))
  * [`80b3fe5c7`](https://github.com/containerd/containerd/commit/80b3fe5c78b93b56b496cdd10b15f2c0ee6d5bb9) Update to current setup-go version
* build(deps): bump github/codeql-action from 4.36.0 to 4.36.2 ([#13555](https://github.com/containerd/containerd/pull/13555))
  * [`dfb00c477`](https://github.com/containerd/containerd/commit/dfb00c477001dd4a82ac106b8e6beb10a8ab34bc) build(deps): bump github/codeql-action from 4.36.0 to 4.36.2
* Configure udevd children-max for root-test ([#13562](https://github.com/containerd/containerd/pull/13562))
  * [`4adafdf7e`](https://github.com/containerd/containerd/commit/4adafdf7e1c671bfe58a14d890d632a2d5c77fd1) Configure udevd children-max for root-test
* Add defer in event of mid-function failures in RunPodSandbox to avoid mount leaks ([#13399](https://github.com/containerd/containerd/pull/13399))
  * [`2b2b80f55`](https://github.com/containerd/containerd/commit/2b2b80f558e592610dd2484f1dd8cb43246cce0e) Add deferred call to ShutdownSandbox to avoid leaks
* Upload crash artifacts from go test -fuzz when failed ([#13503](https://github.com/containerd/containerd/pull/13503))
  * [`0ffe456f1`](https://github.com/containerd/containerd/commit/0ffe456f1eaddfe9df40668e024e59b658fed436) github: upload crash artifacts from go test -fuzz
* Use intermediate env variables for bash script runners in github workflows ([#13434](https://github.com/containerd/containerd/pull/13434))
  * [`d5b1a69da`](https://github.com/containerd/containerd/commit/d5b1a69dae9d7ba122d8459414e159054ab17c1f) Use intermediate env variables for bash script runners
* Add max size label for snapshots ([#13520](https://github.com/containerd/containerd/pull/13520))
  * [`f2b7791b2`](https://github.com/containerd/containerd/commit/f2b7791b23b42d702116aaea0c37757a2b85d1f5) Add max size label for snapshots
* CI: update Fedora to 44 ([#13525](https://github.com/containerd/containerd/pull/13525))
  * [`e37dfad05`](https://github.com/containerd/containerd/commit/e37dfad050b2431373a7dc63862638171a697310) CI: update Fedora to 44
* remotes: close fetch reader immediately on EOF ([#13438](https://github.com/containerd/containerd/pull/13438))
  * [`45cc0c578`](https://github.com/containerd/containerd/commit/45cc0c578e8e636c55b9aa57bdfbd54de75ac8b2) integration: use streaming Read in test mirror limiter
  * [`a989093a9`](https://github.com/containerd/containerd/commit/a989093a9cd10df073e7e1fcb4e3359c1568a674) remotes: close fetch reader immediately on EOF
* cri: reset pull progress timer on idle→active transition ([#13304](https://github.com/containerd/containerd/pull/13304))
  * [`6c396d050`](https://github.com/containerd/containerd/commit/6c396d050dc75d64b35bced78b09069fdd03342c) cri: reset pull progress timer on idle→active transition
* runc-shim: don't hold the service lock across runc create ([#13483](https://github.com/containerd/containerd/pull/13483))
  * [`dbcaa504c`](https://github.com/containerd/containerd/commit/dbcaa504c6553f7f52b53b917d0f3c98416281c1) runc-shim: don't hold the service lock across runc create
* integration: deflake TestFailFastWhenConnectShim ([#13471](https://github.com/containerd/containerd/pull/13471))
  * [`a9fba6623`](https://github.com/containerd/containerd/commit/a9fba66231f2e55326e132aa29d0647b10be378f) integration: deflake TestFailFastWhenConnectShim
* Resurrect 2.1 branch for a short period ([#13498](https://github.com/containerd/containerd/pull/13498))
  * [`660e411a3`](https://github.com/containerd/containerd/commit/660e411a3ad09faceb8e098747235ab874730208) Resurrect 2.1 branch for a short period
* build(deps): bump the otel group across 1 directory with 8 updates ([#13495](https://github.com/containerd/containerd/pull/13495))
  * [`de9dcf6aa`](https://github.com/containerd/containerd/commit/de9dcf6aa650b408d88efbcf5f822e5418376db6) build(deps): bump the otel group across 1 directory with 8 updates
* Update typeurl/v2 to v2.3.0 to drop gogo dependency ([#13490](https://github.com/containerd/containerd/pull/13490))
  * [`ce3914324`](https://github.com/containerd/containerd/commit/ce39143249b595d2b275e47c279c129f67e3a2a9) Update typeurl/v2 to v2.3.0 to drop gogo dependency
* build(deps): bump google.golang.org/grpc from 1.81.0 to 1.81.1 ([#13428](https://github.com/containerd/containerd/pull/13428))
  * [`8f3c916a7`](https://github.com/containerd/containerd/commit/8f3c916a76a11eb7b3bbf22468c126c06ac733b0) build(deps): bump google.golang.org/grpc from 1.81.0 to 1.81.1
* cri: skip pause image pull for shim sandboxer ([#13424](https://github.com/containerd/containerd/pull/13424))
  * [`8f7c7fb44`](https://github.com/containerd/containerd/commit/8f7c7fb447056adaf0f274658b8b0dae2cccd32e) cri: skip pause image pull for non-podsandbox sandboxers
* Vagrantfile: update DNF cache ([#13487](https://github.com/containerd/containerd/pull/13487))
  * [`8ef3b6a12`](https://github.com/containerd/containerd/commit/8ef3b6a12bcde4653c3ec5f17a166c09ac14cf64) Vagrantfile: update DNF cache
* build(deps): bump docker/login-action from 4.1.0 to 4.2.0 ([#13476](https://github.com/containerd/containerd/pull/13476))
  * [`4939e073d`](https://github.com/containerd/containerd/commit/4939e073d54ad6323fbe48f8ff4bc0235d5b8f9b) build(deps): bump docker/login-action from 4.1.0 to 4.2.0
* core/runtime/v2: fix race on Windows deferredPipeConnection.c in Read ([#13462](https://github.com/containerd/containerd/pull/13462))
  * [`88af11e08`](https://github.com/containerd/containerd/commit/88af11e081b3ef90e06b479c2b3da7769187211f) core/runtime/v2: fix race on Windows deferredPipeConnection.c in Read
* build(deps): bump the k8s group across 1 directory with 6 updates ([#13427](https://github.com/containerd/containerd/pull/13427))
  * [`f19f84cfe`](https://github.com/containerd/containerd/commit/f19f84cfe07bbdb4b771c1d1b578dad38182bbff) build(deps): bump the k8s group across 1 directory with 6 updates
* build(deps): bump actions/stale from 10.2.0 to 10.3.0 ([#13473](https://github.com/containerd/containerd/pull/13473))
  * [`8baa17cce`](https://github.com/containerd/containerd/commit/8baa17ccedadd3abd6683550dccb85742b141ce3) build(deps): bump actions/stale from 10.2.0 to 10.3.0
* build(deps): bump golang.org/x/sys from 0.44.0 to 0.45.0 in the golang-x group ([#13474](https://github.com/containerd/containerd/pull/13474))
  * [`be9c7a857`](https://github.com/containerd/containerd/commit/be9c7a85714b85141813f85af608a2461d18ff34) build(deps): bump golang.org/x/sys in the golang-x group
* build(deps): bump github/codeql-action from 4.35.2 to 4.36.0 ([#13475](https://github.com/containerd/containerd/pull/13475))
  * [`032232ac0`](https://github.com/containerd/containerd/commit/032232ac0b299133388e9f9bfdd40d64900ced75) build(deps): bump github/codeql-action from 4.35.2 to 4.36.0
* build(deps): bump golangci/golangci-lint-action from 9.2.0 to 9.2.1 ([#13477](https://github.com/containerd/containerd/pull/13477))
  * [`95ccda2f2`](https://github.com/containerd/containerd/commit/95ccda2f2300672fde2f46bfb26a59dfdfc20ed6) build(deps): bump golangci/golangci-lint-action from 9.2.0 to 9.2.1
* build(deps): bump docker/setup-buildx-action from 4.0.0 to 4.1.0 ([#13478](https://github.com/containerd/containerd/pull/13478))
  * [`db807068a`](https://github.com/containerd/containerd/commit/db807068a7986b3996ed82cd7731882f11f107a9) build(deps): bump docker/setup-buildx-action from 4.0.0 to 4.1.0
* pkg/oci: WithUser: remove redundant isErrRange utility ([#13480](https://github.com/containerd/containerd/pull/13480))
  * [`633a5be1c`](https://github.com/containerd/containerd/commit/633a5be1c991e1d93d9a2ea730ecb8429a7915f5) pkg/oci: WithUser: remove redundant isErrRange utility
* Fix flaky e2e test ([#13470](https://github.com/containerd/containerd/pull/13470))
  * [`8e0713454`](https://github.com/containerd/containerd/commit/8e0713454f5b8e1e44c7dc78796d87a8fc2b943d) cri: use per-metric timestamp in background stats collector
* Fix: TestCgroupNamespace failure on cgroups v1 hosts ([#13240](https://github.com/containerd/containerd/pull/13240))
  * [`970b5d46b`](https://github.com/containerd/containerd/commit/970b5d46bc30b5aafe16c4fbb245500f885cc9cd) Fix TestCgroupNamespace failure on cgroups v1 hosts
* do not hide linitng errors ([#13423](https://github.com/containerd/containerd/pull/13423))
  * [`7f10e9eb5`](https://github.com/containerd/containerd/commit/7f10e9eb5fe3b6e89438fd4806f75bcddfbf576e) do not hide linitng errors
* contrib/checkpoint: increase timeouts to 30s ([#13436](https://github.com/containerd/containerd/pull/13436))
  * [`7515c32ea`](https://github.com/containerd/containerd/commit/7515c32ea46a540809d50d182855ae1fb814d4d3) contrib/checkpoint: increase timeouts to 30s
* oci: return explicit error for out-of-range USER values ([#13446](https://github.com/containerd/containerd/pull/13446))
  * [`9439355c2`](https://github.com/containerd/containerd/commit/9439355c2bffd12d9e15f1fa57cdd1c6da677cd2) oci: return explicit error for out-of-range USER values
* use local go toolchain in CI to confirm that build actually uses requ… ([#13102](https://github.com/containerd/containerd/pull/13102))
  * [`6a80f19a1`](https://github.com/containerd/containerd/commit/6a80f19a1cfeaa6ef6998e7a395a093fc3edc876) use local go toolchain in CI to confirm that build actually uses requested toolchain
* Fix sandbox task API endpoints for non-runc runtimes ([#13360](https://github.com/containerd/containerd/pull/13360))
  * [`b88ab5af4`](https://github.com/containerd/containerd/commit/b88ab5af4fdfd17b626a7dc76b4d6a150af78adf) Wire task address and version fields
  * [`ac01ae5c2`](https://github.com/containerd/containerd/commit/ac01ae5c2766961c3592523ab679dc06ca73c331) protos: include task API address to CreateTaskRequest
* remove 1.26.2 from CI builds as it is not supported any longer due to… ([#13419](https://github.com/containerd/containerd/pull/13419))
  * [`d7a834660`](https://github.com/containerd/containerd/commit/d7a8346600520943daac967eb9ff30ca25bb355c) remove 1.26.2 from CI builds as it is not supported any longer due to the dependency
* ci: skip advisory jobs in merge queue ([#13404](https://github.com/containerd/containerd/pull/13404))
  * [`342edf84a`](https://github.com/containerd/containerd/commit/342edf84abe985f462224fb343491f516bcb7b64) ci: skip advisory jobs in merge queue
* cleanup the systemd debug notification logging ([#13400](https://github.com/containerd/containerd/pull/13400))
  * [`7b1604739`](https://github.com/containerd/containerd/commit/7b1604739f9c38a6f5ecc86b33c41e5bdb7f7939) cleanup the systemd debug notification logging
* RELEASES.md: 2.1 EOL (2026-05-05) ([#13376](https://github.com/containerd/containerd/pull/13376))
  * [`bef924dcb`](https://github.com/containerd/containerd/commit/bef924dcb7568f0be7af96c4ab1cf7d80aadc2c5) RELEASES.md: 2.1 EOL (2026-05-05)
* build(deps): bump the golang-x group with 2 updates ([#13384](https://github.com/containerd/containerd/pull/13384))
  * [`8c2e686ff`](https://github.com/containerd/containerd/commit/8c2e686ffbb4dd7fe361b2799b9467ca9539274a) build(deps): bump the golang-x group with 2 updates
* build(deps): bump github.com/pelletier/go-toml/v2 from 2.3.0 to 2.3.1 ([#13345](https://github.com/containerd/containerd/pull/13345))
  * [`67121b9ab`](https://github.com/containerd/containerd/commit/67121b9ab6dbd26b48fc135c4fd6fe0b20342da0) build(deps): bump github.com/pelletier/go-toml/v2 from 2.3.0 to 2.3.1
* pkg: remove unused nolint annotations ([#13391](https://github.com/containerd/containerd/pull/13391))
  * [`899dee1f5`](https://github.com/containerd/containerd/commit/899dee1f59dadf21e8d3405c8253de763ede58f9) pkg: remove unused nolint annotations
* seccomp: Block AF_ALG in default socket policy ([#13327](https://github.com/containerd/containerd/pull/13327))
  * [`0c23e946a`](https://github.com/containerd/containerd/commit/0c23e946a784ebd48cc53d5df9d16ec8199747a1) seccomp: Block AF_ALG in default socket policy
  * [`ed061a08d`](https://github.com/containerd/containerd/commit/ed061a08de19ce99d223c60dfdbdf6054dd94290) seccomp: Document socket rule scope and socketcall limitation
* overlay: disable "rebase" capability when running in UserNS ([#13389](https://github.com/containerd/containerd/pull/13389))
  * [`65d75e997`](https://github.com/containerd/containerd/commit/65d75e997bbdde96e34d652045fce63fa7f7af63) overlay: disable "rebase" capability when running in UserNS
* build(deps): bump github.com/klauspost/compress from 1.18.5 to 1.18.6 ([#13344](https://github.com/containerd/containerd/pull/13344))
  * [`d30223f09`](https://github.com/containerd/containerd/commit/d30223f09f11e7c6911c2703afa97ac4f63da4b9) build(deps): bump github.com/klauspost/compress from 1.18.5 to 1.18.6
* server: tolerate failed gRPC plugins when starting listeners ([#13363](https://github.com/containerd/containerd/pull/13363))
  * [`ef985f862`](https://github.com/containerd/containerd/commit/ef985f8628344d803d511adf12e5af7cf4606aef) server: tolerate failed gRPC plugins when starting listeners
* fix(erofs): set TMPDIR for mkfs.erofs on Windows ([#13008](https://github.com/containerd/containerd/pull/13008))
  * [`1a6bd7020`](https://github.com/containerd/containerd/commit/1a6bd7020a151263a5fe2320c33f16c6a21be2fa) fix(erofs): set TMPDIR for mkfs.erofs on Windows
* Update Go to 1.26.3 ([#13361](https://github.com/containerd/containerd/pull/13361))
  * [`c4275193b`](https://github.com/containerd/containerd/commit/c4275193b6bd4a7dd5a79f7434ddf94a69bc21f4) Update Go to 1.26.3
* build(deps): bump google.golang.org/grpc from 1.80.0 to 1.81.0 ([#13342](https://github.com/containerd/containerd/pull/13342))
  * [`f698202ed`](https://github.com/containerd/containerd/commit/f698202ed81eb8ba11d6d13982870ef20e655b1e) build(deps): bump google.golang.org/grpc from 1.80.0 to 1.81.0
* fix: close boltdb on metadata and mount plugin close ([#13348](https://github.com/containerd/containerd/pull/13348))
  * [`3bc019ea3`](https://github.com/containerd/containerd/commit/3bc019ea3d09ae1e4ce3da2b44f24e6c2dd1b0e1) fix: close boltdb on metadata and mount plugin close
* Fix optional EROFS differ setup in transfer plugin ([#13328](https://github.com/containerd/containerd/pull/13328))
  * [`f8a5f8d2c`](https://github.com/containerd/containerd/commit/f8a5f8d2c04bde833d578f5dbbe215bffda6c83a) Refactor transfer unpack configuration setup
  * [`5860534c3`](https://github.com/containerd/containerd/commit/5860534c355b9bb06246863cd6c60ad21698a968) Fix optional transfer differ setup
</p>
</details>

### Changes from containerd/nri
<details><summary>7 commits</summary>
<p>

* adaptation: avoid holding lock across runtime update callback ([containerd/nri#301](https://github.com/containerd/nri/pull/301))
  * [`55afaa2`](https://github.com/containerd/nri/commit/55afaa25d2d7827cd51841a5cc2f09981544b894) adaptation: avoid holding lock across runtime update callback
* docs: Fix typo in containerd config for default validator. ([containerd/nri#297](https://github.com/containerd/nri/pull/297))
  * [`b7e479f`](https://github.com/containerd/nri/commit/b7e479f52f51be794ff24af3a5103f7db47ce08d) docs: Fix typo in containerd config for default validator.
* Fix .gitignore ([containerd/nri#290](https://github.com/containerd/nri/pull/290))
  * [`0d37892`](https://github.com/containerd/nri/commit/0d37892494085e17e266a7643d8ac37fe6e7eea1) fix .gitignore to include info/none
  * [`0a92ac9`](https://github.com/containerd/nri/commit/0a92ac958717b461fbf43d76fd56e0de6eef3115) delete manually-added none file
</p>
</details>

### Changes from containerd/ttrpc
<details><summary>25 commits</summary>
<p>

* build(deps): bump golang.org/x/sys from 0.42.0 to 0.46.0 in the golang-x group across 1 directory ([containerd/ttrpc#215](https://github.com/containerd/ttrpc/pull/215))
  * [`093db7f`](https://github.com/containerd/ttrpc/commit/093db7f71f2dcdeee642719481ba5927a384fcbc) build(deps): bump golang.org/x/sys
* build(deps): bump google.golang.org/grpc from 1.69.2 to 1.81.1 ([containerd/ttrpc#237](https://github.com/containerd/ttrpc/pull/237))
  * [`651f052`](https://github.com/containerd/ttrpc/commit/651f052e274fd290e140243c349c25e12d91f6d6) build(deps): bump google.golang.org/grpc from 1.69.2 to 1.81.1
* build(deps): bump golangci/golangci-lint-action from 9.2.0 to 9.2.1 ([containerd/ttrpc#238](https://github.com/containerd/ttrpc/pull/238))
  * [`ae8cc36`](https://github.com/containerd/ttrpc/commit/ae8cc36b9ec4bcc265f214c6407e54c4b668c09d) build(deps): bump golangci/golangci-lint-action from 9.2.0 to 9.2.1
* build(deps): bump actions/checkout from 6.0.2 to 6.0.3 ([containerd/ttrpc#240](https://github.com/containerd/ttrpc/pull/240))
  * [`abdb054`](https://github.com/containerd/ttrpc/commit/abdb0541a8053aec47e154c969c95162b85195a9) build(deps): bump actions/checkout from 6.0.2 to 6.0.3
* Remove gogo vanity command and gogo dependency ([containerd/ttrpc#239](https://github.com/containerd/ttrpc/pull/239))
  * [`5909255`](https://github.com/containerd/ttrpc/commit/5909255a26ba77df1a17448b2ef4f18beec22d22) Remove gogo vanity command
* Fix deadlock when stream is not consumed ([containerd/ttrpc#229](https://github.com/containerd/ttrpc/pull/229))
  * [`cc8699e`](https://github.com/containerd/ttrpc/commit/cc8699ea6f11f8d0ae818cb77645d71cf1707f19) Bump minimum go version to 1.23 for immediate GC of timers
  * [`61715d2`](https://github.com/containerd/ttrpc/commit/61715d2134168e0dd3eb6b1ad57dafd85ad5955e) Add deadlock fix when stream is not consumed
  * [`25b19dd`](https://github.com/containerd/ttrpc/commit/25b19dd07e9b4c51f1a3c4e0ea5c0a65e4b3f729) Add unit test to check for deadlock on unconsumed stream
* server: cancel per-stream context when handler returns ([containerd/ttrpc#231](https://github.com/containerd/ttrpc/pull/231))
  * [`acefd00`](https://github.com/containerd/ttrpc/commit/acefd00e4c172a17a2f51250f76de7cea1674809) server: cancel per-stream context when handler returns
* Set buf version from file and match dev version ([containerd/ttrpc#233](https://github.com/containerd/ttrpc/pull/233))
  * [`02f1a13`](https://github.com/containerd/ttrpc/commit/02f1a13e35a7d6ffb0d21c9a18e66aa57e72bfbd) Set buf version from file and match dev version
* Fix proto generation ([containerd/ttrpc#232](https://github.com/containerd/ttrpc/pull/232))
  * [`45d5a6c`](https://github.com/containerd/ttrpc/commit/45d5a6c128a59e2d56371abcb24b81c305e39dd0) Fix proto generation
* build(deps): bump actions/setup-go from 6.3.0 to 6.4.0 ([containerd/ttrpc#228](https://github.com/containerd/ttrpc/pull/228))
  * [`f0dc2d5`](https://github.com/containerd/ttrpc/commit/f0dc2d5a3994af8f06a5e8befe420410d300c45a) build(deps): bump actions/setup-go from 6.3.0 to 6.4.0
* Migrate from protobuild to buf ([containerd/ttrpc#226](https://github.com/containerd/ttrpc/pull/226))
  * [`056f619`](https://github.com/containerd/ttrpc/commit/056f6193c49266cd49c71628cfe3a7380c877a93) Update CI workflow to use buf instead of protobuild
  * [`4308a4e`](https://github.com/containerd/ttrpc/commit/4308a4e35ad3f738bf0c4efca169ac606875a303) Migrate from protobuild to buf
</p>
</details>

### Dependency Changes

* **cyphar.com/go-pathrs**                                                         v0.2.1 -> v0.2.4
* **github.com/Microsoft/hcsshim**                                                 v0.15.0-rc.1 -> v0.15.0-rc.3
* **github.com/cilium/ebpf**                                                       v0.16.0 -> v0.17.3
* **github.com/containerd/nri**                                                    v0.12.0 -> v0.12.1
* **github.com/containerd/ttrpc**                                                  v1.2.8 -> v1.2.9
* **github.com/containerd/typeurl/v2**                                             v2.2.3 -> v2.3.0
* **github.com/cyphar/filepath-securejoin**                                        v0.6.0 -> v0.6.1
* **github.com/erofs/go-erofs**                                                    v0.3.0 -> v0.3.1
* **github.com/fsnotify/fsnotify**                                                 v1.9.0 -> v1.10.1
* **github.com/grpc-ecosystem/grpc-gateway/v2**                                    v2.28.0 -> v2.29.0
* **github.com/intel/goresctrl**                                                   v0.12.0 -> v0.13.0
* **github.com/klauspost/compress**                                                v1.18.5 -> v1.19.0
* **github.com/mdlayher/socket**                                                   v0.5.1 -> v0.6.0
* **github.com/mdlayher/vsock**                                                    v1.2.1 -> v1.3.0
* **github.com/moby/sys/user**                                                     v0.4.0 -> v0.4.1
* **github.com/pelletier/go-toml/v2**                                              v2.3.0 -> v2.4.3
* **go.etcd.io/bbolt**                                                             v1.4.3 -> v1.5.0
* **go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc**  v0.68.0 -> v0.69.0
* **go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp**                v0.68.0 -> v0.69.0
* **go.opentelemetry.io/otel**                                                     v1.43.0 -> v1.44.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace**                            v1.43.0 -> v1.44.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc**              v1.43.0 -> v1.44.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp**              v1.43.0 -> v1.44.0
* **go.opentelemetry.io/otel/metric**                                              v1.43.0 -> v1.44.0
* **go.opentelemetry.io/otel/sdk**                                                 v1.43.0 -> v1.44.0
* **go.opentelemetry.io/otel/trace**                                               v1.43.0 -> v1.44.0
* **go.yaml.in/yaml/v2**                                                           v2.4.3 -> v2.4.4
* **golang.org/x/crypto**                                                          v0.49.0 -> v0.53.0
* **golang.org/x/mod**                                                             v0.35.0 -> v0.38.0
* **golang.org/x/net**                                                             v0.52.0 -> v0.56.0
* **golang.org/x/oauth2**                                                          v0.35.0 -> v0.36.0
* **golang.org/x/sync**                                                            v0.20.0 -> v0.22.0
* **golang.org/x/sys**                                                             v0.43.0 -> v0.47.0
* **golang.org/x/term**                                                            v0.41.0 -> v0.44.0
* **golang.org/x/text**                                                            v0.35.0 -> v0.38.0
* **google.golang.org/genproto/googleapis/api**                                    9d38bb4040a9 -> 3dc84a4a5aaa
* **google.golang.org/genproto/googleapis/rpc**                                    6f92a3bedf2d -> 3dc84a4a5aaa
* **google.golang.org/grpc**                                                       v1.80.0 -> v1.82.0
* **k8s.io/api**                                                                   v0.36.0 -> v0.36.3
* **k8s.io/apimachinery**                                                          v0.36.0 -> v0.36.3
* **k8s.io/client-go**                                                             v0.36.0 -> v0.36.3
* **k8s.io/component-base**                                                        v0.36.0 -> v0.36.3
* **k8s.io/cri-api**                                                               v0.36.0 -> v0.36.3
* **k8s.io/cri-client**                                                            v0.36.0 -> v0.36.3
* **k8s.io/cri-streaming**                                                         v0.36.0 -> v0.36.3
* **sigs.k8s.io/structured-merge-diff/v6**                                         v6.3.2 -> v6.3.3

Previous release can be found at [v2.3.0](https://github.com/containerd/containerd/releases/tag/v2.3.0)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.35 (Ubuntu 22.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on Linux distributions that do not use glibc >= 2.35. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
