### PR TITLE
fix: prevent premature close of exec stdin stream [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/internal/cri/io/exec_io.go
+++ b/internal/cri/io/exec_io.go
@@ -121,9 +121,6 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 		}
 		out.Close()
 		stream.Close()
-		if stdinStreamRC != nil {
-			stdinStreamRC.Close()
-		}
 		e.closer.wg.Done()
 		wg.Done()
 		log.L.Debugf("Finish piping %q of container exec %q", t, e.id)


### PR DESCRIPTION
## Description

When an exec command produces no stdout/stderr output (e.g., `cat >/file`), the stdout FIFO reaches EOF immediately, causing `attachOutput` to close the stdin stream via `stdinStreamRC.Close()` before all stdin data has been transferred to the container. This truncates the input stream, typically at 192 KiB.

### Root Cause

In `internal/cri/io/exec_io.go`, the `attachOutput` function unconditionally closes `stdinStreamRC` (the client's stdin HTTP stream) when stdout or stderr finishes copying. For commands that produce no output, this happens immediately while the stdin copy goroutine is still reading data from the client.

The `stdinStreamRC.Close()` call in `attachOutput` is removed. The stdin stream is now properly closed only when:
1. The stdin copy goroutine finishes (client has sent all data via EOF).
2. The streaming server closes the SPDY connection when the process exits.

### Reproduction

```bash
dd if=/dev/zero bs=1M count=500 2>/dev/null | \
crictl exec -i <CONTAINER_ID> sh -c 'cat >/tmp/test'
```

Expected: 524288000 bytes. Actual: 196608 bytes (192 KiB).

### Fix

Remove the `stdinStreamRC.Close()` call from `attachOutput`. The stdin copy goroutine already owns stdin lifecycle — it calls `opts.CloseStdin()` when `io.Copy` completes.

### Testing

- `go build ./internal/cri/io/` — passes
- `go vet ./internal/cri/io/` — passes
- `go test ./internal/cri/io/` — passes

Fixes containerd#13934
