### PR TITLE
cri: delete the image ID reference first on RemoveImage

### DIFF
--- a/internal/cri/server/images/image_remove.go
+++ b/internal/cri/server/images/image_remove.go
@@ -19,6 +19,7 @@ package images
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/tracing"
@@ -54,10 +55,15 @@ func (c *CRIImageService) RemoveImage(ctx context.Context, imageSpec *runtime.Im
 		return fmt.Errorf("can not resolve %q locally: %w", imageSpec.GetImage(), err)
 	}
 	span.SetAttributes(tracing.Attribute("image.id", image.ID))
-	// Remove all image references.
-	for i, ref := range image.References {
+	// Remove all image references, the image ID reference first. It is the only
+	// reference that cannot be resolved by name, so if the removal is interrupted
+	// part way through, a leftover named reference can still be listed and removed
+	// again, whereas a leftover ID-only record is unreachable and pins the manifest,
+	// layers and snapshot chain indefinitely.
+	refs := imageIDFirst(image.References, image.ID)
+	for i, ref := range refs {
 		var opts []images.DeleteOpt
-		if i == len(image.References)-1 {
+		if i == len(refs)-1 {
 			// Delete the last image reference synchronously to trigger garbage collection.
 			// This is best effort. It is possible that the image reference is deleted by
 			// someone else before this point.
@@ -74,4 +80,17 @@ func (c *CRIImageService) RemoveImage(ctx context.Context, imageSpec *runtime.Im
 		return fmt.Errorf("failed to delete image reference %q for %q: %w", ref, image.ID, err)
 	}
 	return nil
+}
+
+// imageIDFirst returns refs with the image ID reference moved to the front, keeping
+// the relative order of the remaining references. refs is not modified.
+func imageIDFirst(refs []string, id string) []string {
+	idx := slices.Index(refs, id)
+	if idx <= 0 {
+		return refs
+	}
+	ordered := make([]string, 0, len(refs))
+	ordered = append(ordered, id)
+	ordered = append(ordered, refs[:idx]...)
+	return append(ordered, refs[idx+1:]...)
 }

--- a/internal/cri/server/images/image_remove_test.go
+++ b/internal/cri/server/images/image_remove_test.go
@@ -1,0 +1,167 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/containerd/errdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/v2/core/images"
+	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
+)
+
+// fakeImageStore records the order in which references are deleted and can fail
+// after a given number of deletions to emulate an interrupted removal.
+type fakeImageStore struct {
+	images.Store
+
+	deleted   []string
+	failAfter int
+	err       error
+}
+
+func (f *fakeImageStore) Delete(_ context.Context, name string, _ ...images.DeleteOpt) error {
+	if f.failAfter > 0 && len(f.deleted) >= f.failAfter {
+		return f.err
+	}
+	f.deleted = append(f.deleted, name)
+	return nil
+}
+
+// Get satisfies the image store Getter used to refresh the CRI image cache. Every
+// reference is reported as gone, which is the state after a successful delete.
+func (f *fakeImageStore) Get(_ context.Context, _ string) (images.Image, error) {
+	return images.Image{}, errdefs.ErrNotFound
+}
+
+const (
+	testRemoveImageID   = "sha256:c75bebcdd211f41b3a460c7bf82970ed6c75acaab9cd4c9a4e125b03ca113799"
+	testRemoveRepoTag   = "docker.io/library/busybox:latest"
+	testRemoveRepoDigst = "docker.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"
+)
+
+func addTestImage(t *testing.T, c *CRIImageService, refs []string, getter imagestore.Getter) {
+	t.Helper()
+	img := imagestore.Image{
+		ID:         testRemoveImageID,
+		ChainID:    "test-chain-id",
+		References: refs,
+	}
+	store, err := imagestore.NewFakeStoreWithGetter([]imagestore.Image{img}, getter)
+	require.NoError(t, err)
+	c.imageStore = store
+}
+
+func TestRemoveImageDeletesImageIDFirst(t *testing.T) {
+	// The image ID reference is the only one that cannot be resolved by name, so it
+	// must be removed first: an interrupted removal then always leaves a reference
+	// that can still be found and removed again.
+	c, _ := newTestCRIService()
+	fake := &fakeImageStore{}
+	c.images = fake
+
+	// References are stored sorted, which places the bare config digest last.
+	addTestImage(t, c, []string{testRemoveRepoTag, testRemoveRepoDigst, testRemoveImageID}, fake)
+
+	err := c.RemoveImage(context.Background(), &runtime.ImageSpec{Image: testRemoveImageID})
+	require.NoError(t, err)
+
+	require.Len(t, fake.deleted, 3)
+	assert.Equal(t, testRemoveImageID, fake.deleted[0], "image ID reference must be deleted first")
+	assert.ElementsMatch(t, []string{testRemoveRepoTag, testRemoveRepoDigst}, fake.deleted[1:])
+}
+
+func TestRemoveImageInterruptedLeavesNamedReference(t *testing.T) {
+	// An interrupted removal must not strand an ID-only record, which nothing can
+	// reach by name afterwards.
+	c, _ := newTestCRIService()
+	fake := &fakeImageStore{failAfter: 1, err: errors.New("context deadline exceeded")}
+	c.images = fake
+
+	addTestImage(t, c, []string{testRemoveRepoTag, testRemoveRepoDigst, testRemoveImageID}, fake)
+
+	err := c.RemoveImage(context.Background(), &runtime.ImageSpec{Image: testRemoveImageID})
+	require.Error(t, err)
+
+	require.Len(t, fake.deleted, 1)
+	assert.Equal(t, testRemoveImageID, fake.deleted[0])
+}
+
+func TestImageIDFirst(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		refs     []string
+		id       string
+		expected []string
+	}{
+		{
+			name:     "id last",
+			refs:     []string{"tag", "digest", "id"},
+			id:       "id",
+			expected: []string{"id", "tag", "digest"},
+		},
+		{
+			name:     "id already first",
+			refs:     []string{"id", "tag"},
+			id:       "id",
+			expected: []string{"id", "tag"},
+		},
+		{
+			name:     "id in the middle",
+			refs:     []string{"tag", "id", "digest"},
+			id:       "id",
+			expected: []string{"id", "tag", "digest"},
+		},
+		{
+			name:     "id absent",
+			refs:     []string{"tag", "digest"},
+			id:       "id",
+			expected: []string{"tag", "digest"},
+		},
+		{
+			name:     "only the id",
+			refs:     []string{"id"},
+			id:       "id",
+			expected: []string{"id"},
+		},
+		{
+			name:     "no references",
+			refs:     nil,
+			id:       "id",
+			expected: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			refs := slicesClone(tc.refs)
+			assert.Equal(t, tc.expected, imageIDFirst(tc.refs, tc.id))
+			assert.Equal(t, refs, tc.refs, "input must not be modified")
+		})
+	}
+}
+
+func slicesClone(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	return append([]string(nil), s...)
+}

