### PR TITLE
[release/2.2] snapshots/erofs: protect snapshot staging from cleanup

### DIFF
--- a/plugins/snapshots/erofs/erofs.go
+++ b/plugins/snapshots/erofs/erofs.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/errdefs"
@@ -32,6 +33,8 @@ import (
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
 	"github.com/containerd/containerd/v2/internal/fsverity"
 )
+
+const snapshotTempDirPrefix = "new-"
 
 // SnapshotterConfig is used to configure the erofs snapshotter instance
 type SnapshotterConfig struct {
@@ -181,7 +184,7 @@ func (s *snapshotter) lowerPath(id string) (string, error) {
 }
 
 func (s *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
-	td, err := os.MkdirTemp(snapshotDir, "new-")
+	td, err := os.MkdirTemp(snapshotDir, snapshotTempDirPrefix)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
@@ -545,6 +548,12 @@ func (s *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, erro
 
 	cleanup := []string{}
 	for _, d := range dirs {
+		// A new-* directory may belong to a concurrent snapshot creation. It is
+		// renamed to its metadata ID after the writer transaction is acquired, so
+		// Remove must not treat it as an orphan in the meantime.
+		if strings.HasPrefix(d, snapshotTempDirPrefix) {
+			continue
+		}
 		if _, ok := ids[d]; ok {
 			continue
 		}

--- a/plugins/snapshots/erofs/erofs_linux_test.go
+++ b/plugins/snapshots/erofs/erofs_linux_test.go
@@ -26,6 +26,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -104,6 +107,34 @@ func TestErofs(t *testing.T) {
 func TestErofsWithQuota(t *testing.T) {
 	testutil.RequiresRoot(t)
 	testsuite.SnapshotterSuite(t, "erofs", newSnapshotter(t, WithDefaultSize(16*1024*1024)))
+}
+
+func TestGetCleanupDirectoriesSkipsSnapshotTempDirs(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	snapshotDir := filepath.Join(root, "snapshots")
+	require.NoError(t, os.Mkdir(snapshotDir, 0700))
+
+	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ms.Close()) })
+	s := &snapshotter{root: root, ms: ms}
+
+	_, err = os.MkdirTemp(snapshotDir, snapshotTempDirPrefix)
+	require.NoError(t, err)
+	orphanDir := filepath.Join(snapshotDir, "orphan")
+	require.NoError(t, os.Mkdir(orphanDir, 0700))
+	require.NoError(t, ms.WithTransaction(ctx, true, func(ctx context.Context) error {
+		_, err := storage.CreateSnapshot(ctx, snapshots.KindActive, "existing", "")
+		return err
+	}))
+
+	var cleanup []string
+	require.NoError(t, ms.WithTransaction(ctx, true, func(ctx context.Context) error {
+		cleanup, err = s.getCleanupDirectories(ctx)
+		return err
+	}))
+	assert.Equal(t, []string{orphanDir}, cleanup)
 }
 
 func TestErofsFsverity(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of https://github.com/containerd/containerd/pull/13932

```release-note
Fix EROFS snapshot creation failure caused by concurrent snapshot removal
```