### PR TITLE
core/remotes/docker: don't send credentials on cross-host redirects

### DIFF
--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -669,9 +669,12 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 			}
 			// Credentials belong to the host and scheme the request was created
 			// for, so a redirect that changes either is followed without them.
-			// This mirrors how the pusher drops the authorizer when an upload
-			// location changes host or scheme.
+			// net/http only strips the Authorization header when the host
+			// changes, so drop it explicitly to also cover a scheme change on
+			// the same host. This mirrors how the pusher drops the authorizer
+			// when an upload location changes host or scheme.
 			if req.URL.Host != r.host.Host || req.URL.Scheme != r.host.Scheme {
+				req.Header.Del("Authorization")
 				return nil
 			}
 			if err := r.authorize(ctx, req); err != nil {

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -667,10 +667,11 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 			if len(via) >= 10 {
 				return errors.New("stopped after 10 redirects")
 			}
-			// Credentials belong to the host the request was created for, so a
-			// redirect elsewhere is followed without them. This mirrors how the
-			// pusher drops the authorizer when an upload location changes host.
-			if req.URL.Host != r.host.Host {
+			// Credentials belong to the host and scheme the request was created
+			// for, so a redirect that changes either is followed without them.
+			// This mirrors how the pusher drops the authorizer when an upload
+			// location changes host or scheme.
+			if req.URL.Host != r.host.Host || req.URL.Scheme != r.host.Scheme {
 				return nil
 			}
 			if err := r.authorize(ctx, req); err != nil {

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -667,6 +667,12 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 			if len(via) >= 10 {
 				return errors.New("stopped after 10 redirects")
 			}
+			// Credentials belong to the host the request was created for, so a
+			// redirect elsewhere is followed without them. This mirrors how the
+			// pusher drops the authorizer when an upload location changes host.
+			if req.URL.Host != r.host.Host {
+				return nil
+			}
 			if err := r.authorize(ctx, req); err != nil {
 				return fmt.Errorf("failed to authorize redirect: %w", err)
 			}

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -1804,7 +1804,7 @@ func TestResolveForbiddenGETFallbackNetworkError(t *testing.T) {
 }
 
 // TestRedirectAuthorization verifies that credentials are only attached to a
-// redirect that stays on the host the request was created for.
+// redirect that stays on the host and scheme the request was created for.
 func TestRedirectAuthorization(t *testing.T) {
 	const (
 		user   = "totallyvaliduser"
@@ -1858,6 +1858,66 @@ func TestRedirectAuthorization(t *testing.T) {
 		defer mu.Unlock()
 		if len(authSeen) > 0 {
 			t.Fatalf("credentials sent to redirect target on another host: %v", authSeen)
+		}
+	})
+
+	t.Run("scheme downgrade", func(t *testing.T) {
+		// A redirect from https to http on the same host keeps the
+		// Authorization header as far as net/http is concerned, so the
+		// redirect hook has to strip it. Both schemes are served from a
+		// single stub transport since one listener cannot speak both.
+		var (
+			mu       sync.Mutex
+			authSeen []string
+		)
+		const host = "registry.example.com"
+		rt := rtFunc(func(req *http.Request) (*http.Response, error) {
+			resp := &http.Response{
+				Header:  http.Header{},
+				Body:    http.NoBody,
+				Request: req,
+			}
+			if req.URL.Scheme == "http" {
+				mu.Lock()
+				if a := req.Header.Get("Authorization"); a != "" {
+					authSeen = append(authSeen, a)
+				}
+				mu.Unlock()
+				resp.StatusCode = http.StatusUnauthorized
+				resp.Header.Set("WWW-Authenticate", `Basic realm="downgraded"`)
+				return resp, nil
+			}
+			if req.Header.Get("Authorization") == "" {
+				resp.StatusCode = http.StatusUnauthorized
+				resp.Header.Set("WWW-Authenticate", `Basic realm="registry"`)
+				return resp, nil
+			}
+			resp.StatusCode = http.StatusFound
+			resp.Header.Set("Location", "http://"+host+req.URL.Path)
+			return resp, nil
+		})
+
+		resolver := NewResolver(ResolverOptions{
+			Hosts: func(string) ([]RegistryHost, error) {
+				return []RegistryHost{{
+					Client:       &http.Client{Transport: rt},
+					Host:         host,
+					Scheme:       "https",
+					Path:         "/v2",
+					Capabilities: HostCapabilityPull | HostCapabilityResolve,
+					Authorizer:   NewDockerAuthorizer(WithAuthCreds(creds)),
+				}}, nil
+			},
+		})
+
+		if _, _, err := resolver.Resolve(context.Background(), host+"/somerepo:sometag"); err == nil {
+			t.Fatal("expected resolve to fail")
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(authSeen) > 0 {
+			t.Fatalf("credentials sent over downgraded scheme: %v", authSeen)
 		}
 	})
 

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1800,4 +1801,110 @@ func TestResolveForbiddenGETFallbackNetworkError(t *testing.T) {
 	if !strings.Contains(err.Error(), "403") {
 		t.Errorf("expected 403 in error, got: %s", err.Error())
 	}
+}
+
+// TestRedirectAuthorization verifies that credentials are only attached to a
+// redirect that stays on the host the request was created for.
+func TestRedirectAuthorization(t *testing.T) {
+	const (
+		user   = "totallyvaliduser"
+		secret = "totallyvalidpassword"
+	)
+	creds := func(string) (string, string, error) {
+		return user, secret, nil
+	}
+	content := newContent(ocispec.MediaTypeImageManifest, []byte("not anything parse-able"))
+
+	t.Run("other host", func(t *testing.T) {
+		var (
+			mu       sync.Mutex
+			authSeen []string
+		)
+		other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			if a := r.Header.Get("Authorization"); a != "" {
+				authSeen = append(authSeen, a)
+			}
+			mu.Unlock()
+			w.Header().Set("WWW-Authenticate", `Basic realm="other"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer other.Close()
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, other.URL+r.URL.Path, http.StatusFound)
+		}))
+		defer s.Close()
+
+		base := s.URL[len("http://"):]
+		resolver := NewResolver(ResolverOptions{
+			Hosts: func(host string) ([]RegistryHost, error) {
+				return []RegistryHost{{
+					Client:       s.Client(),
+					Host:         host,
+					Scheme:       "http",
+					Path:         "/v2",
+					Capabilities: HostCapabilityPull | HostCapabilityResolve,
+					Authorizer:   NewDockerAuthorizer(WithAuthCreds(creds)),
+				}}, nil
+			},
+		})
+
+		if _, _, err := resolver.Resolve(context.Background(), base+"/somerepo:sometag"); err == nil {
+			t.Fatal("expected resolve to fail")
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(authSeen) > 0 {
+			t.Fatalf("credentials sent to redirect target on another host: %v", authSeen)
+		}
+	})
+
+	t.Run("same host", func(t *testing.T) {
+		var (
+			mu            sync.Mutex
+			authenticated bool
+		)
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if u, p, ok := r.BasicAuth(); !ok || u != user || p != secret {
+				w.Header().Set("WWW-Authenticate", `Basic realm="same"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			if strings.HasSuffix(r.URL.Path, "/sometag") {
+				http.Redirect(w, r, "/v2/somerepo/manifests/redirected", http.StatusFound)
+				return
+			}
+			mu.Lock()
+			authenticated = true
+			mu.Unlock()
+			content.ServeHTTP(w, r)
+		}))
+		defer s.Close()
+
+		base := s.URL[len("http://"):]
+		resolver := NewResolver(ResolverOptions{
+			Hosts: func(host string) ([]RegistryHost, error) {
+				return []RegistryHost{{
+					Client:       s.Client(),
+					Host:         host,
+					Scheme:       "http",
+					Path:         "/v2",
+					Capabilities: HostCapabilityPull | HostCapabilityResolve,
+					Authorizer:   NewDockerAuthorizer(WithAuthCreds(creds)),
+				}}, nil
+			},
+		})
+
+		if _, _, err := resolver.Resolve(context.Background(), base+"/somerepo:sometag"); err != nil {
+			t.Fatal(err)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if !authenticated {
+			t.Fatal("redirect on the same host was not authorized")
+		}
+	})
 }


### PR DESCRIPTION
The resolver installs a CheckRedirect hook on the HTTP client so it can re-run the authorizer on each hop of a redirect. net/http already strips the Authorization header when a redirect leaves the original host, and that hook puts it back for whichever host the redirect names, provided the authorizer has a handler cached for it. A registry can arrange exactly that: answer a manifest request with a 302 to a host it controls, let that host reply 401 with a Basic challenge, and AddResponses keys the challenge on the redirect target because net/http has rewritten resp.Request to the final hop, so it asks the credential callback for that host and caches a handler under it. The retry follows the same redirect and the credentials go out to a host the operator never configured, which I confirmed with a pair of test servers where the pull secret showed up as a Basic header on the second one. Skipping authorization once the redirect leaves the host the request was built for keeps the hook useful for same-host redirects and leaves blob redirects to object storage alone, since those are pre-signed and never had a handler cached anyway. The pusher already works this way, dropping the authorizer when an upload location changes host, so this brings the resolver in line with it.