### PR TITLE
internal/cri/server: avoid debug log formatting for container spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.1
 	github.com/coreos/go-systemd/v22 v22.7.0
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.6.0
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 	github.com/docker/go-metrics v0.1.0
@@ -104,6 +103,7 @@ require (
 	github.com/containers/ocicrypt v1.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/containerd/typeurl/v2"
-	"github.com/davecgh/go-spew/spew"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -300,7 +299,10 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 		}
 	}()
 
-	log.G(r.ctx).Debugf("Container %q spec: %#+v", r.containerID, spew.NewFormatter(spec))
+	logger := log.G(r.ctx)
+	if logger.Logger.IsLevelEnabled(log.DebugLevel) {
+		logger.WithField("spec", spec).Debugf("Container %q spec", r.containerID)
+	}
 
 	// Grab any platform specific snapshotter opts.
 	sOpts, err := snapshotterOpts(r.containerConfig)

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containerd/nri"
 	v1 "github.com/containerd/nri/types/v1"
 	"github.com/containerd/typeurl/v2"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/opencontainers/selinux/go-selinux"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -144,7 +143,13 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 		return cin, fmt.Errorf("failed to generate sandbox container spec: %w", err)
 	}
 
-	log.G(ctx).WithField("podsandboxid", id).Debugf("sandbox container spec: %#+v", spew.NewFormatter(spec))
+	logger := log.G(ctx)
+	if logger.Logger.IsLevelEnabled(log.DebugLevel) {
+		logger.WithFields(log.Fields{
+			"podsandboxid": id,
+			"spec":         spec,
+		}).Debug("sandbox container spec")
+	}
 
 	metadata.ProcessLabel = spec.Process.SelinuxLabel
 	defer func() {


### PR DESCRIPTION
Only construct the debug log entry when debug logging is enabled, and log the runtime spec as a structured field instead of formatting it with spew.