### PR TITLE
Protect content ingest with temporary lease

### DIFF
--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -40,7 +40,12 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const defaultIngestLeaseDuration = 5 * time.Minute
+const (
+	defaultIngestLeaseDuration = 5 * time.Minute
+	ingestLeaseCleanupTimeout  = 10 * time.Second
+	ingestLeaseLabel           = "containerd.io/ctr/content-ingest"
+	ingestLeaseRefLabel        = "containerd.io/ctr/content-ingest.ref"
+)
 
 var (
 	// Command is the cli command for managing content
@@ -587,19 +592,28 @@ var (
 
 func ingestContent(ctx context.Context, cs content.Ingester, lm leases.Manager, leaseDuration time.Duration, ref string, r io.Reader, desc ocispec.Descriptor) error {
 	if leaseDuration < 0 {
-		return errors.New("lease duration must not be negative")
+		return fmt.Errorf("--lease-duration must be >= 0, got %s", leaseDuration)
 	}
 	if leaseDuration == 0 {
 		return content.WriteBlob(ctx, cs, ref, r, desc)
 	}
 
-	lease, err := lm.Create(ctx, leases.WithRandomID(), leases.WithExpiration(leaseDuration))
+	lease, err := lm.Create(ctx,
+		leases.WithRandomID(),
+		leases.WithExpiration(leaseDuration),
+		leases.WithLabels(map[string]string{
+			ingestLeaseLabel:    "true",
+			ingestLeaseRefLabel: ref,
+		}),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create temporary lease: %w", err)
 	}
 
 	if err := content.WriteBlob(leases.WithLease(ctx, lease.ID), cs, ref, r, desc); err != nil {
-		if cleanupErr := lm.Delete(ctx, lease, leases.SynchronousDelete); cleanupErr != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), ingestLeaseCleanupTimeout)
+		defer cancel()
+		if cleanupErr := lm.Delete(cleanupCtx, lease, leases.SynchronousDelete); cleanupErr != nil {
 			return errors.Join(err, fmt.Errorf("failed to delete temporary lease: %w", cleanupErr))
 		}
 		return err

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -17,6 +17,7 @@
 package content
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
@@ -37,6 +39,8 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli/v2"
 )
+
+const defaultIngestLeaseDuration = 5 * time.Minute
 
 var (
 	// Command is the cli command for managing content
@@ -102,6 +106,11 @@ var (
 				Name:  "expected-digest",
 				Usage: "Verify content against expected digest",
 			},
+			&cli.DurationFlag{
+				Name:  "lease-duration",
+				Usage: "Protect ingested content with a temporary lease (0 disables)",
+				Value: defaultIngestLeaseDuration,
+			},
 		},
 		Action: func(cliContext *cli.Context) error {
 			var (
@@ -121,12 +130,10 @@ var (
 			}
 			defer cancel()
 
-			cs := client.ContentStore()
-
 			// TODO(stevvooe): Allow ingest to be reentrant. Currently, we expect
 			// all data to be written in a single invocation. Allow multiple writes
 			// to the same transaction key followed by a commit.
-			return content.WriteBlob(ctx, cs, ref, os.Stdin, ocispec.Descriptor{Size: expectedSize, Digest: expectedDigest})
+			return ingestContent(ctx, client.ContentStore(), client.LeasesService(), cliContext.Duration("lease-duration"), ref, os.Stdin, ocispec.Descriptor{Size: expectedSize, Digest: expectedDigest})
 		},
 	}
 
@@ -577,6 +584,29 @@ var (
 		},
 	}
 )
