### PR TITLE
fix(cri): CRI image pull is sometimes canceled by image_pull_progress…

### DIFF
--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -991,10 +991,10 @@ func (reporter *transferProgressReporter) handleProgress(p transfer.Progress) {
 			delete(reporter.statuses, p.Name)
 		}
 
-	case "complete":
+	case "complete", "extracting", "extracted", "already exists":
 		if node, exists := reporter.statuses[p.Name]; exists {
-			if curProgress := p.Progress - node.Progress; curProgress > 0 {
-				reporter.IncBytesRead(curProgress)
+			if remaining := node.Total - node.Progress; remaining > 0 {
+				reporter.IncBytesRead(remaining)
 			}
 			reporter.reqReporter.decRequest()
 			delete(reporter.statuses, p.Name)

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -723,6 +723,102 @@ func TestTransferProgressReporter(t *testing.T) {
 				assert.Equal(t, uint64(2000), totalBytesRead, "Expected 2000 bytes read")
 			},
 		},
+		{
+			name: "ExtractingEventCompletesRequest",
+			progress: []transfer.Progress{
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "downloading",
+				},
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "extracting",
+				},
+			},
+			check: func(t *testing.T, r *transferProgressReporter, cancelCalled <-chan struct{}) {
+				activeReqs, totalBytesRead := r.reqReporter.status()
+				assert.Equal(t, int32(0), activeReqs, "Expected 0 active requests")
+				assert.Equal(t, uint64(1000), totalBytesRead, "Expected 1000 bytes read")
+			},
+		},
+		{
+			name: "ExtractedEventCompletesRequest",
+			progress: []transfer.Progress{
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "downloading",
+				},
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "extracted",
+				},
+			},
+			check: func(t *testing.T, r *transferProgressReporter, cancelCalled <-chan struct{}) {
+				activeReqs, totalBytesRead := r.reqReporter.status()
+				assert.Equal(t, int32(0), activeReqs, "Expected 0 active requests")
+				assert.Equal(t, uint64(1000), totalBytesRead, "Expected 1000 bytes read")
+			},
+		},
+		{
+			name: "AlreadyExistsEventCompletesRequest",
+			progress: []transfer.Progress{
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "downloading",
+				},
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "already exists",
+				},
+			},
+			check: func(t *testing.T, r *transferProgressReporter, cancelCalled <-chan struct{}) {
+				activeReqs, totalBytesRead := r.reqReporter.status()
+				assert.Equal(t, int32(0), activeReqs, "Expected 0 active requests")
+				assert.Equal(t, uint64(1000), totalBytesRead, "Expected 1000 bytes read")
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #13909.

### Description
When the CRI plugin pulls an image through the transfer service, the image pull can be canceled by `image_pull_progress_timeout` even when all blob downloads have finished and the remaining unpack is progressing.

This happens because the transfer service's polling period is 300ms, and extraction can start within a few milliseconds after download completes. The job transitions directly to `jobExtracting` and sends `"extracting"`/`"extracted"` events instead of `"complete"`.

Since the CRI `transferProgressReporter.handleProgress` only handled `"complete"`, the active request counter was never decremented, causing the watchdog to eventually time out the pull due to lack of download progress.

This patch fixes the issue by allowing the CRI reporter to treat `"extracting"`, `"extracted"`, and `"already exists"` events as completion of the download phase, properly decrementing the active request counter and avoiding the timeout.


