### PR TITLE
Export config in CRI plugin

### DIFF
--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/metadata"
@@ -164,6 +165,11 @@ func init() {
 			service, err := images.NewService(config, options)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create image service: %w", err)
+			}
+
+			ic.Meta.Exports = map[string]string{
+				"DiscardUnpackedLayers": strconv.FormatBool(config.DiscardUnpackedLayers),
+				"RegistryConfigPath":    config.Registry.ConfigPath,
 			}
 
 			return service, nil


### PR DESCRIPTION
This adds two properties to the CRI plugin export. This adds back similar functionality which was previously present in Containerd 1.7 but was removed from the CRI config output. 

Instead of adding the properties back to the CRI config output as tried in #13709 this change instead adds the needed properties to the export of the plugin. This solution feels more natural and does not require exporting all fields from the config.

Fixes #10780

```release-note
Export sandbox image and CNI directory configuration in CRI plugin info
```