+
+func ingestContent(ctx context.Context, cs content.Ingester, lm leases.Manager, leaseDuration time.Duration, ref string, r io.Reader, desc ocispec.Descriptor) error {
+	if leaseDuration < 0 {
+		return errors.New("lease duration must not be negative")
+	}
+	if leaseDuration == 0 {
+		return content.WriteBlob(ctx, cs, ref, r, desc)
+	}
+
+	lease, err := lm.Create(ctx, leases.WithRandomID(), leases.WithExpiration(leaseDuration))
+	if err != nil {
+		return fmt.Errorf("failed to create temporary lease: %w", err)
+	}
+
+	if err := content.WriteBlob(leases.WithLease(ctx, lease.ID), cs, ref, r, desc); err != nil {
+		if cleanupErr := lm.Delete(ctx, lease, leases.SynchronousDelete); cleanupErr != nil {
+			return errors.Join(err, fmt.Errorf("failed to delete temporary lease: %w", cleanupErr))
+		}
+		return err
+	}
+
+	return nil
+}
 
 func edit(cliContext *cli.Context, rd io.Reader) (_ io.ReadCloser, retErr error) {
 	editor := cliContext.String("editor")

--- a/cmd/ctr/commands/content/content_test.go
+++ b/cmd/ctr/commands/content/content_test.go
@@ -1,0 +1,154 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package content
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/core/metadata"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	localcontent "github.com/containerd/containerd/v2/plugins/content/local"
+	"github.com/containerd/errdefs"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestIngestContentLease(t *testing.T) {
+	t.Run("protects until durable root is established", func(t *testing.T) {
+		ctx, db, cs, lm := newIngestStore(t)
+		data := []byte("temporarily protected content")
+		desc := descriptorFromBytes(data)
+		leaseCreatedAt := time.Now()
+
+		require.NoError(t, ingestContent(ctx, cs, lm, defaultIngestLeaseDuration, "protected", bytes.NewReader(data), desc))
+		lease := requireSingleLease(t, ctx, lm)
+		expiresAt, err := time.Parse(time.RFC3339, lease.Labels["containerd.io/gc.expire"])
+		require.NoError(t, err)
+		require.WithinDuration(t, leaseCreatedAt.Add(defaultIngestLeaseDuration), expiresAt, time.Second)
+
+		_, err = db.GarbageCollect(ctx)
+		require.NoError(t, err)
+		info, err := cs.Info(ctx, desc.Digest)
+		require.NoError(t, err, "temporary lease should protect content from GC")
+
+		info.Labels = map[string]string{
+			"containerd.io/gc.root": time.Now().Format(time.RFC3339Nano),
+		}
+		_, err = cs.Update(ctx, info, "labels.containerd.io/gc.root")
+		require.NoError(t, err)
+		require.NoError(t, lm.Delete(ctx, lease))
+
+		_, err = db.GarbageCollect(ctx)
+		require.NoError(t, err)
+		_, err = cs.Info(ctx, desc.Digest)
+		require.NoError(t, err, "durable GC root should protect content after the temporary lease is removed")
+	})
+
+	t.Run("zero duration leaves content unleased", func(t *testing.T) {
+		ctx, db, cs, lm := newIngestStore(t)
+		data := []byte("unleased content")
+		desc := descriptorFromBytes(data)
+
+		require.NoError(t, ingestContent(ctx, cs, lm, 0, "unleased", bytes.NewReader(data), desc))
+		listed, err := lm.List(ctx)
+		require.NoError(t, err)
+		require.Empty(t, listed)
+
+		_, err = db.GarbageCollect(ctx)
+		require.NoError(t, err)
+		_, err = cs.Info(ctx, desc.Digest)
+		require.ErrorIs(t, err, errdefs.ErrNotFound)
+	})
+
+	t.Run("content is collectible after temporary protection is removed", func(t *testing.T) {
+		ctx, db, cs, lm := newIngestStore(t)
+		data := []byte("eventually collectible content")
+		desc := descriptorFromBytes(data)
+
+		require.NoError(t, ingestContent(ctx, cs, lm, defaultIngestLeaseDuration, "collectible", bytes.NewReader(data), desc))
+		lease := requireSingleLease(t, ctx, lm)
+		require.NoError(t, lm.Delete(ctx, lease))
+
+		_, err := db.GarbageCollect(ctx)
+		require.NoError(t, err)
+		_, err = cs.Info(ctx, desc.Digest)
+		require.ErrorIs(t, err, errdefs.ErrNotFound)
+	})
+
+	t.Run("failed ingest removes temporary lease", func(t *testing.T) {
+		ctx, _, cs, lm := newIngestStore(t)
+		data := []byte("content with the wrong digest")
+		desc := descriptorFromBytes([]byte("different content"))
+		desc.Size = int64(len(data))
+
+		err := ingestContent(ctx, cs, lm, defaultIngestLeaseDuration, "failed", bytes.NewReader(data), desc)
+		require.Error(t, err)
+		listed, err := lm.List(ctx)
+		require.NoError(t, err)
+		require.Empty(t, listed)
+	})
+}
+
+func TestIngestLeaseDurationDefault(t *testing.T) {
+	for _, flag := range ingestCommand.Flags {
+		if flag.Names()[0] == "lease-duration" {
+			require.Equal(t, defaultIngestLeaseDuration, flag.(*cli.DurationFlag).Value)
+			return
+		}
+	}
+	t.Fatal("lease-duration flag not found")
+}
+
+func newIngestStore(t *testing.T) (context.Context, *metadata.DB, content.Store, leases.Manager) {
+	t.Helper()
+
+	ctx := namespaces.WithNamespace(t.Context(), "testing")
+	dir := t.TempDir()
+	localStore, err := localcontent.NewStore(filepath.Join(dir, "content"))
+	require.NoError(t, err)
+	bdb, err := bolt.Open(filepath.Join(dir, "metadata.db"), 0600, nil)
+	require.NoError(t, err)
+	db := metadata.NewDB(bdb, localStore, nil)
+	require.NoError(t, db.Init(ctx))
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	return ctx, db, db.ContentStore(), metadata.NewLeaseManager(db)
+}
+
+func descriptorFromBytes(data []byte) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		Digest: digest.FromBytes(data),
+		Size:   int64(len(data)),
+	}
+}
+
+func requireSingleLease(t *testing.T, ctx context.Context, lm leases.Manager) leases.Lease {
+	t.Helper()
+	listed, err := lm.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	return listed[0]
+}

