### PR TITLE
runtime/v2: fix misleading LoadBundle root parameter name

### DIFF
--- a/core/runtime/v2/bundle.go
+++ b/core/runtime/v2/bundle.go
@@ -31,14 +31,14 @@ import (
 )
 
 // LoadBundle loads an existing bundle from disk
-func LoadBundle(ctx context.Context, root, id string) (*Bundle, error) {
+func LoadBundle(ctx context.Context, state, id string) (*Bundle, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return &Bundle{
 		ID:        id,
-		Path:      filepath.Join(root, ns, id),
+		Path:      filepath.Join(state, ns, id),
 		Namespace: ns,
 	}, nil
 }


### PR DESCRIPTION
## What this PR does

Renames the second parameter of `LoadBundle` from `root` to `state`, to match the semantics of the same parameter in `NewBundle`.

## Why

While reading `LoadBundle(ctx, root, id)`, the `root` parameter name is misleading: a reader naturally expects it to refer to the work/root directory (as `root` does in `NewBundle` and `TaskManager.root`), but it is actually the **state directory**.

The body confirms this — `root` is used to build `b.Path`, the bundle's state path:

```go
func LoadBundle(ctx context.Context, root, id string) (*Bundle, error) {
    ...
    return &Bundle{
        Path: filepath.Join(root, ns, id),  // builds b.Path
        ...
    }, nil
}
```

In `NewBundle`, the same `b.Path` is built from the **`state`** parameter, while `root` is used for the **work** directory:

```go
func NewBundle(ctx context.Context, root, state, id string, ...) {
    work := filepath.Join(root, ns, id)    // work dir from root
    b.Path = filepath.Join(state, ns, id)  // bundle path from state
    ...
}
```

So `LoadBundle`'s `root` is semantically `NewBundle`'s `state`, not its `root`. The same parameter name means different things across two functions in the same file — that's where the confusion comes from.

The only caller already treats it correctly — `loadShims` passes a variable literally named `stateDir`:

```go
func (m *ShimManager) loadShims(ctx context.Context, stateDir string) error {
    ...
    bundle, err := LoadBundle(ctx, stateDir, id)
    ...
}
```

This rename aligns `LoadBundle` with `NewBundle` and the rest of the v2 package (`TaskManager.state`, `Controller.state`, `loadShims`'s `stateDir`).

## Verification

- No behavior change: the call site is positional and unchanged.
- `go build ./core/runtime/v2/...` passes.
