### PR TITLE
pkg/shim: Report bootstrap API mismatch on startup

### DIFF
--- a/pkg/shim/compat.go
+++ b/pkg/shim/compat.go
@@ -22,32 +22,28 @@ package shim
 // Once settled, this file should be removed.
 
 import (
-	"bytes"
+	"errors"
 	"fmt"
-	"os"
 
 	bootapi "github.com/containerd/containerd/api/runtime/bootstrap/v1"
-	"github.com/containerd/containerd/api/types/runc/options"
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 )
 
-func readBootstrapParamsFromDeprecatedFields(input []byte, params *bootapi.BootstrapParams, parsedID string, parsedNamespace string, parsedBinary string, parsedDebug bool) error {
-	params.InstanceID = parsedID
-	params.Namespace = parsedNamespace
-	params.ContainerdTtrpcAddress = os.Getenv(ttrpcAddressEnv)
-	params.ContainerdGrpcAddress = os.Getenv(grpcAddressEnv)
-	params.ContainerdBinary = parsedBinary
+var errDeprecatedBootstrapAPI = errors.New("shim was started through the deprecated API but was built against the new API; if you upgraded containerd, you may need to restart the daemon")
 
-	if parsedDebug {
-		params.LogLevel = bootapi.LogLevel_LOG_LEVEL_DEBUG
+// parseBootstrapParams parses input from a caller using the bootstrap API.
+// Legacy runtime options can unmarshal as BootstrapParams, so verify the
+// identity against the command-line values.
+func parseBootstrapParams(input []byte, cliID, cliNamespace string) (*bootapi.BootstrapParams, error) {
+	params := &bootapi.BootstrapParams{}
+	if len(input) == 0 {
+		return nil, errDeprecatedBootstrapAPI
 	}
-
-	// Task options
-
-	if opts, err := ReadRuntimeOptions[*options.Options](bytes.NewBuffer(input)); err == nil {
-		if err := params.AddExtension(opts); err != nil {
-			return fmt.Errorf("unable to add runc options: %w", err)
-		}
+	if err := proto.Unmarshal(input, params); err != nil {
+		return nil, fmt.Errorf("%w: failed to unmarshal bootstrap parameters: %w", errDeprecatedBootstrapAPI, err)
 	}
-
-	return nil
+	if params.InstanceID != cliID || params.Namespace != cliNamespace {
+		return nil, fmt.Errorf("bootstrap parameters do not match command-line arguments: %w", errDeprecatedBootstrapAPI)
+	}
+	return params, nil
 }

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -271,20 +271,16 @@ func run(ctx context.Context, manager Shim, config Config) error {
 		}
 		return nil
 	case "start":
-		// We try reading stdin twice: first for the new boot API, then runc Options.
-		// The stdin pipe is not seekable, so this should be read into memory first.
+		// Read stdin into memory so the bootstrap payload can be validated.
 		// Protect against unbounded memory consumption with a limit (e.g., 10MB).
 		input, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
 		if err != nil {
 			return fmt.Errorf("failed to read stdin: %w", err)
 		}
 
-		var params bootapi.BootstrapParams
-		if len(input) == 0 || proto.Unmarshal(input, &params) != nil {
-			// TODO: Return error once the new API is stable
-			if err := readBootstrapParamsFromDeprecatedFields(input, &params, id, namespaceFlag, containerdBinaryFlag, debugFlag); err != nil {
-				return err
-			}
+		params, err := parseBootstrapParams(input, id, namespaceFlag)
+		if err != nil {
+			return err
 		}
 
 		// Persist the socket directory so the long-running server process
@@ -295,7 +291,7 @@ func run(ctx context.Context, manager Shim, config Config) error {
 			}
 		}
 
-		result, err := manager.Start(ctx, &params)
+		result, err := manager.Start(ctx, params)
 		if err != nil {
 			return err
 		}

--- a/pkg/shim/shim_test.go
+++ b/pkg/shim/shim_test.go
@@ -18,8 +18,14 @@ package shim
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"testing"
+
+	bootapi "github.com/containerd/containerd/api/runtime/bootstrap/v1"
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
+	"github.com/containerd/containerd/v2/pkg/protobuf/types"
+	googleproto "google.golang.org/protobuf/proto"
 )
 
 func TestRuntimeWithEmptyMaxEnvProcs(t *testing.T) {
@@ -59,4 +65,73 @@ func TestShimOptWithValue(t *testing.T) {
 	if !op.Debug {
 		t.Fatal("opts.Debug should be true")
 	}
+}
+
+func TestParseBootstrapParams(t *testing.T) {
+	const (
+		id        = "container-id"
+		namespace = "moby"
+	)
+
+	t.Run("bootstrap protocol", func(t *testing.T) {
+		input, err := proto.Marshal(&bootapi.BootstrapParams{
+			InstanceID: id,
+			Namespace:  namespace,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		params, err := parseBootstrapParams(input, id, namespace)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if params.InstanceID != id || params.Namespace != namespace {
+			t.Fatalf("bootstrap params not preserved: %+v", params)
+		}
+	})
+
+	t.Run("mismatched identity", func(t *testing.T) {
+		input, err := proto.Marshal(&bootapi.BootstrapParams{
+			InstanceID: id,
+			Namespace:  namespace,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = parseBootstrapParams(input, "different-id", namespace)
+		if err == errDeprecatedBootstrapAPI {
+			t.Fatal("expected details for mismatched bootstrap parameters")
+		}
+		if !errors.Is(err, errDeprecatedBootstrapAPI) {
+			t.Fatalf("expected deprecated bootstrap API error, got %v", err)
+		}
+	})
+
+	t.Run("deprecated protocol", func(t *testing.T) {
+		input, err := proto.Marshal(&types.Any{
+			TypeUrl: "types.containerd.io/containerd.runc.v1.Options",
+			Value:   []byte("runc options"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = parseBootstrapParams(input, id, namespace)
+		if !errors.Is(err, errDeprecatedBootstrapAPI) {
+			t.Fatalf("expected deprecated bootstrap API error, got %v", err)
+		}
+	})
+
+	t.Run("malformed bootstrap protocol", func(t *testing.T) {
+		input := []byte{0xff}
+		_, err := parseBootstrapParams(input, id, namespace)
+		if !errors.Is(err, errDeprecatedBootstrapAPI) {
+			t.Fatalf("expected deprecated bootstrap API error, got %v", err)
+		}
+		if !errors.Is(err, googleproto.Error) {
+			t.Fatalf("expected protobuf error, got %v", err)
+		}
+	})
 }


### PR DESCRIPTION
- replace / close: https://github.com/containerd/containerd/pull/13764
- address / close: https://github.com/containerd/containerd/issues/13763

A pre-2.3 containerd daemon can start a newly installed shim through the deprecated CLI, environment, and stdin API.
The shim currently accepts that request but returns a protobuf bootstrap result, which the old daemon cannot parse.
It treats the protobuf bytes as a socket address and fails later with a cryptic error:

```
failed to create TTRPC connection: unsupported protocol: \b\x03\x12Yunix
```

This patch makes the shim reject the deprecated startup request before starting and tell the user that the containerd daemon may need to be restarted.
The 2.2 daemon includes the shim's stderr in its start error, so this message reaches the user directly.

This explicitly removes input-side support for the deprecated startup API, but it does not break a working standard containerd pairing. Pre-2.3 daemons already cannot consume the response from the new shim. After a package upgrade, a restarted daemon uses the new bootstrap API.

Custom callers that send the deprecated request format while supporting the new protobuf response will now also be rejected.

```release-note
Improve error message when newer shim is invoked by older daemon using deprecated bootstrap API
```
