### PR TITLE
Carry #13587: Fix missing additional groups matching username

### DIFF
--- a/internal/cri/opts/spec_opts_gid_test.go
+++ b/internal/cri/opts/spec_opts_gid_test.go
@@ -1,0 +1,90 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package opts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/v2/core/containers"
+)
+
+// TestWithAdditionalGIDsSharedUserGroupName reproduces
+// https://github.com/containerd/containerd/issues/11937 for the CRI codepath.
+//
+// The CRI WithAdditionalGIDs wraps oci.WithAdditionalGIDs, so it shares the
+// same bug: the container user "name" (uid 2, primary gid 1/daemon) is a
+// member of group "name" (gid 2), which is therefore a supplemental group and
+// must appear in the additional GID list. containerd currently drops it
+// because a group whose name matches the user's name is assumed to be that
+// user's primary group.
+func TestWithAdditionalGIDsSharedUserGroupName(t *testing.T) {
+	expectedPasswd := `name:x:2:1::/home/name:/usr/sbin/nologin
+`
+	expectedGroup := `daemon:x:1:
+name:x:2:name
+`
+	td := t.TempDir()
+	apply := fstest.Apply(
+		fstest.CreateDir("/etc", 0777),
+		fstest.CreateFile("/etc/passwd", []byte(expectedPasswd), 0777),
+		fstest.CreateFile("/etc/group", []byte(expectedGroup), 0777),
+	)
+	if err := apply.Apply(td); err != nil {
+		t.Fatalf("failed to apply: %v", err)
+	}
+	c := containers.Container{ID: t.Name()}
+
+	testCases := []struct {
+		user     string
+		expected []uint32
+	}{
+		// Resolve the supplemental groups by username.
+		{
+			user:     "name",
+			expected: []uint32{1, 2},
+		},
+		// Resolving by uid must produce the same result.
+		{
+			user:     "2",
+			expected: []uint32{1, 2},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.user, func(t *testing.T) {
+			s := &runtimespec.Spec{
+				Version: runtimespec.Version,
+				Root: &runtimespec.Root{
+					Path: td,
+				},
+				Process: &runtimespec.Process{
+					User: runtimespec.User{
+						UID: 2,
+						GID: 1,
+					},
+				},
+			}
+			err := WithAdditionalGIDs(testCase.user)(context.Background(), nil, &c, s)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected, s.Process.User.AdditionalGids)
+		})
+	}
+}

--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -893,10 +893,12 @@ func WithAdditionalGIDs(userstr string) SpecOpts {
 				username = userstr
 			}
 			gids, err := getSupplementalGroupsFromFS(root, func(g user.Group) bool {
-				// we only want supplemental groups
-				if g.Name == username {
-					return false
-				}
+				// A user belongs to a supplemental group if they are listed as
+				// a member of that group in /etc/group. We must not exclude a
+				// group merely because it shares its name with the user: a
+				// same-named group is not necessarily the user's primary group
+				// (see https://github.com/containerd/containerd/issues/11937).
+				// The primary group is added separately by ensureAdditionalGids.
 				return slices.Contains(g.List, username)
 			})
 			if err != nil {

--- a/pkg/oci/spec_opts_user_test.go
+++ b/pkg/oci/spec_opts_user_test.go
@@ -280,16 +280,21 @@ sys:x:3:root,bin,adm
 			expected: []uint32{0},
 		},
 		{
+			// "bin" is a member of the "bin" group (gid 1); a group sharing
+			// the user's name is still a supplemental group unless it is the
+			// user's primary group.
 			user:     "bin",
-			expected: []uint32{0, 2, 3},
+			expected: []uint32{0, 1, 2, 3},
 		},
 		{
 			user:     "bin:root",
 			expected: []uint32{0},
 		},
 		{
+			// "daemon" is a member of the "daemon" group (gid 2); it must not
+			// be dropped just because it shares the user's name.
 			user:     "daemon",
-			expected: []uint32{0, 1},
+			expected: []uint32{0, 1, 2},
 		},
 	}
 	for _, testCase := range testCases {
@@ -299,6 +304,70 @@ sys:x:3:root,bin,adm
 				Version: specs.Version,
 				Root: &specs.Root{
 					Path: td,
+				},
+			}
+			err := WithAdditionalGIDs(testCase.user)(context.Background(), nil, &c, &s)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected, s.Process.User.AdditionalGids)
+		})
+	}
+}
+
+// TestWithAdditionalGIDsSharedUserGroupName reproduces
+// https://github.com/containerd/containerd/issues/11937.
+//
+// The container user "name" has uid 2 and primary gid 1 (daemon). There is
+// also a group "name" with gid 2 that lists "name" as a member. Because gid 2
+// is not the user's primary group, it is a genuine supplemental group and must
+// be included in the additional GID list. containerd currently drops it,
+// because WithAdditionalGIDs assumes any group whose name matches the user's
+// name is that user's primary group.
+func TestWithAdditionalGIDsSharedUserGroupName(t *testing.T) {
+	t.Parallel()
+	expectedPasswd := `name:x:2:1::/home/name:/usr/sbin/nologin
+`
+	expectedGroup := `daemon:x:1:
+name:x:2:name
+`
+	td := t.TempDir()
+	apply := fstest.Apply(
+		fstest.CreateDir("/etc", 0777),
+		fstest.CreateFile("/etc/passwd", []byte(expectedPasswd), 0777),
+		fstest.CreateFile("/etc/group", []byte(expectedGroup), 0777),
+	)
+	if err := apply.Apply(td); err != nil {
+		t.Fatalf("failed to apply: %v", err)
+	}
+	c := containers.Container{ID: t.Name()}
+
+	testCases := []struct {
+		user     string
+		expected []uint32
+	}{
+		// Resolve the supplemental groups by username.
+		{
+			user:     "name",
+			expected: []uint32{1, 2},
+		},
+		// Resolving by uid must produce the same result.
+		{
+			user:     "2",
+			expected: []uint32{1, 2},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.user, func(t *testing.T) {
+			t.Parallel()
+			s := Spec{
+				Version: specs.Version,
+				Root: &specs.Root{
+					Path: td,
+				},
+				Process: &specs.Process{
+					User: specs.User{
+						UID: 2,
+						GID: 1,
+					},
 				},
 			}
 			err := WithAdditionalGIDs(testCase.user)(context.Background(), nil, &c, &s)


### PR DESCRIPTION
It is possible to have a supplemental group that matches the name of the user that is not the user's primary group. This PR fixes that silent drop of supplemental groups with the same name as the user.

Signed-off-by: chansuke <moonset20@gmail.com>
(cherry picked from commit 1c3cdfd009fe1dca3855e0908dc32ea53ae3e07c)
Signed-off-by: Phil Estes <estesp@amazon.com>
Assisted-by: Claude Code (Opus 4.8)

Closes: #13587 
Fixes: #11937 
