### PR TITLE
tracing: align span attribute keys with OTel semantic conventions

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -46,6 +46,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-spec/specs-go/features"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
@@ -363,12 +364,14 @@ func (c *Client) NewContainer(ctx context.Context, id string, opts ...NewContain
 		}
 	}
 
-	span.SetAttributes(
+	attrs := []attribute.KeyValue{
 		tracing.Attribute("container.id", container.ID),
 		tracing.Attribute("container.image.ref", container.Image),
 		tracing.Attribute("container.runtime.name", container.Runtime.Name),
-		tracing.Attribute("container.snapshotter.name", container.Snapshotter),
-	)
+		tracing.Attribute("containerd.snapshotter.name", container.Snapshotter),
+	}
+	span.SetAttributes(attrs...)
+	span.SetAttributes(tracing.LegacyAttributes(attrs)...)
 	r, err := c.ContainerService().Create(ctx, container)
 	if err != nil {
 		return nil, err
@@ -385,14 +388,16 @@ func (c *Client) LoadContainer(ctx context.Context, id string) (Container, error
 		return nil, err
 	}
 
-	span.SetAttributes(
+	attrs := []attribute.KeyValue{
 		tracing.Attribute("container.id", r.ID),
 		tracing.Attribute("container.image.ref", r.Image),
 		tracing.Attribute("container.runtime.name", r.Runtime.Name),
-		tracing.Attribute("container.snapshotter.name", r.Snapshotter),
+		tracing.Attribute("containerd.snapshotter.name", r.Snapshotter),
 		tracing.Attribute("container.createdAt", r.CreatedAt.Format(time.RFC3339)),
 		tracing.Attribute("container.updatedAt", r.UpdatedAt.Format(time.RFC3339)),
-	)
+	}
+	span.SetAttributes(attrs...)
+	span.SetAttributes(tracing.LegacyAttributes(attrs)...)
 	return containerFromRecord(c, r), nil
 }
 

--- a/client/container.go
+++ b/client/container.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/typeurl/v2"
 	ver "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/images"
@@ -289,19 +290,20 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 		request.Checkpoint = info.Checkpoint
 	}
 
-	span.SetAttributes(
-		tracing.Attribute("task.container.id", request.ContainerID),
+	attrs := []attribute.KeyValue{
+		tracing.Attribute("container.id", request.ContainerID),
 		tracing.Attribute("task.request.options", request.Options.String()),
-		tracing.Attribute("task.runtime.name", info.runtime),
-	)
+		tracing.Attribute("container.runtime.name", info.runtime),
+	}
+	span.SetAttributes(attrs...)
+	span.SetAttributes(tracing.LegacyAttributes(attrs)...)
 	response, err := c.client.TaskService().Create(ctx, request)
 	if err != nil {
 		return nil, errgrpc.ToNative(err)
 	}
 
-	span.AddEvent("task created",
-		tracing.Attribute("task.process.id", int(response.Pid)),
-	)
+	eventAttrs := []attribute.KeyValue{tracing.Attribute("process.pid", int(response.Pid))}
+	span.AddEvent("task created", append(eventAttrs, tracing.LegacyAttributes(eventAttrs)...)...)
 	t.pid = response.Pid
 	return t, nil
 }

--- a/client/pull.go
+++ b/client/pull.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/containerd/containerd/v2/core/images"
@@ -75,13 +76,15 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 		}
 	}
 
