### PR TITLE
ctr: register EROFS fsview

### DIFF
--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -43,6 +43,9 @@ import (
 	versionCmd "github.com/containerd/containerd/v2/cmd/ctr/commands/version"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+
+	// Register the EROFS fsview handler for client-side OCI user resolution.
+	_ "github.com/containerd/containerd/v2/plugins/mount/fsview/erofs"
 	"github.com/containerd/containerd/v2/version"
 )
 


### PR DESCRIPTION
## Summary

`ctr` resolves named users and groups for `run --user` and
`tasks exec --user` in the client process. Although `pkg/oci` can inspect
EROFS snapshots directly through fsview, the `ctr` application does not
currently register the EROFS handler and falls back to a temporary host
mount.

Register the EROFS fsview handler with the `ctr` application. For non-EROFS
mounts, fsview skips this handler and continues through the existing built-in
handlers and mount fallback paths.

## Testing

- Ran `go test ./cmd/ctr/app ./cmd/gen-manpages ./internal/fsview`. This
  compiles the affected `ctr` application and manpage generator and runs the
  existing fsview test suite.
- Started a container using the EROFS snapshotter and
  `io.containerd.kata.v2`.
- Ran `ctr tasks exec --user nobody ... id` with baseline and patched `ctr`
  binaries. Both resolved `nobody` to UID and GID `65534`.
- Traced `ctr` using `strace -f -e mount,umount2`. The baseline binary mounted
  and unmounted a temporary `/tmp/containerd-mount*` path, while the patched
  binary issued no `mount` or `umount2` calls.
- Host mount and loop-device counts remained unchanged after the patched
  execution.