### PR TITLE
mounts: handle temporary activation without system mounts

### DIFF
--- a/core/mount/manager/manager.go
+++ b/core/mount/manager/manager.go
@@ -473,7 +473,7 @@ func (mm *mountManager) Activate(ctx context.Context, name string, mounts []moun
 	}
 
 	// If first system mount is converted, fill in the format
-	if mountConv != nil {
+	if mountConv != nil && firstSystemMount < len(mounts) {
 		for _, tr := range mountConv[firstSystemMount] {
 			newM, err := tr.Transform(ctx, mounts[firstSystemMount], mounted)
 			if err != nil {

--- a/core/mount/manager/manager_test.go
+++ b/core/mount/manager/manager_test.go
@@ -371,6 +371,37 @@ func TestActivateAlreadyExists(t *testing.T) {
 	assert.NoError(t, m.Deactivate(ctx, "task1"))
 }
 
+func TestTemporaryActivationWithAllMountsHandled(t *testing.T) {
+	td := t.TempDir()
+	db, err := bolt.Open(filepath.Join(td, "mounts.db"), 0600, nil)
+	require.NoError(t, err)
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+
+	mountC := new(atomic.Int32)
+	m, err := NewManager(
+		db,
+		filepath.Join(td, "m"),
+		WithMountHandler("noop", &noopHandler{mounts: mountC}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, m.(io.Closer).Close()) })
+
+	info, err := m.Activate(
+		ctx,
+		"task1",
+		[]mount.Mount{{Type: "format/noop"}},
+		mount.WithTemporary,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, m.Deactivate(ctx, "task1")) })
+
+	require.Len(t, info.Active, 1)
+	require.Len(t, info.System, 1)
+	assert.Equal(t, "bind", info.System[0].Type)
+	assert.Equal(t, info.Active[0].MountPoint, info.System[0].Source)
+	assert.Equal(t, []string{"rbind"}, info.System[0].Options)
+}
+
 func TestActivateStaleIncomplete(t *testing.T) {
 	td := t.TempDir()
 	metadb := filepath.Join(td, "mounts.db")


### PR DESCRIPTION
## Summary

- avoid indexing the mount conversion list when temporary activation handles every mount
- add a regression test for transformed, fully handled temporary activation

## Details

During temporary activation, the mount manager performs every mount and
`firstSystemMount` advances to `len(mounts)`. This is a valid sentinel indicating
that no system mounts remain.

When at least one mount has a transformer, `mountConv` is non-nil and the
post-activation conversion block currently treats `firstSystemMount` as an
index. This causes an out-of-range panic when all mounts were handled.

Only convert the first system mount when one actually remains. The existing
temporary bind-mount behavior is unchanged.

## Testing

- `go test ./core/mount/manager -run TestTemporaryActivationWithAllMountsHandled -count=1`
- `go test ./core/mount/manager -count=1`