### PR TITLE
cri: skip failed container instead of dropping entire sandbox metrics

### DIFF
--- a/internal/cri/server/list_pod_sandbox_metrics_linux.go
+++ b/internal/cri/server/list_pod_sandbox_metrics_linux.go
@@ -109,7 +109,7 @@ func (c *criService) ListPodSandboxMetrics(ctx context.Context, r *runtime.ListP
 					case errdefs.IsUnavailable(err), errdefs.IsNotFound(err):
 						log.G(gctx).WithField("podsandboxid", sandbox.ID).WithField("containerid", container.ID).WithError(err).Error("failed to get container metrics, this is likely a transient error")
 						// Don't return error for transient issues, just log and continue
-						return nil
+						continue
 					case errdefs.IsCanceled(err):
 						log.G(gctx).WithField("podsandboxid", sandbox.ID).WithField("containerid", container.ID).WithError(err).Debug("metrics collection cancelled")
 						// Return the cancellation error to stop other goroutines
@@ -117,7 +117,7 @@ func (c *criService) ListPodSandboxMetrics(ctx context.Context, r *runtime.ListP
 					default:
 						log.G(gctx).WithField("podsandboxid", sandbox.ID).WithField("containerid", container.ID).WithError(err).Error("failed to collect container metrics")
 						// Don't return error for individual failures, just log and continue
-						return nil
+						continue
 					}
 				}
 


### PR DESCRIPTION
In `ListPodSandboxMetrics`, when `collectContainerMetrics` fails for any
container in a sandbox, the goroutine uses `return nil` to handle the error.
This exits the goroutine entirely, so the sandbox's metrics (including
pod-level network metrics and any successfully collected container metrics)
are never appended to the response. The comments say "just log and continue"
but `return nil` does not continue the loop.

This causes entire pods to silently disappear from `/metrics/cadvisor` when
the kubelet uses the `PodAndContainerStatsFromCRI` feature gate. A single
container whose task is momentarily unavailable (e.g., during a restart)
drops all metrics for the pod.

This was observed in [kubernetes/kubernetes#140786](https://github.com/kubernetes/kubernetes/pull/140786)
where a CRI container metrics e2e test failed because all container-level
metrics were missing for the test pods.

The [containerd.log](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/140786/pull-kubernetes-node-e2e-containerd-alpha-features/2083246937322033152/artifacts/tmp-node-e2e-cd7832b2-cos-129-19506-299-60/containerd.log)
from the CI run shows 23 occurrences of this error, each one causing the
entire sandbox's metrics to be dropped:

```
Jul 31 17:53:39 containerd[1296]: level=error msg="failed to get container metrics, this is likely a transient error"
    containerid=f033200dbd4c error="failed to get task for container f033200dbd4c: no running task found:
    task f033200dbd4c not found" podsandboxid=02fb600b65eb

Jul 31 17:53:39 containerd[1296]: level=error msg="failed to get container metrics, this is likely a transient error"
    containerid=aca1b703f6ce error="failed to get task for container aca1b703f6ce: no running task found:
    task aca1b703f6ce not found" podsandboxid=92c225bdb4e5

Jul 31 17:54:25 containerd[1296]: level=error msg="failed to get container metrics, this is likely a transient error"
    containerid=c4a42ecea761 error="failed to get task for container c4a42ecea761: no running task found:
    container not created: not found" podsandboxid=9bb8daab77e6
```

Each of these errors triggers `return nil`, which exits the sandbox's
goroutine before appending `sandboxMetrics` to the response. The test
retried for 60 seconds and never saw the pods' metrics appear.

Full CI logs: [pull-kubernetes-node-e2e-containerd-alpha-features #2083246937322033152](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/140786/pull-kubernetes-node-e2e-containerd-alpha-features/2083246937322033152)

The fix replaces `return nil` with `continue` in the two affected error
cases (`IsUnavailable`/`IsNotFound` and `default`), so that individual
container failures skip only that container. The `IsCanceled` case is left
unchanged since cancellation should stop the goroutine.

```release-note
Avoid dropping pod sandbox metrics when collecting metrics for an individual container fails
```
