### PR TITLE
Ensure credentials are forwarded to configured mirrors 

### DIFF
--- a/integration/image_pull_mirror_auth_test.go
+++ b/integration/image_pull_mirror_auth_test.go
@@ -1,0 +1,157 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
+	"github.com/containerd/containerd/v2/internal/cri/server/images"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+)
+
+// TestCRIImagePullAllowRequestAuthOnMirrors verifies how the credentials
+// supplied on a CRI PullImageRequest are distributed across the registry
+// named by the image reference and its configured mirror, based on the
+// AllowRequestAuthOnMirrors setting. In both cases the primary registry
+// must see the credentials.
+func TestCRIImagePullAllowRequestAuthOnMirrors(t *testing.T) {
+	// The test writes hosts.toml under a directory named after the primary
+	// registry host, which is "127.0.0.1:<port>" — ':' is not valid in a
+	// Windows path element.
+	if goruntime.GOOS != "linux" {
+		t.Skip("Only runs on linux")
+	}
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name            string
+		allowOnMirrors  bool
+		mirrorSeesCreds bool
+	}{
+		{name: "False", allowOnMirrors: false, mirrorSeesCreds: false},
+		{name: "True", allowOnMirrors: true, mirrorSeesCreds: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			t.Run("LocalPull", func(t *testing.T) {
+				t.Parallel()
+				testCRIImagePullAllowRequestAuthOnMirrors(t, tc.allowOnMirrors, tc.mirrorSeesCreds, true)
+			})
+			t.Run("TransferService", func(t *testing.T) {
+				t.Parallel()
+				testCRIImagePullAllowRequestAuthOnMirrors(t, tc.allowOnMirrors, tc.mirrorSeesCreds, false)
+			})
+		})
+	}
+}
+
+func testCRIImagePullAllowRequestAuthOnMirrors(t *testing.T, allowOnMirrors, mirrorSeesCreds, useLocal bool) {
+	const (
+		testUser   = "user"
+		testPasswd = "passwd"
+	)
+	expectedAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(testUser+":"+testPasswd))
+
+	tmpDir := t.TempDir()
+	cli := buildLocalContainerdClient(t, tmpDir, nil)
+
+	primary, primarySeen := newRecordingRegistry()
+	defer primary.Close()
+	mirror, mirrorSeen := newRecordingRegistry()
+	defer mirror.Close()
+
+	primaryURL, err := url.Parse(primary.URL)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(tmpDir, "certs.d")
+	hostDir := filepath.Join(configPath, primaryURL.Host)
+	require.NoError(t, os.MkdirAll(hostDir, 0700))
+	hostsToml := fmt.Sprintf(
+		"server = %q\n\n[host.%q]\n  capabilities = [\"pull\", \"resolve\"]\n",
+		primary.URL, mirror.URL,
+	)
+	require.NoError(t, os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hostsToml), 0600))
+
+	registryCfg := criconfig.Registry{
+		ConfigPath:                configPath,
+		AllowRequestAuthOnMirrors: allowOnMirrors,
+	}
+	svc, err := initLocalCRIImageService(cli, tmpDir, registryCfg, useLocal)
+	require.NoError(t, err)
+
+	// Go through the GRPC surface so the credential callback is built by
+	// credentialsForRef, which is the code path we want to exercise.
+	gsvc := &images.GRPCCRIImageService{CRIImageService: svc.(*images.CRIImageService)}
+
+	// The transfer service may still be emitting log lines when the subtest
+	// returns, so use a plain background context to avoid tying log output to
+	// *testing.T (which panics on Write after test completion).
+	ctx := namespaces.WithNamespace(context.Background(), k8sNamespace)
+	ref := primaryURL.Host + "/test/image:latest"
+	_, err = gsvc.PullImage(ctx, &runtime.PullImageRequest{
+		Image: &runtime.ImageSpec{Image: ref},
+		Auth:  &runtime.AuthConfig{Username: testUser, Password: testPasswd},
+	})
+	assert.Error(t, err, "both registries always answer 401 so the pull must fail")
+
+	assert.Contains(t, primarySeen(), expectedAuth,
+		"primary registry should be offered the request auth")
+	assert.NotEmpty(t, mirrorSeen(), "mirror should have been contacted")
+	if mirrorSeesCreds {
+		assert.Contains(t, mirrorSeen(), expectedAuth,
+			"mirror should see the request auth when AllowRequestAuthOnMirrors=true")
+	} else {
+		assert.NotContains(t, mirrorSeen(), expectedAuth,
+			"mirror must not see the request auth when AllowRequestAuthOnMirrors=false")
+	}
+}
+
+// newRecordingRegistry returns an httptest.Server that always answers 401 and
+// a function that returns the Authorization header seen on every request.
+func newRecordingRegistry() (*httptest.Server, func() []string) {
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), seen...)
+	}
+}

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -254,6 +254,21 @@ type Registry struct {
 	Auths map[string]AuthConfig `toml:"auths" json:"auths"`
 	// Headers adds additional HTTP headers that get sent to all registries
 	Headers map[string][]string `toml:"headers" json:"headers"`
+	// AllowRequestAuthOnMirrors controls whether the auth config from a CRI
+	// PullImageRequest (e.g. a pod's imagePullSecrets) is sent to mirror
+	// endpoints in addition to the image reference's own registry.
+	//
+	// When false, request auth is only sent to the registry the image
+	// reference names, so credentials for one registry are not disclosed to
+	// unrelated mirror hosts. Mirrors then authenticate on their own: client
+	// certificates via the `client` option in hosts.toml, or username/password
+	// and token auth via `configs`, since hosts.toml has no auth field.
+	//
+	// Defaults to true for backwards compatibility. The default is expected to
+	// flip to false in a future release once mirror operators have had time to
+	// configure per-mirror auth via hosts.toml `client` certs or `configs`;
+	// see https://github.com/containerd/containerd/issues/<TODO> for tracking.
+	AllowRequestAuthOnMirrors bool `toml:"allow_request_auth_on_mirrors" json:"allowRequestAuthOnMirrors"`
 }
 
 // RegistryConfig contains configuration used to communicate with the registry.

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -266,8 +266,7 @@ type Registry struct {
 	//
 	// Defaults to true for backwards compatibility. The default is expected to
 	// flip to false in a future release once mirror operators have had time to
-	// configure per-mirror auth via hosts.toml `client` certs or `configs`;
-	// see https://github.com/containerd/containerd/issues/<TODO> for tracking.
+	// configure per-mirror auth via hosts.toml `client` certs or `configs`.
 	AllowRequestAuthOnMirrors bool `toml:"allow_request_auth_on_mirrors" json:"allowRequestAuthOnMirrors"`
 }
 

