### PR TITLE
contrib/apparmor: allow signals/ptrace for stacked-label exec processes

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -65,6 +65,8 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   signal (receive) peer={{.DaemonProfile}},
   # Container processes may send signals amongst themselves.
   signal (send,receive) peer={{.Name}},
+  # Exec sessions carry a stacked label on kernels with label stacking (>= 6.17).
+  signal (send,receive) peer="{{.Name}}//&unconfined",
 {{if .RootlessKit}}
   # https://github.com/containerd/nerdctl/issues/2730
   signal (receive) peer={{.RootlessKit}},
@@ -92,6 +94,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   # allow processes within the container to trace each other,
   # provided all other LSM and yama setting allow it.
   ptrace (trace,tracedby,read,readby) peer={{.Name}},
+  ptrace (trace,tracedby,read,readby) peer="{{.Name}}//&unconfined",
 }
 `
 


### PR DESCRIPTION
On kernels with AppArmor label stacking enabled by default (>= 6.17), processes entered through the runtime exec API carry the stacked label `<profile>//&unconfined`, while the container's init tree keeps the plain `<profile>` label. The profile's peer rules only match the plain label, so every signal sent by an exec-spawned process is denied, including root killing its own child and a process signalling itself. 

This breaks `timeout(1)`, exec-based debugging, and any exec'd client that signals its own children (observed: Slurm's `srun` wedging at exit).

 The `abi <abi/3.0>` pin from #12864 doesn't help: signal mediation is part of the 3.0 ABI, and the pin changes mediation semantics, not the task's label. This PR adds symmetric signal and ptrace peer rules for the stacked label. Related: #12726, k3s-io/k3s#13625, moby/moby#47720.

Repro (containerd 2.1.4 / kernel 7.0; passes on 1.7.2 / kernel 6.5):
```
$ kubectl exec <pod> -- bash -c 'sleep 30 & kill -9 $!'
bash: kill: Permission denied
```

Verified on Ubuntu 25.10 (kernel 6.17.0-40) by driving the labels directly with `aa-exec`: unpatched rules deny kill-own-child and self-signal from the stacked label; patched rules restore both, plain-label behavior is unchanged, and stacked tasks still cannot signal unconfined (host) processes.

**Security considerations:** the new peer string matches only tasks whose entire label is `<profile>//&unconfined`, i.e. the runtime-exec sessions themselves. Host processes (plain `unconfined`) do not match and gain nothing new; the scope mirrors the existing `peer=<profile>` rule, and ptrace remains gated by Yama and capability checks.

Happy to switch to the glob form (`peer="<profile>//**"`) if preferred; the explicit stack is the minimal grant matching what the kernel emits today. A cherry-pick to `release/2.1` would be appreciated (affected fleet runs 2.1.4).