--- a/cmd/ctr/commands/content/content_test.go
+++ b/cmd/ctr/commands/content/content_test.go
@@ -41,13 +41,20 @@ func TestIngestContentLease(t *testing.T) {
 		ctx, db, cs, lm := newIngestStore(t)
 		data := []byte("temporarily protected content")
 		desc := descriptorFromBytes(data)
-		leaseCreatedAt := time.Now()
+		ingestStartedAt := time.Now()
 
 		require.NoError(t, ingestContent(ctx, cs, lm, defaultIngestLeaseDuration, "protected", bytes.NewReader(data), desc))
+		ingestFinishedAt := time.Now()
 		lease := requireSingleLease(t, ctx, lm)
-		expiresAt, err := time.Parse(time.RFC3339, lease.Labels["containerd.io/gc.expire"])
+		expiresAt, err := time.Parse(time.RFC3339Nano, lease.Labels["containerd.io/gc.expire"])
 		require.NoError(t, err)
-		require.WithinDuration(t, leaseCreatedAt.Add(defaultIngestLeaseDuration), expiresAt, time.Second)
+		// Lease expiration is recorded with one-second precision. Bound creation by
+		// timestamps on both sides of ingest so service or scheduler latency cannot
+		// make this assertion flaky.
+		require.False(t, expiresAt.Before(ingestStartedAt.Add(defaultIngestLeaseDuration-time.Second)))
+		require.False(t, expiresAt.After(ingestFinishedAt.Add(defaultIngestLeaseDuration+time.Second)))
+		require.Equal(t, "true", lease.Labels[ingestLeaseLabel])
+		require.Equal(t, "protected", lease.Labels[ingestLeaseRefLabel])
 
 		_, err = db.GarbageCollect(ctx)
 		require.NoError(t, err)
@@ -59,7 +66,7 @@ func TestIngestContentLease(t *testing.T) {
 		}
 		_, err = cs.Update(ctx, info, "labels.containerd.io/gc.root")
 		require.NoError(t, err)
-		require.NoError(t, lm.Delete(ctx, lease))
+		require.NoError(t, lm.Delete(ctx, lease, leases.SynchronousDelete))
 
 		_, err = db.GarbageCollect(ctx)
 		require.NoError(t, err)
@@ -90,7 +97,7 @@ func TestIngestContentLease(t *testing.T) {
 
 		require.NoError(t, ingestContent(ctx, cs, lm, defaultIngestLeaseDuration, "collectible", bytes.NewReader(data), desc))
 		lease := requireSingleLease(t, ctx, lm)
-		require.NoError(t, lm.Delete(ctx, lease))
+		require.NoError(t, lm.Delete(ctx, lease, leases.SynchronousDelete))
 
 		_, err := db.GarbageCollect(ctx)
 		require.NoError(t, err)
@@ -110,16 +117,41 @@ func TestIngestContentLease(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, listed)
 	})
