### PR TITLE
snapshots/erofs: protect snapshot staging from cleanup

### DIFF
--- a/plugins/snapshots/erofs/erofs.go
+++ b/plugins/snapshots/erofs/erofs.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/errdefs"
@@ -38,6 +39,8 @@ import (
 	"github.com/containerd/containerd/v2/internal/fsverity"
 	"github.com/containerd/containerd/v2/internal/userns"
 )
+
+const snapshotTempDirPrefix = "new-"
 
 // SnapshotterConfig is used to configure the erofs snapshotter instance
 type SnapshotterConfig struct {
@@ -293,7 +296,7 @@ func (s *snapshotter) lowerPath(id string) (string, error) {
 }
 
 func (s *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind, cacheBlob string) (string, error) {
-	td, err := os.MkdirTemp(snapshotDir, "new-")
+	td, err := os.MkdirTemp(snapshotDir, snapshotTempDirPrefix)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
@@ -891,6 +894,12 @@ func (s *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, erro
 
 	cleanup := []string{}
 	for _, d := range dirs {
+		// A new-* directory may belong to a concurrent snapshot creation. It is
+		// renamed to its metadata ID after the writer transaction is acquired, so
+		// Remove must not treat it as an orphan in the meantime.
+		if strings.HasPrefix(d, snapshotTempDirPrefix) {
+			continue
+		}
 		if _, ok := ids[d]; ok {
 			continue
 		}

--- a/plugins/snapshots/erofs/erofs_linux_test.go
+++ b/plugins/snapshots/erofs/erofs_linux_test.go
@@ -113,6 +113,34 @@ func TestErofsWithQuota(t *testing.T) {
 	testsuite.SnapshotterSuite(t, "erofs", newSnapshotter(t, WithDefaultSize(16*1024*1024)))
 }
 
+func TestGetCleanupDirectoriesSkipsSnapshotTempDirs(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	snapshotDir := filepath.Join(root, "snapshots")
+	require.NoError(t, os.Mkdir(snapshotDir, 0700))
+
+	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ms.Close()) })
+	s := &snapshotter{root: root, ms: ms}
+
+	_, err = os.MkdirTemp(snapshotDir, snapshotTempDirPrefix)
+	require.NoError(t, err)
+	orphanDir := filepath.Join(snapshotDir, "orphan")
+	require.NoError(t, os.Mkdir(orphanDir, 0700))
+	require.NoError(t, ms.WithTransaction(ctx, true, func(ctx context.Context) error {
+		_, err := storage.CreateSnapshot(ctx, snapshots.KindActive, "existing", "")
+		return err
+	}))
+
+	var cleanup []string
+	require.NoError(t, ms.WithTransaction(ctx, true, func(ctx context.Context) error {
+		cleanup, err = s.getCleanupDirectories(ctx)
+		return err
+	}))
+	assert.Equal(t, []string{orphanDir}, cleanup)
+}
+
 // TestWritableSize exercises the LabelSnapshotMaxSize override that the
 // block-mode mkfs path passes to X-containerd.mkfs.size. Covers the
 // happy path (label overrides default), fallback cases (missing, empty,


### PR DESCRIPTION
## Summary

Exclude in-flight EROFS `new-*` staging directories from orphan cleanup during
snapshot removal.

This prevents a concurrent `Remove` from deleting a directory that
`createSnapshot` is still preparing, without extending the metadata writer
transaction.

## Problem

`createSnapshot` creates a `snapshots/new-*` directory before acquiring the
metadata writer transaction.

A concurrent `Remove` performs a global orphan scan of the snapshots directory.
Because the staging directory does not yet have a metadata ID, the scan can
classify it as an orphan and delete it. Snapshot creation then fails when it
tries to rename the missing staging directory:

```text
failed to rename: rename .../snapshots/new-* .../snapshots/<id>: no such file or directory
```

This was observed downstream under concurrent image pulls and snapshot
removals.

## Fix

Define a shared local prefix for snapshot staging directories and exclude
directories with that prefix from `getCleanupDirectories`.

Successful snapshot creation renames the staging directory to its allocated
metadata ID. Normal preparation failures continue to remove it through the
existing deferred cleanup.

A staging directory left by a daemon crash can be handled separately by a
future `Cleanup` implementation.

```release-note
Fix EROFS snapshot creation failure caused by concurrent snapshot removal
```
