### PR TITLE
docs: fix duplicated word and broken verb in comments

### DIFF
--- a/client/container_opts.go
+++ b/client/container_opts.go
@@ -51,7 +51,7 @@ type InfoOpts func(*InfoConfig)
 
 // InfoConfig specifies how container metadata is fetched
 type InfoConfig struct {
-	// Refresh will to a fetch of the latest container metadata
+	// Refresh will trigger a fetch of the latest container metadata
 	Refresh bool
 }
 

--- a/docs/historical/reports/2017-06-23.md
+++ b/docs/historical/reports/2017-06-23.md
@@ -150,7 +150,7 @@ Slack.
     - Another more complicated aspect of garbage collection is around policy, allowing to clean up resources based on age or client specified policies.
     - Client side implementations would allow establishing policies.
     - Containerd will require a stop the world to do the garbage collection.
-    - A heavy delete which does not garbage collect is an option and similar to to the interface today. The API does not guarantee that disk is cleaned up after a deletion, only that the resource is freed. Inline deletion would require reference counting to know when to delete. This would also require global locking to protect the references.
+    - A heavy delete which does not garbage collect is an option and similar to the interface today. The API does not guarantee that disk is cleaned up after a deletion, only that the resource is freed. Inline deletion would require reference counting to know when to delete. This would also require global locking to protect the references.
     - How to handle content which is active but unreferenced, leasing vs pre-allocate. This has not been decided on.
 
 * "What will need to change in Docker in regards to graphdrivers for accommodating the containerd snapshotters?"


### PR DESCRIPTION
### WHY

Two comments contain text corruption:

- `docs/historical/reports/2017-06-23.md`: `similar to to the interface` — duplicated `to`
- `client/container_opts.go`: `Refresh will to a fetch` — missing verb (`will to` reads ungrammatical)

### WHAT

```diff
-...similar to to the interface today.
+...similar to the interface today.
-// Refresh will to a fetch of the latest container metadata
+// Refresh will trigger a fetch of the latest container metadata
```

Comments only; no code behavior change.