### PR TITLE
erofs: serve layer content cache on parented Prepare

### DIFF
--- a/core/unpack/unpacker_test.go
+++ b/core/unpack/unpacker_test.go
@@ -266,18 +266,22 @@ func (a failApplier) Apply(_ context.Context, desc ocispec.Descriptor, _ []mount
 	return ocispec.Descriptor{}, nil
 }
 
-// TestUnpackStagedLayers verifies that when the snapshotter reports layers as
-// staged (read-only mounts from Prepare) in parallel mode, the unpacker skips
-// fetch+apply but still commits each layer, rebasing the real parent in at
-// Commit time.
-func TestUnpackStagedLayers(t *testing.T) {
+// unpackStaged unpacks an image of nLayers staged layers and returns the
+// snapshotter's recorded calls together with the layer chainIDs. A staged layer
+// must never be fetched or applied, which the fake handler and applier enforce.
+func unpackStaged(t *testing.T, nLayers int, opts ...UnpackerOpt) (*stagedSnapshotter, []digest.Digest) {
+	t.Helper()
 	ctx := context.Background()
 
-	diffIDs := generateRandomDiffIDs(t, 2)
+	diffIDs := generateRandomDiffIDs(t, nLayers)
 	chainIDs := identity.ChainIDs(append([]digest.Digest{}, diffIDs...))
-	layers := []ocispec.Descriptor{
-		{MediaType: ocispec.MediaTypeImageLayerGzip, Digest: digest.FromString("layer-0"), Size: 1},
-		{MediaType: ocispec.MediaTypeImageLayerGzip, Digest: digest.FromString("layer-1"), Size: 1},
+	layers := make([]ocispec.Descriptor, nLayers)
+	for i := range layers {
+		layers[i] = ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageLayerGzip,
+			Digest:    digest.FromString(fmt.Sprintf("layer-%d", i)),
+			Size:      1,
+		}
 	}
 
 	cs := imagetest.NewContentStore(ctx, t)
@@ -292,24 +296,29 @@ func TestUnpackStagedLayers(t *testing.T) {
 	}).Descriptor
 
 	sn := &stagedSnapshotter{}
-	u, err := NewUnpacker(ctx, cs.Store,
-		WithUnpackLimiter(semaphore.NewWeighted(4)),
-		WithUnpackPlatform(Platform{
-			Platform:                platforms.All,
-			Snapshotter:             sn,
-			Applier:                 failApplier{t},
-			SnapshotterCapabilities: []string{snapshots.RebaseCap},
-		}),
-	)
+	u, err := NewUnpacker(ctx, cs.Store, append(opts, WithUnpackPlatform(Platform{
+		Platform:                platforms.All,
+		Snapshotter:             sn,
+		Applier:                 failApplier{t},
+		SnapshotterCapabilities: []string{snapshots.RebaseCap},
+	}))...)
 	require.NoError(t, err)
 
-	// A staged layer must never be fetched.
 	fetch := images.HandlerFunc(func(_ context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		t.Errorf("fetch must not happen for a staged layer (%s)", desc.Digest)
 		return nil, nil
 	})
 
 	require.NoError(t, u.unpack(fetch, config, layers))
+	return sn, chainIDs
+}
+
+// TestUnpackStagedLayers verifies that when the snapshotter reports layers as
+// staged (read-only mounts from Prepare) in parallel mode, the unpacker skips
+// fetch+apply but still commits each layer, rebasing the real parent in at
+// Commit time.
+func TestUnpackStagedLayers(t *testing.T) {
+	sn, chainIDs := unpackStaged(t, 2, WithUnpackLimiter(semaphore.NewWeighted(4)))
 
 	// Parallel mode: Prepare gets no parent...
 	require.Len(t, sn.prepares, 2)
@@ -398,4 +407,26 @@ func TestUnpackParallelPrepareError(t *testing.T) {
 	// The layer prepared before the failure is still committed.
 	require.Len(t, sn.commits, 1)
 	assert.Equal(t, chainIDs[0].String(), sn.commits[0].name)
+}
+
+// TestUnpackStagedSequential verifies that a snapshotter which stages a layer on
+// a parented Prepare (as the erofs layer content cache does) is handled on the
+// staged path in sequential mode too: no fetch, no apply, and a plain Commit
+// whose parent came in at Prepare time.
+func TestUnpackStagedSequential(t *testing.T) {
+	// No unpack limiter, so layers are unpacked sequentially.
+	sn, chainIDs := unpackStaged(t, 3)
+
+	// Sequential mode: the parent is passed to Prepare...
+	require.Len(t, sn.prepares, 3)
+	assert.Equal(t, "", sn.prepares[0].parent)
+	assert.Equal(t, chainIDs[0].String(), sn.prepares[1].parent)
+	assert.Equal(t, chainIDs[1].String(), sn.prepares[2].parent)
+
+	// ...so Commit does not rebase one in, and the chain is still linked.
+	require.Len(t, sn.commits, 3)
+	for i, c := range sn.commits {
+		assert.Equal(t, chainIDs[i].String(), c.name)
+		assert.Equal(t, "", c.parent, "a sequentially staged layer is committed without WithParent")
+	}
 }

--- a/internal/erofsutils/mount.go
+++ b/internal/erofsutils/mount.go
@@ -19,6 +19,7 @@ package erofsutils
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -206,6 +207,22 @@ func MountsToLayer(mounts []mount.Mount) (string, error) {
 		return "", fmt.Errorf("mount layer type must be erofs-layer: %w", errdefs.ErrNotImplemented)
 	}
 	return layer, nil
+}
+
+// StagedLayerBlob reports whether the layer directory's blob was staged from a
+// layer content cache, which makes it a symlink into that operator-owned cache
+// and shared with every other snapshot of the layer. Such a blob must never be
+// written to.
+func StagedLayerBlob(layer string) (bool, error) {
+	layerBlob := filepath.Join(layer, "layer.erofs")
+	fi, err := os.Lstat(layerBlob)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to stat layer blob %q: %w", layerBlob, err)
+	}
+	return fi.Mode()&os.ModeSymlink != 0, nil
 }
 
 // SupportGenerateFromTar checks if the installed version of mkfs.erofs supports

