### PR TITLE
plugins/services/tasks: add timeout to per-task Stats() call in getTasksMetrics

### DIFF
--- a/plugins/services/tasks/local.go
+++ b/plugins/services/tasks/local.go
@@ -47,6 +47,7 @@ import (
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/metadata"
+	cmetrics "github.com/containerd/containerd/v2/core/metrics"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/containerd/v2/pkg/archive"
@@ -698,7 +699,9 @@ func getTasksMetrics(ctx context.Context, filter filters.Filter, tasks []runtime
 			continue
 		}
 		collected := time.Now()
-		stats, err := tk.Stats(ctx)
+	        sctx, cancel := timeout.WithContext(ctx, cmetrics.ShimStatsRequestTimeout)
+                stats, err := tk.Stats(sctx)
+                cancel()
 		if err != nil {
 			if !errdefs.IsNotFound(err) {
 				log.G(ctx).WithError(err).Errorf("collecting metrics for %s", tk.ID())

--- a/plugins/services/tasks/local.go
+++ b/plugins/services/tasks/local.go
@@ -699,9 +699,9 @@ func getTasksMetrics(ctx context.Context, filter filters.Filter, tasks []runtime
 			continue
 		}
 		collected := time.Now()
-	        sctx, cancel := timeout.WithContext(ctx, cmetrics.ShimStatsRequestTimeout)
-                stats, err := tk.Stats(sctx)
-                cancel()
+		sctx, cancel := timeout.WithContext(ctx, cmetrics.ShimStatsRequestTimeout)
+		stats, err := tk.Stats(sctx)
+		cancel()
 		if err != nil {
 			if !errdefs.IsNotFound(err) {
 				log.G(ctx).WithError(err).Errorf("collecting metrics for %s", tk.ID())


### PR DESCRIPTION
## What this PR fixes

Fixes/complements #13848 (companion to #13852). PR #13852 bounds the unbounded `shim.delete()` call that can hang `containerd`'s **startup** path (`loadShims`) forever if a leftover shim never replies. This PR bounds a second, structurally identical unbounded call that we found while investigating why containerd was *also* observed hanging on the **graceful shutdown** path in the same incident described in #13848.

## Root cause

`getTasksMetrics` (`plugins/services/tasks/local.go`) is the implementation behind the Tasks service's `Metrics` RPC. It iterates every task on the node and calls `tk.Stats(ctx)` for each one, sequentially, using whatever context the caller passed in — with no timeout applied at this layer:


On the CRI side, `internal/cri/server/stats_collector.go`'s `StatsCollector` calls this RPC once a second from a background goroutine (`collectLoop`), using a bare `context.Background()`-derived context.

Put together: if even one task's shim hangs on `Stats()` (the same shim-unresponsive condition described in #13848 — sandbox already exited, shim doesn't answer a specific request), the entire per-second metrics-collection loop wedges on that one task indefinitely. Every *other* task silently stops getting metrics collected too, since the loop is sequential and never reaches them. And because `StatsCollector.Stop()` waits for that same wedged goroutine to exit, containerd's graceful shutdown (`criService.Close()` → `c.statsCollector.Stop()`) hangs for as long as the shim stays unresponsive — in practice, until `systemd`'s stop timeout gives up and sends `SIGKILL`. This matches the "Stop-side hang" behavior observed in #13848 before the node hit the (separately-fixed) startup hang on its next boot.

We also note `getTasksMetrics`'s `"collecting metrics for %s"` error log line matches log lines we independently captured from an affected production node, which is what led us to this function.

## The fix

Wrap the per-task `Stats()` call with a bounded timeout, using the timeout key containerd's own cgroups-based metrics collector (`core/metrics/cgroups/v1` and `v2`) already uses for exactly this same kind of call (`ShimStatsRequestTimeout`, `io.containerd.timeout.metrics.shimstats`, 2s default) — so this reuses an existing, already-tunable timeout rather than introducing a new config key, consistent with the approach in #13852.

```go
sctx, cancel := timeout.WithContext(ctx, cmetrics.ShimStatsRequestTimeout)
stats, err := tk.Stats(sctx)
cancel()
```

With this change, one wedged shim can no longer block metrics collection for every other task, and can no longer block `StatsCollector.Stop()` indefinitely.