--- a/internal/cri/server/images/image_remove_test.go
+++ b/internal/cri/server/images/image_remove_test.go
@@ -55,9 +55,9 @@ func (f *fakeImageStore) Get(_ context.Context, _ string) (images.Image, error) 
 }
 
 const (
-	testRemoveImageID   = "sha256:c75bebcdd211f41b3a460c7bf82970ed6c75acaab9cd4c9a4e125b03ca113799"
-	testRemoveRepoTag   = "docker.io/library/busybox:latest"
-	testRemoveRepoDigst = "docker.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"
+	testRemoveImageID    = "sha256:c75bebcdd211f41b3a460c7bf82970ed6c75acaab9cd4c9a4e125b03ca113799"
+	testRemoveRepoTag    = "docker.io/library/busybox:latest"
+	testRemoveRepoDigest = "docker.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"
 )
 
 func addTestImage(t *testing.T, c *CRIImageService, refs []string, getter imagestore.Getter) {
@@ -81,14 +81,14 @@ func TestRemoveImageDeletesImageIDFirst(t *testing.T) {
 	c.images = fake
 
 	// References are stored sorted, which places the bare config digest last.
-	addTestImage(t, c, []string{testRemoveRepoTag, testRemoveRepoDigst, testRemoveImageID}, fake)
+	addTestImage(t, c, []string{testRemoveRepoTag, testRemoveRepoDigest, testRemoveImageID}, fake)
 
 	err := c.RemoveImage(context.Background(), &runtime.ImageSpec{Image: testRemoveImageID})
 	require.NoError(t, err)
 
 	require.Len(t, fake.deleted, 3)
 	assert.Equal(t, testRemoveImageID, fake.deleted[0], "image ID reference must be deleted first")
-	assert.ElementsMatch(t, []string{testRemoveRepoTag, testRemoveRepoDigst}, fake.deleted[1:])
+	assert.ElementsMatch(t, []string{testRemoveRepoTag, testRemoveRepoDigest}, fake.deleted[1:])
 }
 
 func TestRemoveImageInterruptedLeavesNamedReference(t *testing.T) {
@@ -98,7 +98,7 @@ func TestRemoveImageInterruptedLeavesNamedReference(t *testing.T) {
 	fake := &fakeImageStore{failAfter: 1, err: errors.New("context deadline exceeded")}
 	c.images = fake
 
-	addTestImage(t, c, []string{testRemoveRepoTag, testRemoveRepoDigst, testRemoveImageID}, fake)
+	addTestImage(t, c, []string{testRemoveRepoTag, testRemoveRepoDigest, testRemoveImageID}, fake)
 
 	err := c.RemoveImage(context.Background(), &runtime.ImageSpec{Image: testRemoveImageID})
 	require.Error(t, err)

--- a/internal/cri/store/image/fake_image.go
+++ b/internal/cri/store/image/fake_image.go
@@ -25,7 +25,17 @@ import (
 // NewFakeStore returns an image store with predefined images.
 // Update is not allowed for this fake store.
 func NewFakeStore(images []Image) (*Store, error) {
-	s := NewStore(nil, nil, platforms.Default())
+	return newFakeStore(images, nil)
+}
+
+// NewFakeStoreWithGetter returns an image store with predefined images that
+// resolves updates through the given getter, so Update may be called.
+func NewFakeStoreWithGetter(images []Image, getter Getter) (*Store, error) {
+	return newFakeStore(images, getter)
+}
+
+func newFakeStore(images []Image, getter Getter) (*Store, error) {
+	s := NewStore(getter, nil, platforms.Default())
 	for _, i := range images {
 		for _, ref := range i.References {
 			s.refCache[ref] = i.ID


### PR DESCRIPTION
Fixes #13875

## Problem

`CRIImageService.RemoveImage` deletes an image's references one at a time and returns on the first non-`NotFound` error. The references come from the CRI image store, which keeps them sorted with `distribution/reference.Sort`. That sort ranks a bare config digest (`refRank` returns 5 for a non-`Named` reference) below every named reference, so the image ID reference is **always deleted last**.

That is the worst possible order to be interrupted in. The ID reference is the only one that cannot be resolved by name: kubelet never lists it for name-based removal, and with `deletion_threshold=0` nothing forces a collection. So an ID-only record left behind by a failed removal is unreachable, and it keeps the manifest, the layer blobs and the unpacked snapshot chain alive indefinitely.

The reporter hit this in production: a burst of image-GC removals left 241 ID-only records pinning 84.3% of a 4 GiB devmapper thin pool, with no running containers.

Note the asymmetry with the pull path, which already creates the ID reference **first** (`for _, r := range []string{imageID, repoTag, repoDigest}` in `image_pull.go`).

## Fix

Delete the ID reference first, keeping the relative order of the rest. Any reference that survives an interrupted removal is then still a named one, so it can be listed and removed again. The synchronous delete that triggers garbage collection stays on the last reference, so GC still runs once all references are gone.

This does not make the removal atomic — that would be a larger change in the image store — but it removes the failure mode where the interruption strands the one record nothing can reach.

## Testing

`internal/cri/server/images/image_remove_test.go` (new):

- `TestRemoveImageDeletesImageIDFirst` — the ID reference is deleted before the named ones.
- `TestRemoveImageInterruptedLeavesNamedReference` — when the second delete fails, the ID reference is already gone and only named references remain.
- `TestImageIDFirst` — table test for the ordering helper, including that it does not mutate its input.

Both `RemoveImage` tests fail on `main` (they observe `docker.io/library/busybox:latest` deleted first) and pass with this change.

`RemoveImage` calls `imageStore.Update`, which the existing `NewFakeStore` explicitly does not support ("Update is not allowed for this fake store"). I added `NewFakeStoreWithGetter` alongside it rather than changing the existing helper, so its current callers are untouched.

`go test ./internal/cri/server/images/... ./internal/cri/store/image/...` passes, along with `go build ./internal/cri/...` and `go vet`.

I could not reproduce the production strand locally — as the issue notes, it needs real contention to make the server-side loop actually abort mid-way — so the tests drive the interruption through a fake image store instead.