### PR TITLE
erofs: instrument warm up cache

### DIFF
--- a/plugins/diff/erofs/differ.go
+++ b/plugins/diff/erofs/differ.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/internal/erofsutils"
+	"github.com/containerd/containerd/v2/pkg/tracing"
 
 	"github.com/google/uuid"
 )
@@ -97,15 +98,30 @@ func NewErofsDiffer(store content.Store, opts ...DifferOpt) differ {
 	return d
 }
 
+// spanPrefix names this package's tracing spans.
+const spanPrefix = "plugins.diff.erofs"
+
 func (s erofsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (d ocispec.Descriptor, err error) {
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(spanPrefix, "Apply"))
+	span.SetAttributes(
+		tracing.Attribute("layer.media.type", desc.MediaType),
+		tracing.Attribute("layer.media.size", desc.Size),
+		tracing.Attribute("layer.media.digest", desc.Digest.String()),
+	)
+
 	t1 := time.Now()
+	var mode string
 	defer func() {
+		span.SetStatus(err)
+		span.End()
+
 		if err == nil {
 			log.G(ctx).WithFields(log.Fields{
 				"d":      time.Since(t1),
 				"digest": desc.Digest,
 				"size":   desc.Size,
 				"media":  desc.MediaType,
+				"mode":   mode,
 			}).Debugf("diff applied")
 		}
 	}()
@@ -137,6 +153,18 @@ func (s erofsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []
 	} else if _, err := images.DiffCompression(ctx, diffLayerType); err != nil {
 		return emptyDesc, fmt.Errorf("unsupported media type: %s", desc.MediaType)
 	}
+
+	switch {
+	case fastcopy:
+		mode = "fastcopy"
+	case native:
+		mode = "native"
+	case s.enableTarIndex:
+		mode = "tar-index"
+	default:
+		mode = "convert"
+	}
+	span.SetAttributes(tracing.Attribute("erofs.apply.mode", mode))
 
 	var config diff.ApplyConfig
 	for _, o := range opts {

--- a/plugins/snapshots/erofs/erofs.go
+++ b/plugins/snapshots/erofs/erofs.go
@@ -698,6 +698,13 @@ func (s *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 	return s.createSnapshot(ctx, snapshots.KindActive, key, parent, opts)
 }
 
+// cacheID identifies a layer content cache in metrics by its position in the
+// configured list and the directory's base name. The path itself varies by
+// host, so the same cache wouldn't aggregate across a fleet.
+func cacheID(i int, dir string) string {
+	return strconv.Itoa(i) + ":" + filepath.Base(dir)
+}
+
 // lookupCache returns the absolute path of the cached erofs blob that can serve
 // the layer being prepared, or "" on a miss. It gates on: at least one cache
 // being configured, the Prepare being an image-layer extraction (carries the
@@ -731,21 +738,28 @@ func (s *snapshotter) lookupCache(ctx context.Context, opts ...snapshots.Opt) st
 		return ""
 	}
 
-	for _, dir := range s.layerContentCaches {
+	for i, dir := range s.layerContentCaches {
 		blob := erofsutils.CacheBlobPath(dir, diffID)
-		if _, err := os.Stat(blob); err != nil {
+		fi, err := os.Stat(blob)
+		if err != nil {
 			if !os.IsNotExist(err) {
 				// An unreadable cache (a down FUSE mount, a permission change since
 				// startup) shouldn't fail the pull or mask a hit in a later cache.
+				cacheErrors.WithValues("unreadable", cacheID(i, dir)).Inc()
 				log.G(ctx).WithError(err).WithField("blob", blob).
 					Warn("erofs layer cache: failed to stat cache blob, skipping this cache")
 			}
 			continue
 		}
+		cacheLookups.WithValues("hit").Inc()
+		cacheHits.WithValues(cacheID(i, dir)).Inc()
+		cacheHitBytes.Inc(float64(fi.Size()))
 		// Absolute, since the configured dirs are validated as such: the hit is
 		// symlinked into the snapshot dir, where a relative target would dangle.
 		return blob
 	}
+
+	cacheLookups.WithValues("miss").Inc()
 
 	log.G(ctx).WithField("diffID", diffID.String()).Trace("erofs layer cache miss")
 	return ""

--- a/plugins/snapshots/erofs/metrics.go
+++ b/plugins/snapshots/erofs/metrics.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofs
+
+import "github.com/docker/go-metrics"
+
+var (
+	// cacheLookups counts lookups by result. Only layers eligible for the cache
+	// are counted, which today means parentless extractions alone.
+	cacheLookups metrics.LabeledCounter
+
+	// cacheHits counts hits by the cache that served them (see cacheID), so
+	// caches can be told apart. Counted before the snapshot is created, so one
+	// that then fails still counts.
+	cacheHits metrics.LabeledCounter
+
+	// cacheHitBytes is the size of the blobs served, i.e. blob bytes that didn't
+	// have to be built here.
+	cacheHitBytes metrics.Counter
+
+	// cacheErrors counts unreadable caches by reason and cache: a down FUSE
+	// mount, a permission change since startup. These don't fail the pull, the
+	// next cache (or a local conversion) serves the layer instead.
+	cacheErrors metrics.LabeledCounter
+)
+
+func init() {
+	ns := metrics.NewNamespace("containerd", "erofs", nil)
+
+	cacheLookups = ns.NewLabeledCounter("layer_cache_lookups", "layer content cache lookups by result", "result")
+	cacheHits = ns.NewLabeledCounter("layer_cache_hits", "layer content cache hits by serving cache", "cache")
+	cacheHitBytes = ns.NewCounter("layer_cache_hit_bytes", "bytes of layer blobs served from a layer content cache")
+	cacheErrors = ns.NewLabeledCounter("layer_cache_errors", "layer content cache lookup errors", "reason", "cache")
+
+	metrics.Register(ns)
+}


### PR DESCRIPTION
It'd good go understand:
- Rate of cache lookups.
- How many cache hits alone / layer bytes served from cache.
- Amount of time spent converting layers on cache miss

```release-note
Add Prometheus metrics for EROFS snapshotter layer content cache
```