+
+	t.Run("canceled ingest removes temporary lease", func(t *testing.T) {
+		ctx, _, cs, lm := newIngestStore(t)
+		data := []byte("canceled content")
+		desc := descriptorFromBytes(data)
+		canceledCtx, cancel := context.WithCancel(ctx)
+
+		err := ingestContent(canceledCtx, cs, lm, defaultIngestLeaseDuration, "canceled", cancelingReader{cancel: cancel}, desc)
+		require.ErrorIs(t, err, context.Canceled)
+		listed, err := lm.List(ctx)
+		require.NoError(t, err)
+		require.Empty(t, listed)
+	})
 }
 
 func TestIngestLeaseDurationDefault(t *testing.T) {
 	for _, flag := range ingestCommand.Flags {
-		if flag.Names()[0] == "lease-duration" {
-			require.Equal(t, defaultIngestLeaseDuration, flag.(*cli.DurationFlag).Value)
+		for _, name := range flag.Names() {
+			if name != "lease-duration" {
+				continue
+			}
+			durationFlag, ok := flag.(*cli.DurationFlag)
+			if !ok {
+				t.Fatalf("lease-duration flag has type %T, want *cli.DurationFlag", flag)
+			}
+			require.Equal(t, defaultIngestLeaseDuration, durationFlag.Value)
 			return
 		}
 	}
 	t.Fatal("lease-duration flag not found")
+}
+
+func TestIngestLeaseDurationValidation(t *testing.T) {
+	err := ingestContent(t.Context(), nil, nil, -time.Second, "negative", bytes.NewReader(nil), ocispec.Descriptor{})
+	require.EqualError(t, err, "--lease-duration must be >= 0, got -1s")
 }
 
 func newIngestStore(t *testing.T) (context.Context, *metadata.DB, content.Store, leases.Manager) {
@@ -151,4 +183,13 @@ func requireSingleLease(t *testing.T, ctx context.Context, lm leases.Manager) le
 	require.NoError(t, err)
 	require.Len(t, listed, 1)
 	return listed[0]
+}
+
+type cancelingReader struct {
+	cancel context.CancelFunc
+}
+
+func (r cancelingReader) Read([]byte) (int, error) {
+	r.cancel()
+	return 0, context.Canceled
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #8570.

`ctr content ingest` currently leaves newly ingested content vulnerable to garbage collection until the caller can establish durable protection. A GC during that window can remove the content before it can be labeled or otherwise retained.

This PR:

- protects newly ingested content with a temporary lease, defaulting to approximately five minutes;
- allows a zero duration to disable temporary lease protection;
- cleans up the temporary lease when ingestion fails;
- preserves durable `gc.root` protection after the temporary lease is removed;
- adds focused regression coverage for the GC lifecycle.

### Verification

The exact submitted commit was independently verified with [FalseGreen](https://falsegreen.com/) against a frozen verification contract.

- forced GC cannot collect content while the temporary lease is active;
- durable `gc.root` protection survives temporary lease removal;
- zero-duration ingestion creates no lease and remains collectible;
- content becomes collectible after temporary protection is removed when no durable root exists;
- failed ingestion cleans up its lease;
- all tests and package builds beneath `cmd/ctr` pass using vendored dependencies;
- 2/2 verification criteria passed;
- verified source: `54c1e189ec5a47c981e66288769c99f047395f14`.

The verification is scoped to these criteria and does not claim broader correctness of containerd.

Assisted-by: Codex