### PR TITLE
[release/2.3] nri,deprecation: record and emit warnings for NRI deprecations.

### DIFF
--- a/internal/nri/deprecations.go
+++ b/internal/nri/deprecations.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package nri
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/v2/pkg/deprecation"
+	"github.com/containerd/containerd/v2/plugins/services/warning"
+	"github.com/containerd/log"
+
+	nri "github.com/containerd/nri/pkg/adaptation"
+)
+
+type recorder struct {
+	ws warning.Service
+}
+
+func (r *recorder) PluginWarning(ctx context.Context, d nri.Deprecation, plugin, details string) {
+	switch d {
+	case nri.DeprecatedStateChange:
+		r.ws.Emit(ctx, deprecation.NRIPluginInterface)
+		msg, _ := deprecation.Message(deprecation.NRIPluginInterface)
+		log.G(ctx).WithFields(log.Fields{
+			"deprecated": "StateChange",
+			"plugin":     plugin,
+			"details":    details,
+		}).Warn(msg)
+	default:
+		log.G(ctx).WithFields(log.Fields{
+			"deprecated": d.String(),
+			"plugin":     plugin,
+			"details":    details,
+		}).Warnf("unknown NRI deprecation (%d)", d)
+	}
+}

--- a/internal/nri/nri.go
+++ b/internal/nri/nri.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/containerd/log"
 
+	"github.com/containerd/containerd/v2/plugins/services/warning"
 	"github.com/containerd/containerd/v2/version"
+
 	nri "github.com/containerd/nri/pkg/adaptation"
 )
 
@@ -111,7 +113,7 @@ type local struct {
 var _ API = &local{}
 
 // New creates an instance of the NRI interface with the given configuration.
-func New(cfg *Config) (API, error) {
+func New(cfg *Config, ws warning.Service) (API, error) {
 	l := &local{
 		cfg: cfg,
 	}
@@ -131,6 +133,7 @@ func New(cfg *Config) (API, error) {
 	)
 
 	cfg.ConfigureTimeouts()
+	opts = append(opts, nri.WithDeprecationRecorder(&recorder{ws: ws}))
 
 	l.nri, err = nri.New(name, version, syncFn, updateFn, opts...)
 	if err != nil {

--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -35,6 +35,8 @@ const (
 	TracingServiceConfig Warning = Prefix + "tracing-service-config"
 	// NRIV010Plugin is a warning for the use of NRI 0.1.0-style plugins
 	NRIV010Plugin Warning = Prefix + "nri-v010-plugin"
+	// NRIPluginInterface is a warning for the use of a deprecated NRI interface.
+	NRIPluginInterface Warning = Prefix + "nri-plugin-interface"
 	// CgroupV1 is a warning for the use of cgroup v1
 	CgroupV1 Warning = Prefix + "cgroup-v1"
 	// CRIEnableCDI is a warning for the use of the `enable_cdi` property
@@ -65,9 +67,10 @@ var messages = map[Warning]string{
 		"Use OTLP environment variables instead: https://opentelemetry.io/docs/specs/otel/protocol/exporter/",
 	TracingServiceConfig: "The `tracing` property of `[plugins.\"io.containerd.internal.v1\".tracing]` is deprecated since containerd v1.6 and will be removed in containerd v2.4. " +
 		"Use OTEL environment variables instead: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/",
-	NRIV010Plugin: "NRI 0.1.0-style plugins are deprecated since containerd 2.2 and should only be used through the v010-adapter plugin.",
-	CgroupV1:      "The support for cgroup v1 is deprecated since containerd v2.2 and will be removed by no later than May 2029. Upgrade the host to use cgroup v2.",
-	CRIEnableCDI:  "The `enable_cdi` property of `[plugins.\"io.containerd.cri.v1.runtime\"]` is deprecated, will be removed in containerd v2.3, and CDI support will always be enabled.",
+	NRIV010Plugin:      "NRI 0.1.0-style plugins are deprecated since containerd 2.2 and should only be used through the v010-adapter plugin.",
+	NRIPluginInterface: "NRI plugin uses a deprecated interface.",
+	CgroupV1:           "The support for cgroup v1 is deprecated since containerd v2.2 and will be removed by no later than May 2029. Upgrade the host to use cgroup v2.",
+	CRIEnableCDI:       "The `enable_cdi` property of `[plugins.\"io.containerd.cri.v1.runtime\"]` is deprecated, will be removed in containerd v2.3, and CDI support will always be enabled.",
 
 	RuncOptionsTaskAPIAddress:           "The `task_api_address` field in runc options is deprecated since containerd v2.3. Set `task_api_address` on CreateTaskRequest instead.",
 	RuncOptionsTaskAPIVersion:           "The `task_api_version` field in runc options is deprecated since containerd v2.3. Set `task_api_version` on CreateTaskRequest instead.",

--- a/plugins/nri/plugin.go
+++ b/plugins/nri/plugin.go
@@ -19,6 +19,7 @@ package nri
 import (
 	"github.com/containerd/containerd/v2/internal/nri"
 	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/services/warning"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 )
@@ -29,6 +30,7 @@ func init() {
 		ID:   "nri",
 		Requires: []plugin.Type{
 			plugins.InternalPlugin,
+			plugins.WarningPlugin,
 		},
 		Config: nri.DefaultConfig(),
 		InitFn: initFunc,
@@ -36,6 +38,12 @@ func init() {
 }
 
 func initFunc(ic *plugin.InitContext) (any, error) {
-	l, err := nri.New(ic.Config.(*nri.Config))
+	ws, err := ic.GetSingle(plugins.WarningPlugin)
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := nri.New(ic.Config.(*nri.Config), ws.(warning.Service))
+
 	return l, err
 }


### PR DESCRIPTION
Record a deprecation and emit a warning for old/unrecompiled plugins using deprecated NRI interfaces.