### PR TITLE
cri: use the platform configured in runtime_platforms

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -159,6 +159,81 @@ spec:
 
 See also [the Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/runtime-class/).
 
+### Per-runtime image platform and snapshotter
+
+`runtime_platforms` maps a CRI runtime handler (the `handler` of a `RuntimeClass`)
+to the platform an image should be pulled for and the snapshotter it should be
+unpacked into. Both keys are optional. An unset `platform` means the platform of
+the node, which is the behaviour when `runtime_platforms` is not configured at
+all. `platform` is an OS and an architecture with an optional variant, such as
+`linux/amd64` or `linux/arm/v7`; an OS version is rejected, since images are
+selected by the OS version of the node. An unset `snapshotter` leaves the choice
+to the runtime: the snapshotter configured on the runtime itself applies if there
+is one, and the default snapshotter otherwise. Setting `snapshotter` here applies
+to pulling and unpacking. Containers are created in the `snapshotter` of the
+runtime itself, so when both are set they have to name the same snapshotter.
+
+```toml
+version = 3
+[plugins."io.containerd.cri.v1.images".runtime_platforms]
+  # Pull images for linux/amd64 for pods scheduled to the "runc-amd64"
+  # RuntimeClass, whatever the platform of the node is.
+  [plugins."io.containerd.cri.v1.images".runtime_platforms."runc-amd64"]
+    platform = "linux/amd64"
+  # Use a dedicated snapshotter for Kata Containers, on the platform of the node.
+  [plugins."io.containerd.cri.v1.images".runtime_platforms.kata]
+    snapshotter = "devmapper"
+```
+
+The runtime handler still has to exist under
+`plugins."io.containerd.cri.v1.runtime".containerd.runtimes`, and a `RuntimeClass`
+pointing at it has to exist in the cluster:
+
+```toml
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc-amd64]
+  runtime_type = "io.containerd.runc.v2"
+```
+
+```yaml
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: runc-amd64
+handler: runc-amd64
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: amd64-only
+spec:
+  runtimeClassName: runc-amd64
+  containers:
+    - name: app
+      image: example.com/amd64-only:latest
+```
+
+A non-native `platform` only makes sense on a host that can execute foreign-architecture
+binaries, through Rosetta on Apple Silicon or a `binfmt_misc` handler such as
+`qemu-user-static` registered with the `F` flag so that it applies inside container
+namespaces. containerd selects the image, it does not provide the emulation.
+
+Some caveats apply when a `platform` differs from the platform of the node:
+
+* The node keeps advertising its own architecture through `kubernetes.io/arch`, so
+  the scheduler and any architecture-based `nodeAffinity` are unaware that a pod
+  runs a foreign-architecture image. Selecting a `RuntimeClass` is the opt-in.
+* Pinned images, including the sandbox (pause) image, are always pulled for the
+  platform of the node. They are shared by every pod on the node and are part of
+  containerd's own infrastructure.
+* Images are stored per platform, so the same reference can be pulled for the
+  platform of the node and for a configured platform at once. `ImageStatus` and
+  `RemoveImage` answer for the runtime handler in the request, and an image that
+  is not unpacked in the snapshotter of that handler is reported as absent so
+  that it is pulled through it.
+* The platforms of one image share its tags and digests in containerd. Removing
+  the image for one platform removes those shared references, so the other
+  platforms remain known by their image id only, and no content is reclaimed
+  until every platform of the image is removed.
 
 ## Image Pull Configuration (since containerd v2.1)
 

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
 	"github.com/pelletier/go-toml/v2"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -549,6 +550,22 @@ func ValidateImageConfig(ctx context.Context, c *ImageConfig) ([]deprecation.War
 	if c.ImagePullProgressTimeout != "" {
 		if _, err := time.ParseDuration(c.ImagePullProgressTimeout); err != nil {
 			return warnings, fmt.Errorf("invalid image pull progress timeout: %w", err)
+		}
+	}
+
+	// Validation for runtime_platforms. Images are keyed by OS, architecture
+	// and variant, and selected by the OS version of the node, so a
+	// configured OS version would be silently ignored. Reject it instead.
+	for name, rp := range c.RuntimePlatforms {
+		if rp.Platform == "" {
+			continue
+		}
+		p, err := platforms.Parse(rp.Platform)
+		if err != nil {
+			return warnings, fmt.Errorf("invalid platform %q in `runtime_platforms.%s`: %w", rp.Platform, name, err)
+		}
+		if p.OSVersion != "" || len(p.OSFeatures) > 0 {
+			return warnings, fmt.Errorf("invalid platform %q in `runtime_platforms.%s`: an OS version or OS features cannot be configured, images are selected by the OS version of the node", rp.Platform, name)
 		}
 	}
 

--- a/internal/cri/config/config_test.go
+++ b/internal/cri/config/config_test.go
@@ -234,6 +234,22 @@ func TestValidateConfig(t *testing.T) {
 			},
 			warnings: []deprecation.Warning{deprecation.CRIRegistryConfigs},
 		},
