### PR TITLE
remotes/docker: retry blob fetch on connection reset by peer

### DIFF
--- a/core/remotes/docker/httpreadseeker.go
+++ b/core/remotes/docker/httpreadseeker.go
@@ -18,6 +18,7 @@ package docker
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 
@@ -59,9 +60,9 @@ func (hrs *httpReadSeeker) Read(p []byte) (n int, err error) {
 	if n > 0 || err == nil {
 		hrs.errsWithNoProgress = 0
 	}
-	switch err {
-	case io.ErrUnexpectedEOF:
-		// connection closed unexpectedly. try reconnecting.
+	switch {
+	case isRetryableReadError(err):
+		// connection closed or reset unexpectedly. try reconnecting.
 		if n == 0 {
 			hrs.errsWithNoProgress++
 			if hrs.errsWithNoProgress > maxRetry {
@@ -77,7 +78,7 @@ func (hrs *httpReadSeeker) Read(p []byte) (n int, err error) {
 		if _, err2 := hrs.reader(); err2 == nil {
 			return n, nil
 		}
-	case io.EOF:
+	case err == io.EOF:
 		// The CRI's imagePullProgressTimeout relies on responseBody.Close to
 		// update the process monitor's status. If the err is io.EOF, close
 		// the connection since there is no more available data.
@@ -89,6 +90,16 @@ func (hrs *httpReadSeeker) Read(p []byte) (n int, err error) {
 		}
 	}
 	return
+}
+
+// isRetryableReadError reports whether a read error may be resolved by reopening the
+// request body at the current offset: an unexpected EOF (the connection was
+// closed before the full body was received) or a connection reset by peer.
+// Reopening issues a ranged request at the current offset and resumes the
+// transfer rather than discarding it, with consecutive retries that make no
+// progress bounded by maxRetry.
+func isRetryableReadError(err error) bool {
+	return errors.Is(err, io.ErrUnexpectedEOF) || isConnResetError(err)
 }
 
 func (hrs *httpReadSeeker) Close() error {

--- a/core/remotes/docker/httpreadseeker_test.go
+++ b/core/remotes/docker/httpreadseeker_test.go
@@ -1,0 +1,138 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// connResetError returns a connection-reset error shaped the way it
+// surfaces from a TCP read: a *net.OpError wrapping an *os.SyscallError
+// wrapping the raw errno.
+func connResetError() error {
+	return &net.OpError{
+		Op:  "read",
+		Net: "tcp",
+		Err: os.NewSyscallError("read", syscall.ECONNRESET),
+	}
+}
+
+// flakyReader serves from data, failing with failErr after serving limit
+// bytes. A natural io.EOF is returned once data is exhausted.
+type flakyReader struct {
+	data    []byte
+	limit   int
+	served  int
+	failErr error
+}
+
+func (r *flakyReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+	if r.served >= r.limit {
+		return 0, r.failErr
+	}
+	n := min(len(p), r.limit-r.served, len(r.data))
+	copy(p, r.data[:n])
+	r.data = r.data[n:]
+	r.served += n
+	return n, nil
+}
+
+func (r *flakyReader) Close() error { return nil }
+
+// retryableReadErrors are the error classes for which Read retries by
+// reopening the body at the current offset.
+var retryableReadErrors = []struct {
+	name string
+	err  error
+}{
+	{"unexpected EOF", io.ErrUnexpectedEOF},
+	{"connection reset", connResetError()},
+}
+
+func TestHTTPReadSeekerReopensOnRetryableError(t *testing.T) {
+	for _, tc := range retryableReadErrors {
+		t.Run(tc.name, func(t *testing.T) {
+			content := []byte("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+			const serveChunk = 16
+
+			var openOffsets []int64
+			open := func(offset int64) (io.ReadCloser, error) {
+				openOffsets = append(openOffsets, offset)
+				return &flakyReader{
+					data:    content[offset:],
+					limit:   serveChunk,
+					failErr: tc.err,
+				}, nil
+			}
+
+			rs, err := newHTTPReadSeeker(int64(len(content)), open)
+			require.NoError(t, err)
+			defer rs.Close()
+
+			got, err := io.ReadAll(rs)
+			require.NoError(t, err, "transfer should complete across mid-body errors when progress is made")
+			assert.Equal(t, content, got, "reassembled content should match despite reconnects")
+			assert.Equal(t, []int64{0, 16, 32, 48}, openOffsets,
+				"each reopen should be at the advanced offset, preserving progress")
+		})
+	}
+}
+
+func TestHTTPReadSeekerAbortsAfterRetriesWithNoProgress(t *testing.T) {
+	for _, tc := range retryableReadErrors {
+		t.Run(tc.name, func(t *testing.T) {
+			opens := 0
+			open := func(offset int64) (io.ReadCloser, error) {
+				opens++
+				assert.EqualValues(t, 0, offset, "no progress was made, so every reopen should be at offset 0")
+				// limit of zero: every read fails without progress
+				return &flakyReader{data: []byte("0123"), limit: 0, failErr: tc.err}, nil
+			}
+
+			rs, err := newHTTPReadSeeker(4, open)
+			require.NoError(t, err)
+			defer rs.Close()
+
+			_, err = io.ReadAll(rs)
+			require.Error(t, err, "retries with no progress should eventually surface the error")
+			require.ErrorIs(t, err, tc.err)
+			assert.Equal(t, 1+maxRetry, opens, "one initial open plus maxRetry reopens")
+		})
+	}
+}
+
+func TestIsRetryableReadError(t *testing.T) {
+	assert.True(t, isRetryableReadError(io.ErrUnexpectedEOF))
+	assert.True(t, isRetryableReadError(fmt.Errorf("read: %w", io.ErrUnexpectedEOF)))
+	assert.True(t, isRetryableReadError(connResetError()))
+	assert.True(t, isRetryableReadError(syscall.ECONNRESET))
+	assert.False(t, isRetryableReadError(io.EOF))
+	assert.False(t, isRetryableReadError(errors.New("some other error")))
+	assert.False(t, isRetryableReadError(syscall.ECONNREFUSED))
+}

--- a/core/remotes/docker/httpreadseeker_windows_test.go
+++ b/core/remotes/docker/httpreadseeker_windows_test.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 /*
    Copyright The containerd Authors.
 
@@ -19,21 +17,18 @@
 package docker
 
 import (
-	"errors"
-	"syscall"
+	"net"
+	"os"
+	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/windows"
 )
 
-func isConnError(err error) bool {
-	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, windows.WSAECONNREFUSED)
-}
-
-// isConnResetError reports whether err represents a connection reset by
-// peer. On Windows a reset surfaces as WSAECONNRESET; syscall.ECONNRESET
-// is also matched for callers that construct portable errors. The errno
-// typically arrives wrapped in *net.OpError and *os.SyscallError;
-// errors.Is unwraps it.
-func isConnResetError(err error) bool {
-	return errors.Is(err, syscall.ECONNRESET) || errors.Is(err, windows.WSAECONNRESET)
+func TestIsRetryableReadErrorWindowsReset(t *testing.T) {
+	assert.True(t, isRetryableReadError(windows.WSAECONNRESET))
+	assert.True(t, isRetryableReadError(&net.OpError{
+		Op: "read", Net: "tcp",
+		Err: os.NewSyscallError("wsarecv", windows.WSAECONNRESET),
+	}))
 }

--- a/core/remotes/docker/resolver_unix.go
+++ b/core/remotes/docker/resolver_unix.go
@@ -26,3 +26,10 @@ import (
 func isConnError(err error) bool {
 	return errors.Is(err, syscall.ECONNREFUSED)
 }
+
+// isConnResetError reports whether err represents a connection reset by
+// peer. The errno typically arrives wrapped in *net.OpError and
+// *os.SyscallError; errors.Is unwraps it.
+func isConnResetError(err error) bool {
+	return errors.Is(err, syscall.ECONNRESET)
+}


### PR DESCRIPTION
## What this does

`httpReadSeeker` already resumes a blob fetch when the connection closes cleanly before the full body arrives (`io.ErrUnexpectedEOF`): it reopens the body with a ranged request at the current offset, bounded by `maxRetry` consecutive reopens that make no progress. A mid-body TCP RST, however, surfaces as a connection-reset error, misses that case, and fails the whole fetch — discarding everything already transferred.

This PR treats connection resets like unexpected EOFs: retry by reopening at the current offset, under the exact same `maxRetry`/no-progress bound. The reset class is matched per-platform alongside the existing `isConnError` helpers (`ECONNRESET`, plus `WSAECONNRESET` on Windows, where `syscall.ECONNRESET` is a synthetic constant a real reset never matches), unwrapping with `errors.Is`. The unexpected-EOF match also moves from bare equality to `errors.Is`, so a wrapped `io.ErrUnexpectedEOF` now retries as well.

## Why

On congested or middlebox-mediated paths, long blob transfers can stall, and far-end idle timers kill stalled flows with a RST after ~30s. In one observed case, a pull repeatedly transferred about 63% of a ~190MB layer at steady throughput, took a mid-body reset, and restarted from byte zero each time, never completing. With reconnect-at-offset covering the reset class, such a pull completes within the existing retry budget. Registries and range-capable blob backends already serve the reopen path today; only the error classification is blind to resets.

Symptom report: #11365. Adjacent precedent: google/go-containerregistry#1415, which retries resets during blob reads.

## Caveats and scope

- **Deliberate refusal:** retrying on RST could mask a far end intentionally killing the transfer. The existing consecutive-zero-progress bound caps that at `maxRetry` reopens — identical to today's handling of the unexpected-EOF class.
- **Deliberately narrow:** `ETIMEDOUT` and generic temporary network errors are *not* covered. Question for maintainers: would you want those classes in a follow-up, or is reset-only the right scope?
- **HTTP/2:** stream-level resets (e.g. `RST_STREAM`) surface as different error types and are out of scope here.
- **Interaction with #13571:** that PR (activity-based timeout) touches the same area; this change does not restructure the reader. Happy to rebase/adjust if #13571 lands first.

## How it was tested

New `httpreadseeker_test.go`, table-driven over both retryable classes (unexpected EOF, and a reset built as `*net.OpError` → `*os.SyscallError` → `ECONNRESET`, as a TCP read surfaces it):

- reopen is re-invoked at the **advanced** offset and the transfer completes across mid-body failures when progress occurs;
- `maxRetry` consecutive zero-progress failures abort with the original error (exactly `1 + maxRetry` opens);
- unit coverage of `isRetryableReadError`, including wrapped forms and negative cases (`io.EOF`, `ECONNREFUSED`).
- a Windows-only test (`httpreadseeker_windows_test.go`) covering the `WSAECONNRESET` arm, bare and wrapped in `*net.OpError`/`*os.SyscallError`;

Also run locally: `go build`, `go vet`, full `core/remotes/docker/...` tests, `golangci-lint` with the repo config (0 issues), and cross-compiles for `GOOS=windows` (build + vet), `darwin`, and `freebsd`.

