### PR TITLE
cri: trace image pull result attributes

### DIFF
--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -201,6 +201,7 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 		return "", fmt.Errorf("get image config descriptor: %w", err)
 	}
 	imageID := configDesc.Digest.String()
+	span.SetAttributes(tracing.Attribute("image.id", imageID))
 
 	repoDigest, repoTag := util.GetRepoDigestAndTag(namedRef, image.Target().Digest)
 	for _, r := range []string{imageID, repoTag, repoDigest} {
@@ -223,7 +224,10 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 	recordImagePullThroughput(imagePullThroughput, bytesPulled, elapsed)
 	recordImagePullThroughput(imagePullThroughputMiBps, bytesPulled, elapsed)
 
-	size, _ := image.Size(ctx)
+	size, sizeErr := image.Size(ctx)
+	if sizeErr == nil {
+		span.SetAttributes(tracing.Attribute("image.size.bytes", size))
+	}
 	log.G(ctx).Infof("Pulled image %q with image id %q, repo tag %q, repo digest %q, size %q in %s", name, imageID,
 		repoTag, repoDigest, strconv.FormatInt(size, 10), elapsed)
 	// NOTE(random-liu): the actual state in containerd is the source of truth, even we maintain


### PR DESCRIPTION
This adds success-result attributes to the existing CRI image pull span:

- `image.id` records the resolved image identifier returned by CRI.
- `image.size.bytes` records the image size when the existing best-effort size lookup succeeds.

The change uses the existing tracing API and does not add new tracing configuration or alter image-pull behavior. It is intentionally limited to one file as a small follow-up to #12226.

Validation:
- `go test ./internal/cri/server/images`
- `go vet ./internal/cri/server/images`
- `git diff --check`