-	span.SetAttributes(
-		tracing.Attribute("image.ref", ref),
-		tracing.Attribute("unpack", pullCtx.Unpack),
+	attrs := []attribute.KeyValue{
+		tracing.Attribute("containerd.image.ref", ref),
+		tracing.Attribute("containerd.pull.unpack", pullCtx.Unpack),
 		tracing.Attribute("max.concurrent.downloads", pullCtx.MaxConcurrentDownloads),
 		tracing.Attribute("concurrent.layer.fetch.buffer", pullCtx.ConcurrentLayerFetchBuffer),
 		tracing.Attribute("platforms.count", len(pullCtx.Platforms)),
-	)
+	}
+	span.SetAttributes(attrs...)
+	span.SetAttributes(tracing.LegacyAttributes(attrs)...)
 
 	ctx, done, err := c.WithLease(ctx)
 	if err != nil {
@@ -96,7 +99,9 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 		if err != nil {
 			return nil, fmt.Errorf("unable to resolve snapshotter: %w", err)
 		}
-		span.SetAttributes(tracing.Attribute("snapshotter.name", snapshotterName))
+		attrs := []attribute.KeyValue{tracing.Attribute("containerd.snapshotter.name", snapshotterName)}
+		span.SetAttributes(attrs...)
+		span.SetAttributes(tracing.LegacyAttributes(attrs)...)
 
 		snCapabilities, err := c.GetSnapshotterCapabilities(ctx, snapshotterName)
 		if err != nil {
@@ -177,7 +182,9 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 	}
 
 	i := NewImageWithPlatform(c, img, pullCtx.PlatformMatcher)
-	span.SetAttributes(tracing.Attribute("image.ref", i.Name()))
+	attrs = []attribute.KeyValue{tracing.Attribute("containerd.image.ref", i.Name())}
+	span.SetAttributes(attrs...)
+	span.SetAttributes(tracing.LegacyAttributes(attrs)...)
 
 	if unpacker != nil && ur.Unpacks == 0 {
 		// Unpack was tried previously but nothing was unpacked

--- a/client/task.go
+++ b/client/task.go
@@ -36,6 +36,7 @@ import (
 	is "github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/diff"
@@ -263,7 +264,9 @@ func (t *task) Start(ctx context.Context) error {
 		}
 		return errgrpc.ToNative(err)
 	}
-	span.SetAttributes(tracing.Attribute("task.pid", r.Pid))
+	attrs := []attribute.KeyValue{tracing.Attribute("process.pid", int(r.Pid))}
+	span.SetAttributes(attrs...)
+	span.SetAttributes(tracing.LegacyAttributes(attrs)...)
 	t.pid = r.Pid
 	return nil
 }
@@ -271,10 +274,13 @@ func (t *task) Start(ctx context.Context) error {
 func (t *task) Kill(ctx context.Context, s syscall.Signal, opts ...KillOpts) error {
 	ctx, span := tracing.StartSpan(ctx, tracing.Name("client.task", "Kill"),
 		tracing.WithAttribute("task.id", t.ID()),
-		tracing.WithAttribute("task.pid", int(t.Pid())),
 		tracing.WithNamespace(ctx),
 	)
 	defer span.End()
+
+	attrs := []attribute.KeyValue{tracing.Attribute("process.pid", int(t.Pid()))}
+	span.SetAttributes(attrs...)
+	span.SetAttributes(tracing.LegacyAttributes(attrs)...)
 
 	var i KillInfo
 	for _, o := range opts {

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -201,6 +201,24 @@ OpenTelemetry maintains a set of recommended [semantic conventions](https://open
 
 Manually instrumented spans in Containerd follow the conventions defined for [Spans](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/) and [Attributes](https://opentelemetry.io/docs/reference/specification/common/attribute-naming/)
 
+Concepts defined by the OpenTelemetry semantic conventions use the corresponding semantic convention attribute keys. Containerd-specific concepts, such as snapshotters, pull references, and unpack operations, use the `containerd.` namespace.
+
+The following legacy attribute keys are deprecated in favor of semantic convention or containerd-namespaced keys:
+
+| Deprecated key | New key |
+| --- | --- |
+| `task.container.id` | `container.id` |
+| `task.runtime.name` | `container.runtime.name` |
+| `task.pid` | `process.pid` |
+| `task.process.id` | `process.pid` |
+| `image.ref` | `containerd.image.ref` |
+| `snapshotter.name` | `containerd.snapshotter.name` |
+| `container.snapshotter.name` | `containerd.snapshotter.name` |
+| `image.id` | `container.image.id` |
+| `unpack` | `containerd.pull.unpack` |
+
+During the migration period, both the new and legacy keys are emitted. The legacy keys will be removed in a future release.
+
 ### Span Names
 * Dot-separated notation.
 * Span Names may include relative path to the package.

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -38,6 +38,7 @@ import (
 	"github.com/containerd/platforms"
 	distribution "github.com/distribution/reference"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.opentelemetry.io/otel/attribute"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -170,10 +171,12 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 		return "", err
 	}
 
-	span.SetAttributes(
-		tracing.Attribute("image.ref", ref),
-		tracing.Attribute("snapshotter.name", snapshotter),
-	)
+	attrs := []attribute.KeyValue{
+		tracing.Attribute("containerd.image.ref", ref),
+		tracing.Attribute("containerd.snapshotter.name", snapshotter),
+	}
+	span.SetAttributes(attrs...)
+	span.SetAttributes(tracing.LegacyAttributes(attrs)...)
 	labels := c.getLabels(ctx, ref)
 
 	// If UseLocalImagePull is true, use client.Pull to pull the image, else use transfer service by default.

--- a/internal/cri/server/images/image_remove.go
+++ b/internal/cri/server/images/image_remove.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/errdefs"
@@ -53,7 +55,9 @@ func (c *CRIImageService) RemoveImage(ctx context.Context, imageSpec *runtime.Im
 		}
 		return fmt.Errorf("can not resolve %q locally: %w", imageSpec.GetImage(), err)
 	}
-	span.SetAttributes(tracing.Attribute("image.id", image.ID))
+	attrs := []attribute.KeyValue{tracing.Attribute("container.image.id", image.ID)}
+	span.SetAttributes(attrs...)
+	span.SetAttributes(tracing.LegacyAttributes(attrs)...)
 	// Remove all image references.
 	for i, ref := range image.References {
 		var opts []images.DeleteOpt

--- a/pkg/tracing/attributes.go
+++ b/pkg/tracing/attributes.go
@@ -1,0 +1,45 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tracing
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// legacyAttributes maps current attribute keys to the deprecated legacy keys
+// that are still emitted during the migration period.
+var legacyAttributes = map[attribute.Key][]attribute.Key{
+	"container.id":                {"task.container.id"},
+	"container.runtime.name":      {"task.runtime.name"},
+	"process.pid":                 {"task.pid", "task.process.id"},
+	"container.image.id":          {"image.id"},
+	"containerd.image.ref":        {"image.ref"},
+	"containerd.snapshotter.name": {"snapshotter.name", "container.snapshotter.name"},
+	"containerd.pull.unpack":      {"unpack"},
+}
+
+// LegacyAttributes returns the deprecated legacy attributes corresponding to
+// attrs. The legacy keys will be removed in a future release.
+func LegacyAttributes(attrs []attribute.KeyValue) []attribute.KeyValue {
+	var legacy []attribute.KeyValue
+	for _, attr := range attrs {
+		for _, key := range legacyAttributes[attr.Key] {
+			legacy = append(legacy, attribute.KeyValue{Key: key, Value: attr.Value})
+		}
+	}
+	return legacy
+}

--- a/pkg/tracing/attributes_test.go
+++ b/pkg/tracing/attributes_test.go
@@ -1,0 +1,105 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tracing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestLegacyAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []attribute.KeyValue
+		expected []attribute.KeyValue
+	}{
+		{
+			name:     "ContainerID",
+			input:    []attribute.KeyValue{attribute.String("container.id", "container-1")},
+			expected: []attribute.KeyValue{attribute.String("task.container.id", "container-1")},
+		},
+		{
+			name:     "ContainerRuntimeName",
+			input:    []attribute.KeyValue{attribute.String("container.runtime.name", "io.containerd.runc.v2")},
+			expected: []attribute.KeyValue{attribute.String("task.runtime.name", "io.containerd.runc.v2")},
+		},
+		{
+			name:  "ProcessPIDExpandsToBothLegacyKeys",
+			input: []attribute.KeyValue{attribute.Int("process.pid", 1234)},
+			expected: []attribute.KeyValue{
+				attribute.Int("task.pid", 1234),
+				attribute.Int("task.process.id", 1234),
+			},
+		},
+		{
+			name:     "ContainerImageID",
+			input:    []attribute.KeyValue{attribute.String("container.image.id", "sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f")},
+			expected: []attribute.KeyValue{attribute.String("image.id", "sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f")},
+		},
+		{
+			name:     "ImageRef",
+			input:    []attribute.KeyValue{attribute.String("containerd.image.ref", "docker.io/library/busybox:latest")},
+			expected: []attribute.KeyValue{attribute.String("image.ref", "docker.io/library/busybox:latest")},
+		},
+		{
+			name:  "SnapshotterNameExpandsToBothLegacyKeys",
+			input: []attribute.KeyValue{attribute.String("containerd.snapshotter.name", "overlayfs")},
+			expected: []attribute.KeyValue{
+				attribute.String("snapshotter.name", "overlayfs"),
+				attribute.String("container.snapshotter.name", "overlayfs"),
+			},
+		},
+		{
+			name:     "Unpack",
+			input:    []attribute.KeyValue{attribute.Bool("containerd.pull.unpack", true)},
+			expected: []attribute.KeyValue{attribute.Bool("unpack", true)},
+		},
+		{
+			name: "UnknownKeysIgnored",
+			input: []attribute.KeyValue{
+				attribute.Int("max.concurrent.downloads", 3),
+				attribute.String("container.image.ref", "docker.io/library/redis:latest"),
+			},
+			expected: nil,
+		},
+		{
+			name: "MixedKnownAndUnknownPreservesInputOrder",
+			input: []attribute.KeyValue{
+				attribute.String("containerd.image.ref", "docker.io/library/busybox:latest"),
+				attribute.Bool("containerd.pull.unpack", false),
+				attribute.Int("platforms.count", 1),
+			},
+			expected: []attribute.KeyValue{
+				attribute.String("image.ref", "docker.io/library/busybox:latest"),
+				attribute.Bool("unpack", false),
+			},
+		},
+		{
+			name:     "EmptyInput",
+			input:    nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, LegacyAttributes(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
Closes #12191

Rename trace span attribute keys to follow the OpenTelemetry semantic conventions. Keys that have no semconv equivalent (snapshotter, pull ref, unpack) are moved under the `containerd.` namespace instead.

| Legacy key | New key |
| --- | --- |
| `task.container.id` | `container.id` |
| `task.runtime.name` | `container.runtime.name` |
| `task.pid` | `process.pid` |
| `task.process.id` | `process.pid` |
| `image.id` | `container.image.id` |
| `image.ref` | `containerd.image.ref` |
| `snapshotter.name` | `containerd.snapshotter.name` |
| `container.snapshotter.name` | `containerd.snapshotter.name` |
| `unpack` | `containerd.pull.unpack` |

To avoid breaking existing consumers, both the new and legacy keys are emitted for now (same approach as `HTTPStatusCodeAttributes`). The legacy keys are documented as deprecated in `docs/tracing.md` and can be dropped in a future release.

`container.image.ref` is kept as is, since an image ref is not equivalent to `container.image.id`, `container.image.name` (see discussion in #12191). Attributes not mentioned in the issue are left untouched.