### PR TITLE
oci: fix env deduplication for keys appearing only in overrides

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -218,6 +218,7 @@ func replaceOrAppendEnvValues(defaults, overrides []string) []string {
 		if i, exists := cache[k]; exists {
 			results[i] = value
 		} else {
+			cache[k] = len(results)
 			results = append(results, value)
 		}
 	}

--- a/pkg/oci/spec_opts_test.go
+++ b/pkg/oci/spec_opts_test.go
@@ -168,6 +168,48 @@ func TestReplaceOrAppendEnvValues(t *testing.T) {
 	}
 }
 
+func TestReplaceOrAppendEnvValuesDuplicateOverrides(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		defaults  []string
+		overrides []string
+		expected  []string
+	}{
+		{
+			// A key repeated within overrides must resolve to the last
+			// value, not be appended twice. This mirrors how CRI merges
+			// image config env followed by container config env into a
+			// single WithEnv call (container_create.go), where a key set
+			// by both must be overridden rather than duplicated.
+			name:      "override key repeated is deduplicated to last",
+			defaults:  nil,
+			overrides: []string{"FOO=image", "FOO=container"},
+			expected:  []string{"FOO=container"},
+		},
+		{
+			name:      "unset applies to a key introduced by overrides",
+			defaults:  nil,
+			overrides: []string{"FOO=1", "FOO"},
+			expected:  []string{},
+		},
+		{
+			name:      "later override wins over an appended default and override",
+			defaults:  []string{"A=1"},
+			overrides: []string{"B=x", "B=y"},
+			expected:  []string{"A=1", "B=y"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			results := replaceOrAppendEnvValues(tc.defaults, tc.overrides)
+			if err := assertEqualsStringArrays(results, tc.expected); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestWithDefaultSpecForPlatform(t *testing.T) {
 	t.Parallel()
 	var (


### PR DESCRIPTION
`replaceOrAppendEnvValues` caches the index of each key in `defaults` so a later override with the same key replaces it in place. A key that first appears in `overrides` is appended but never added to the cache, so a second override with that key is appended again instead of replacing the first, and a later unset (a bare `KEY` with no `=`) of that key is ignored.

CRI hits this. In `container_create.go` the container env is built by appending the container config env after the image config env and passing the combined slice to a single `oci.WithEnv`, with the stated intent ("Apply envs from image config first, so that envs from container config can override them"). When a key is set in both the image and the container config, both entries end up in `process.env` instead of the container value winning. This was reported in #7348.

The fix records the index of a newly appended key, so repeated keys in the overrides collapse to the last value and unset applies. It keeps the existing structure and output ordering; #7348 proposed a larger rewrite that also reordered the result.

Tests: added cases in `pkg/oci` for a repeated override key, an unset of an override-introduced key, and a repeated key with a default present. They fail before this change and pass after. `go test ./pkg/oci/... ./internal/cri/server/...` passes.
