### PR TITLE
fix: handle extract/extracted/already-exists progress events as download completion

### DIFF
--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -987,7 +987,7 @@ func (reporter *transferProgressReporter) handleProgress(p transfer.Progress) {
 			delete(reporter.statuses, p.Name)
 		}
 
-	case "complete":
+	case "complete", "extracting", "extracted", "already exists":
 		if node, exists := reporter.statuses[p.Name]; exists {
 			if curProgress := p.Progress - node.Progress; curProgress > 0 {
 				reporter.IncBytesRead(curProgress)


### PR DESCRIPTION
## Description

When the CRI plugin pulls an image through the transfer service (`use_local_image_pull = false`), the image pull can be canceled by `image_pull_progress_timeout` even when all blob downloads have finished and the remaining unpack is still progressing.

**Root cause**: The CRI progress reporter's `handleProgress` only handles `"waiting"`, `"downloading"`, and `"complete"` events. The transfer service skips `"complete"` events due to a race between download-completion detection and the start of extraction — the job transitions directly from `jobInProgress` to `jobExtracting` before the next tick can report completion. The `"extracting"`, `"extracted"`, and `"already exists"` progress events are therefore ignored, causing the `activeReqs` counter to leak (never decremented). The watchdog then cancels the pull after `image_pull_progress_timeout`.

**Fix**: Treat `"extracting"`, `"extracted"`, and `"already exists"` progress events as download completion, just like `"complete"`. This properly decrements the active request counter and resets the progress watchdog.

Closes #13909
