### PR TITLE
core/remotes/docker: bound Range header for parallel fetch chunks

### DIFF
--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -553,7 +553,24 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 							}
 							defer r.Release(1)
 							reqClone := req.clone()
-							reqClone.setOffset(offset + i*chunkSize)
+							// Request only this chunk's bytes (bounded range)
+							// rather than an open-ended range from the start
+							// offset to the end of the blob. Since this
+							// goroutine only ever reads chunkSize bytes from
+							// the response before closing it (see
+							// io.LimitReader below), an open-ended range
+							// causes a well-behaved server to prepare and
+							// start streaming the entire remainder of the
+							// blob for every chunk, only for the connection
+							// to be closed early once this chunk's bytes are
+							// read - wasting server-side bandwidth/CPU that
+							// scales with the number of chunks.
+							start := offset + i*chunkSize
+							end := start + chunkSize - 1
+							if last := offset + remaining - 1; end > last {
+								end = last
+							}
+							reqClone.setRange(start, end)
 							nresp, err := reqClone.doWithRetries(ctx, lastHost, withErrorCheck)
 							if err != nil {
 								_ = writers[i].CloseWithError(err)

--- a/core/remotes/docker/fetcher_test.go
+++ b/core/remotes/docker/fetcher_test.go
@@ -293,6 +293,92 @@ func TestFetcherOpenParallel(t *testing.T) {
 	assert.Error(t, err, "this should have failed")
 }
 
+// TestFetcherOpenParallelUsesBoundedRange is a regression test for
+// https://github.com/containerd/containerd/issues/12476: parallel chunked
+// requests (chunk index >= 1) used to send an open-ended Range header
+// ("bytes=<offset>-") even though the goroutine only ever reads chunkSize
+// bytes from the response before closing it. A well-behaved server honors
+// an open-ended range by streaming everything from the offset to the end
+// of the blob, so every chunk beyond the first wasted server-side
+// bandwidth/CPU preparing data the client would immediately discard after
+// its chunkSize bytes. This asserts every non-initial chunk request now
+// carries an explicit, bounded end in its Range header.
+func TestFetcherOpenParallelUsesBoundedRange(t *testing.T) {
+	const chunkSize = 64 * 1024
+	const numChunks = 3
+	size := int64(numChunks * chunkSize)
+	content := make([]byte, size)
+	rand.New(rand.NewSource(2)).Read(content)
+
+	var mu sync.Mutex
+	var ranges []string
+
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rangeHeader := r.Header.Get("Range")
+		mu.Lock()
+		ranges = append(ranges, rangeHeader)
+		mu.Unlock()
+
+		rng, err := parseRange(rangeHeader, size)
+		if errors.Is(err, errNoOverlap) {
+			err = nil
+		}
+		require.NoError(t, err)
+		if len(rng) == 0 {
+			rw.Header().Set("content-length", strconv.Itoa(len(content)))
+			_, _ = rw.Write(content)
+			return
+		}
+		b := content[rng[0].start : rng[0].start+rng[0].length]
+		rw.Header().Set("content-range", rng[0].contentRange(size))
+		rw.Header().Set("content-length", strconv.Itoa(len(b)))
+		_, _ = rw.Write(b)
+	}))
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err)
+
+	f := dockerFetcher{
+		&dockerBase{
+			repository: "nonempty",
+			performances: transfer.ImageResolverPerformanceSettings{
+				MaxConcurrentDownloads:     numChunks,
+				ConcurrentLayerFetchBuffer: chunkSize,
+			},
+			limiter: semaphore.NewWeighted(numChunks),
+		},
+	}
+	host := RegistryHost{
+		Client: s.Client(),
+		Host:   u.Host,
+		Scheme: u.Scheme,
+		Path:   u.Path,
+	}
+	req := f.request(host, http.MethodGet)
+
+	rc, _, err := f.open(context.Background(), req, "", 0, true)
+	require.NoError(t, err)
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	require.Equal(t, content, got)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, ranges, numChunks)
+	for i, rangeHeader := range ranges {
+		if i == 0 {
+			// The very first request doesn't yet know the total size, so
+			// it's necessarily open-ended - that's how the total size is
+			// discovered in the first place.
+			continue
+		}
+		require.NotEmpty(t, rangeHeader, "chunk %d: expected a Range header", i)
+		require.Falsef(t, strings.HasSuffix(rangeHeader, "-"), "chunk %d: Range header %q must specify an explicit end, not be open-ended", i, rangeHeader)
+	}
+}
+
 func TestFetcherOpenParallel_CloseAfterCopyError(t *testing.T) {
 	size := int64(10 * 1024 * 1024)
 	content := make([]byte, size)

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -905,6 +905,17 @@ func (r *request) setOffset(offset int64) {
 	r.header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
 }
 
+// setRange sets an explicit, bounded byte range (inclusive on both ends),
+// unlike setOffset's open-ended "from offset to the end of the resource".
+// This is used when the caller already knows exactly how many bytes it
+// wants (e.g. a single chunk of a parallel download), so a well-behaved
+// server can respond with just that range instead of streaming everything
+// from start to the end of the resource only for the client to discard the
+// remainder after reading its chunk.
+func (r *request) setRange(start, end int64) {
+	r.header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+}
+
 func requestFields(req *http.Request) log.Fields {
 	fields := map[string]any{
 		"request.method": req.Method,

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -764,6 +764,29 @@ func TestRequestSanitize(t *testing.T) {
 	}
 }
 
+// TestRequestSetRange is a regression test for
+// https://github.com/containerd/containerd/issues/12476: parallel chunked
+// downloads (concurrent_layer_fetch_buffer) issued an open-ended Range
+// header ("bytes=<offset>-") for every chunk, even though each chunk
+// request only ever reads a bounded number of bytes before closing the
+// response. An open-ended range lets a well-behaved server prepare and
+// stream the entire remainder of the blob for every single chunk, wasting
+// bandwidth that scales with the number of chunks. setRange must produce an
+// explicit, bounded "bytes=<start>-<end>" range instead.
+func TestRequestSetRange(t *testing.T) {
+	r := &request{header: http.Header{}}
+
+	r.setOffset(100)
+	if got, want := r.header.Get("Range"), "bytes=100-"; got != want {
+		t.Fatalf("setOffset: unexpected Range header %q, want %q", got, want)
+	}
+
+	r.setRange(100, 199)
+	if got, want := r.header.Get("Range"), "bytes=100-199"; got != want {
+		t.Fatalf("setRange: unexpected Range header %q, want %q", got, want)
+	}
+}
+
 type fakeTimeoutErr struct{}
 
 func (fakeTimeoutErr) Error() string   { return "fake timeout" }


### PR DESCRIPTION
Fixes #12476

## What this PR does / why we need it

When `concurrent_layer_fetch_buffer` (`ConcurrentLayerFetchBuffer`) and `MaxConcurrentDownloads` are configured, `dockerFetcher.open` (`core/remotes/docker/fetcher.go`) splits a blob download into fixed-size chunks and fetches them in parallel. For every chunk beyond the first, it issues a new request via `reqClone.setOffset(offset + i*chunkSize)`, which sets:

```
Range: bytes=<offset>-
```

This is an *open-ended* range — per RFC 7233 it asks the server for everything from `offset` to the end of the resource, not just one chunk's worth. But the goroutine handling that chunk only ever reads `chunkSize` bytes from the response before closing it:

```go
_, err := io.Copy(writers[i], io.LimitReader(body, chunkSize))
_ = body.Close()
```

A well-behaved server (in particular most object-storage-backed registries, which honor Range headers precisely) responds to the open-ended range by preparing and starting to stream the *entire remainder* of the blob, only for the connection to be closed early once this chunk's `chunkSize` bytes have been read. This happens once per chunk, so the amount of data the server prepares/streams (and then has discarded via early connection close) scales with the number of chunks rather than the blob size — for a large blob split into many chunks, this can mean a large multiple of the actual blob size in server-side bandwidth, as the original report on #12476 suspected (verified against a packet capture showing exactly this `Range: bytes=8388608-` / `Range: bytes=16777216-` pattern with `concurrent_layer_fetch_buffer=8388608`).

## Fix

- Added `request.setRange(start, end int64)` in `core/remotes/docker/resolver.go`, which sets an explicit, bounded `Range: bytes=<start>-<end>` header, alongside the existing open-ended `setOffset`.
- In `dockerFetcher.open`'s parallel-chunk loop, chunk indices `>= 1` now use `setRange` with `start = offset + i*chunkSize` and `end` capped at the resource's last byte (`offset + remaining - 1`), so the final (possibly short) chunk doesn't request past the end of the blob.
- Chunk index `0` is unchanged: it reuses the *initial* request/response (`ibody`), which is necessarily open-ended, since that's the very request used to discover the resource's total remaining size (`remaining = resp.ContentLength`) in the first place — there's nothing to bound it against yet.

## Testing

- `TestRequestSetRange` (`core/remotes/docker/resolver_test.go`): confirms `setRange` produces `bytes=<start>-<end>`, distinct from `setOffset`'s open-ended `bytes=<offset>-`.
- `TestFetcherOpenParallelUsesBoundedRange` (`core/remotes/docker/fetcher_test.go`): drives a real parallel chunked fetch through `dockerFetcher.open` against an `httptest` server, capturing every `Range` header received, and asserts every chunk beyond the first has an explicit, non-open-ended range.

Verified via `git stash` that reverting only `resolver.go`/`fetcher.go` (keeping the new tests) fails to *compile* (`setRange` undefined) — a clear demonstration this protection didn't exist before. Restoring the fix makes both new tests pass, and the pre-existing `TestFetcherOpenParallel` (which already exercises multiple chunk/offset/retry scenarios against a fake server) continues to pass unchanged.

`go build ./core/remotes/...`, `go vet ./core/remotes/docker/...`, and `go test ./core/remotes/docker/` all pass with no regressions.
