### PR TITLE
fix: preserve tag in ParseImageReferences when reference has both tag and digest

### DIFF
--- a/internal/cri/util/references.go
+++ b/internal/cri/util/references.go
@@ -32,7 +32,8 @@ func ParseImageReferences(refs []string) ([]string, []string) {
 		}
 		if _, ok := parsed.(reference.Canonical); ok {
 			digests = append(digests, parsed.String())
-		} else if _, ok := parsed.(reference.Tagged); ok {
+		}
+		if _, ok := parsed.(reference.Tagged); ok {
 			tags = append(tags, parsed.String())
 		}
 	}

--- a/internal/cri/util/references.go
+++ b/internal/cri/util/references.go
@@ -30,11 +30,16 @@ func ParseImageReferences(refs []string) ([]string, []string) {
 		if err != nil {
 			continue
 		}
-		if _, ok := parsed.(reference.Canonical); ok {
-			digests = append(digests, parsed.String())
+		if canonical, ok := parsed.(reference.Canonical); ok {
+			digests = append(digests, canonical.Name()+"@"+canonical.Digest().String())
 		}
-		if _, ok := parsed.(reference.Tagged); ok {
-			tags = append(tags, parsed.String())
+		if tagged, ok := parsed.(reference.Tagged); ok {
+			// Tagged does not embed Named, retrieve the name via Canonical when available.
+			if canonical, ok := parsed.(reference.Canonical); ok {
+				tags = append(tags, canonical.Name()+":"+tagged.Tag())
+			} else {
+				tags = append(tags, tagged.String())
+			}
 		}
 	}
 	return tags, digests

--- a/internal/cri/util/references_test.go
+++ b/internal/cri/util/references_test.go
@@ -29,13 +29,18 @@ func TestParseImageReferences(t *testing.T) {
 	refs := []string{
 		"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 		"gcr.io/library/busybox:1.2",
+		"gcr.io/library/busybox:1.2@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 		"sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 		"arbitrary-ref",
 	}
 	expectedTags := []string{
 		"gcr.io/library/busybox:1.2",
+		"gcr.io/library/busybox:1.2",
 	}
-	expectedDigests := []string{"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"}
+	expectedDigests := []string{
+		"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+		"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+	}
 	tags, digests := ParseImageReferences(refs)
 	assert.Equal(t, expectedTags, tags)
 	assert.Equal(t, expectedDigests, digests)


### PR DESCRIPTION
When an image is pulled with both a tag and a digest reference (e.g. `busybox:1.2@sha256:...`), `ParseImageReferences` in the CRI util package drops the tag because the `getBestReferenceType` function returns a `reference` struct that implements both `Canonical` and `Tagged` interfaces, but the old `if/else if` logic only added the reference to `digests` and never to `tags`.

**Root cause**: `reference.ParseAnyReference` returns a single `reference` struct for references that carry both a tag and a digest. This struct implements both `Canonical` (via `Digest()`) and `Tagged` (via `Tag()`). However, its `String()` method returns `name:tag@digest`, which is not suitable for either `RepoTags` or `RepoDigests`.

**Fix**:
1. Use separate `if` statements for `Canonical` and `Tagged` assertions (instead of `if/else if`)
2. Construct the digest reference as `name@digest` via `canonical.Name() + "@" + canonical.Digest().String()`
3. Construct the tag reference as `name:tag` via `canonical.Name() + ":" + tagged.Tag()` (or `tagged.String()` for tagged-only references)

**Testing**: Added a test case with `gcr.io/library/busybox:1.2@sha256:e6693c...` to verify both `RepoTags` and `RepoDigests` are populated correctly.

Fixes #13969