+		"runtime_platforms with an OS version": {
+			imageConfig: &ImageConfig{
+				RuntimePlatforms: map[string]ImagePlatform{
+					"hyperv": {Platform: "windows(10.0.17763)/amd64"},
+				},
+			},
+			imageExpectedErr: "OS version",
+		},
+		"runtime_platforms with an invalid platform": {
+			imageConfig: &ImageConfig{
+				RuntimePlatforms: map[string]ImagePlatform{
+					"bad": {Platform: "linux/amd64/v3/extra"},
+				},
+			},
+			imageExpectedErr: "invalid platform",
+		},
 		"cgroup_writable enabled": {
 			runtimeConfig: &RuntimeConfig{
 				ContainerdConfig: ContainerdConfig{

--- a/internal/cri/opts/container.go
+++ b/internal/cri/opts/container.go
@@ -65,7 +65,12 @@ func unpackImage(ctx context.Context, client *containerd.Client, i containerd.Im
 	}
 	defer done(ctx)
 
-	matcher := platforms.Default()
+	// Unpack for the platform the image was resolved for, which is not
+	// necessarily the platform of the node (see the runtime_platforms config).
+	matcher := i.Platform()
+	if matcher == nil {
+		matcher = platforms.Default()
+	}
 
 	capabilities, err := client.GetSnapshotterCapabilities(ctx, snapshotter)
 	if err != nil {

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -128,7 +128,10 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 
 	// Prepare container image snapshot. For container, the image should have
 	// been pulled before creating the container, so do not ensure the image.
-	image, err := c.LocalResolve(config.GetImage().GetImage())
+	// Resolve the image on the platform of the runtime handler of the
+	// sandbox, which is the platform it was pulled for.
+	platform := c.ImageService.PlatformForImage(config.GetImage().GetImage(), sandbox.Metadata.RuntimeHandler)
+	image, err := c.LocalResolve(config.GetImage().GetImage(), platform)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve image %q: %w", config.GetImage().GetImage(), err)
 	}

--- a/internal/cri/server/container_image_mount.go
+++ b/internal/cri/server/container_image_mount.go
@@ -25,9 +25,9 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
-	"github.com/containerd/platforms"
 	"github.com/opencontainers/image-spec/identity"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -88,7 +88,7 @@ func (c *criService) mutateImageMount(
 	if ref == "" {
 		return fmt.Errorf("image not specified in: %+v", imageSpec)
 	}
-	image, err := c.LocalResolve(ref)
+	image, err := c.LocalResolve(ref, platform)
 	if err != nil {
 		return fmt.Errorf("failed to resolve image %q: %w", ref, err)
 	}
@@ -113,7 +113,7 @@ func (c *criService) mutateImageMount(
 			return fmt.Errorf("failed to get image volume ref %q: %w", ref, err)
 		}
 
-		i := containerd.NewImageWithPlatform(c.client, img, platforms.Only(platform))
+		i := containerd.NewImageWithPlatform(c.client, img, util.PlatformMatcher(platform))
 		if err := i.Unpack(ctx, snapshotter); err != nil {
 			return fmt.Errorf("failed to unpack image volume: %w", err)
 		}

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -28,6 +28,7 @@ import (
 	snapshotstore "github.com/containerd/containerd/v2/internal/cri/store/snapshot"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/typeurl/v2"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -381,7 +382,11 @@ func (s *fakeImageService) GetSnapshot(key, snapshotter string) (snapshotstore.S
 	return snapshotstore.Snapshot{}, errors.New("not implemented")
 }
 
-func (s *fakeImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
+func (s *fakeImageService) PlatformForImage(string, string) imagespec.Platform {
+	return imagespec.Platform{}
+}
+
+func (s *fakeImageService) LocalResolve(refOrID string, _ imagespec.Platform) (imagestore.Image, error) {
 	return imagestore.Image{}, errors.New("not implemented")
 }
 

--- a/internal/cri/server/helpers.go
+++ b/internal/cri/server/helpers.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/containerd/typeurl/v2"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -36,8 +37,10 @@ import (
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
+	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
 )
 
 // TODO: Move common helpers for sbserver and podsandbox to a dedicated package once basic services are functional.
@@ -171,7 +174,29 @@ func (c *criService) toContainerdImage(ctx context.Context, image imagestore.Ima
 	if len(image.References) == 0 {
 		return nil, fmt.Errorf("invalid image with no reference %q", image.ID)
 	}
-	return c.client.GetImage(ctx, image.References[0])
+	img, err := c.client.GetImage(ctx, image.References[0])
+	if err != nil {
+		return nil, err
+	}
+
+	if matcher := containerImagePlatform(image.Platform); matcher != nil {
+		return containerd.NewImageWithPlatform(c.client, img.Metadata(), matcher), nil
+	}
+	return img, nil
+}
+
+// containerImagePlatform returns the platform matcher to use for an image the
+// CRI image store resolved, or nil to keep the matcher of the client.
+//
+// The client matches the platform of the node, which on Windows also carries
+// the OS version handling that picks the right image out of an index. That is
+// only replaced when the image was resolved for a different platform, through
+// the runtime_platforms config, which the client cannot match at all.
+func containerImagePlatform(platform imagespec.Platform) platforms.MatchComparer {
+	if util.IsNodePlatform(platform) {
+		return nil
+	}
+	return util.PlatformMatcher(platform)
 }
 
 // getUserFromImage gets uid or user name of the image user.

--- a/internal/cri/server/helpers_platform_test.go
+++ b/internal/cri/server/helpers_platform_test.go
@@ -1,0 +1,53 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	"github.com/containerd/platforms"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContainerImagePlatform pins that only an image resolved for a platform
+// other than the platform of the node replaces the matcher of the client.
+// Replacing it for the platform of the node would drop the matching the client
+// does, including the OS version handling Windows needs to pick an image out of
+// an index.
+func TestContainerImagePlatform(t *testing.T) {
+	t.Run("unset platform keeps the client matcher", func(t *testing.T) {
+		assert.Nil(t, containerImagePlatform(imagespec.Platform{}))
+		assert.Nil(t, containerImagePlatform(imagespec.Platform{OS: "linux"}))
+		assert.Nil(t, containerImagePlatform(imagespec.Platform{Architecture: "amd64"}))
+	})
+
+	t.Run("platform of the node keeps the client matcher", func(t *testing.T) {
+		assert.Nil(t, containerImagePlatform(platforms.DefaultSpec()))
+	})
+
+	t.Run("foreign platform is pinned", func(t *testing.T) {
+		foreign := imagespec.Platform{OS: "linux", Architecture: "mips64le"}
+		require.False(t, platforms.Default().Match(foreign), "fixture must not be the platform of the node")
+
+		matcher := containerImagePlatform(foreign)
+		require.NotNil(t, matcher)
+		assert.True(t, matcher.Match(foreign))
+		assert.False(t, matcher.Match(platforms.DefaultSpec()))
+	})
+}

--- a/internal/cri/server/images/check.go
+++ b/internal/cri/server/images/check.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 	"sync"
 
+	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/log"
-	"github.com/containerd/platforms"
 )
 
 // CheckImages checks all existing images to ensure they are ready to
@@ -42,25 +43,37 @@ func (c *CRIImageService) CheckImages(ctx context.Context) error {
 	for _, i := range cImages {
 		wg.Go(func() {
 			// TODO: Check platform/snapshot combination. Snapshot check should come first
-			ok, _, _, _, err := images.Check(ctx, i.ContentStore(), i.Target(), platforms.Default())
+			onNodePlatform, matched, err := c.checkImagePlatforms(ctx, i)
 			if err != nil {
 				log.G(ctx).WithError(err).Errorf("Failed to check image content readiness for %q", i.Name())
 				return
 			}
-			if !ok {
+			if !matched {
 				log.G(ctx).Warnf("The image content readiness for %q is not ok", i.Name())
 				return
 			}
-			// Checking existence of top-level snapshot for each image being recovered.
-			// TODO: This logic should be done elsewhere and owned by the image service
-			unpacked, err := i.IsUnpacked(ctx, snapshotter)
-			if err != nil {
-				log.G(ctx).WithError(err).Warnf("Failed to check whether image is unpacked for image %s", i.Name())
-				return
-			}
-			if !unpacked {
-				log.G(ctx).Warnf("The image %s is not unpacked.", i.Name())
-				// TODO(random-liu): Consider whether we should try unpack here.
+			if onNodePlatform {
+				// Checking existence of top-level snapshot for each image being recovered.
+				// TODO: This logic should be done elsewhere and owned by the image service
+				unpacked, err := i.IsUnpacked(ctx, snapshotter)
+				if err != nil {
+					log.G(ctx).WithError(err).Warnf("Failed to check whether image %s is unpacked in snapshotter %q", i.Name(), snapshotter)
+					return
+				}
+				if !unpacked {
+					// Only the default snapshotter is checked, so an image
+					// unpacked in the snapshotter of a runtime reaches here too.
+					log.G(ctx).Warnf("The image %s is not unpacked in snapshotter %q.", i.Name(), snapshotter)
+					// TODO(random-liu): Consider whether we should try unpack here.
+				}
+			} else {
+				// The image is only present for a platform configured through
+				// runtime_platforms. The containerd client resolves images
+				// against the platform of the node, so the top-level snapshot
+				// cannot be checked here. The image still has to be recovered,
+				// otherwise ImageStatus would not report it and the kubelet
+				// would keep pulling it.
+				log.G(ctx).Debugf("Skipping unpack check for image %q, which is not present for the platform of the node", i.Name())
 			}
 			if err := c.UpdateImage(ctx, i.Name()); err != nil {
 				log.G(ctx).WithError(err).Warnf("Failed to update reference for image %q", i.Name())
@@ -71,4 +84,25 @@ func (c *CRIImageService) CheckImages(ctx context.Context) error {
 	}
 	wg.Wait()
 	return nil
+}
+
+// checkImagePlatforms reports whether the content of the image is complete for
+// at least one of the platforms images may be stored for, and whether the
+// platform that matched is the platform of the node.
+//
+// An image is only present locally for the platforms it was actually pulled
+// for, so an image pulled for a platform configured through runtime_platforms
+// would not be recovered if only the platform of the node were checked.
+func (c *CRIImageService) checkImagePlatforms(ctx context.Context, i containerd.Image) (onNodePlatform, matched bool, err error) {
+	for idx, platform := range c.platformsForImages() {
+		ok, _, _, _, err := images.Check(ctx, i.ContentStore(), i.Target(), util.PlatformMatcher(platform))
+		if err != nil {
+			return false, false, err
+		}
+		if ok {
+			// platformsForImages always returns the platform of the node first.
+			return idx == 0, true, nil
+		}
+	}
+	return false, false, nil
 }

--- a/internal/cri/server/images/image_config_test.go
+++ b/internal/cri/server/images/image_config_test.go
@@ -1,0 +1,138 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blobStore is a content.Store holding only the blobs it was given, so that a
+// platform can be made partially present.
+type blobStore struct {
+	content.Store
+	blobs map[digest.Digest][]byte
+}
+
+func (b blobStore) ReaderAt(_ context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	raw, ok := b.blobs[desc.Digest]
+	if !ok {
+		return nil, fmt.Errorf("content %v: %w", desc.Digest, errdefs.ErrNotFound)
+	}
+	return blobReaderAt{bytes.NewReader(raw)}, nil
+}
+
+func (b blobStore) Info(_ context.Context, dgst digest.Digest) (content.Info, error) {
+	raw, ok := b.blobs[dgst]
+	if !ok {
+		return content.Info{}, fmt.Errorf("content %v: %w", dgst, errdefs.ErrNotFound)
+	}
+	return content.Info{Digest: dgst, Size: int64(len(raw))}, nil
+}
+
+type blobReaderAt struct{ *bytes.Reader }
+
+func (r blobReaderAt) Close() error { return nil }
+func (r blobReaderAt) Size() int64  { return r.Reader.Size() }
+
+// fakeImage is a containerd.Image exposing only what imageConfig uses.
+type fakeImage struct {
+	containerd.Image
+	target ocispec.Descriptor
+	store  content.Store
+}
+
+func (f fakeImage) Target() ocispec.Descriptor  { return f.target }
+func (f fakeImage) ContentStore() content.Store { return f.store }
+
+func marshalBlob(t *testing.T, blobs map[digest.Digest][]byte, mediaType string, v any, platform *ocispec.Platform, present bool) ocispec.Descriptor {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	require.NoError(t, err)
+	dgst := digest.FromBytes(raw)
+	if present {
+		blobs[dgst] = raw
+	}
+	return ocispec.Descriptor{MediaType: mediaType, Digest: dgst, Size: int64(len(raw)), Platform: platform}
+}
+
+// TestImageConfigSkipsPlatformWithoutConfigBlob builds an index advertising two
+// platforms where the first one has its manifest but not its image config, the
+// state a torn pull leaves behind. imageConfig must skip it and pick the
+// platform the image store would also resolve, otherwise UpdateImage mints an
+// image id reference for a platform the store then rejects.
+func TestImageConfigSkipsPlatformWithoutConfigBlob(t *testing.T) {
+	nodePlatform := platforms.DefaultSpec()
+	otherPlatform := ocispec.Platform{OS: "linux", Architecture: "mips64le"}
+
+	blobs := map[digest.Digest][]byte{}
+	var manifests []ocispec.Descriptor
+	var wantDigest digest.Digest
+
+	for _, tc := range []struct {
+		platform    ocispec.Platform
+		configFound bool
+	}{
+		{nodePlatform, false}, // manifest present, config missing
+		{otherPlatform, true}, // fully present
+	} {
+		p := tc.platform
+		layer := []byte("layer-" + p.Architecture)
+		layerDigest := digest.FromBytes(layer)
+		configDesc := marshalBlob(t, blobs, ocispec.MediaTypeImageConfig, ocispec.Image{
+			Platform: p,
+			RootFS:   ocispec.RootFS{Type: "layers", DiffIDs: []digest.Digest{layerDigest}},
+		}, nil, tc.configFound)
+		if tc.configFound {
+			wantDigest = configDesc.Digest
+		}
+		manifests = append(manifests, marshalBlob(t, blobs, ocispec.MediaTypeImageManifest, ocispec.Manifest{
+			MediaType: ocispec.MediaTypeImageManifest,
+			Config:    configDesc,
+			Layers:    []ocispec.Descriptor{{MediaType: ocispec.MediaTypeImageLayer, Digest: layerDigest, Size: int64(len(layer))}},
+		}, &p, true))
+	}
+
+	index := marshalBlob(t, blobs, ocispec.MediaTypeImageIndex, ocispec.Index{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: manifests,
+	}, nil, true)
+
+	c, _ := newTestCRIService()
+	c.imagePlatforms = imagePlatforms(map[string]ImagePlatform{
+		"runc-other": {Platform: otherPlatform},
+	})
+
+	desc, err := c.imageConfig(context.Background(), fakeImage{
+		target: index,
+		store:  blobStore{blobs: blobs},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, wantDigest, desc.Digest, "should select the platform whose config is present locally")
+}

--- a/internal/cri/server/images/image_handler_test.go
+++ b/internal/cri/server/images/image_handler_test.go
@@ -1,0 +1,227 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
+	"github.com/containerd/containerd/v2/internal/cri/util"
+	"github.com/containerd/errdefs"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// fakeSnapshotter reports a fixed set of snapshot keys as present.
+type fakeSnapshotter struct {
+	snapshots.Snapshotter
+	present map[string]bool
+}
+
+func (f fakeSnapshotter) Stat(_ context.Context, key string) (snapshots.Info, error) {
+	if f.present[key] {
+		return snapshots.Info{Name: key}, nil
+	}
+	return snapshots.Info{}, fmt.Errorf("snapshot %q: %w", key, errdefs.ErrNotFound)
+}
+
+const (
+	testChainID  = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	testImageID  = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	testImageRef = "gcr.io/library/busybox:latest"
+)
+
+// withStoredImage puts an image in the CRI store for the given platform.
+func withStoredImage(t *testing.T, c *CRIImageService, platform imagespec.Platform) imagestore.Image {
+	t.Helper()
+	img := imagestore.Image{
+		ID:         testImageID,
+		ChainID:    testChainID,
+		References: []string{testImageRef},
+		Platform:   platform,
+	}
+	store, err := imagestore.NewFakeStore([]imagestore.Image{img})
+	require.NoError(t, err)
+	c.imageStore = store
+	return img
+}
+
+// TestImageStatusReportsAbsentWhenNotUnpacked covers what mikebrow and mxpv
+// asked for: the same image can be unpacked in several snapshotters, and that
+// changes outside of CRI, so presence is looked up rather than stored. An image
+// that is not unpacked in the snapshotter of the handler is reported as absent,
+// which makes the caller pull it through that snapshotter.
+func TestImageStatusReportsAbsentWhenNotUnpacked(t *testing.T) {
+	for _, tt := range []struct {
+		desc           string
+		unpackedIn     string
+		runtimeHandler string
+		wantPresent    bool
+	}{
+		{
+			desc:        "present in the default snapshotter, no handler",
+			unpackedIn:  "overlayfs",
+			wantPresent: true,
+		},
+		{
+			// Without a handler the question is whether the image is known,
+			// not whether it can be run by a particular runtime. An image
+			// pulled outside CRI is not unpacked and has to stay visible,
+			// which integration covers in
+			// TestContainerdSandboxImagePulledOutsideCRI.
+			desc:        "not unpacked anywhere, no handler",
+			unpackedIn:  "nowhere",
+			wantPresent: true,
+		},
+		{
+			desc:           "present in the snapshotter of the handler",
+			unpackedIn:     "devmapper",
+			runtimeHandler: "kata",
+			wantPresent:    true,
+		},
+		{
+			desc:           "unpacked only in the default snapshotter, asked for the handler",
+			unpackedIn:     "overlayfs",
+			runtimeHandler: "kata",
+			wantPresent:    false,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			c, _ := newTestCRIService()
+			c.config.Snapshotter = "overlayfs"
+			c.runtimePlatforms["kata"] = ImagePlatform{Snapshotter: "devmapper"}
+			withStoredImage(t, c, util.NodePlatform())
+			c.snapshotterProvider = func(name string) snapshots.Snapshotter {
+				return fakeSnapshotter{present: map[string]bool{testChainID: name == tt.unpackedIn}}
+			}
+
+			resp, err := c.ImageStatus(context.Background(), &runtime.ImageStatusRequest{
+				Image: &runtime.ImageSpec{Image: testImageRef, RuntimeHandler: tt.runtimeHandler},
+			})
+			require.NoError(t, err)
+			if !tt.wantPresent {
+				assert.Nil(t, resp.GetImage(), "image must be reported as absent")
+				return
+			}
+			require.NotNil(t, resp.GetImage())
+			assert.Equal(t, testImageID, resp.GetImage().GetId())
+			if tt.runtimeHandler != "" {
+				assert.Equal(t, tt.runtimeHandler, resp.GetImage().GetSpec().GetRuntimeHandler(),
+					"the status has to say which handler it is for")
+			}
+		})
+	}
+}
+
+// TestImageStatusResolvesOnTheHandlerPlatform pins that the handler selects the
+// platform the image is looked up on.
+func TestImageStatusResolvesOnTheHandlerPlatform(t *testing.T) {
+	c, _ := newTestCRIService()
+	c.config.Snapshotter = "overlayfs"
+	c.runtimePlatforms["runc-foreign"] = ImagePlatform{Platform: testForeignPlatform}
+	c.snapshotterProvider = func(string) snapshots.Snapshotter {
+		return fakeSnapshotter{present: map[string]bool{testChainID: true}}
+	}
+
+	// The image is only stored for the foreign platform.
+	withStoredImage(t, c, testForeignPlatform)
+
+	t.Run("found for the handler that names that platform", func(t *testing.T) {
+		resp, err := c.ImageStatus(context.Background(), &runtime.ImageStatusRequest{
+			Image: &runtime.ImageSpec{Image: testImageRef, RuntimeHandler: "runc-foreign"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetImage())
+		assert.Equal(t, testImageID, resp.GetImage().GetId())
+	})
+
+	t.Run("absent on the platform of the node", func(t *testing.T) {
+		resp, err := c.ImageStatus(context.Background(), &runtime.ImageStatusRequest{
+			Image: &runtime.ImageSpec{Image: testImageRef},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, resp.GetImage())
+	})
+}
+
+// TestImageStatusToleratesUnreachableSnapshotter pins that a snapshotter that
+// cannot be resolved does not fail the request. Before this check existed the
+// image was reported as present, and failing here would stall the caller.
+func TestImageStatusToleratesUnreachableSnapshotter(t *testing.T) {
+	c, _ := newTestCRIService()
+	c.config.Snapshotter = "overlayfs"
+	withStoredImage(t, c, util.NodePlatform())
+	c.snapshotterProvider = func(string) snapshots.Snapshotter { return nil }
+
+	resp, err := c.ImageStatus(context.Background(), &runtime.ImageStatusRequest{
+		Image: &runtime.ImageSpec{Image: testImageRef},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.GetImage())
+	assert.Equal(t, testImageID, resp.GetImage().GetId())
+}
+
+func TestPlatformAndSnapshotterForRuntimeHandler(t *testing.T) {
+	c, _ := newTestCRIService()
+	c.config.Snapshotter = "overlayfs"
+	c.runtimePlatforms["runc-foreign"] = ImagePlatform{Platform: testForeignPlatform}
+	c.runtimePlatforms["kata"] = ImagePlatform{Snapshotter: "devmapper"}
+
+	assert.True(t, util.IsNodePlatform(c.PlatformForRuntimeHandler("")))
+	assert.True(t, util.IsNodePlatform(c.PlatformForRuntimeHandler("does-not-exist")))
+	assert.True(t, util.IsNodePlatform(c.PlatformForRuntimeHandler("kata")))
+	assert.Equal(t, util.PlatformKey(testForeignPlatform), util.PlatformKey(c.PlatformForRuntimeHandler("runc-foreign")))
+
+	assert.Equal(t, "overlayfs", c.SnapshotterForRuntimeHandler(""))
+	assert.Equal(t, "overlayfs", c.SnapshotterForRuntimeHandler("does-not-exist"))
+	assert.Equal(t, "overlayfs", c.SnapshotterForRuntimeHandler("runc-foreign"))
+	assert.Equal(t, "devmapper", c.SnapshotterForRuntimeHandler("kata"))
+
+	// Sanity: the fixture must not be the platform of the node, or the
+	// assertions above are vacuous.
+	require.False(t, util.IsNodePlatform(testForeignPlatform))
+}
+
+// TestPinnedImageStaysOnNodePlatform pins that a pinned image is looked up on
+// the platform of the node whatever handler asks about it, which is the platform
+// PullImage pulls it for. Otherwise ImageStatus reports it absent right after a
+// pull for that handler succeeded, and the caller pulls it again on every sync.
+func TestPinnedImageStaysOnNodePlatform(t *testing.T) {
+	c, _ := newTestCRIService()
+	c.config.Snapshotter = "overlayfs"
+	c.config.PinnedImages = map[string]string{"sandbox": testImageRef}
+	c.runtimePlatforms["runc-foreign"] = ImagePlatform{Platform: testForeignPlatform}
+	c.snapshotterProvider = func(string) snapshots.Snapshotter {
+		return fakeSnapshotter{present: map[string]bool{testChainID: true}}
+	}
+	withStoredImage(t, c, util.NodePlatform())
+
+	assert.True(t, util.IsNodePlatform(c.PlatformForImage(testImageRef, "runc-foreign")))
+	assert.False(t, util.IsNodePlatform(c.PlatformForImage("docker.io/library/other:latest", "runc-foreign")))
+
+	resp, err := c.ImageStatus(context.Background(), &runtime.ImageStatusRequest{
+		Image: &runtime.ImageSpec{Image: testImageRef, RuntimeHandler: "runc-foreign"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.GetImage(), "a pinned image pulled for the node must be found for any handler")
+	assert.Equal(t, testImageID, resp.GetImage().GetId())
+}

--- a/internal/cri/server/images/image_list.go
+++ b/internal/cri/server/images/image_list.go
@@ -33,7 +33,7 @@ func (c *GRPCCRIImageService) ListImages(ctx context.Context, r *runtime.ListIma
 	for _, image := range imagesInStore {
 		// TODO(random-liu): [P0] Make sure corresponding snapshot exists. What if snapshot
 		// doesn't exist?
-		images = append(images, toCRIImage(image))
+		images = append(images, toCRIImage(image, ""))
 	}
 
 	return &runtime.ListImagesResponse{Images: images}, nil

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -165,14 +165,17 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 		return "", fmt.Errorf("failed to parse image_pull_progress_timeout %q: %w", c.config.ImagePullProgressTimeout, err)
 	}
 
-	snapshotter, err := c.snapshotterFromPodSandboxConfig(ctx, ref, sandboxConfig, runtimeHandler)
+	imagePlatform, err := c.imagePlatformFromPodSandboxConfig(ctx, ref, sandboxConfig, runtimeHandler)
 	if err != nil {
 		return "", err
 	}
+	snapshotter := imagePlatform.Snapshotter
+	platformMatcher := util.PlatformMatcher(imagePlatform.Platform)
 
 	span.SetAttributes(
 		tracing.Attribute("image.ref", ref),
 		tracing.Attribute("snapshotter.name", snapshotter),
+		tracing.Attribute("image.platform", platforms.FormatAll(imagePlatform.Platform)),
 	)
 	labels := c.getLabels(ctx, ref)
 
@@ -185,9 +188,9 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 		bytesPulled uint64
 	)
 	if c.config.UseLocalImagePull {
-		image, bytesPulled, err = c.pullImageWithLocalPull(ctx, ref, credentials, snapshotter, labels, imagePullProgressTimeout)
+		image, bytesPulled, err = c.pullImageWithLocalPull(ctx, ref, credentials, snapshotter, imagePlatform.Platform, labels, imagePullProgressTimeout)
 	} else {
-		image, bytesPulled, err = c.pullImageWithTransferService(ctx, ref, credentials, snapshotter, labels, imagePullProgressTimeout)
+		image, bytesPulled, err = c.pullImageWithTransferService(ctx, ref, credentials, snapshotter, imagePlatform.Platform, labels, imagePullProgressTimeout)
 	}
 
 	if err != nil {
@@ -196,7 +199,10 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 
 	span.AddEvent("Pull and unpack image complete")
 
-	configDesc, err := image.Config(ctx)
+	// Resolve the config against the platform that was pulled rather than
+	// against the platform the client was created with, which is always the
+	// platform of the node.
+	configDesc, err := containerdimages.Config(ctx, image.ContentStore(), image.Target(), platformMatcher)
 	if err != nil {
 		return "", fmt.Errorf("get image config descriptor: %w", err)
 	}
@@ -215,7 +221,7 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 		// No need to use `updateImage`, because the image reference must
 		// have been managed by the cri plugin.
 		// TODO: Use image service directly
-		if err := c.imageStore.Update(ctx, r); err != nil {
+		if err := c.imageStore.Update(ctx, r, imagePlatform.Platform); err != nil {
 			return "", fmt.Errorf("failed to update image store %q: %w", r, err)
 		}
 	}
@@ -224,12 +230,16 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 	recordImagePullThroughput(imagePullThroughput, bytesPulled, elapsed)
 	recordImagePullThroughput(imagePullThroughputMiBps, bytesPulled, elapsed)
 
-	size, sizeErr := image.Size(ctx)
-	if sizeErr == nil {
+	// Report the size recorded by the image store, which resolved the image
+	// against the platform it was pulled for. image.Size resolves against the
+	// platform of the node, which is not necessarily the platform pulled.
+	var size int64
+	if storedImage, err := c.imageStore.Get(imageID); err == nil {
+		size = storedImage.Size
 		span.SetAttributes(tracing.Attribute("image.size.bytes", size))
 	}
-	log.G(ctx).Infof("Pulled image %q with image id %q, repo tag %q, repo digest %q, size %q in %s", name, imageID,
-		repoTag, repoDigest, strconv.FormatInt(size, 10), elapsed)
+	log.G(ctx).Infof("Pulled image %q with image id %q, repo tag %q, repo digest %q, platform %q, size %q in %s", name, imageID,
+		repoTag, repoDigest, platforms.FormatAll(imagePlatform.Platform), strconv.FormatInt(size, 10), elapsed)
 	// NOTE(random-liu): the actual state in containerd is the source of truth, even we maintain
 	// in-memory image store, it's only for in-memory indexing. The image could be removed
 	// by someone else anytime, before/during/after we create the metadata. We should always
@@ -248,6 +258,7 @@ func (c *CRIImageService) pullImageWithLocalPull(
 	ref string,
 	credentials func(string) (string, string, error),
 	snapshotter string,
+	platform imagespec.Platform,
 	labels map[string]string,
 	imagePullProgressTimeout time.Duration,
 ) (containerd.Image, uint64, error) {
@@ -259,9 +270,10 @@ func (c *CRIImageService) pullImageWithLocalPull(
 		Hosts:   c.registryHosts(ctx, credentials, pullReporter.optionUpdateClient),
 	})
 
-	log.G(ctx).Debugf("PullImage %q with snapshotter %s using client.Pull()", ref, snapshotter)
+	log.G(ctx).Debugf("PullImage %q with snapshotter %s and platform %s using client.Pull()", ref, snapshotter, platforms.FormatAll(platform))
 	pullOpts := []containerd.RemoteOpt{
 		containerd.WithResolver(resolver),
+		containerd.WithPlatformMatcher(util.PlatformMatcher(platform)),
 		containerd.WithPullSnapshotter(snapshotter),
 		containerd.WithPullUnpack,
 		containerd.WithPullLabels(labels),
@@ -306,18 +318,19 @@ func (c *CRIImageService) pullImageWithTransferService(
 	ref string,
 	credentials func(string) (string, string, error),
 	snapshotter string,
+	platform imagespec.Platform,
 	labels map[string]string,
 	imagePullProgressTimeout time.Duration,
 ) (containerd.Image, uint64, error) {
-	log.G(ctx).Debugf("PullImage %q with snapshotter %s using transfer service", ref, snapshotter)
+	log.G(ctx).Debugf("PullImage %q with snapshotter %s and platform %s using transfer service", ref, snapshotter, platforms.FormatAll(platform))
 	rctx, rcancel := context.WithCancel(ctx)
 	defer rcancel()
 	transferProgressReporter := newTransferProgressReporter(ref, rcancel, imagePullProgressTimeout)
 
 	// Set image store opts
 	sopts := []transferimage.StoreOpt{
-		transferimage.WithPlatforms(platforms.DefaultSpec()),
-		transferimage.WithUnpack(platforms.DefaultSpec(), snapshotter),
+		transferimage.WithPlatforms(platform),
+		transferimage.WithUnpack(platform, snapshotter),
 		transferimage.WithImageLabels(labels),
 	}
 
@@ -437,12 +450,72 @@ func (c *CRIImageService) createOrUpdateImageReference(ctx context.Context, name
 // getLabels get image labels to be added on CRI image
 func (c *CRIImageService) getLabels(ctx context.Context, name string) map[string]string {
 	labels := map[string]string{crilabels.ImageLabelKey: crilabels.ImageLabelValue}
-	for _, pinned := range c.config.PinnedImages {
-		if pinned == name {
-			labels[crilabels.PinnedImageLabelKey] = crilabels.PinnedImageLabelValue
-		}
+	if c.isPinnedImage(name) {
+		labels[crilabels.PinnedImageLabelKey] = crilabels.PinnedImageLabelValue
 	}
 	return labels
+}
+
+// updateImageStore refreshes a reference on every platform images may be
+// stored for. A reference that does not resolve on a platform is dropped from
+// that platform, which is the normal state of an image pulled for another one.
+func (c *CRIImageService) updateImageStore(ctx context.Context, r string) error {
+	for _, platform := range c.platformsForImages() {
+		if !c.storesImageForPlatform(ctx, r, platform) {
+			continue
+		}
+		if err := c.imageStore.Update(ctx, r, platform); err != nil {
+			return fmt.Errorf("update image store for %q on %s: %w", r, platforms.FormatAll(platform), err)
+		}
+	}
+	return nil
+}
+
+// storesImageForPlatform reports whether a reference should be stored for a
+// platform when the platform it was pulled for is not known, as on reload.
+//
+// Resolving is not enough on its own for a platform other than the one of the
+// node: an image may carry the manifest and the config of a platform it was
+// never pulled for, and storing that would list an image that cannot be run.
+// Requiring it to be unpacked distinguishes the two. The platform of the node
+// keeps resolving alone, which is what it did before images were stored per
+// platform.
+func (c *CRIImageService) storesImageForPlatform(ctx context.Context, r string, platform imagespec.Platform) bool {
+	if util.IsNodePlatform(platform) {
+		return true
+	}
+	image, err := c.imageStore.Lookup(ctx, r, platform)
+	if err != nil {
+		// Let Update record that the reference no longer resolves here.
+		return true
+	}
+	for _, snapshotter := range c.snapshottersForPlatform(platform) {
+		if unpacked, err := c.IsImageUnpacked(ctx, image, snapshotter); err == nil && unpacked {
+			return true
+		}
+	}
+	log.G(ctx).Debugf("Not storing image %q for platform %s, it is not unpacked in any snapshotter of that platform",
+		r, platforms.FormatAll(platform))
+	return false
+}
+
+// snapshottersForPlatform returns the snapshotters images on that platform may
+// be unpacked into.
+func (c *CRIImageService) snapshottersForPlatform(platform imagespec.Platform) []string {
+	var result []string
+	seen := map[string]struct{}{}
+	for handler, p := range c.runtimePlatforms {
+		if util.PlatformKey(p.Platform) != util.PlatformKey(platform) {
+			continue
+		}
+		snapshotter := c.SnapshotterForRuntimeHandler(handler)
+		if _, ok := seen[snapshotter]; ok {
+			continue
+		}
+		seen[snapshotter] = struct{}{}
+		result = append(result, snapshotter)
+	}
+	return result
 }
 
 // UpdateImage updates image store to reflect the newest state of an image reference
@@ -457,8 +530,8 @@ func (c *CRIImageService) UpdateImage(ctx context.Context, r string) error {
 		}
 		// If the image is not found, we should continue updating the cache,
 		// so that the image can be removed from the cache.
-		if err := c.imageStore.Update(ctx, r); err != nil {
-			return fmt.Errorf("update image store for %q: %w", r, err)
+		if err := c.updateImageStore(ctx, r); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -469,7 +542,7 @@ func (c *CRIImageService) UpdateImage(ctx context.Context, r string) error {
 		if labels[key] != value {
 			// Make sure the image has the image id as its unique
 			// identifier that references the image in its lifetime.
-			configDesc, err := img.Config(ctx)
+			configDesc, err := c.imageConfig(ctx, img)
 			if err != nil {
 				return fmt.Errorf("get image id: %w", err)
 			}
@@ -477,8 +550,8 @@ func (c *CRIImageService) UpdateImage(ctx context.Context, r string) error {
 			if err := c.createOrUpdateImageReference(ctx, id, img.Target(), criLabels); err != nil {
 				return fmt.Errorf("create image id reference %q: %w", id, err)
 			}
-			if err := c.imageStore.Update(ctx, id); err != nil {
-				return fmt.Errorf("update image store for %q: %w", id, err)
+			if err := c.updateImageStore(ctx, id); err != nil {
+				return err
 			}
 			// The image id is ready, add the label to mark the image as managed.
 			if err := c.createOrUpdateImageReference(ctx, r, img.Target(), criLabels); err != nil {
@@ -487,10 +560,7 @@ func (c *CRIImageService) UpdateImage(ctx context.Context, r string) error {
 			break
 		}
 	}
-	if err := c.imageStore.Update(ctx, r); err != nil {
-		return fmt.Errorf("update image store for %q: %w", r, err)
-	}
-	return nil
+	return c.updateImageStore(ctx, r)
 }
 
 func hostDirFromRoots(roots []string) func(string) (string, error) {
@@ -854,9 +924,11 @@ func (rt *pullRequestReporterRoundTripper) RoundTrip(req *http.Request) (*http.R
 	return resp, err
 }
 
-// snapshotterFromPodSandboxConfig returns the snapshotter to use for the given
-// runtime handler. If a runtime-specific snapshotter is configured, it will be
-// returned; otherwise the default snapshotter is used.
+// imagePlatformFromPodSandboxConfig returns the snapshotter and the image
+// platform to use for the given runtime handler. If a runtime-specific
+// snapshotter or platform is configured through runtime_platforms, it will be
+// returned; otherwise the default snapshotter and the platform of the node are
+// used.
 //
 // The runtimeHandler parameter (from CRI PullImageRequest, available since cri-api v0.29.0)
 // takes precedence. If empty, we fall back to the experimental annotation for backward
@@ -866,22 +938,22 @@ func (rt *pullRequestReporterRoundTripper) RoundTrip(req *http.Request) (*http.R
 // deprecated and will be removed in containerd 2.5.
 //
 // See https://github.com/containerd/containerd/issues/6657
-func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, imageRef string,
-	s *runtime.PodSandboxConfig, runtimeHandler string) (string, error) {
-	snapshotter := c.config.Snapshotter
-	if s == nil {
-		return snapshotter, nil
+func (c *CRIImageService) imagePlatformFromPodSandboxConfig(ctx context.Context, imageRef string,
+	s *runtime.PodSandboxConfig, runtimeHandler string) (ImagePlatform, error) {
+	imagePlatform := ImagePlatform{
+		Snapshotter: c.config.Snapshotter,
+		Platform:    platforms.DefaultSpec(),
 	}
 
 	// If runtimeHandler parameter is empty, fall back to annotation for backward compatibility
 	if runtimeHandler == "" {
-		if s.Annotations == nil {
-			return snapshotter, nil
+		if s == nil || s.Annotations == nil {
+			return imagePlatform, nil
 		}
 		var ok bool
 		runtimeHandler, ok = s.Annotations[annotations.RuntimeHandler]
 		if !ok {
-			return snapshotter, nil
+			return imagePlatform, nil
 		}
 		log.G(ctx).Warnf("Using deprecated annotation %q for runtime handler. "+
 			"This will be removed in a future release (2.5). "+
@@ -889,14 +961,45 @@ func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, i
 			annotations.RuntimeHandler)
 	}
 
-	if c.runtimePlatforms != nil {
-		if p, ok := c.runtimePlatforms[runtimeHandler]; ok && p.Snapshotter != snapshotter {
-			snapshotter = p.Snapshotter
-			log.G(ctx).Infof("experimental: PullImage %q for runtime %s, using snapshotter %s", imageRef, runtimeHandler, snapshotter)
-		}
+	p, ok := c.runtimePlatforms[runtimeHandler]
+	if !ok {
+		return imagePlatform, nil
 	}
 
-	return snapshotter, nil
+	if p.Snapshotter != "" && p.Snapshotter != imagePlatform.Snapshotter {
+		imagePlatform.Snapshotter = p.Snapshotter
+		log.G(ctx).Infof("experimental: PullImage %q for runtime %s, using snapshotter %s", imageRef, runtimeHandler, imagePlatform.Snapshotter)
+	}
+
+	imagePlatform.Platform = c.PlatformForImage(imageRef, runtimeHandler)
+	if !util.IsNodePlatform(imagePlatform.Platform) {
+		log.G(ctx).Infof("experimental: PullImage %q for runtime %s, using platform %s",
+			imageRef, runtimeHandler, platforms.FormatAll(imagePlatform.Platform))
+	}
+	return imagePlatform, nil
+}
+
+// isPinnedImage reports whether the given reference is configured as a pinned
+// image. Both sides are compared normalized as well, since PullImage sees the
+// normalized reference while the other image requests see it as written.
+func (c *CRIImageService) isPinnedImage(name string) bool {
+	normalized := normalizeImageRef(name)
+	for _, pinned := range c.config.PinnedImages {
+		if pinned == name || normalizeImageRef(pinned) == normalized {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeImageRef returns the normalized form of a reference, or the
+// reference itself when it does not parse as one.
+func normalizeImageRef(ref string) string {
+	named, err := distribution.ParseDockerRef(ref)
+	if err != nil {
+		return ref
+	}
+	return named.String()
 }
 
 type criCredentials struct {

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/platforms"
@@ -31,6 +32,7 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/labels"
+	"github.com/containerd/containerd/v2/internal/cri/util"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -375,38 +377,50 @@ func TestEncryptedImagePullOpts(t *testing.T) {
 	}
 }
 
-func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
+// testForeignPlatform is a platform that is never the platform of the machine
+// running the tests, so that a runtime handler configured with it always
+// exercises the non-default path.
+var testForeignPlatform = ocispec.Platform{OS: "linux", Architecture: "mips64le"}
+
+func TestImagePlatformFromPodSandboxConfig(t *testing.T) {
 	defaultSnapshotter := "native"
 	runtimeSnapshotter := "devmapper"
+	defaultPlatform := platforms.DefaultSpec()
 	tests := []struct {
 		desc                string
 		podSandboxConfig    *runtime.PodSandboxConfig
 		runtimeHandler      string
+		imageRef            string
 		expectedSnapshotter string
+		expectedPlatform    ocispec.Platform
 		expectedErr         bool
 	}{
 		{
 			desc:                "should return default snapshotter for nil podSandboxConfig",
 			runtimeHandler:      "",
 			expectedSnapshotter: defaultSnapshotter,
+			expectedPlatform:    defaultPlatform,
 		},
 		{
 			desc:                "should return default snapshotter for empty runtimeHandler",
 			podSandboxConfig:    &runtime.PodSandboxConfig{},
 			runtimeHandler:      "",
 			expectedSnapshotter: defaultSnapshotter,
+			expectedPlatform:    defaultPlatform,
 		},
 		{
 			desc:                "should return default snapshotter for runtime not found",
 			podSandboxConfig:    &runtime.PodSandboxConfig{},
 			runtimeHandler:      "runtime-not-exists",
 			expectedSnapshotter: defaultSnapshotter,
+			expectedPlatform:    defaultPlatform,
 		},
 		{
 			desc:                "should return snapshotter for existing runtime",
 			podSandboxConfig:    &runtime.PodSandboxConfig{},
 			runtimeHandler:      "existing-runtime",
 			expectedSnapshotter: runtimeSnapshotter,
+			expectedPlatform:    defaultPlatform,
 		},
 		{
 			desc: "should fall back to annotation when runtimeHandler is empty",
@@ -417,6 +431,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 			},
 			runtimeHandler:      "",
 			expectedSnapshotter: runtimeSnapshotter,
+			expectedPlatform:    defaultPlatform,
 		},
 		{
 			desc: "should prefer runtimeHandler parameter over annotation",
@@ -427,6 +442,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 			},
 			runtimeHandler:      "existing-runtime",
 			expectedSnapshotter: runtimeSnapshotter,
+			expectedPlatform:    defaultPlatform,
 		},
 		{
 			desc: "should return default when annotation has unknown runtime and runtimeHandler is empty",
@@ -437,6 +453,46 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 			},
 			runtimeHandler:      "",
 			expectedSnapshotter: defaultSnapshotter,
+			expectedPlatform:    defaultPlatform,
+		},
+		{
+			desc:                "should return configured platform for existing runtime",
+			podSandboxConfig:    &runtime.PodSandboxConfig{},
+			runtimeHandler:      "foreign-runtime",
+			expectedSnapshotter: defaultSnapshotter,
+			expectedPlatform:    testForeignPlatform,
+		},
+		{
+			desc: "should return configured platform when falling back to annotation",
+			podSandboxConfig: &runtime.PodSandboxConfig{
+				Annotations: map[string]string{
+					annotations.RuntimeHandler: "foreign-runtime",
+				},
+			},
+			runtimeHandler:      "",
+			expectedSnapshotter: defaultSnapshotter,
+			expectedPlatform:    testForeignPlatform,
+		},
+		{
+			desc:                "should return default platform for runtime with unset platform",
+			podSandboxConfig:    &runtime.PodSandboxConfig{},
+			runtimeHandler:      "unset-platform-runtime",
+			expectedSnapshotter: runtimeSnapshotter,
+			expectedPlatform:    defaultPlatform,
+		},
+		{
+			desc:                "should use the runtime handler without a podSandboxConfig",
+			runtimeHandler:      "foreign-runtime",
+			expectedSnapshotter: defaultSnapshotter,
+			expectedPlatform:    testForeignPlatform,
+		},
+		{
+			desc:                "should keep pinned images on the platform of the node",
+			podSandboxConfig:    &runtime.PodSandboxConfig{},
+			runtimeHandler:      "foreign-runtime",
+			imageRef:            testSandboxImage,
+			expectedSnapshotter: defaultSnapshotter,
+			expectedPlatform:    defaultPlatform,
 		},
 	}
 
@@ -448,8 +504,21 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 				Platform:    platforms.DefaultSpec(),
 				Snapshotter: runtimeSnapshotter,
 			}
-			snapshotter, err := cri.snapshotterFromPodSandboxConfig(context.Background(), "test-image", tt.podSandboxConfig, tt.runtimeHandler)
-			assert.Equal(t, tt.expectedSnapshotter, snapshotter)
+			cri.runtimePlatforms["foreign-runtime"] = ImagePlatform{
+				Platform: testForeignPlatform,
+			}
+			// An unset platform in the config is materialized as the platform
+			// of the node by the plugin, but tolerate a zero value here too.
+			cri.runtimePlatforms["unset-platform-runtime"] = ImagePlatform{
+				Snapshotter: runtimeSnapshotter,
+			}
+			imageRef := tt.imageRef
+			if imageRef == "" {
+				imageRef = "test-image"
+			}
+			imagePlatform, err := cri.imagePlatformFromPodSandboxConfig(context.Background(), imageRef, tt.podSandboxConfig, tt.runtimeHandler)
+			assert.Equal(t, tt.expectedSnapshotter, imagePlatform.Snapshotter)
+			assert.Equal(t, tt.expectedPlatform, imagePlatform.Platform)
 			if tt.expectedErr {
 				assert.Error(t, err)
 			}
@@ -457,6 +526,33 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 	}
 }
 
+func TestImagePlatforms(t *testing.T) {
+	t.Run("no runtime platforms is only the platform of the node", func(t *testing.T) {
+		got := imagePlatforms(nil)
+		require.Len(t, got, 1)
+		assert.True(t, util.IsNodePlatform(got[0]))
+	})
+
+	t.Run("a runtime platform equal to the platform of the node is not duplicated", func(t *testing.T) {
+		got := imagePlatforms(map[string]ImagePlatform{
+			"runc":  {Platform: platforms.DefaultSpec()},
+			"empty": {},
+		})
+		assert.Len(t, got, 1)
+	})
+
+	t.Run("a distinct runtime platform follows the platform of the node", func(t *testing.T) {
+		got := imagePlatforms(map[string]ImagePlatform{
+			"runc":         {Platform: platforms.DefaultSpec()},
+			"runc-foreign": {Platform: testForeignPlatform},
+			// A second handler on the same platform must not add an entry.
+			"kata-foreign": {Platform: testForeignPlatform},
+		})
+		require.Len(t, got, 2)
+		assert.True(t, util.IsNodePlatform(got[0]))
+		assert.Equal(t, util.PlatformKey(testForeignPlatform), util.PlatformKey(got[1]))
+	})
+}
 func TestImageGetLabels(t *testing.T) {
 
 	criService, _ := newTestCRIService()

--- a/internal/cri/server/images/image_remove.go
+++ b/internal/cri/server/images/image_remove.go
@@ -44,7 +44,8 @@ func (c *GRPCCRIImageService) RemoveImage(ctx context.Context, r *runtime.Remove
 func (c *CRIImageService) RemoveImage(ctx context.Context, imageSpec *runtime.ImageSpec) error {
 	span := tracing.SpanFromContext(ctx)
 
-	image, err := c.LocalResolve(imageSpec.GetImage())
+	platform := c.PlatformForImage(imageSpec.GetImage(), imageSpec.GetRuntimeHandler())
+	image, err := c.LocalResolve(imageSpec.GetImage(), platform)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			span.AddEvent(err.Error())
@@ -66,7 +67,9 @@ func (c *CRIImageService) RemoveImage(ctx context.Context, imageSpec *runtime.Im
 		err = c.images.Delete(ctx, ref, opts...)
 		if err == nil || errdefs.IsNotFound(err) {
 			// Update image store to reflect the newest state in containerd.
-			if err := c.imageStore.Update(ctx, ref); err != nil {
+			// The reference is gone for every platform it was stored for,
+			// not only for the platform of this request.
+			if err := c.updateImageStore(ctx, ref); err != nil {
 				return fmt.Errorf("failed to update image reference %q for %q: %w", ref, image.ID, err)
 			}
 			continue

--- a/internal/cri/server/images/image_remove_test.go
+++ b/internal/cri/server/images/image_remove_test.go
@@ -1,0 +1,128 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/images"
+	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
+	"github.com/containerd/containerd/v2/internal/cri/util"
+	"github.com/containerd/errdefs"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// recordStore is an images.Store holding image records by name, enough for
+// RemoveImage and for the CRI image store to resolve against.
+type recordStore struct {
+	images.Store
+	records map[string]images.Image
+}
+
+func (s *recordStore) Get(_ context.Context, name string) (images.Image, error) {
+	i, ok := s.records[name]
+	if !ok {
+		return images.Image{}, fmt.Errorf("image %q: %w", name, errdefs.ErrNotFound)
+	}
+	return i, nil
+}
+
+func (s *recordStore) Delete(_ context.Context, name string, _ ...images.DeleteOpt) error {
+	if _, ok := s.records[name]; !ok {
+		return fmt.Errorf("image %q: %w", name, errdefs.ErrNotFound)
+	}
+	delete(s.records, name)
+	return nil
+}
+
+// TestRemoveImageRefreshesEveryPlatform pins that removing an image drops it
+// from the CRI store whatever platform the request names. The containerd
+// records RemoveImage deletes are shared by every platform a reference was
+// pulled for, so refreshing only the platform of the request left the entry of
+// the other platform behind until an image event happened to arrive.
+func TestRemoveImageRefreshesEveryPlatform(t *testing.T) {
+	ctx := context.Background()
+	const tag = "docker.io/library/busybox:latest"
+
+	// An index with both the platform of the node and the foreign platform
+	// fully present, the state after the tag was pulled for both.
+	blobs := map[digest.Digest][]byte{}
+	var manifests []ocispec.Descriptor
+	ids := map[string]string{}
+	for _, p := range []ocispec.Platform{util.NodePlatform(), testForeignPlatform} {
+		layer := []byte("layer-" + util.PlatformKey(p))
+		layerDigest := digest.FromBytes(layer)
+		blobs[layerDigest] = layer
+		config := marshalBlob(t, blobs, ocispec.MediaTypeImageConfig, ocispec.Image{
+			Platform: p,
+			RootFS:   ocispec.RootFS{Type: "layers", DiffIDs: []digest.Digest{layerDigest}},
+		}, nil, true)
+		ids[util.PlatformKey(p)] = config.Digest.String()
+		manifests = append(manifests, marshalBlob(t, blobs, ocispec.MediaTypeImageManifest, ocispec.Manifest{
+			MediaType: ocispec.MediaTypeImageManifest,
+			Config:    config,
+			Layers:    []ocispec.Descriptor{{MediaType: ocispec.MediaTypeImageLayer, Digest: layerDigest, Size: int64(len(layer))}},
+		}, &p, true))
+	}
+	index := marshalBlob(t, blobs, ocispec.MediaTypeImageIndex, ocispec.Index{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: manifests,
+	}, nil, true)
+	nodeID, foreignID := ids[util.PlatformKey(util.NodePlatform())], ids[util.PlatformKey(testForeignPlatform)]
+	require.NotEqual(t, nodeID, foreignID)
+
+	records := &recordStore{records: map[string]images.Image{}}
+	for _, name := range []string{tag, nodeID, foreignID} {
+		records.records[name] = images.Image{Name: name, Target: index}
+	}
+
+	c, _ := newTestCRIService()
+	c.images = records
+	c.imageStore = imagestore.NewStore(records, blobStore{blobs: blobs})
+	c.runtimePlatforms["runc-foreign"] = ImagePlatform{Platform: testForeignPlatform}
+	c.imagePlatforms = imagePlatforms(c.runtimePlatforms)
+
+	for _, ref := range []string{tag, nodeID} {
+		require.NoError(t, c.imageStore.Update(ctx, ref, util.NodePlatform()))
+	}
+	for _, ref := range []string{tag, foreignID} {
+		require.NoError(t, c.imageStore.Update(ctx, ref, testForeignPlatform))
+	}
+	require.Len(t, c.imageStore.List(), 2)
+
+	// Remove the foreign image by id without a handler, which is how an image
+	// listed by ListImages comes back to be removed.
+	require.NoError(t, c.RemoveImage(ctx, &runtime.ImageSpec{Image: foreignID}))
+
+	_, err := records.Get(ctx, foreignID)
+	require.True(t, errdefs.IsNotFound(err), "the containerd record of the foreign id must be gone")
+	_, err = c.imageStore.Get(foreignID)
+	assert.True(t, errdefs.IsNotFound(err), "the foreign image must no longer be listed, got %+v", c.imageStore.List())
+
+	// The tag record was shared with the node platform and is gone with it,
+	// so the image of the node is only known by its id from here on.
+	node, err := c.imageStore.Get(nodeID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{nodeID}, node.References)
+	assert.Len(t, c.imageStore.List(), 1)
+}

--- a/internal/cri/server/images/image_status.go
+++ b/internal/cri/server/images/image_status.go
@@ -36,7 +36,8 @@ import (
 // TODO(random-liu): We should change CRI to distinguish image id and image spec. (See
 // kubernetes/kubernetes#46255)
 func (c *CRIImageService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
-	image, err := c.LocalResolve(r.GetImage().GetImage())
+	runtimeHandler := r.GetImage().GetRuntimeHandler()
+	image, err := c.LocalResolve(r.GetImage().GetImage(), c.PlatformForImage(r.GetImage().GetImage(), runtimeHandler))
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			// return empty without error when image not found.
@@ -44,10 +45,31 @@ func (c *CRIImageService) ImageStatus(ctx context.Context, r *runtime.ImageStatu
 		}
 		return nil, fmt.Errorf("can not resolve %q locally: %w", r.GetImage().GetImage(), err)
 	}
-	// TODO(random-liu): [P0] Make sure corresponding snapshot exists. What if snapshot
-	// doesn't exist?
 
-	runtimeImage := toCRIImage(image)
+	// Asked about a runtime handler, the question is whether the image is
+	// usable by it, which needs it unpacked in the snapshotter of that
+	// handler. Reporting it as absent otherwise makes the caller pull it,
+	// which unpacks it in the right snapshotter.
+	//
+	// Without a handler the question is whether the image is known at all,
+	// which is what it has always meant. An image that exists but is not
+	// unpacked, as one pulled outside CRI, stays visible.
+	//
+	// A failure to determine that is not a reason to fail the request: a
+	// snapshotter that cannot be reached fails loudly on pull and on
+	// container creation.
+	if runtimeHandler != "" {
+		snapshotter := c.SnapshotterForRuntimeHandler(runtimeHandler)
+		switch unpacked, err := c.IsImageUnpacked(ctx, image, snapshotter); {
+		case err != nil:
+			log.G(ctx).WithError(err).Warnf("Failed to check whether image %q is unpacked in snapshotter %q", image.ID, snapshotter)
+		case !unpacked:
+			log.G(ctx).Debugf("Image %q is not unpacked in snapshotter %q, reporting it as absent", image.ID, snapshotter)
+			return &runtime.ImageStatusResponse{}, nil
+		}
+	}
+
+	runtimeImage := toCRIImage(image, runtimeHandler)
 	info, err := c.toCRIImageInfo(ctx, &image, r.GetVerbose())
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate image info: %w", err)
@@ -60,7 +82,7 @@ func (c *CRIImageService) ImageStatus(ctx context.Context, r *runtime.ImageStatu
 }
 
 // toCRIImage converts internal image object to CRI runtime.Image.
-func toCRIImage(image imagestore.Image) *runtime.Image {
+func toCRIImage(image imagestore.Image, runtimeHandler string) *runtime.Image {
 	repoTags, repoDigests := util.ParseImageReferences(image.References)
 	runtimeImage := &runtime.Image{
 		Id:          image.ID,
@@ -68,6 +90,14 @@ func toCRIImage(image imagestore.Image) *runtime.Image {
 		RepoDigests: repoDigests,
 		Size:        uint64(image.Size),
 		Pinned:      image.Pinned,
+	}
+	if runtimeHandler != "" {
+		// Answer for the runtime handler that was asked about, so the caller
+		// can tell which one this status is for.
+		runtimeImage.Spec = &runtime.ImageSpec{
+			Image:          image.ID,
+			RuntimeHandler: runtimeHandler,
+		}
 	}
 	uid, username := getUserFromImage(image.ImageSpec.Config.User)
 	if uid != nil {

--- a/internal/cri/server/images/image_stream.go
+++ b/internal/cri/server/images/image_stream.go
@@ -30,7 +30,7 @@ func (c *GRPCCRIImageService) StreamImages(r *runtime.StreamImagesRequest, s grp
 
 	var images []*runtime.Image
 	for _, image := range imagesInStore {
-		images = append(images, toCRIImage(image))
+		images = append(images, toCRIImage(image, ""))
 	}
 
 	return criutil.SendInBatches(ctx, images, criutil.DefaultStreamBatchSize, func(batch []*runtime.Image) error {

--- a/internal/cri/server/images/service.go
+++ b/internal/cri/server/images/service.go
@@ -18,6 +18,9 @@ package images
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -28,9 +31,10 @@ import (
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
 	snapshotstore "github.com/containerd/containerd/v2/internal/cri/store/snapshot"
+	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/containerd/v2/internal/kmutex"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
-	"github.com/containerd/platforms"
 	"golang.org/x/sync/semaphore"
 
 	docker "github.com/distribution/reference"
@@ -65,6 +69,14 @@ type CRIImageService struct {
 	imageFSPaths map[string]string
 	// runtimePlatforms are the platforms configured for a runtime.
 	runtimePlatforms map[string]ImagePlatform
+	// imagePlatforms are the distinct platforms images may be stored for,
+	// the platform of the node first, followed by any other platform
+	// configured through runtime_platforms.
+	imagePlatforms []imagespec.Platform
+	// snapshotterProvider resolves a snapshotter by name, so that the
+	// presence of an image in the snapshotter of a runtime can be checked
+	// without caching state that changes outside of CRI.
+	snapshotterProvider func(string) snapshots.Snapshotter
 	// imageStore stores all resources associated with images.
 	imageStore *imagestore.Store
 	// snapshotStore stores information of all snapshots.
@@ -95,6 +107,10 @@ type CRIImageServiceOptions struct {
 
 	Snapshotters map[string]snapshots.Snapshotter
 
+	// SnapshotterProvider resolves any snapshotter by name. It may be nil,
+	// in which case only the snapshotters in Snapshotters are reachable.
+	SnapshotterProvider func(string) snapshots.Snapshotter
+
 	Client imageClient
 
 	Transferrer transfer.Transferrer
@@ -115,13 +131,21 @@ func NewService(config criconfig.ImageConfig, options *CRIImageServiceOptions) (
 	if config.MaxConcurrentDownloads > 0 {
 		downloadLimiter = semaphore.NewWeighted(int64(config.MaxConcurrentDownloads))
 	}
+	snapshotterProvider := options.SnapshotterProvider
+	if snapshotterProvider == nil {
+		snapshotterProvider = func(name string) snapshots.Snapshotter {
+			return options.Snapshotters[name]
+		}
+	}
 	svc := CRIImageService{
 		config:                      config,
 		images:                      options.Images,
 		client:                      options.Client,
-		imageStore:                  imagestore.NewStore(options.Images, options.Content, platforms.Default()),
+		imageStore:                  imagestore.NewStore(options.Images, options.Content),
 		imageFSPaths:                options.ImageFSPaths,
 		runtimePlatforms:            options.RuntimePlatforms,
+		imagePlatforms:              imagePlatforms(options.RuntimePlatforms),
+		snapshotterProvider:         snapshotterProvider,
 		snapshotStore:               snapshotstore.NewStore(),
 		transferrer:                 options.Transferrer,
 		unpackDuplicationSuppressor: kmutex.New(),
@@ -139,25 +163,128 @@ func NewService(config criconfig.ImageConfig, options *CRIImageServiceOptions) (
 	return &svc, nil
 }
 
+// imagePlatforms returns the distinct platforms images may be stored for.
+//
+// The platform of the node always comes first, so the common case is
+// unaffected. Any other platform configured through runtime_platforms follows,
+// so that an image pulled for such a runtime is still found when every stored
+// platform has to be visited, as in ListImages and image reload.
+func imagePlatforms(runtimePlatforms map[string]ImagePlatform) []imagespec.Platform {
+	result := []imagespec.Platform{util.NodePlatform()}
+	seen := map[string]struct{}{util.PlatformKey(util.NodePlatform()): {}}
+	// Sort by runtime name so the order is deterministic.
+	for _, runtimeName := range slices.Sorted(maps.Keys(runtimePlatforms)) {
+		p := runtimePlatforms[runtimeName].Platform
+		if util.IsNodePlatform(p) {
+			continue
+		}
+		key := util.PlatformKey(p)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, p)
+		log.L.Infof("Runtime %q adds image platform %q", runtimeName, key)
+	}
+	return result
+}
+
+// platformsForImages returns the platforms images may be stored for.
+func (c *CRIImageService) platformsForImages() []imagespec.Platform {
+	if len(c.imagePlatforms) == 0 {
+		return []imagespec.Platform{util.NodePlatform()}
+	}
+	return c.imagePlatforms
+}
+
+// PlatformForRuntimeHandler returns the platform images are pulled for on the
+// given runtime handler. An unknown or empty handler is the platform of the
+// node.
+func (c *CRIImageService) PlatformForRuntimeHandler(runtimeHandler string) imagespec.Platform {
+	if p, ok := c.runtimePlatforms[runtimeHandler]; ok && !util.IsNodePlatform(p.Platform) {
+		return p.Platform
+	}
+	return util.NodePlatform()
+}
+
+// PlatformForImage returns the platform an image is pulled for and looked up on
+// for the given runtime handler. Pinned images, the sandbox image in particular,
+// are shared by every pod on the node and stay on the platform of the node
+// whatever the handler asks for. Every lookup has to agree on this with
+// PullImage, otherwise an image that was just pulled for a handler is reported
+// absent to that same handler.
+func (c *CRIImageService) PlatformForImage(ref, runtimeHandler string) imagespec.Platform {
+	if c.isPinnedImage(ref) {
+		return util.NodePlatform()
+	}
+	return c.PlatformForRuntimeHandler(runtimeHandler)
+}
+
+// imageConfig resolves the config descriptor of an image against the first of
+// the configured image platforms whose content is present locally.
+//
+// containerd.Image carries the platform matcher of the client, which is always
+// the platform of the node, so it cannot be used to resolve an image that was
+// pulled for a different platform.
+func (c *CRIImageService) imageConfig(ctx context.Context, img containerd.Image) (imagespec.Descriptor, error) {
+	provider := img.ContentStore()
+	var firstErr error
+	for _, platform := range c.platformsForImages() {
+		desc, err := images.Config(ctx, provider, img.Target(), util.PlatformMatcher(platform))
+		if err == nil {
+			// images.Config only requires the manifest of the platform to be
+			// present, while the image store also reads the image config.
+			// Require it here as well, so that this cannot select a platform
+			// that the image store would then reject, which would map the
+			// minted image id reference to a different platform.
+			if _, err = provider.Info(ctx, desc.Digest); err == nil {
+				return desc, nil
+			}
+		}
+		if !errdefs.IsNotFound(err) {
+			return imagespec.Descriptor{}, err
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return imagespec.Descriptor{}, firstErr
+}
+
 // UpdateRuntimeSnapshotter adds or updates the snapshotter mapping for a runtime.
 // This is called by the main CRI plugin after both image and runtime plugins are initialized,
 // to propagate runtime-specific snapshotters configured in the runtime plugin's config.
+//
+// NOTE: only the snapshotter is propagated this way; the platform of the given
+// ImagePlatform is expected to be the platform of the node. The set of image
+// platforms is fixed when the service is created, so a non-default platform can
+// only be configured through the runtime_platforms image config.
 func (c *CRIImageService) UpdateRuntimeSnapshotter(runtimeName string, imagePlatform ImagePlatform) {
 	if c.runtimePlatforms == nil {
 		c.runtimePlatforms = make(map[string]ImagePlatform)
 	}
-	// Don't override if already configured
-	if _, exists := c.runtimePlatforms[runtimeName]; exists {
-		log.L.Debugf("Runtime %q already has snapshotter configured, not overriding", runtimeName)
+	if existing, exists := c.runtimePlatforms[runtimeName]; exists {
+		// Don't override a snapshotter that runtime_platforms configured.
+		if existing.Snapshotter != "" {
+			log.L.Debugf("Runtime %q already has snapshotter %q configured, not overriding", runtimeName, existing.Snapshotter)
+			return
+		}
+		// The runtime_platforms entry only configured a platform, so the
+		// snapshotter of the runtime still applies to it.
+		existing.Snapshotter = imagePlatform.Snapshotter
+		c.runtimePlatforms[runtimeName] = existing
+		log.L.Infof("Registered runtime %q with snapshotter %q", runtimeName, existing.Snapshotter)
 		return
 	}
 	c.runtimePlatforms[runtimeName] = imagePlatform
 	log.L.Infof("Registered runtime %q with snapshotter %q", runtimeName, imagePlatform.Snapshotter)
 }
 
-// LocalResolve resolves image reference locally and returns corresponding image metadata. It
-// returns errdefs.ErrNotFound if the reference doesn't exist.
-func (c *CRIImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
+// LocalResolve resolves an image reference locally on the given platform and
+// returns the corresponding image metadata. An unset platform means the
+// platform of the node. It returns errdefs.ErrNotFound if the reference does
+// not exist on that platform.
+func (c *CRIImageService) LocalResolve(refOrID string, platform imagespec.Platform) (imagestore.Image, error) {
 	getImageID := func(refOrId string) string {
 		if _, err := imagedigest.Parse(refOrID); err == nil {
 			return refOrID
@@ -169,7 +296,7 @@ func (c *CRIImageService) LocalResolve(refOrID string) (imagestore.Image, error)
 			if err != nil {
 				return ""
 			}
-			id, err := c.imageStore.Resolve(normalized.String())
+			id, err := c.imageStore.Resolve(normalized.String(), platform)
 			if err != nil {
 				return ""
 			}
@@ -183,6 +310,41 @@ func (c *CRIImageService) LocalResolve(refOrID string) (imagestore.Image, error)
 		imageID = refOrID
 	}
 	return c.imageStore.Get(imageID)
+}
+
+// IsImageUnpacked reports whether the image is unpacked in the given
+// snapshotter.
+//
+// The same image can be unpacked in several snapshotters at once, and that
+// changes outside of CRI, so it is looked up rather than cached: the chain id
+// of the image is the key of its top level snapshot.
+func (c *CRIImageService) IsImageUnpacked(ctx context.Context, image imagestore.Image, snapshotter string) (bool, error) {
+	if image.ChainID == "" {
+		return false, nil
+	}
+	if snapshotter == "" {
+		snapshotter = c.config.Snapshotter
+	}
+	sn := c.snapshotterProvider(snapshotter)
+	if sn == nil {
+		return false, fmt.Errorf("snapshotter %q: %w", snapshotter, errdefs.ErrNotFound)
+	}
+	if _, err := sn.Stat(ctx, image.ChainID); err != nil {
+		if errdefs.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat snapshot %q in snapshotter %q: %w", image.ChainID, snapshotter, err)
+	}
+	return true, nil
+}
+
+// SnapshotterForRuntimeHandler returns the snapshotter images are unpacked
+// into for the given runtime handler.
+func (c *CRIImageService) SnapshotterForRuntimeHandler(runtimeHandler string) string {
+	if p, ok := c.runtimePlatforms[runtimeHandler]; ok && p.Snapshotter != "" {
+		return p.Snapshotter
+	}
+	return c.config.Snapshotter
 }
 
 // RuntimeSnapshotter overrides the default snapshotter if Snapshotter is set for this runtime.

--- a/internal/cri/server/images/service_test.go
+++ b/internal/cri/server/images/service_test.go
@@ -20,11 +20,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/containerd/containerd/v2/core/snapshots"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
 	snapshotstore "github.com/containerd/containerd/v2/internal/cri/store/snapshot"
+	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,9 +44,13 @@ func newTestCRIService() (*CRIImageService, *GRPCCRIImageService) {
 	service := &CRIImageService{
 		config:           testImageConfig,
 		runtimePlatforms: map[string]ImagePlatform{},
-		imageFSPaths:     map[string]string{"overlayfs": testImageFSPath},
-		imageStore:       imagestore.NewStore(nil, nil, platforms.Default()),
-		snapshotStore:    snapshotstore.NewStore(),
+		imagePlatforms:   []imagespec.Platform{util.NodePlatform()},
+		snapshotterProvider: func(string) snapshots.Snapshotter {
+			return nil
+		},
+		imageFSPaths:  map[string]string{"overlayfs": testImageFSPath},
+		imageStore:    imagestore.NewStore(nil, nil),
+		snapshotStore: snapshotstore.NewStore(),
 	}
 
 	return service, &GRPCCRIImageService{service}
@@ -85,11 +92,11 @@ func TestLocalResolve(t *testing.T) {
 		"docker.io/library/busybox:latest",
 		"docker.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 	} {
-		img, err := c.LocalResolve(ref)
+		img, err := c.LocalResolve(ref, imagespec.Platform{})
 		assert.NoError(t, err)
 		assert.Equal(t, image, img)
 	}
-	img, err := c.LocalResolve("randomid")
+	img, err := c.LocalResolve("randomid", imagespec.Platform{})
 	assert.Equal(t, errdefs.IsNotFound(err), true)
 	assert.Equal(t, imagestore.Image{}, img)
 }
@@ -123,6 +130,53 @@ func TestRuntimeSnapshotter(t *testing.T) {
 			cri, _ := newTestCRIService()
 			cri.config = criconfig.DefaultImageConfig()
 			assert.Equal(t, test.expectSnapshotter, cri.RuntimeSnapshotter(context.Background(), test.runtime))
+		})
+	}
+}
+
+func TestUpdateRuntimeSnapshotter(t *testing.T) {
+	const (
+		defaultSnapshotter = "overlayfs"
+		runtimeSnapshotter = "devmapper"
+	)
+	foreign := imagespec.Platform{OS: "linux", Architecture: "mips64le"}
+
+	for _, tt := range []struct {
+		desc                string
+		existing            *ImagePlatform
+		expectedSnapshotter string
+		expectedPlatform    imagespec.Platform
+	}{
+		{
+			desc:                "runtime without a runtime_platforms entry is registered",
+			expectedSnapshotter: runtimeSnapshotter,
+			expectedPlatform:    platforms.DefaultSpec(),
+		},
+		{
+			desc:                "a runtime_platforms entry with only a platform takes the runtime snapshotter",
+			existing:            &ImagePlatform{Platform: foreign},
+			expectedSnapshotter: runtimeSnapshotter,
+			expectedPlatform:    foreign,
+		},
+		{
+			desc:                "an explicit snapshotter in runtime_platforms is not overridden",
+			existing:            &ImagePlatform{Platform: foreign, Snapshotter: defaultSnapshotter},
+			expectedSnapshotter: defaultSnapshotter,
+			expectedPlatform:    foreign,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			c, _ := newTestCRIService()
+			if tt.existing != nil {
+				c.runtimePlatforms["runc-foreign"] = *tt.existing
+			}
+			c.UpdateRuntimeSnapshotter("runc-foreign", ImagePlatform{
+				Snapshotter: runtimeSnapshotter,
+				Platform:    platforms.DefaultSpec(),
+			})
+			got := c.runtimePlatforms["runc-foreign"]
+			assert.Equal(t, tt.expectedSnapshotter, got.Snapshotter)
+			assert.Equal(t, tt.expectedPlatform, got.Platform)
 		})
 	}
 }

--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/core/leases"
@@ -422,7 +423,8 @@ func (c *criService) ensurePauseImageExists(ctx context.Context, config *runtime
 		ref = img
 	}
 
-	_, err := c.ImageService.LocalResolve(ref)
+	// The sandbox image is pinned and always runs on the platform of the node.
+	_, err := c.ImageService.LocalResolve(ref, imagespec.Platform{})
 	if err == nil {
 		return nil
 	} else if !errdefs.IsNotFound(err) {

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -109,7 +109,8 @@ type ImageService interface {
 	GetImage(id string) (imagestore.Image, error)
 	GetSnapshot(key, snapshotter string) (snapshotstore.Snapshot, error)
 
-	LocalResolve(refOrID string) (imagestore.Image, error)
+	LocalResolve(refOrID string, platform imagespec.Platform) (imagestore.Image, error)
+	PlatformForImage(ref, runtimeHandler string) imagespec.Platform
 
 	ImageFSPaths() map[string]string
 

--- a/internal/cri/store/image/fake_image.go
+++ b/internal/cri/store/image/fake_image.go
@@ -19,16 +19,16 @@ package image
 import (
 	"fmt"
 
-	"github.com/containerd/platforms"
+	"github.com/containerd/containerd/v2/internal/cri/util"
 )
 
 // NewFakeStore returns an image store with predefined images.
 // Update is not allowed for this fake store.
 func NewFakeStore(images []Image) (*Store, error) {
-	s := NewStore(nil, nil, platforms.Default())
+	s := NewStore(nil, nil)
 	for _, i := range images {
 		for _, ref := range i.References {
-			s.refCache[ref] = i.ID
+			s.refCache[refKey{ref: ref, platform: util.PlatformKey(i.Platform)}] = i.ID
 		}
 		if err := s.store.add(i); err != nil {
 			return nil, fmt.Errorf("add image %+v: %w", i, err)

--- a/internal/cri/store/image/image.go
+++ b/internal/cri/store/image/image.go
@@ -51,8 +51,20 @@ type Image struct {
 	Size int64
 	// ImageSpec is the oci image structure which describes basic information about the image.
 	ImageSpec imagespec.Image
+	// Platform is the platform the image was resolved for.
+	Platform imagespec.Platform
 	// Pinned image to prevent it from garbage collection
 	Pinned bool
+}
+
+// refKey identifies an image reference for a given platform. The same
+// reference can name a different image on each platform it was pulled for.
+//
+// The image id does not need this treatment: it is the digest of the image
+// config, which differs per platform, so an id already names one platform.
+type refKey struct {
+	ref      string
+	platform string
 }
 
 // Getter is used to get images but does not make changes
@@ -63,8 +75,9 @@ type Getter interface {
 // Store stores all images.
 type Store struct {
 	lock sync.RWMutex
-	// refCache is a containerd image reference to image id cache.
-	refCache map[string]string
+	// refCache maps a reference on a platform to the id of the image it
+	// resolves to.
+	refCache map[refKey]string
 
 	// images is the local image store
 	images Getter
@@ -72,21 +85,20 @@ type Store struct {
 	// content provider
 	provider content.InfoReaderProvider
 
-	// platform represents the currently supported platform for images
-	// TODO: Make this store multi-platform
-	platform platforms.MatchComparer
-
 	// store is the internal image store indexed by image id.
 	store *store
 }
 
 // NewStore creates an image store.
-func NewStore(img Getter, provider content.InfoReaderProvider, platform platforms.MatchComparer) *Store {
+//
+// An image is stored per platform it was pulled for, so the same reference can
+// name a different image on each platform. Callers name the platform they want
+// on every lookup; an unset platform means the platform of the node.
+func NewStore(img Getter, provider content.InfoReaderProvider) *Store {
 	return &Store{
-		refCache: make(map[string]string),
+		refCache: make(map[refKey]string),
 		images:   img,
 		provider: provider,
-		platform: platform,
 		store: &store{
 			images:     make(map[string]Image),
 			digestSet:  digestset.NewSet(),
@@ -95,8 +107,9 @@ func NewStore(img Getter, provider content.InfoReaderProvider, platform platform
 	}
 }
 
-// Update updates cache for a reference.
-func (s *Store) Update(ctx context.Context, ref string) error {
+// Update updates the cache for a reference on a platform. An unset platform
+// means the platform of the node.
+func (s *Store) Update(ctx context.Context, ref string, platform imagespec.Platform) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -107,59 +120,94 @@ func (s *Store) Update(ctx context.Context, ref string) error {
 
 	var img *Image
 	if err == nil {
-		img, err = s.getImage(ctx, i)
+		img, err = s.getImageForRef(ctx, i, ref, platform)
 		if err != nil {
-			return fmt.Errorf("get image info from containerd: %w", err)
+			// The image exists in containerd but not for this platform,
+			// which is the normal state of an image that was pulled for
+			// another one. Drop whatever this reference used to resolve to
+			// on this platform rather than failing the caller.
+			if !errdefs.IsNotFound(err) {
+				return fmt.Errorf("get image info from containerd: %w", err)
+			}
+			img = nil
 		}
 	}
-	return s.update(ref, img)
+	return s.update(refKey{ref: ref, platform: util.PlatformKey(platform)}, img)
 }
 
 // update updates the internal cache. img == nil means that
-// the image does not exist in containerd.
-func (s *Store) update(ref string, img *Image) error {
-	oldID, oldExist := s.refCache[ref]
+// the image does not exist in containerd for that platform.
+func (s *Store) update(key refKey, img *Image) error {
+	oldID, oldExist := s.refCache[key]
 	if img == nil {
 		// The image reference doesn't exist in containerd.
 		if oldExist {
 			// Remove the reference from the store.
-			s.store.delete(oldID, ref)
-			delete(s.refCache, ref)
+			s.store.delete(oldID, key.ref)
+			delete(s.refCache, key)
 		}
 		return nil
 	}
 	if oldExist {
 		if oldID == img.ID {
-			if s.store.isPinned(img.ID, ref) == img.Pinned {
+			if s.store.isPinned(img.ID, key.ref) == img.Pinned {
 				return nil
 			}
 			if img.Pinned {
-				return s.store.pin(img.ID, ref)
+				return s.store.pin(img.ID, key.ref)
 			}
-			return s.store.unpin(img.ID, ref)
+			return s.store.unpin(img.ID, key.ref)
 		}
 		// Updated. Remove tag from old image.
-		s.store.delete(oldID, ref)
+		s.store.delete(oldID, key.ref)
 	}
 	// New image. Add new image.
-	s.refCache[ref] = img.ID
+	s.refCache[key] = img.ID
 	return s.store.add(*img)
 }
 
-// getImage gets image information from containerd for current platform.
-func (s *Store) getImage(ctx context.Context, i images.Image) (*Image, error) {
-	diffIDs, err := i.RootFS(ctx, s.provider, s.platform)
+// getImage gets image information from containerd for the given platform.
+//
+// An image is only present locally for the platforms it was actually pulled
+// for, so a platform that is not backed by local content reports ErrNotFound.
+func (s *Store) getImage(ctx context.Context, i images.Image, platform imagespec.Platform) (*Image, error) {
+	return s.getImageForPlatform(ctx, i, platform, util.PlatformMatcher(platform))
+}
+
+// getImageForRef is getImage with the constraint that a reference which is a
+// bare digest is an image id, and an image id names the image config of one
+// platform.
+//
+// Resolving such a reference on another platform would map it to that
+// platform's id and add the digest to that image's references, which would
+// make the id name the wrong image. There is nothing to record for it there.
+func (s *Store) getImageForRef(ctx context.Context, i images.Image, ref string, platform imagespec.Platform) (*Image, error) {
+	img, err := s.getImage(ctx, i, platform)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := imagedigest.Parse(ref); err == nil && img.ID != ref {
+		return nil, fmt.Errorf("image id %s does not name the image of platform %s: %w",
+			ref, util.PlatformKey(platform), errdefs.ErrNotFound)
+	}
+	return img, nil
+}
+
+// getImageForPlatform gets image information from containerd using the given
+// matcher, and records platform as the platform it was resolved for.
+func (s *Store) getImageForPlatform(ctx context.Context, i images.Image, platform imagespec.Platform, matcher platforms.MatchComparer) (*Image, error) {
+	diffIDs, err := i.RootFS(ctx, s.provider, matcher)
 	if err != nil {
 		return nil, fmt.Errorf("get image diffIDs: %w", err)
 	}
 	chainID := imageidentity.ChainID(diffIDs)
 
-	size, err := usage.CalculateImageUsage(ctx, i, s.provider, usage.WithManifestLimit(s.platform, 1), usage.WithManifestUsage())
+	size, err := usage.CalculateImageUsage(ctx, i, s.provider, usage.WithManifestLimit(matcher, 1), usage.WithManifestUsage())
 	if err != nil {
 		return nil, fmt.Errorf("get image compressed resource size: %w", err)
 	}
 
-	desc, err := i.Config(ctx, s.provider, s.platform)
+	desc, err := i.Config(ctx, s.provider, matcher)
 	if err != nil {
 		return nil, fmt.Errorf("get image config descriptor: %w", err)
 	}
@@ -183,20 +231,50 @@ func (s *Store) getImage(ctx context.Context, i images.Image) (*Image, error) {
 		ChainID:    chainID.String(),
 		Size:       size,
 		ImageSpec:  spec,
+		Platform:   platformOf(spec, platform),
 		Pinned:     pinned,
 	}, nil
 
 }
 
-// Resolve resolves a image reference to image id.
-func (s *Store) Resolve(ref string) (string, error) {
+// Lookup resolves a reference on a platform against containerd without
+// changing the store. It returns errdefs.ErrNotFound when the reference does
+// not resolve on that platform.
+func (s *Store) Lookup(ctx context.Context, ref string, platform imagespec.Platform) (Image, error) {
+	i, err := s.images.Get(ctx, ref)
+	if err != nil {
+		return Image{}, err
+	}
+	img, err := s.getImage(ctx, i, platform)
+	if err != nil {
+		return Image{}, err
+	}
+	return *img, nil
+}
+
+// Resolve resolves an image reference on a platform to an image id. An unset
+// platform means the platform of the node.
+func (s *Store) Resolve(ref string, platform imagespec.Platform) (string, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	id, ok := s.refCache[ref]
+	id, ok := s.refCache[refKey{ref: ref, platform: util.PlatformKey(platform)}]
 	if !ok {
 		return "", errdefs.ErrNotFound
 	}
 	return id, nil
+}
+
+// platformOf reports the platform an image was resolved for. The image config
+// is authoritative, since it is the config of the manifest that was selected,
+// and the requested platform may be partially specified.
+func platformOf(spec imagespec.Image, requested imagespec.Platform) imagespec.Platform {
+	if spec.Platform.OS != "" && spec.Platform.Architecture != "" {
+		return spec.Platform
+	}
+	if requested.OS == "" || requested.Architecture == "" {
+		return util.NodePlatform()
+	}
+	return requested
 }
 
 // Get gets image metadata by image id. The id can be truncated.

--- a/internal/cri/store/image/image_platform_test.go
+++ b/internal/cri/store/image/image_platform_test.go
@@ -1,0 +1,333 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package image
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/internal/cri/util"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	assertlib "github.com/stretchr/testify/assert"
+	requirelib "github.com/stretchr/testify/require"
+)
+
+// memoryProvider is a content.InfoReaderProvider backed by a map, so that a
+// blob can be deliberately left out to represent a platform that was never
+// pulled.
+type memoryProvider map[digest.Digest][]byte
+
+func (m memoryProvider) ReaderAt(_ context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	b, ok := m[desc.Digest]
+	if !ok {
+		return nil, fmt.Errorf("content %v: %w", desc.Digest, errdefs.ErrNotFound)
+	}
+	return memoryReaderAt{Reader: bytes.NewReader(b)}, nil
+}
+
+func (m memoryProvider) Info(_ context.Context, dgst digest.Digest) (content.Info, error) {
+	b, ok := m[dgst]
+	if !ok {
+		return content.Info{}, fmt.Errorf("content %v: %w", dgst, errdefs.ErrNotFound)
+	}
+	return content.Info{Digest: dgst, Size: int64(len(b))}, nil
+}
+
+// add marshals v, stores it and returns a descriptor for it.
+func (m memoryProvider) add(t *testing.T, mediaType string, v any, platform *ocispec.Platform) ocispec.Descriptor {
+	t.Helper()
+	b, err := json.Marshal(v)
+	requirelib.NoError(t, err)
+	dgst := digest.FromBytes(b)
+	m[dgst] = b
+	return ocispec.Descriptor{
+		MediaType: mediaType,
+		Digest:    dgst,
+		Size:      int64(len(b)),
+		Platform:  platform,
+	}
+}
+
+type memoryReaderAt struct {
+	*bytes.Reader
+}
+
+func (r memoryReaderAt) Close() error { return nil }
+
+func (r memoryReaderAt) Size() int64 { return r.Reader.Size() }
+
+type fakeGetter struct {
+	image images.Image
+}
+
+func (g fakeGetter) Get(_ context.Context, name string) (images.Image, error) {
+	if name != g.image.Name {
+		return images.Image{}, fmt.Errorf("image %q: %w", name, errdefs.ErrNotFound)
+	}
+	return g.image, nil
+}
+
+var (
+	testPlatformA = ocispec.Platform{OS: "linux", Architecture: "amd64"}
+	testPlatformB = ocispec.Platform{OS: "linux", Architecture: "arm64"}
+)
+
+// newMultiPlatformImage builds an image whose index advertises both
+// testPlatformA and testPlatformB, but whose content is only present for
+// pulledPlatform. This is the shape of a multi-platform image that was pulled
+// for a single platform.
+func newMultiPlatformImage(t *testing.T, ref string, pulledPlatform ocispec.Platform) (memoryProvider, images.Image, digest.Digest) {
+	t.Helper()
+	provider := memoryProvider{}
+
+	manifestDescs := make([]ocispec.Descriptor, 0, 2)
+	var pulledConfigDigest digest.Digest
+	for _, p := range []ocispec.Platform{testPlatformA, testPlatformB} {
+		pulled := platforms.Only(pulledPlatform).Match(p)
+
+		layer := []byte("layer-" + p.Architecture)
+		layerDigest := digest.FromBytes(layer)
+		configBlob := ocispec.Image{
+			Platform: p,
+			RootFS: ocispec.RootFS{
+				Type:    "layers",
+				DiffIDs: []digest.Digest{layerDigest},
+			},
+		}
+
+		// Compute the descriptors for every platform, but only keep the
+		// content of the platform that was pulled.
+		target := provider
+		if !pulled {
+			target = memoryProvider{}
+		}
+		configDesc := target.add(t, ocispec.MediaTypeImageConfig, configBlob, nil)
+		if pulled {
+			provider[layerDigest] = layer
+			pulledConfigDigest = configDesc.Digest
+		}
+		manifest := ocispec.Manifest{
+			MediaType: ocispec.MediaTypeImageManifest,
+			Config:    configDesc,
+			Layers: []ocispec.Descriptor{{
+				MediaType: ocispec.MediaTypeImageLayer,
+				Digest:    layerDigest,
+				Size:      int64(len(layer)),
+			}},
+		}
+		manifestDescs = append(manifestDescs, target.add(t, ocispec.MediaTypeImageManifest, manifest, &p))
+	}
+
+	indexDesc := provider.add(t, ocispec.MediaTypeImageIndex, ocispec.Index{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: manifestDescs,
+	}, nil)
+
+	return provider, images.Image{Name: ref, Target: indexDesc}, pulledConfigDigest
+}
+
+// newSinglePlatformImage builds an image present for exactly one platform.
+func newSinglePlatformImage(t *testing.T, ref string, p ocispec.Platform) (memoryProvider, images.Image, digest.Digest) {
+	t.Helper()
+	provider := memoryProvider{}
+	layer := []byte("layer-" + p.Architecture)
+	layerDigest := digest.FromBytes(layer)
+	provider[layerDigest] = layer
+	configDesc := provider.add(t, ocispec.MediaTypeImageConfig, ocispec.Image{
+		Platform: p,
+		RootFS:   ocispec.RootFS{Type: "layers", DiffIDs: []digest.Digest{layerDigest}},
+	}, nil)
+	manifestDesc := provider.add(t, ocispec.MediaTypeImageManifest, ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{{MediaType: ocispec.MediaTypeImageLayer, Digest: layerDigest, Size: int64(len(layer))}},
+	}, &p)
+	indexDesc := provider.add(t, ocispec.MediaTypeImageIndex, ocispec.Index{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{manifestDesc},
+	}, nil)
+	return provider, images.Image{Name: ref, Target: indexDesc}, configDesc.Digest
+}
+
+func TestStoreResolvesNonDefaultPlatform(t *testing.T) {
+	const ref = "containerd.io/multi-platform:latest"
+	ctx := context.Background()
+
+	// The image is only present for platform B, which stands in for an image
+	// pulled through a runtime handler configured with a foreign platform.
+	provider, image, configDigest := newMultiPlatformImage(t, ref, testPlatformB)
+	s := NewStore(fakeGetter{image}, provider)
+
+	t.Run("it does not resolve on a platform it was not pulled for", func(t *testing.T) {
+		requirelib.NoError(t, s.Update(ctx, ref, testPlatformA))
+		_, err := s.Resolve(ref, testPlatformA)
+		assertlib.ErrorIs(t, err, errdefs.ErrNotFound)
+		assertlib.Empty(t, s.List())
+	})
+
+	t.Run("it resolves on the platform it was pulled for", func(t *testing.T) {
+		requirelib.NoError(t, s.Update(ctx, ref, testPlatformB))
+
+		id, err := s.Resolve(ref, testPlatformB)
+		requirelib.NoError(t, err)
+		assertlib.Equal(t, configDigest.String(), id)
+
+		got, err := s.Get(id)
+		requirelib.NoError(t, err)
+		assertlib.Equal(t, testPlatformB.Architecture, got.ImageSpec.Architecture)
+		assertlib.Equal(t, testPlatformB.Architecture, got.Platform.Architecture)
+		assertlib.Equal(t, []string{ref}, got.References)
+		assertlib.Len(t, s.List(), 1)
+	})
+}
+
+// TestStoreKeepsBothPlatformsOfOneRef is the case the ordered matcher could not
+// represent: one reference pulled for two platforms. Each platform has to keep
+// its own entry, and the tag has to resolve to the right one on each.
+func TestStoreKeepsBothPlatformsOfOneRef(t *testing.T) {
+	const tag = "containerd.io/multi-platform:latest"
+	ctx := context.Background()
+
+	providerA, image, configA := newMultiPlatformImage(t, tag, testPlatformA)
+	providerB, _, configB := newMultiPlatformImage(t, tag, testPlatformB)
+	maps.Copy(providerA, providerB)
+	requirelib.NotEqual(t, configA, configB)
+
+	s := NewStore(fakeGetter{image}, providerA)
+	requirelib.NoError(t, s.Update(ctx, tag, testPlatformA))
+	requirelib.NoError(t, s.Update(ctx, tag, testPlatformB))
+
+	for _, tc := range []struct {
+		platform ocispec.Platform
+		want     digest.Digest
+	}{{testPlatformA, configA}, {testPlatformB, configB}} {
+		id, err := s.Resolve(tag, tc.platform)
+		requirelib.NoError(t, err, "tag must resolve on %v", tc.platform)
+		assertlib.Equal(t, tc.want.String(), id)
+
+		got, err := s.Get(id)
+		requirelib.NoError(t, err)
+		assertlib.Equal(t, tc.platform.Architecture, got.Platform.Architecture)
+	}
+
+	// Both platforms are listed, each under its own image id.
+	assertlib.Len(t, s.List(), 2)
+}
+
+// TestStoreRemovesOnlyTheGivenPlatform pins that dropping a reference on one
+// platform leaves the other platform resolvable.
+func TestStoreRemovesOnlyTheGivenPlatform(t *testing.T) {
+	const tag = "containerd.io/multi-platform:latest"
+	ctx := context.Background()
+
+	providerA, image, configA := newMultiPlatformImage(t, tag, testPlatformA)
+	providerB, _, configB := newMultiPlatformImage(t, tag, testPlatformB)
+	maps.Copy(providerA, providerB)
+
+	s := NewStore(fakeGetter{image}, providerA)
+	requirelib.NoError(t, s.Update(ctx, tag, testPlatformA))
+	requirelib.NoError(t, s.Update(ctx, tag, testPlatformB))
+
+	// The reference disappears from containerd for platform A only.
+	requirelib.NoError(t, s.update(refKey{ref: tag, platform: util.PlatformKey(testPlatformA)}, nil))
+
+	_, err := s.Resolve(tag, testPlatformA)
+	assertlib.ErrorIs(t, err, errdefs.ErrNotFound)
+	_, err = s.Get(configA.String())
+	assertlib.ErrorIs(t, err, errdefs.ErrNotFound)
+
+	id, err := s.Resolve(tag, testPlatformB)
+	requirelib.NoError(t, err)
+	assertlib.Equal(t, configB.String(), id)
+	assertlib.Len(t, s.List(), 1)
+}
+
+// TestStoreUnsetPlatformIsTheNode pins that an unset platform and the platform
+// of the node are the same key, so callers that do not care keep working.
+func TestStoreUnsetPlatformIsTheNode(t *testing.T) {
+	const ref = "containerd.io/node-platform:latest"
+	ctx := context.Background()
+
+	provider, image, cfg := newSinglePlatformImage(t, ref, platforms.DefaultSpec())
+	s := NewStore(fakeGetter{image}, provider)
+	requirelib.NoError(t, s.Update(ctx, ref, ocispec.Platform{}))
+
+	id, err := s.Resolve(ref, platforms.DefaultSpec())
+	requirelib.NoError(t, err)
+	assertlib.Equal(t, cfg.String(), id)
+}
+
+// TestStoreDigestRefStaysOnItsOwnPlatform pins that an image id, which is the
+// digest of the image config of one platform, is never recorded against
+// another. Doing so would add the digest to the references of the other
+// platform's image and make the id name the wrong image.
+func TestStoreDigestRefStaysOnItsOwnPlatform(t *testing.T) {
+	const tag = "containerd.io/multi-platform:latest"
+	ctx := context.Background()
+
+	providerA, imageA, configA := newMultiPlatformImage(t, tag, testPlatformA)
+	providerB, _, configB := newMultiPlatformImage(t, tag, testPlatformB)
+	maps.Copy(providerA, providerB)
+	requirelib.NotEqual(t, configA, configB)
+
+	// The image id of platform A, named as a reference, as PullImage records it.
+	idA := configA.String()
+	getter := multiGetter{images: map[string]images.Image{
+		tag: imageA,
+		idA: {Name: idA, Target: imageA.Target},
+	}}
+	s := NewStore(getter, providerA)
+
+	// Refreshing the id on every platform, as the reload path does.
+	requirelib.NoError(t, s.Update(ctx, idA, testPlatformA))
+	requirelib.NoError(t, s.Update(ctx, idA, testPlatformB))
+
+	// It resolves on its own platform only.
+	got, err := s.Resolve(idA, testPlatformA)
+	requirelib.NoError(t, err)
+	assertlib.Equal(t, idA, got)
+	_, err = s.Resolve(idA, testPlatformB)
+	assertlib.ErrorIs(t, err, errdefs.ErrNotFound)
+
+	// And it never becomes a reference of the other platform's image.
+	requirelib.NoError(t, s.Update(ctx, tag, testPlatformB))
+	imgB, err := s.Get(configB.String())
+	requirelib.NoError(t, err)
+	assertlib.NotContains(t, imgB.References, idA,
+		"the image id of another platform must not reference this image")
+}
+
+type multiGetter struct {
+	images map[string]images.Image
+}
+
+func (g multiGetter) Get(_ context.Context, name string) (images.Image, error) {
+	i, ok := g.images[name]
+	if !ok {
+		return images.Image{}, fmt.Errorf("image %q: %w", name, errdefs.ErrNotFound)
+	}
+	return i, nil
+}

--- a/internal/cri/store/image/image_test.go
+++ b/internal/cri/store/image/image_test.go
@@ -21,7 +21,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/errdefs"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/opencontainers/go-digest/digestset"
 	assertlib "github.com/stretchr/testify/assert"
@@ -293,7 +295,7 @@ func TestImageStore(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			s, err := NewFakeStore([]Image{image})
 			assert.NoError(err)
-			assert.NoError(s.update(test.ref, test.image))
+			assert.NoError(s.update(refKey{ref: test.ref, platform: util.PlatformKey(imagespec.Platform{})}, test.image))
 
 			assert.Len(s.List(), len(test.expected))
 			for _, expect := range test.expected {
@@ -301,7 +303,7 @@ func TestImageStore(t *testing.T) {
 				assert.NoError(err)
 				equal(got, expect)
 				for _, ref := range expect.References {
-					id, err := s.Resolve(ref)
+					id, err := s.Resolve(ref, imagespec.Platform{})
 					assert.NoError(err)
 					assert.Equal(expect.ID, id)
 				}
@@ -309,7 +311,7 @@ func TestImageStore(t *testing.T) {
 
 			if test.image == nil {
 				// Shouldn't be able to index by removed ref.
-				id, err := s.Resolve(test.ref)
+				id, err := s.Resolve(test.ref, imagespec.Platform{})
 				assert.Equal(errdefs.ErrNotFound, err)
 				assert.Empty(id)
 			}

--- a/internal/cri/util/platform.go
+++ b/internal/cri/util/platform.go
@@ -1,0 +1,75 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/containerd/platforms"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// NodePlatform returns the platform of the node, and is what an unset platform
+// means everywhere in the CRI plugin.
+func NodePlatform() imagespec.Platform {
+	return platforms.DefaultSpec()
+}
+
+// PlatformKey returns a stable string identifying a platform, used to key
+// images by the platform they were pulled for. An unset platform is the
+// platform of the node.
+//
+// The OS version and the OS features are deliberately left out. On Windows they
+// distinguish images that run on the same platform, and choosing between those
+// is the job of a platform matcher, not of the key.
+func PlatformKey(platform imagespec.Platform) string {
+	p := platforms.Normalize(platformOrNode(platform))
+	p.OSVersion = ""
+	p.OSFeatures = nil
+	return platforms.FormatAll(p)
+}
+
+// IsNodePlatform reports whether the given platform is the platform of the
+// node. An unset platform means the platform of the node.
+//
+// The platform is compared to the platform of the node rather than run through
+// its matcher, because the matcher of the node also accepts platforms the node
+// can merely execute: on linux/amd64 it accepts linux/386, and on linux/arm64
+// it accepts linux/arm/v7. A runtime_platforms entry naming one of those is
+// asking for that platform to be selected, not for the platform of the node.
+func IsNodePlatform(platform imagespec.Platform) bool {
+	return PlatformKey(platform) == PlatformKey(NodePlatform())
+}
+
+// PlatformMatcher returns the matcher to use for an image on the given
+// platform.
+//
+// The platform of the node gets the matcher of the node rather than an exact
+// matcher for it. The two are not interchangeable: on Windows the matcher of
+// the node selects an image out of an index by OS version, and on darwin it
+// also accepts Linux binaries, neither of which platforms.Only does.
+func PlatformMatcher(platform imagespec.Platform) platforms.MatchComparer {
+	if IsNodePlatform(platform) {
+		return platforms.Default()
+	}
+	return platforms.Only(platform)
+}
+
+func platformOrNode(platform imagespec.Platform) imagespec.Platform {
+	if platform.OS == "" || platform.Architecture == "" {
+		return NodePlatform()
+	}
+	return platform
+}

--- a/internal/cri/util/platform_test.go
+++ b/internal/cri/util/platform_test.go
@@ -1,0 +1,120 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/containerd/platforms"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testForeignPlatform = imagespec.Platform{OS: "linux", Architecture: "mips64le"}
+
+// TestPlatformKeyRejectsMerelyRunnable pins that a platform the node can run
+// but which is not its own gets a distinct key. The matcher of the node accepts
+// those, so a configured linux/386 on linux/amd64 would otherwise be pulled and
+// stored as amd64.
+func TestPlatformKeyRejectsMerelyRunnable(t *testing.T) {
+	amd64 := imagespec.Platform{OS: "linux", Architecture: "amd64"}
+	arm64 := imagespec.Platform{OS: "linux", Architecture: "arm64", Variant: "v8"}
+
+	for _, tt := range []struct {
+		desc string
+		a, b imagespec.Platform
+		same bool
+	}{
+		{"same platform", amd64, amd64, true},
+		{"arm64 variant is normalized away", imagespec.Platform{OS: "linux", Architecture: "arm64"}, arm64, true},
+		{"the OS version is not part of the key",
+			imagespec.Platform{OS: "windows", Architecture: "amd64"},
+			imagespec.Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.20348.1"}, true},
+		{"386 is runnable on amd64 but is not amd64", imagespec.Platform{OS: "linux", Architecture: "386"}, amd64, false},
+		{"arm/v7 is runnable on arm64 but is not arm64", imagespec.Platform{OS: "linux", Architecture: "arm", Variant: "v7"}, arm64, false},
+		{"another OS is a different platform", imagespec.Platform{OS: "windows", Architecture: "amd64"}, amd64, false},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			// The matcher accepts the runnable cases, which is why the key
+			// cannot be derived from it.
+			if !tt.same && tt.a.OS == tt.b.OS {
+				assert.True(t, platforms.Only(tt.b).Match(tt.a),
+					"fixture should be one the matcher of the node accepts")
+			}
+			assert.Equal(t, tt.same, PlatformKey(tt.a) == PlatformKey(tt.b))
+		})
+	}
+}
+
+// TestPlatformKeyIsStable pins that an unset platform and the platform of the
+// node produce the same key, since an unset platform means the node.
+func TestPlatformKeyIsStable(t *testing.T) {
+	assert.Equal(t, PlatformKey(NodePlatform()), PlatformKey(imagespec.Platform{}))
+	assert.Equal(t, PlatformKey(imagespec.Platform{}), PlatformKey(imagespec.Platform{OS: "linux"}))
+	assert.NotEqual(t, PlatformKey(testForeignPlatform), PlatformKey(imagespec.Platform{}))
+}
+
+func TestIsNodePlatform(t *testing.T) {
+	assert.True(t, IsNodePlatform(imagespec.Platform{}), "an unset platform is the platform of the node")
+	assert.True(t, IsNodePlatform(imagespec.Platform{OS: "linux"}))
+	assert.True(t, IsNodePlatform(imagespec.Platform{Architecture: "amd64"}))
+	assert.True(t, IsNodePlatform(platforms.DefaultSpec()))
+	assert.False(t, IsNodePlatform(testForeignPlatform))
+}
+
+// TestPlatformMatcherKeepsNodeMatcher pins that the platform of the node gets
+// the matcher of the node and not an exact matcher for it. They are not
+// interchangeable: on Windows the matcher of the node selects an image out of
+// an index by OS version, and on darwin it also accepts Linux binaries.
+func TestPlatformMatcherKeepsNodeMatcher(t *testing.T) {
+	nodeSpec := platforms.DefaultSpec()
+
+	node := platforms.Default()
+	// Probes chosen to separate the matcher of the node from an exact matcher
+	// for it. They only diverge on Windows and darwin, where the matcher of
+	// the node carries OS version selection and a Linux fallback; on Linux
+	// platforms.Default is defined as platforms.Only of the node platform, so
+	// there is nothing to tell apart.
+	probes := []imagespec.Platform{
+		nodeSpec,
+		testForeignPlatform,
+		{OS: "linux", Architecture: "386"},
+		{OS: "linux", Architecture: "amd64"},
+		{OS: "linux", Architecture: "arm64", Variant: "v8"},
+		{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.1"},
+		{OS: "windows", Architecture: "amd64", OSVersion: "10.0.20348.1"},
+	}
+
+	for _, p := range []imagespec.Platform{{}, nodeSpec} {
+		matcher := PlatformMatcher(p)
+		require.NotNil(t, matcher)
+		for _, probe := range probes {
+			assert.Equal(t, node.Match(probe), matcher.Match(probe),
+				"matcher for %v must behave like the matcher of the node on %v", p, probe)
+		}
+	}
+}
+
+func TestPlatformMatcherPinsForeignPlatform(t *testing.T) {
+	require.False(t, platforms.Default().Match(testForeignPlatform), "fixture must not be the platform of the node")
+
+	matcher := PlatformMatcher(testForeignPlatform)
+	require.NotNil(t, matcher)
+	assert.True(t, matcher.Match(testForeignPlatform))
+	assert.False(t, matcher.Match(platforms.DefaultSpec()))
+}

--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -122,6 +122,14 @@ func init() {
 				return nil, fmt.Errorf("failed to find snapshotter %q", defaultSnapshotter)
 			}
 
+			// Any snapshotter has to be reachable by name, so that the image
+			// service can check whether an image is unpacked in the
+			// snapshotter of a runtime. That includes snapshotters propagated
+			// from the runtime config after this plugin is initialized.
+			options.SnapshotterProvider = func(name string) snapshots.Snapshotter {
+				return allSnapshotters[name]
+			}
+
 			snapshotRoot := func(snapshotter string) (snapshotRoot string) {
 				if plugin := ic.Plugins().Get(plugins.SnapshotPlugin, snapshotter); plugin != nil {
 					snapshotRoot = plugin.Meta.Exports["root"]
@@ -146,6 +154,11 @@ func init() {
 					options.ImageFSPaths[snapshotter] = snapshotRoot(snapshotter)
 					log.L.Infof("Get image filesystem path %q for snapshotter %q", options.ImageFSPaths[snapshotter], snapshotter)
 				}
+				// Collect stats for it too, otherwise ImageFsInfo reports
+				// nothing for images unpacked in this snapshotter.
+				if s, ok := allSnapshotters[snapshotter]; ok {
+					options.Snapshotters[snapshotter] = s
+				}
 
 				platform := platforms.DefaultSpec()
 				if rp.Platform != "" {
@@ -157,7 +170,11 @@ func init() {
 				}
 
 				options.RuntimePlatforms[runtimeName] = images.ImagePlatform{
-					Snapshotter: snapshotter,
+					// Keep the snapshotter unset when runtime_platforms does
+					// not configure one, so that a snapshotter configured on
+					// the runtime itself can still be propagated. An unset
+					// snapshotter resolves to the default at pull time.
+					Snapshotter: rp.Snapshotter,
 					Platform:    platform,
 				}
 			}

--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -238,22 +238,23 @@ func migrateConfig(dst, src map[string]any) {
 	}
 
 	var runtimePlatforms map[string]any
-	if v, ok := dst["runtime_platform"]; ok {
+	if v, ok := dst["runtime_platforms"]; ok {
 		runtimePlatforms = v.(map[string]any)
 	} else {
 		runtimePlatforms = map[string]any{}
 	}
 	for runtime, v := range runtimesConf.(map[string]any) {
 		runtimeConf := v.(map[string]any)
-		if snapshotter, ok := runtimeConf["snapshot"]; ok && snapshotter != "" {
+		if snapshotter, ok := runtimeConf["snapshotter"]; ok && snapshotter != "" {
+			// Leave the platform unset so that it defaults to the platform
+			// of the node, which is what a v2 config implies.
 			runtimePlatforms[runtime] = map[string]any{
-				"platform":    platforms.DefaultStrict(),
 				"snapshotter": snapshotter,
 			}
 		}
 	}
 	if len(runtimePlatforms) > 0 {
-		dst["runtime_platform"] = runtimePlatforms
+		dst["runtime_platforms"] = runtimePlatforms
 	}
 
 	for _, key := range []string{

--- a/plugins/cri/images/plugin_test.go
+++ b/plugins/cri/images/plugin_test.go
@@ -68,3 +68,41 @@ func TestRegistryConfigMigration(t *testing.T) {
 	configPath := v.(string)
 	assert.Equal(t, path, configPath)
 }
+
+func TestRuntimePlatformsConfigMigration(t *testing.T) {
+	grpcCri := map[string]any{
+		"containerd": map[string]any{
+			"runtimes": map[string]any{
+				"kata": map[string]any{
+					"snapshotter": "devmapper",
+				},
+				"runc": map[string]any{
+					"snapshotter": "",
+				},
+			},
+		},
+	}
+	pluginConfigs := map[string]any{
+		string(plugins.GRPCPlugin) + ".cri": grpcCri,
+	}
+	configMigration(context.Background(), 2, pluginConfigs)
+	v, ok := pluginConfigs[string(plugins.CRIServicePlugin)+".images"]
+	require.True(t, ok)
+	images := v.(map[string]any)
+
+	// The key has to match the `runtime_platforms` toml tag of ImageConfig,
+	// otherwise the migrated snapshotters are silently dropped.
+	v, ok = images["runtime_platforms"]
+	require.True(t, ok)
+	runtimePlatforms := v.(map[string]any)
+
+	// A runtime without a snapshotter does not need an entry.
+	assert.NotContains(t, runtimePlatforms, "runc")
+
+	v, ok = runtimePlatforms["kata"]
+	require.True(t, ok)
+	kata := v.(map[string]any)
+	assert.Equal(t, "devmapper", kata["snapshotter"])
+	// An unset platform means the platform of the node.
+	assert.NotContains(t, kata, "platform")
+}


### PR DESCRIPTION
# cri: use the platform configured in `runtime_platforms`

## Motivation

A lot of dev clusters run on arm64 now: an Apple Silicon laptop running a KinD node, an arm64 CI runner. Plenty of software is still published for `linux/amd64` only.

containerd only pulls for the node's own platform, so those images fail with `no match for platform in manifest` and the pod never starts. The host can usually run amd64 binaries fine through Rosetta or `qemu-user-static`. containerd just won't fetch the image.

The workaround today is to rewrite the `architecture` field in the image config and side-load it. You have to redo it for every image and every tag, and it puts a lie in the image metadata.

The config for doing this properly already exists. `runtime_platforms` maps a CRI runtime handler to an `ImagePlatform{Platform, Snapshotter}`. Only `Snapshotter` is read. The platform is parsed by the plugin, stored on the image service, and then nothing looks at it. This PR reads it.

```toml
[plugins."io.containerd.cri.v1.images".runtime_platforms."runc-amd64"]
  platform = "linux/amd64"
```

```yaml
spec:
  runtimeClassName: runc-amd64   # images pulled and unpacked as linux/amd64
```

The node stays arm64. Kubelet, etcd and containerd keep running natively. Only pods that opt into the `RuntimeClass` get images for another platform.

## Changes

* `runtime_platforms.platform` now selects the platform on pull and unpack, on the local pull path and through the transfer service.
* The CRI image store is keyed by `(ref, platform)`. The image id doesn't need the platform. It's the digest of the image config, which already differs per platform.
* The snapshotter is not in the key, and not in the entry either. Presence is a `Stat` of the entry's `ChainID` in the handler's snapshotter. The same image can be unpacked in several snapshotters, and that changes outside of CRI.
* `ImageStatus` and `RemoveImage` honour the runtime handler, not just `PullImage`. `ImageStatus` returns the handler in the response spec.
* `ImageStatus` only checks that the image is unpacked when the request names a handler. That asks whether a specific runtime can use it. Without a handler it asks whether the image is known, so an image pulled outside CRI stays visible.
* An image is only stored for a platform other than the node's if it's actually unpacked there.
* Pinned images, including the sandbox image, stay on the node's platform.

An unset `platform` behaves as before. The node's platform is always considered first, so the default path doesn't change.

The first commit is unrelated to the feature. The v2 to v3 config migration wrote the field as `runtime_platform` and read the v2 snapshotter from `snapshot`, so migrated runtime snapshotters were dropped on the floor.

`runtime_platforms` had no docs. `docs/cri/config.md` now has an example and the caveats, including the fact that the node still advertises its own architecture, so picking a `RuntimeClass` is the opt-in and this only makes sense on hosts that can emulate.

Follows on from #12710, which made `PullImage` honour the `runtimeHandler` parameter and pick a snapshotter, but left `Platform` unused.

## Requires the `RuntimeClassInImageCriApi` kubelet feature gate

Same as #12710: this needs the kubelet to populate `ImageSpec.RuntimeHandler` in `PullImageRequest`. It's behind `RuntimeClassInImageCriApi`, still alpha and off by default in Kubernetes 1.35. With the gate off, `runtimeHandler` is empty and nothing changes.

## Testing

arm64 KinD node, Kubernetes 1.35, Rosetta available, `RuntimeClassInImageCriApi=true`, `runc-amd64` handler configured with `platform = "linux/amd64"`:

| Pod | Image | Result |
|---|---|---|
| `runtimeClassName: runc-amd64` | `amd64/alpine:3.21` (amd64-only index) | Running, `uname -m` gives `x86_64` |
| `runtimeClassName: runc-amd64` | `alpine:3.21` (multi-arch index) | Running, `uname -m` gives `x86_64` |
| no `runtimeClassName` | `alpine:3.21` | Running, `uname -m` gives `aarch64`, at the same time |
| no `runtimeClassName` | `amd64/busybox:1.37` (amd64-only index) | `ErrImagePull`, `no match for platform in manifest` |

Both platforms of `alpine:3.21` sit in the store at once, each under its own image id. The sandbox image stays `arm64`. All of it survives a containerd restart.