--- a/internal/cri/config/config_unix.go
+++ b/internal/cri/config/config_unix.go
@@ -32,7 +32,7 @@ func DefaultImageConfig() ImageConfig {
 		Snapshotter:                defaults.DefaultSnapshotter,
 		DisableSnapshotAnnotations: true,
 		MaxConcurrentDownloads:     3,
-		Registry:                   Registry{},
+		Registry:                   Registry{AllowRequestAuthOnMirrors: true},
 		ImageDecryption: ImageDecryption{
 			KeyModel: KeyModelNode,
 		},

--- a/internal/cri/config/config_windows.go
+++ b/internal/cri/config/config_windows.go
@@ -32,6 +32,7 @@ func DefaultImageConfig() ImageConfig {
 		Snapshotter:            defaults.DefaultSnapshotter,
 		StatsCollectPeriod:     10,
 		MaxConcurrentDownloads: 3,
+		Registry:               Registry{AllowRequestAuthOnMirrors: true},
 		ImageDecryption: ImageDecryption{
 			KeyModel: KeyModelNode,
 		},

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -102,22 +102,50 @@ func (c *GRPCCRIImageService) PullImage(ctx context.Context, r *runtime.PullImag
 
 	imageRef := r.GetImage().GetImage()
 
-	credentials := func(host string) (string, string, error) {
-		hostauth := r.GetAuth()
-		if hostauth == nil {
-			config := c.config.Registry.Configs[host]
-			if config.Auth != nil {
-				hostauth = toRuntimeAuthConfig(*config.Auth)
-			}
-		}
-		return ParseAuth(hostauth, host)
-	}
+	credentials := c.credentialsForRef(imageRef, r.GetAuth())
 
 	ref, err := c.CRIImageService.PullImage(ctx, imageRef, credentials, r.SandboxConfig, r.GetImage().GetRuntimeHandler())
 	if err != nil {
 		return nil, err
 	}
 	return &runtime.PullImageResponse{ImageRef: ref}, nil
+}
+
+// credentialsForRef builds the per-host credentials callback for a PullImage
+// call.
+//
+// The callback is installed on every host the resolver may contact, mirrors
+// included, and the request's auth is meant for the registry the image
+// reference names. So on any other host, per-host Registry.Configs auth wins:
+// an operator who configured credentials for a mirror meant them to be used.
+// AllowRequestAuthOnMirrors then decides whether mirrors with no configured
+// auth still see the request's, which is how a pod's imagePullSecrets can
+// reach an unrelated endpoint.
+func (c *CRIImageService) credentialsForRef(ref string, reqAuth *runtime.AuthConfig) func(string) (string, string, error) {
+	var refDomain, refHost string
+	// An unparseable ref leaves both empty, so no host counts as the ref's own;
+	// PullImage rejects such a ref moments later regardless.
+	if named, err := distribution.ParseDockerRef(ref); err == nil {
+		refDomain = distribution.Domain(named)
+		// The resolver invokes the callback with the remapped host, so compare
+		// against "registry-1.docker.io" as well as "docker.io".
+		refHost, _ = docker.DefaultHost(refDomain)
+	}
+	allowOnMirrors := c.config.Registry.AllowRequestAuthOnMirrors
+
+	return func(host string) (string, string, error) {
+		hostauth := reqAuth
+		if hostauth == nil || (host != refDomain && host != refHost) {
+			if config := c.config.Registry.Configs[host]; config.Auth != nil {
+				hostauth = toRuntimeAuthConfig(*config.Auth)
+			} else if !allowOnMirrors && hostauth.GetServerAddress() == "" {
+				// A ServerAddress is left alone: the client scoped the
+				// credentials itself and ParseAuth already enforces it.
+				hostauth = nil
+			}
+		}
+		return ParseAuth(hostauth, host)
+	}
 }
 
 func (c *CRIImageService) PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (_ string, err error) {

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -19,6 +19,14 @@ package images
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,6 +35,7 @@ import (
 
 	"github.com/containerd/platforms"
 
+	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
@@ -121,6 +130,260 @@ func TestParseAuth(t *testing.T) {
 			assert.Equal(t, test.expectErr, err != nil)
 			assert.Equal(t, test.expectedUser, u)
 			assert.Equal(t, test.expectedSecret, s)
+		})
+	}
+}
+
+func TestCredentialsForRef(t *testing.T) {
+	reqUser, reqPass := "req-user", "req-pass"
+	mirrorUser, mirrorPass := "mirror-user", "mirror-pass"
+	primaryUser, primaryPass := "primary-user", "primary-pass"
+
+	reqAuth := &runtime.AuthConfig{Username: reqUser, Password: reqPass}
+
+	for _, test := range []struct {
+		desc           string
+		ref            string
+		reqAuth        *runtime.AuthConfig
+		configs        map[string]criconfig.RegistryConfig
+		allowOnMirrors bool
+		host           string
+		expectedUser   string
+		expectedPass   string
+	}{
+		{
+			desc:         "request auth applies to ref's default host",
+			ref:          "docker.io/library/nginx:latest",
+			reqAuth:      reqAuth,
+			host:         "registry-1.docker.io",
+			expectedUser: reqUser,
+			expectedPass: reqPass,
+		},
+		{
+			desc:         "request auth applies to ref's domain",
+			ref:          "quay.io/foo/bar:latest",
+			reqAuth:      reqAuth,
+			host:         "quay.io",
+			expectedUser: reqUser,
+			expectedPass: reqPass,
+		},
+		{
+			desc:    "request auth does not leak to mirror hosts",
+			ref:     "docker.io/library/nginx:latest",
+			reqAuth: reqAuth,
+			host:    "mirror.example.com",
+		},
+		{
+			desc:    "request auth does not leak to a different primary registry",
+			ref:     "docker.io/library/nginx:latest",
+			reqAuth: reqAuth,
+			host:    "quay.io",
+		},
+		{
+			desc:           "request auth reaches mirrors when allow_request_auth_on_mirrors is set",
+			ref:            "docker.io/library/nginx:latest",
+			reqAuth:        reqAuth,
+			allowOnMirrors: true,
+			host:           "mirror.example.com",
+			expectedUser:   reqUser,
+			expectedPass:   reqPass,
+		},
+		{
+			desc: "request auth reaches a mirror it explicitly names via ServerAddress",
+			ref:  "docker.io/library/nginx:latest",
+			reqAuth: &runtime.AuthConfig{
+				Username:      reqUser,
+				Password:      reqPass,
+				ServerAddress: "https://mirror.example.com",
+			},
+			host:         "mirror.example.com",
+			expectedUser: reqUser,
+			expectedPass: reqPass,
+		},
+		{
+			desc: "ServerAddress still scopes auth away from non-matching mirrors",
+			ref:  "docker.io/library/nginx:latest",
+			reqAuth: &runtime.AuthConfig{
+				Username:      reqUser,
+				Password:      reqPass,
+				ServerAddress: "https://mirror.example.com",
+			},
+			host: "other-mirror.example.com",
+		},
+		{
+			desc:    "per-host Registry.Configs auth is honored for mirror hosts",
+			ref:     "docker.io/library/nginx:latest",
+			reqAuth: reqAuth,
+			configs: map[string]criconfig.RegistryConfig{
+				"mirror.example.com": {Auth: &criconfig.AuthConfig{Username: mirrorUser, Password: mirrorPass}},
+			},
+			host:         "mirror.example.com",
+			expectedUser: mirrorUser,
+			expectedPass: mirrorPass,
+		},
+		{
+			// Configured mirror auth is what the operator asked for, so it wins
+			// over the request's even when mirrors are allowed to see it.
+			desc:           "per-host Registry.Configs auth wins on mirrors with allow_request_auth_on_mirrors set",
+			ref:            "docker.io/library/nginx:latest",
+			reqAuth:        reqAuth,
+			allowOnMirrors: true,
+			configs: map[string]criconfig.RegistryConfig{
+				"mirror.example.com": {Auth: &criconfig.AuthConfig{Username: mirrorUser, Password: mirrorPass}},
+			},
+			host:         "mirror.example.com",
+			expectedUser: mirrorUser,
+			expectedPass: mirrorPass,
+		},
+		{
+			desc:    "request auth takes precedence over Registry.Configs on the primary host",
+			ref:     "docker.io/library/nginx:latest",
+			reqAuth: reqAuth,
+			configs: map[string]criconfig.RegistryConfig{
+				"registry-1.docker.io": {Auth: &criconfig.AuthConfig{Username: primaryUser, Password: primaryPass}},
+			},
+			host:         "registry-1.docker.io",
+			expectedUser: reqUser,
+			expectedPass: reqPass,
+		},
+		{
+			desc: "no request auth falls back to per-host config",
+			ref:  "docker.io/library/nginx:latest",
+			configs: map[string]criconfig.RegistryConfig{
+				"mirror.example.com": {Auth: &criconfig.AuthConfig{Username: mirrorUser, Password: mirrorPass}},
+			},
+			host:         "mirror.example.com",
+			expectedUser: mirrorUser,
+			expectedPass: mirrorPass,
+		},
+		{
+			desc: "no request auth and no per-host config yields anonymous",
+			ref:  "docker.io/library/nginx:latest",
+			host: "registry-1.docker.io",
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			c, _ := newTestCRIService()
+			c.config.Registry.Configs = test.configs
+			c.config.Registry.AllowRequestAuthOnMirrors = test.allowOnMirrors
+
+			u, s, err := c.credentialsForRef(test.ref, test.reqAuth)(test.host)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedUser, u)
+			assert.Equal(t, test.expectedPass, s)
+		})
+	}
+}
+
+// TestPullCredentialScopingWithMirror drives a real resolver against two stub
+// registries so the scoping is verified where it matters: the Authorization
+// headers actually put on the wire.
+func TestPullCredentialScopingWithMirror(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("registry host directories contain ':', which is not a valid path element on Windows")
+	}
+
+	const (
+		testUser   = "user"
+		testPasswd = "passwd"
+	)
+	expectedAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(testUser+":"+testPasswd))
+
+	// Always answers 401 so every request reaches the recorder and the pull
+	// ends without needing a real image.
+	newRegistry := func() (*httptest.Server, func() []string) {
+		var (
+			mu   sync.Mutex
+			seen []string
+		)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			seen = append(seen, r.Header.Get("Authorization"))
+			mu.Unlock()
+			w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		return srv, func() []string {
+			mu.Lock()
+			defer mu.Unlock()
+			return append([]string(nil), seen...)
+		}
+	}
+
+	for _, test := range []struct {
+		desc string
+		// mirrorPath, when set, is appended to the mirror's URL in hosts.toml
+		// and paired with override_path.
+		mirrorPath      string
+		allowOnMirrors  bool
+		mirrorSeesCreds bool
+	}{
+		{
+			desc:            "request auth is withheld from the mirror",
+			allowOnMirrors:  false,
+			mirrorSeesCreds: false,
+		},
+		{
+			desc:            "request auth reaches the mirror when allow_request_auth_on_mirrors is set",
+			allowOnMirrors:  true,
+			mirrorSeesCreds: true,
+		},
+		{
+			// Reproduces the hosts.toml from
+			// https://github.com/containerd/containerd/issues/9997, where a
+			// path-scoped pull-through cache was sent the upstream registry's
+			// pull secret and answered 401.
+			desc:            "request auth is withheld from a path-scoped pull-through mirror",
+			mirrorPath:      "/v2/quay.io",
+			allowOnMirrors:  false,
+			mirrorSeesCreds: false,
+		},
+		{
+			desc:            "path-scoped pull-through mirror still sees request auth by default",
+			mirrorPath:      "/v2/quay.io",
+			allowOnMirrors:  true,
+			mirrorSeesCreds: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			primary, primarySeen := newRegistry()
+			defer primary.Close()
+			mirror, mirrorSeen := newRegistry()
+			defer mirror.Close()
+
+			primaryURL, err := url.Parse(primary.URL)
+			assert.NoError(t, err)
+
+			configPath := t.TempDir()
+			hostDir := filepath.Join(configPath, primaryURL.Host)
+			assert.NoError(t, os.MkdirAll(hostDir, 0700))
+			hostsToml := fmt.Sprintf("server = %q\n\n[host.%q]\n  capabilities = [\"pull\", \"resolve\"]\n", primary.URL, mirror.URL+test.mirrorPath)
+			if test.mirrorPath != "" {
+				hostsToml += "  override_path = true\n"
+			}
+			assert.NoError(t, os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(hostsToml), 0600))
+
+			c, _ := newTestCRIService()
+			c.config.Registry.ConfigPath = configPath
+			c.config.Registry.AllowRequestAuthOnMirrors = test.allowOnMirrors
+
+			ctx := context.Background()
+			ref := primaryURL.Host + "/test/image:latest"
+			credentials := c.credentialsForRef(ref, &runtime.AuthConfig{Username: testUser, Password: testPasswd})
+			resolver := docker.NewResolver(docker.ResolverOptions{
+				Hosts: c.registryHosts(ctx, credentials, nil),
+			})
+
+			_, _, err = resolver.Resolve(ctx, ref)
+			assert.Error(t, err, "both registries always answer 401")
+
+			assert.Contains(t, primarySeen(), expectedAuth, "primary registry should be offered the request auth")
+			if test.mirrorSeesCreds {
+				assert.Contains(t, mirrorSeen(), expectedAuth)
+			} else {
+				assert.NotContains(t, mirrorSeen(), expectedAuth)
+				assert.NotEmpty(t, mirrorSeen(), "mirror should still have been contacted")
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR fixes an issue with image credentials being forwarded to unrelated mirrors 