--- a/internal/erofsutils/mount_test.go
+++ b/internal/erofsutils/mount_test.go
@@ -17,11 +17,15 @@
 package erofsutils
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/v2/core/mount"
 )
 
 func TestCacheBlobPath(t *testing.T) {
@@ -34,4 +38,51 @@ func TestCacheBlobPath(t *testing.T) {
 	want := filepath.Join("/cache", "sha256", enc[:2], enc+".erofs")
 	assert.Equal(t, want, got)
 	assert.Equal(t, enc[:2], filepath.Base(filepath.Dir(got)), "blob must live under a 2-char prefix dir")
+}
+
+// TestStagedLayerBlob covers detection of a blob staged from the layer content
+// cache: it is a symlink shared with every other snapshot of that layer, so the
+// differ must refuse to write it, unlike a regular blob it wrote itself.
+func TestStagedLayerBlob(t *testing.T) {
+	layer := t.TempDir()
+
+	// No blob yet.
+	staged, err := StagedLayerBlob(layer)
+	require.NoError(t, err)
+	assert.False(t, staged)
+
+	// A regular layer blob, written by the erofs differ.
+	blob := filepath.Join(layer, "layer.erofs")
+	require.NoError(t, os.WriteFile(blob, nil, 0644))
+	staged, err = StagedLayerBlob(layer)
+	require.NoError(t, err)
+	assert.False(t, staged)
+
+	// A staged one.
+	cached := filepath.Join(t.TempDir(), "cached.erofs")
+	require.NoError(t, os.WriteFile(cached, []byte("shared blob"), 0644))
+	require.NoError(t, os.Remove(blob))
+	require.NoError(t, os.Symlink(cached, blob))
+	staged, err = StagedLayerBlob(layer)
+	require.NoError(t, err)
+	assert.True(t, staged)
+}
+
+// TestMountsToLayerStagedBlob covers that resolving the layer directory is
+// unaffected by a staged blob: Compare only reads from it, so refusing belongs
+// on the apply path, not here.
+func TestMountsToLayerStagedBlob(t *testing.T) {
+	layer := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(layer, ".erofslayer"), nil, 0644))
+	cached := filepath.Join(t.TempDir(), "cached.erofs")
+	require.NoError(t, os.WriteFile(cached, []byte("shared blob"), 0644))
+	require.NoError(t, os.Symlink(cached, filepath.Join(layer, "layer.erofs")))
+
+	got, err := MountsToLayer([]mount.Mount{{
+		Type:    "erofs",
+		Source:  filepath.Join(layer, "layer.erofs"),
+		Options: []string{"ro"},
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, layer, got)
 }

--- a/plugins/diff/erofs/differ.go
+++ b/plugins/diff/erofs/differ.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -148,6 +149,17 @@ func (s erofsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []
 	layer, err := erofsutils.MountsToLayer(mounts)
 	if err != nil {
 		return emptyDesc, err
+	}
+
+	// A staged blob is shared with every other snapshot of that layer, so
+	// applying would truncate the cache entry through the symlink. Callers are
+	// expected to notice the read-only mounts and skip the layer entirely.
+	staged, err := erofsutils.StagedLayerBlob(layer)
+	if err != nil {
+		return emptyDesc, err
+	}
+	if staged {
+		return emptyDesc, fmt.Errorf("layer %q is already populated from the layer content cache: %w", layer, errdefs.ErrFailedPrecondition)
 	}
 
 	ra, err := s.store.ReaderAt(ctx, desc)

--- a/plugins/snapshots/erofs/erofs.go
+++ b/plugins/snapshots/erofs/erofs.go
@@ -56,8 +56,7 @@ type SnapshotterConfig struct {
 	// layer blobs. Each is checked one by one; the first hit is staged into the
 	// snapshot (symlinked) instead of downloading and converting the layer. A
 	// directory that doesn't exist is treated as a cache miss. Layers missing
-	// from all of them are converted normally. Only parentless Prepares can be
-	// served.
+	// from all of them are converted normally.
 	layerContentCaches []string
 }
 
@@ -411,6 +410,55 @@ func (s *snapshotter) createErofsMount(layerBlob string) (mount.Mount, error) {
 	}, nil
 }
 
+// stagedBlob reports whether the layer blob at path was staged from the layer
+// content cache, which makes it a symlink into the operator-owned cache
+// directory rather than a blob written into the snapshot itself. A missing blob
+// is not staged; any other failure to tell is an error, since callers use this
+// to decide whether writing to the blob is safe.
+func stagedBlob(path string) (bool, error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to stat layer blob %q: %w", path, err)
+	}
+	return fi.Mode()&os.ModeSymlink != 0, nil
+}
+
+// stagedLayerMounts returns the read-only mounts of the cache blob staged into
+// the active snapshot id, or none if it has no staged blob. The caller stacks
+// them on top of the parents. fsverity isn't checked since it's rejected
+// together with the cache (see NewSnapshotter).
+func (s *snapshotter) stagedLayerMounts(id string) ([]mount.Mount, error) {
+	// Just a fast path: erofsutils.MountsToLayer refuses a symlinked layer blob
+	// whatever the config, so a blob staged before caching was turned off stays
+	// safe from the differ.
+	if len(s.layerContentCaches) == 0 {
+		return nil, nil
+	}
+
+	layerBlob := s.layerBlobPath(id)
+	// Don't swallow errors: writable mounts would let the differ write through a
+	// symlink we failed to rule out.
+	staged, err := stagedBlob(layerBlob)
+	if err != nil || !staged {
+		return nil, err
+	}
+	// The entry may have been pruned since staging. A dangling symlink must not
+	// pass as staged content, or Commit would write an empty blob through it and
+	// poison the cache entry.
+	if _, err := os.Stat(layerBlob); err != nil {
+		return nil, fmt.Errorf("staged layer content cache blob %q is unusable: %w", layerBlob, err)
+	}
+
+	m, err := s.createErofsMount(layerBlob)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create erofs mount: %w", err)
+	}
+	return []mount.Mount{m}, nil
+}
+
 func (s *snapshotter) mounts(snap storage.Snapshot, info snapshots.Info) ([]mount.Mount, error) {
 	var options []string
 
@@ -472,9 +520,17 @@ func (s *snapshotter) mounts(snap storage.Snapshot, info snapshots.Info) ([]moun
 
 	var (
 		mounts   []mount.Mount
+		staged   []mount.Mount
 		writable bool
 	)
 	if snap.Kind == snapshots.KindActive {
+		// A staged blob already holds this layer, so no writable upperdir.
+		var err error
+		if staged, err = s.stagedLayerMounts(snap.ID); err != nil {
+			return nil, err
+		}
+	}
+	if snap.Kind == snapshots.KindActive && len(staged) == 0 {
 		if s.blockMode {
 			mounts = append(mounts, mount.Mount{
 				Source: s.writablePath(snap.ID),
@@ -500,7 +556,8 @@ func (s *snapshotter) mounts(snap storage.Snapshot, info snapshots.Info) ([]moun
 			)
 		}
 		writable = true
-	} else if len(snap.ParentIDs) == 1 {
+	} else if snap.Kind != snapshots.KindActive && len(snap.ParentIDs) == 1 {
+		// A view of a single committed layer is that layer, read-only.
 		layerBlob, err := s.lowerPath(snap.ParentIDs[0])
 		if err != nil {
 			return nil, err
@@ -515,6 +572,9 @@ func (s *snapshotter) mounts(snap storage.Snapshot, info snapshots.Info) ([]moun
 	// first marks the start of the lowerdir range. A merged fsmeta ends the
 	// range but never moves its start: lowers stacked above it stay in range.
 	first := len(mounts)
+	// A staged blob is this snapshot's own layer, so it stacks above the parents.
+	// With no upperdir the overlay is read-only, which is what marks it staged.
+	mounts = append(mounts, staged...)
 	for i := range snap.ParentIDs {
 		// If a merged fsmeta is valid for this layer, skip the remaining bottom layers.
 		// Why? Because bottom layers have been flattened with the thin fsmeta.
@@ -559,6 +619,9 @@ func (s *snapshotter) mounts(snap storage.Snapshot, info snapshots.Info) ([]moun
 	} else {
 		options = append(options, fmt.Sprintf("lowerdir={{ overlay %d %d }}", first, len(mounts)-1))
 	}
+	if len(staged) > 0 {
+		options = append(options, "ro")
+	}
 	options = append(options, s.ovlOptions...)
 
 	return append(mounts, mount.Mount{
@@ -569,12 +632,13 @@ func (s *snapshotter) mounts(snap storage.Snapshot, info snapshots.Info) ([]moun
 }
 
 // createSnapshot creates an active (or view) snapshot and returns its mounts.
-// On a parentless image-layer extraction whose diffID blob is in the layer content cache,
+// On an image-layer extraction whose diffID blob is in the layer content cache,
 // it stages the cached blob into the active snapshot (without committing) and
 // returns it as a read-only mount, so the unpacker can detect the fast path
 // (skip the layer download and conversion) while still committing the
-// snapshot normally — applying the parent at Commit time, which keeps the
-// cache compatible with parallel unpacking.
+// snapshot normally. The parent is applied either at Prepare (sequential
+// unpacking) or at Commit via WithParent (parallel unpacking); staging works
+// with both.
 func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ []mount.Mount, err error) {
 	var (
 		snap     storage.Snapshot
@@ -582,11 +646,15 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		info     snapshots.Info
 	)
 
-	// Only parentless extractions can be served: s.mounts picks a staged blob up
-	// only when there are no parents, so with a parent the differ would write
-	// through the staged symlink into the shared cache blob.
+	// Any image-layer extraction can be served, parented or not: s.mounts hands a
+	// staged snapshot out read-only, so the differ can't write the layer through
+	// the staged symlink into the shared cache blob.
+	//
+	// TODO(2.5): staged layers above the unpacker's first cache miss still have
+	// their blobs downloaded; skipping those fetches needs the unpacker rework
+	// planned for 2.5 and is out of scope here.
 	var cacheBlob string
-	if kind == snapshots.KindActive && parent == "" {
+	if kind == snapshots.KindActive {
 		if cacheBlob = s.lookupCache(ctx, opts...); cacheBlob != "" {
 			log.G(ctx).WithFields(log.Fields{
 				"key":  key,
@@ -811,6 +879,18 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 	// the EROFS differ (possibly the walking differ), convert the upperdir instead.
 	layerBlob = s.layerBlobPath(id)
 	if _, err := os.Stat(layerBlob); err != nil {
+		// Unless the blob was staged from the layer content cache and its entry
+		// has been pruned since. Converting would run mkfs.erofs through the
+		// dangling symlink, committing an empty layer and writing that empty
+		// blob into the cache for every future pull of this layer.
+		staged, serr := stagedBlob(layerBlob)
+		if serr != nil {
+			return serr
+		}
+		if staged {
+			return fmt.Errorf("staged layer content cache blob %q is unusable: %w", layerBlob, err)
+		}
+
 		if cerr := s.commitBlock(ctx, layerBlob, id); cerr != nil {
 			if errdefs.IsNotImplemented(cerr) {
 				return err

--- a/plugins/snapshots/erofs/erofs_linux_test.go
+++ b/plugins/snapshots/erofs/erofs_linux_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -963,14 +964,36 @@ func newCacheSnapshotter(t *testing.T, opts ...Opt) *snapshotter {
 	return sn.(*snapshotter)
 }
 
-// stageCacheHit runs an extraction Prepare for target/diffID and asserts the
-// cache staged the blob into the active snapshot: a read-only mount, with no
-// error (so the unpacker skips fetch+apply but still commits). It returns the
-// extraction key so the caller can Commit it as the target chainID.
+// requireStagedSymlink asserts that the snapshot behind key holds the cache blob
+// as an absolute symlink, i.e. it was staged and never converted in place.
+func requireStagedSymlink(t *testing.T, ctx context.Context, s *snapshotter, key, blob string) {
+	t.Helper()
+	link := s.layerBlobPath(snapshotID(t, ctx, s, key))
+	fi, err := os.Lstat(link)
+	require.NoError(t, err, "the cached blob must be staged as layer.erofs")
+	assert.NotZero(t, fi.Mode()&os.ModeSymlink, "layer.erofs should be a symlink")
+	dst, err := os.Readlink(link)
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(dst), "symlink target should be absolute")
+	assert.Equal(t, blob, dst)
+}
+
+// stageCacheHit runs a parentless extraction Prepare for target/diffID, see
+// stageCacheHitFrom.
 func stageCacheHit(t *testing.T, ctx context.Context, s *snapshotter, target string, diffID digest.Digest) string {
 	t.Helper()
+	return stageCacheHitFrom(t, ctx, s, "", target, diffID)
+}
+
+// stageCacheHitFrom runs an extraction Prepare for target/diffID on top of
+// parent and asserts the cache staged the blob into the active snapshot: a
+// read-only mount, with no error (so the unpacker skips fetch+apply but still
+// commits). It returns the extraction key so the caller can Commit it as the
+// target chainID.
+func stageCacheHitFrom(t *testing.T, ctx context.Context, s *snapshotter, parent, target string, diffID digest.Digest) string {
+	t.Helper()
 	key := "extract-1 " + target
-	mounts, err := s.Prepare(ctx, key, "", extractionOpt(target, diffID))
+	mounts, err := s.Prepare(ctx, key, parent, extractionOpt(target, diffID))
 	require.NoError(t, err, "cache hit must stage without an error")
 	require.NotEmpty(t, mounts, "a staged cache hit returns mounts")
 	for _, m := range mounts {
@@ -1001,14 +1024,7 @@ func TestCacheHit(t *testing.T) {
 	assert.Error(t, err, "target chainID must not be committed before Commit")
 
 	// layer.erofs is an absolute symlink into the operator-owned cache blob.
-	link := s.layerBlobPath(snapshotID(t, ctx, s, key))
-	fi, err := os.Lstat(link)
-	require.NoError(t, err)
-	assert.NotZero(t, fi.Mode()&os.ModeSymlink, "layer.erofs should be a symlink")
-	dst, err := os.Readlink(link)
-	require.NoError(t, err)
-	assert.True(t, filepath.IsAbs(dst), "symlink target should be absolute")
-	assert.Equal(t, blob, dst)
+	requireStagedSymlink(t, ctx, s, key, blob)
 
 	// Commit finalizes the staged snapshot as the target chainID, without any
 	// re-conversion (the blob is already present).
@@ -1093,6 +1109,29 @@ func TestCacheMiss(t *testing.T) {
 		assert.NotEmpty(t, mounts)
 	})
 
+	t.Run("no extraction labels, parented", func(t *testing.T) {
+		// Staging is keyed on the extraction labels alone, so a container-rootfs
+		// Prepare on top of a cached layer still gets a writable overlay.
+		cacheDir := t.TempDir()
+		writeCacheBlob(t, cacheDir, diffID, []byte("blob"))
+		s := newCacheSnapshotter(t, WithLayerContentCaches(cacheDir))
+
+		parentChain := "sha256:0000000000000000000000000000000000000000000000000000000000000005"
+		require.NoError(t, s.Commit(ctx, parentChain, stageCacheHit(t, ctx, s, parentChain, diffID)))
+
+		key := "container-rootfs"
+		mounts, err := s.Prepare(ctx, key, parentChain)
+		require.NoError(t, err)
+		require.NotEmpty(t, mounts)
+		// assertFellThrough does not apply here: a parented snapshot also returns
+		// the read-only lowers. The unpacker only inspects the last mount, which
+		// must be the writable overlay.
+		assert.False(t, mounts[len(mounts)-1].ReadOnly(), "a Prepare without extraction labels must expose a writable overlay")
+
+		_, err = os.Lstat(s.layerBlobPath(snapshotID(t, ctx, s, key)))
+		assert.ErrorIs(t, err, os.ErrNotExist, "no cached blob may be staged without extraction labels")
+	})
+
 	t.Run("view is never short-circuited", func(t *testing.T) {
 		cacheDir := t.TempDir()
 		writeCacheBlob(t, cacheDir, diffID, []byte("blob"))
@@ -1104,12 +1143,71 @@ func TestCacheMiss(t *testing.T) {
 	})
 }
 
-// TestCacheParentedPrepare covers a cached blob whose extraction Prepare carries
-// a parent (the sequential unpack path): it must not be staged. mounts() only
-// picks a staged blob up when the snapshot has no parents, so otherwise the
-// unpacker would see a writable overlay, apply the layer, and let the differ
-// write through the symlink into the shared cache blob.
-func TestCacheParentedPrepare(t *testing.T) {
+// TestCacheParentedStage covers a cached blob whose extraction Prepare carries a
+// parent, which is what sequential unpacking does for every layer but the first:
+// it is staged exactly like a parentless one, so an image is served from the
+// cache regardless of the unpack mode. The staged blob is mounted read-only, so
+// the differ can never write through the symlink into the shared cache blob.
+func TestCacheParentedStage(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+
+	var (
+		cacheDir     = t.TempDir()
+		parentDiffID = digest.Digest(cacheTestDiffID)
+		parentChain  = cacheTestChainID
+		childDiffID  = digest.Digest("sha256:0000000000000000000000000000000000000000000000000000000000000003")
+		childChain   = "sha256:0000000000000000000000000000000000000000000000000000000000000004"
+		childData    = []byte("fake child blob")
+	)
+	writeCacheBlob(t, cacheDir, parentDiffID, []byte("fake parent blob"))
+	childBlob := writeCacheBlob(t, cacheDir, childDiffID, childData)
+
+	s := newCacheSnapshotter(t, WithLayerContentCaches(cacheDir))
+
+	// The first layer has no parent, so it is served from the cache as usual.
+	require.NoError(t, s.Commit(ctx, parentChain, stageCacheHit(t, ctx, s, parentChain, parentDiffID)))
+
+	// The second layer is prepared on top of it and is served from the cache too.
+	key := stageCacheHitFrom(t, ctx, s, parentChain, childChain, childDiffID)
+
+	// A parented Prepare must still hand out the parent's content, per the
+	// Snapshotter contract, so the staged blob is stacked as the top lower over
+	// the parent rather than returned on its own. Without an upperdir the
+	// resulting overlay is read-only, which is what marks it staged.
+	mounts, err := s.Mounts(ctx, key)
+	require.NoError(t, err)
+	require.Len(t, mounts, 3, "staged blob, the parent lower and the overlay")
+	assert.Equal(t, s.layerBlobPath(snapshotID(t, ctx, s, key)), mounts[0].Source,
+		"the staged blob is the top lower")
+	assert.Equal(t, "erofs", mounts[1].Type, "the parent layer is stacked below it")
+	assert.Equal(t, "format/mkdir/overlay", mounts[2].Type)
+	assert.Contains(t, strings.Join(mounts[2].Options, ","), "lowerdir={{ overlay 0 1 }}",
+		"both layers are in the lowerdir range")
+	assert.NotContains(t, strings.Join(mounts[2].Options, ","), "upperdir=",
+		"a staged snapshot has nothing writable")
+	assert.True(t, mounts[len(mounts)-1].ReadOnly(), "the unpacker detects staging on the last mount")
+
+	// The unpacker commits a staged snapshot without WithParent when the parent
+	// was already given to Prepare, so the chain is linked through that parent.
+	require.NoError(t, s.Commit(ctx, childChain, key))
+	info, err := s.Stat(ctx, childChain)
+	require.NoError(t, err)
+	assert.Equal(t, snapshots.KindCommitted, info.Kind)
+	assert.Equal(t, parentChain, info.Parent)
+
+	// Commit ran no conversion: the blob is still the symlinked cache entry and
+	// the operator-owned blob itself is untouched.
+	requireStagedSymlink(t, ctx, s, childChain, childBlob)
+	data, err := os.ReadFile(childBlob)
+	require.NoError(t, err)
+	assert.Equal(t, childData, data, "the cache blob must not be written through")
+}
+
+// TestCacheStaleBlob covers a cache entry pruned after it was staged: Mounts must
+// not report a dangling symlink as staged content, since the caller would skip
+// the layer and Commit would then materialize an empty blob through the symlink,
+// poisoning the cache entry for every image using that layer.
+func TestCacheStaleBlob(t *testing.T) {
 	ctx := namespaces.WithNamespace(context.Background(), "test")
 
 	var (
@@ -1120,24 +1218,51 @@ func TestCacheParentedPrepare(t *testing.T) {
 		childChain   = "sha256:0000000000000000000000000000000000000000000000000000000000000004"
 	)
 	writeCacheBlob(t, cacheDir, parentDiffID, []byte("fake parent blob"))
-	writeCacheBlob(t, cacheDir, childDiffID, []byte("fake child blob"))
+	childBlob := writeCacheBlob(t, cacheDir, childDiffID, []byte("fake child blob"))
 
 	s := newCacheSnapshotter(t, WithLayerContentCaches(cacheDir))
 
-	// The first layer has no parent, so it is served from the cache as usual.
 	require.NoError(t, s.Commit(ctx, parentChain, stageCacheHit(t, ctx, s, parentChain, parentDiffID)))
+	key := stageCacheHitFrom(t, ctx, s, parentChain, childChain, childDiffID)
 
-	key := "extract-1 " + childChain
-	mounts, err := s.Prepare(ctx, key, parentChain, extractionOpt(childChain, childDiffID))
-	require.NoError(t, err)
-	require.NotEmpty(t, mounts)
-	// The unpacker only inspects the last mount, which must be the writable
-	// overlay so the layer gets applied (the parents' lowers are read-only).
-	assert.False(t, mounts[len(mounts)-1].ReadOnly(), "a parented Prepare must expose a writable overlay")
+	// The operator prunes the cache entry while the pull is in flight.
+	require.NoError(t, os.Remove(childBlob))
 
-	// Nothing was staged, so the differ has no symlink to write through.
-	_, err = os.Lstat(s.layerBlobPath(snapshotID(t, ctx, s, key)))
-	assert.ErrorIs(t, err, os.ErrNotExist, "no cached blob may be staged into a parented snapshot")
+	_, err := s.Mounts(ctx, key)
+	require.Error(t, err, "a dangling staged blob must not be served as staged content")
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// TestCacheStaleBlobCommit covers a cache entry pruned between Prepare and
+// Commit, which is the window the unpacker actually runs in (it commits the
+// mounts Prepare returned and never calls Mounts). Commit must not fall back to
+// converting the snapshot: mkfs.erofs would write through the dangling symlink,
+// committing an empty layer and leaving that empty blob in the cache for every
+// future pull of the layer.
+func TestCacheStaleBlobCommit(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+
+	cacheDir := t.TempDir()
+	diffID := digest.Digest(cacheTestDiffID)
+	blob := writeCacheBlob(t, cacheDir, diffID, []byte("fake erofs blob"))
+
+	s := newCacheSnapshotter(t, WithLayerContentCaches(cacheDir))
+
+	target := cacheTestChainID
+	key := stageCacheHit(t, ctx, s, target, diffID)
+
+	// The operator prunes the cache entry while the pull is in flight.
+	require.NoError(t, os.Remove(blob))
+
+	err := s.Commit(ctx, target, key)
+	require.Error(t, err, "a dangling staged blob must not be converted")
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	// Nothing was written back through the symlink.
+	_, err = os.Stat(blob)
+	assert.ErrorIs(t, err, os.ErrNotExist, "the pruned cache entry must not be recreated")
+	_, err = s.Stat(ctx, target)
+	assert.Error(t, err, "the layer must not be committed")
 }
 
 // TestCacheRemove covers removal of a cache-hit snapshot: it succeeds (the

--- a/plugins/snapshots/erofs/plugin/plugin.go
+++ b/plugins/snapshots/erofs/plugin/plugin.go
@@ -58,14 +58,10 @@ type Config struct {
 	DmverityMode string `toml:"dmverity_mode"`
 
 	// LayerContentCaches lists directories of pre-converted, diffID-keyed erofs
-	// layer blobs. Each is checked one by one and the first hit is used instead
-	// of downloading and converting the layer; a directory that doesn't exist is
-	// treated as a cache miss. Layers missing from all of them are converted
-	// normally.
-	//
-	// Only layers prepared without a parent can be served from the cache. With
-	// sequential unpacking that is the first layer alone, so getting hits for a
-	// whole image needs max_concurrent_unpacks > 1, which is not the default.
+	// layer blobs. Each is checked one by one and the first hit is committed
+	// without being converted, in both sequential and parallel unpack modes; a
+	// directory that doesn't exist is treated as a cache miss. Layers missing
+	// from all of them are converted normally.
 	LayerContentCaches []string `toml:"layer_content_caches"`
 }
 


### PR DESCRIPTION
This is a follow up to #13813 (where we had the cache working for sequential mode, but disabled in parallel) and #13826 (where we got it enabled for parallel mode, but only layer 0 in sequential mode).

This PR enables both with minimal changes in the erofs snapshotter: a cached layer is now served whether or not the Prepare carries a parent, and since such a layer is shared with every snapshot that uses it, it's handed out read-only and the differ refuses to write into one.

The cache now serves every cached layer for conversion-skip in both modes. Only the download remains range-limited from the first miss.

Context: https://github.com/containerd/containerd/pull/13826#discussion_r3691134546 — at that point parented layers were still writable, so the shared cache entry really could be overwritten. This adds the protection that was missing, which is what lets the restriction go.

The unpacker downloads layers in one run starting at the first cache miss, so cached layers above a miss are still transferred (they skip conversion, not the download). A fully cached image downloads nothing.

I don't want to mess too much with unpacker since 2.4 is coming soon — there's a TODO to come back to this once 2.4 is out.