### PR TITLE
Revert "add check on version of drop in configs"

### DIFF
--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -454,9 +454,8 @@ func LoadConfigWithPlugins(ctx context.Context, path string, plugins PluginFunc,
 	}
 
 	var (
-		loaded            = map[string]bool{}
-		pending           = []string{path}
-		rootConfigVersion = 0
+		loaded  = map[string]bool{}
+		pending = []string{path}
 	)
 
 	for len(pending) > 0 {
@@ -470,14 +469,6 @@ func LoadConfigWithPlugins(ctx context.Context, path string, plugins PluginFunc,
 		config, err := loadConfigFile(ctx, path)
 		if err != nil {
 			return err
-		}
-
-		// Check to make sure drop-in configs does not have a higher version than the root config version
-		if rootConfigVersion == 0 {
-			rootConfigVersion = config.Version
-		}
-		if config.Version > rootConfigVersion {
-			return fmt.Errorf("drop-in config version %d higher than root config version %d", config.Version, rootConfigVersion)
 		}
 
 		if config.Version < out.Version {

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -376,6 +376,7 @@ disabled_plugins = ["io.containerd.v1.xyz"]
 	var out Config
 	err = LoadConfig(context.Background(), filepath.Join(tempDir, "data1.toml"), &out)
 	assert.NoError(t, err)
+	assert.Equal(t, 3, out.Version)
 }
 
 // https://github.com/containerd/containerd/issues/10905

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -375,7 +375,7 @@ disabled_plugins = ["io.containerd.v1.xyz"]
 
 	var out Config
 	err = LoadConfig(context.Background(), filepath.Join(tempDir, "data1.toml"), &out)
-	assert.Errorf(t, err, "drop-in config version 3 higher than root config version 2")
+	assert.NoError(t, err)
 }
 
 // https://github.com/containerd/containerd/issues/10905


### PR DESCRIPTION
This reverts commit 21248d00762ec572772c41e3bbb69a518e0a0eaf.

Since the config merge now happens after migration, the version check need not be performed before the migration. 