### PR TITLE
Prepare release notes for api/v1.12.0-beta.0

### DIFF
--- a/api/releases/v1.12.0-beta.toml
+++ b/api/releases/v1.12.0-beta.toml
@@ -1,0 +1,16 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+sub_path = "api"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "api/v1.11.0"
+
+pre_release = true
+
+preface = """\
+The 13th release for the containerd 1.x API aligns with the containerd 2.4 release.
+"""


### PR DESCRIPTION
Part of the v2.4 beta process

----

containerd api/v1.12.0-beta.0

Welcome to the api/v1.12.0-beta.0 release of containerd!  
*This is a pre-release of containerd*

The 13th release for the containerd 1.x API aligns with the containerd 2.4 release.

### Highlights

* **Include media type in content create event** ([#13833](https://github.com/containerd/containerd/pull/13833))
* **Add parent path to runc checkpoint options** ([#13699](https://github.com/containerd/containerd/pull/13699))

#### Deprecations

* **Fix sandbox task API endpoints for non-runc runtimes** ([#13360](https://github.com/containerd/containerd/pull/13360))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Maksym Pavlenko
* Jordan Liggitt
* Samuel Karp
* Wei Fu
* Kohei Tokunaga
* Philip Laine
* Sergey Kanzhelev

### Changes
<details><summary>14 commits</summary>
<p>

* Include media type in content create event ([#13833](https://github.com/containerd/containerd/pull/13833))
  * [`a452c2e23`](https://github.com/containerd/containerd/commit/a452c2e2304d43f48299ed2663ed82673b25be81) Include media type in content create event
* build(deps): bump golang.org/x/net from 0.51.0 to 0.55.0 in /api ([#13819](https://github.com/containerd/containerd/pull/13819))
  * [`52c5f1f64`](https://github.com/containerd/containerd/commit/52c5f1f64e2184af56f3550940db29ccdb94e576) build(deps): bump golang.org/x/net from 0.51.0 to 0.55.0 in /api
* build(deps): bump github.com/containerd/ttrpc to v1.2.9 ([#13740](https://github.com/containerd/containerd/pull/13740))
  * [`658a1c78b`](https://github.com/containerd/containerd/commit/658a1c78b52e25002c9c26a504055c8d3af09ea3) build(deps): bump github.com/containerd/ttrpc to v1.2.9
* Add parent path to runc checkpoint options ([#13699](https://github.com/containerd/containerd/pull/13699))
  * [`ea0ed51e2`](https://github.com/containerd/containerd/commit/ea0ed51e2101448874215c0de945197a1cafdea4) shim: allow specifying runc's --parent-path during checkpointing
* Update typeurl/v2 to v2.3.0 to drop gogo dependency ([#13490](https://github.com/containerd/containerd/pull/13490))
  * [`ce3914324`](https://github.com/containerd/containerd/commit/ce39143249b595d2b275e47c279c129f67e3a2a9) Update typeurl/v2 to v2.3.0 to drop gogo dependency
* do not hide linitng errors ([#13423](https://github.com/containerd/containerd/pull/13423))
  * [`7f10e9eb5`](https://github.com/containerd/containerd/commit/7f10e9eb5fe3b6e89438fd4806f75bcddfbf576e) do not hide linitng errors
* Fix sandbox task API endpoints for non-runc runtimes ([#13360](https://github.com/containerd/containerd/pull/13360))
  * [`ac01ae5c2`](https://github.com/containerd/containerd/commit/ac01ae5c2766961c3592523ab679dc06ca73c331) protos: include task API address to CreateTaskRequest
</p>
</details>

### Dependency Changes

* **github.com/containerd/ttrpc**                v1.2.5 -> v1.2.9
* **github.com/containerd/typeurl/v2**           v2.1.1 -> v2.3.0
* **golang.org/x/net**                           v0.48.0 -> v0.55.0
* **golang.org/x/sys**                           v0.39.0 -> v0.46.0
* **golang.org/x/text**                          v0.32.0 -> v0.37.0
* **google.golang.org/genproto/googleapis/rpc**  ff82c1b0f217 -> a57be14db171
* **google.golang.org/grpc**                     v1.79.3 -> v1.81.1
* **google.golang.org/protobuf**                 v1.36.10 -> v1.36.11

Previous release can be found at [api/v1.11.0](https://github.com/containerd/containerd/releases/tag/api/v1.11.0)

