### PR TITLE
ctr: drain exec output before cleanup

### DIFF
--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -186,6 +186,8 @@ var execCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		process.IO().Wait()
+		process.IO().Close()
 		if code != 0 {
 			return cli.Exit("", int(code))
 		}


### PR DESCRIPTION
Wait for stdout and stderr copying to complete after validating process exit so deferred process deletion does not cancel readers with output still in flight.

Similar to: https://github.com/containerd/nerdctl/pull/4392

```release-note
Drain container stdout and stderr before process deletion in ctr exec
```
