### PR TITLE
cri: confine checkpoint archive extraction to the checkpoint dir

### DIFF
--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	crmetadata "github.com/checkpoint-restore/checkpointctl/lib"
@@ -356,7 +355,24 @@ func writeCriuCheckpointData(ctx context.Context, store content.Store, desc v1.D
 	if err := os.MkdirAll(checkpointDirectory, 0o700); err != nil {
 		return err
 	}
-	tr := tar.NewReader(content.NewReader(ra))
+	return unpackCheckpointData(content.NewReader(ra), checkpointDirectory)
+}
+
+// unpackCheckpointData extracts the CRIU data tarball into dir. The entries come
+// from a checkpoint archive or OCI image and are externally provided (see the
+// copyNoFollow comment above), so each one is written through an os.Root rather
+// than a plain filepath.Join + os.Create. os.Root confines every write to dir: a
+// name containing "..", an absolute path, or a symlink component pointing out of
+// dir is rejected instead of followed, which the previous "does the name contain
+// .." check did not cover.
+func unpackCheckpointData(r io.Reader, dir string) error {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
+	tr := tar.NewReader(r)
 	for {
 		header, err := tr.Next()
 		if err != nil {
@@ -365,17 +381,15 @@ func writeCriuCheckpointData(ctx context.Context, store content.Store, desc v1.D
 			}
 			return err
 		}
-		if strings.Contains(header.Name, "..") {
-			return fmt.Errorf("found illegal string '..' in checkpoint archive")
-		}
-		destFile, err := os.Create(filepath.Join(checkpointDirectory, header.Name))
+		destFile, err := root.Create(header.Name)
 		if err != nil {
 			return err
 		}
-		defer destFile.Close()
-
-		_, err = io.CopyN(destFile, tr, header.Size)
-		if err != nil {
+		if _, err := io.CopyN(destFile, tr, header.Size); err != nil {
+			destFile.Close()
+			return err
+		}
+		if err := destFile.Close(); err != nil {
 			return err
 		}
 	}

--- a/internal/cri/server/container_checkpoint_linux_test.go
+++ b/internal/cri/server/container_checkpoint_linux_test.go
@@ -19,6 +19,8 @@
 package server
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -31,6 +33,67 @@ import (
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
+
+// tarball builds an in-memory tar with the given regular-file entries.
+func tarball(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for name, content := range entries {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     name,
+			Mode:     0o600,
+			Size:     int64(len(content)),
+		}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	return buf.Bytes()
+}
+
+func TestUnpackCheckpointDataRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	data := tarball(t, map[string]string{"dump.img": "a", "pages-1.img": "bb"})
+
+	require.NoError(t, unpackCheckpointData(bytes.NewReader(data), dir))
+
+	got, err := os.ReadFile(filepath.Join(dir, "dump.img"))
+	require.NoError(t, err)
+	assert.Equal(t, "a", string(got))
+	got, err = os.ReadFile(filepath.Join(dir, "pages-1.img"))
+	require.NoError(t, err)
+	assert.Equal(t, "bb", string(got))
+}
+
+func TestUnpackCheckpointDataRejectsTraversal(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "checkpoint")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+
+	for _, name := range []string{"../escape", "/etc/escape"} {
+		data := tarball(t, map[string]string{name: "x"})
+		err := unpackCheckpointData(bytes.NewReader(data), dir)
+		require.Error(t, err, "entry %q must be rejected", name)
+	}
+	assert.NoFileExists(t, filepath.Join(parent, "escape"))
+}
+
+func TestUnpackCheckpointDataRejectsSymlinkEscape(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "checkpoint")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+	outside := filepath.Join(parent, "outside")
+	require.NoError(t, os.Mkdir(outside, 0o700))
+	// A symlink left inside the checkpoint dir must not be followed out of it.
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "link")))
+
+	data := tarball(t, map[string]string{"link/evil": "x"})
+	err := unpackCheckpointData(bytes.NewReader(data), dir)
+	require.Error(t, err)
+	assert.NoFileExists(t, filepath.Join(outside, "evil"))
+}
 
 func TestCopyNoFollowRegularFile(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
The CRI checkpoint code unpacks the CRIU data tarball from a checkpoint image into the checkpoint directory, and the `copyNoFollow` helper right above it already treats those entries as externally provided and reads them defensively. The unpack side did not match: it guarded traversal with a single `strings.Contains(header.Name, "..")` check and then wrote each entry with `os.Create(filepath.Join(dir, name))`, which follows a symlink at the final path component. That substring check misses absolute names and does nothing about a symlink that resolves out of the directory, so a crafted entry name (or a link left in the directory by a prior operation) could land a write outside the checkpoint dir. I noticed it while reading the `copyNoFollow` comment and seeing the tar loop next to it rely on the weaker guard. Writing each entry through `os.OpenRoot` confines it to the directory and rejects `..`, absolute paths, and symlink escapes in one place, matching the `os.Root` containment already used in `core/mount/manager`. Valid flat CRIU filenames extract exactly as before, and I moved the per-entry close out of the `defer` so a large archive no longer holds every fd open until the function returns.
