### PR TITLE
cri: mv io create from create  to start stage

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -39,7 +39,6 @@ import (
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
-	cio "github.com/containerd/containerd/v2/internal/cri/io"
 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
@@ -346,26 +345,6 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 			r.podSandboxConfig.GetLogDirectory(), r.containerConfig.GetLogPath())
 	}
 
-	var containerIO *cio.ContainerIO
-	switch ociRuntime.IOType {
-	case criconfig.IOTypeStreaming:
-		containerIO, err = cio.NewContainerIO(r.containerID,
-			cio.WithStreams(r.sandbox.Endpoint.Address, r.containerConfig.GetTty(), r.containerConfig.GetStdin()))
-	default:
-		containerIO, err = cio.NewContainerIO(r.containerID,
-			cio.WithNewFIFOs(volatileContainerRootDir, r.containerConfig.GetTty(), r.containerConfig.GetStdin()))
-	}
-	if err != nil {
-		return "", fmt.Errorf("failed to create container io: %w", err)
-	}
-	defer func() {
-		if retErr != nil {
-			if err := containerIO.Close(); err != nil {
-				log.G(r.ctx).WithError(err).Errorf("Failed to close container io %q", r.containerID)
-			}
-		}
-	}()
-
 	specOpts, err := c.platformSpecOpts(platform, r.containerConfig, r.imageConfig)
 	if err != nil {
 		return "", fmt.Errorf("failed to get container spec opts: %w", err)
@@ -418,7 +397,6 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 	container, err := containerstore.NewContainer(*r.meta,
 		containerstore.WithStatus(status, containerRootDir),
 		containerstore.WithContainer(cntr),
-		containerstore.WithContainerIO(containerIO),
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to create internal container object for %q: %w", r.containerID, err)

--- a/internal/cri/server/container_start.go
+++ b/internal/cri/server/container_start.go
@@ -29,6 +29,7 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
@@ -91,6 +92,36 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 	}
 	span.SetAttributes(tracing.Attribute("sandbox.id", sandboxID))
 
+	ociRuntime, err := c.config.GetSandboxRuntime(sandbox.Config, sandbox.Metadata.RuntimeHandler)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sandbox runtime: %w", err)
+	}
+
+	if cntr.IO == nil {
+		var containerIO *cio.ContainerIO
+		switch ociRuntime.IOType {
+		case criconfig.IOTypeStreaming:
+			containerIO, err = cio.NewContainerIO(cntr.ID,
+				cio.WithStreams(sandbox.Endpoint.Address, cntr.Config.GetTty(), cntr.Config.GetStdin()))
+		default:
+			containerIO, err = cio.NewContainerIO(cntr.ID,
+				cio.WithNewFIFOs(c.getVolatileContainerRootDir(cntr.ID), cntr.Config.GetTty(), cntr.Config.GetStdin()))
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to create container io: %w", err)
+		}
+		defer func() {
+			if retErr != nil {
+				if err := containerIO.Close(); err != nil {
+					log.G(ctx).WithError(err).Errorf("Failed to close container io %q", cntr.ID)
+				}
+			}
+		}()
+		if cntr, err = c.containerStore.AddContainerIO(id, containerIO); err != nil {
+			return nil, err
+		}
+	}
+
 	ioCreation := func(id string) (_ containerdio.IO, err error) {
 		stdoutWC, stderrWC, err := c.createContainerLoggers(meta.LogPath, config.GetTty())
 		if err != nil {
@@ -111,12 +142,6 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 			}
 		}
 	}
-
-	ociRuntime, err := c.config.GetSandboxRuntime(sandbox.Config, sandbox.Metadata.RuntimeHandler)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get sandbox runtime: %w", err)
-	}
-
 	var taskOpts []containerd.NewTaskOpts
 	if ociRuntime.Path != "" {
 		taskOpts = append(taskOpts, containerd.WithRuntimePath(ociRuntime.Path))

--- a/internal/cri/store/container/container.go
+++ b/internal/cri/store/container/container.go
@@ -198,6 +198,26 @@ func (s *Store) UpdateContainerStats(id string, newContainerStats *stats.Contain
 	return nil
 }
 
+func (s *Store) AddContainerIO(id string, io *cio.ContainerIO) (Container, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	id, err := s.idIndex.Get(id)
+	if err != nil {
+		if err == truncindex.ErrNotExist {
+			err = errdefs.ErrNotFound
+		}
+		return Container{}, err
+	}
+
+	c, ok := s.containers[id]
+	if !ok {
+		return Container{}, errdefs.ErrNotFound
+	}
+	c.IO = io
+	s.containers[id] = c
+	return c, nil
+}
+
 // Delete deletes the container from store with specified id.
 func (s *Store) Delete(id string) {
 	s.lock.Lock()


### PR DESCRIPTION
because k8s will reserve several  dead containers
https://kubernetes.io/docs/concepts/architecture/garbage-collection/#container-image-garbage-collection if start container failed container I/O should be closed as soon as possible.