### PR TITLE
Update mount manager schema 

### DIFF
--- a/core/mount/loopback_handler_linux.go
+++ b/core/mount/loopback_handler_linux.go
@@ -52,6 +52,15 @@ func (loopbackHandler) Mount(ctx context.Context, m Mount, mp string, _ []Active
 	}
 	defer loop.Close()
 
+	// A stale symlink from an earlier, no longer live mount may already
+	// be at mp (see Mounted); os.Symlink fails with EEXIST otherwise.
+	// Remove it first, but only if it really is a symlink.
+	if fi, err := os.Lstat(mp); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		if err := os.Remove(mp); err != nil {
+			return ActiveMount{}, err
+		}
+	}
+
 	if err := os.Symlink(loop.Name(), mp); err != nil {
 		return ActiveMount{}, err
 	}

--- a/core/mount/loopback_handler_linux.go
+++ b/core/mount/loopback_handler_linux.go
@@ -18,12 +18,14 @@ package mount
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"golang.org/x/sys/unix"
 )
 
 func LoopbackHandler() Handler {
@@ -65,6 +67,44 @@ func (loopbackHandler) Mount(ctx context.Context, m Mount, mp string, _ []Active
 	}, nil
 }
 
+// Mounted reports whether path is still a symlink to a loop device
+// which is attached and not marked for auto clear.
+func (loopbackHandler) Mounted(ctx context.Context, path string) (bool, error) {
+	loopdev, err := os.Readlink(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	loop, err := os.Open(loopdev)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer loop.Close()
+
+	info, err := unix.IoctlLoopGetStatus64(int(loop.Fd()))
+	if err != nil {
+		// ENXIO: no backing file is attached to the device, so
+		// whatever this symlink once pointed to is gone.
+		if errors.Is(err, unix.ENXIO) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if info.Flags&unix.LO_FLAGS_AUTOCLEAR != 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// Unmount tolerates the loop device already being gone, whether the
+// device node is missing or IoctlLoopGetStatus64 reports ENXIO.
 func (loopbackHandler) Unmount(ctx context.Context, path string) error {
 	loopdev, err := os.Readlink(path)
 	if err != nil {
@@ -73,14 +113,17 @@ func (loopbackHandler) Unmount(ctx context.Context, path string) error {
 		}
 		return err
 	}
-	loop, err := os.Open(loopdev)
-	if err != nil {
-		return err
-	}
-	defer loop.Close()
 
-	if err := setLoopAutoclear(loop, true); err != nil {
-		return fmt.Errorf("failed to set auto clear on loop device %q: %w", loopdev, err)
+	loop, err := os.Open(loopdev)
+	switch {
+	case err == nil:
+		defer loop.Close()
+		if err := setLoopAutoclear(loop, true); err != nil && !errors.Is(err, unix.ENXIO) {
+			return fmt.Errorf("failed to set auto clear on loop device %q: %w", loopdev, err)
+		}
+	case os.IsNotExist(err):
+	default:
+		return err
 	}
 
 	if err := os.Remove(path); err != nil {
@@ -91,10 +134,12 @@ func (loopbackHandler) Unmount(ctx context.Context, path string) error {
 		// if removal of the symlink has failed, its possible for the loop device to get cleaned
 		// up and re-used. Leave the loop device around to prevent re-use and let a retry of
 		// Unmount clear it.`
-		if err := setLoopAutoclear(loop, false); err != nil {
-			// Very unlikely but log to track in case there is a problem with
-			// the loop being cleared and re-used.
-			log.G(ctx).WithError(err).Errorf("Failed to unset auto clear flag on symlink removal failure, loopback %q may be cleaned up while still being tracked", loopdev)
+		if loop != nil {
+			if err := setLoopAutoclear(loop, false); err != nil {
+				// Very unlikely but log to track in case there is a problem with
+				// the loop being cleared and re-used.
+				log.G(ctx).WithError(err).Errorf("Failed to unset auto clear flag on symlink removal failure, loopback %q may be cleaned up while still being tracked", loopdev)
+			}
 		}
 
 		return err

--- a/core/mount/loopback_handler_linux_test.go
+++ b/core/mount/loopback_handler_linux_test.go
@@ -55,3 +55,45 @@ func TestLoopbackUnmountToleratesDetachedDevice(t *testing.T) {
 	_, err = os.Lstat(mp)
 	assert.True(t, os.IsNotExist(err), "the symlink must still be removed even though the device it pointed at was already gone")
 }
+
+// TestLoopbackMountRepairsStaleSymlink verifies that Mount can repair
+// a record found not live: a symlink left at mp from an earlier mount
+// whose device was detached must not make a fresh Mount at the same
+// point fail with EEXIST.
+func TestLoopbackMountRepairsStaleSymlink(t *testing.T) {
+	testutil.RequiresRoot(t)
+
+	td := t.TempDir()
+	mp := filepath.Join(td, "mp")
+	h := LoopbackHandler()
+
+	first := createTempFile(t)
+	_, err := h.Mount(context.Background(), Mount{Type: "loop", Source: first}, mp, nil)
+	require.NoError(t, err)
+
+	loopdev, err := os.Readlink(mp)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Best effort.
+		_ = DetachLoopDevice(loopdev)
+	})
+	require.NoError(t, DetachLoopDevice(loopdev))
+
+	live, err := h.(MountedChecker).Mounted(context.Background(), mp)
+	require.NoError(t, err)
+	require.False(t, live, "the stale symlink must be reported as not mounted")
+
+	second := createTempFile(t)
+	_, err = h.Mount(context.Background(), Mount{Type: "loop", Source: second}, mp, nil)
+	require.NoError(t, err, "repairing a stale symlink must not fail with EEXIST")
+
+	newLoopdev, err := os.Readlink(mp)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Best effort.
+		_ = DetachLoopDevice(newLoopdev)
+	})
+	assert.NotEqual(t, loopdev, newLoopdev, "repair must point the symlink at a new device")
+
+	require.NoError(t, h.Unmount(context.Background(), mp))
+}

--- a/core/mount/loopback_handler_linux_test.go
+++ b/core/mount/loopback_handler_linux_test.go
@@ -1,0 +1,57 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mount
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/continuity/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoopbackUnmountToleratesDetachedDevice verifies that Unmount
+// succeeds when the loop device a symlink points at is already
+// detached from its backing file.
+func TestLoopbackUnmountToleratesDetachedDevice(t *testing.T) {
+	testutil.RequiresRoot(t)
+
+	td := t.TempDir()
+	backingFile := createTempFile(t)
+	mp := filepath.Join(td, "mp")
+
+	h := LoopbackHandler()
+	_, err := h.Mount(context.Background(), Mount{Type: "loop", Source: backingFile}, mp, nil)
+	require.NoError(t, err)
+
+	loopdev, err := os.Readlink(mp)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Best effort.
+		_ = DetachLoopDevice(loopdev)
+	})
+
+	require.NoError(t, DetachLoopDevice(loopdev))
+
+	require.NoError(t, h.Unmount(context.Background(), mp))
+
+	_, err = os.Lstat(mp)
+	assert.True(t, os.IsNotExist(err), "the symlink must still be removed even though the device it pointed at was already gone")
+}

--- a/core/mount/manager.go
+++ b/core/mount/manager.go
@@ -48,6 +48,25 @@ type Handler interface {
 	Unmount(context.Context, string) error
 }
 
+// MountedChecker is an optional interface a Handler may implement to
+// report whether the mount it manages at path is still in effect. A
+// manager which reuses a Handler's mounts across activations uses this
+// to verify a recorded mount is still live before handing it out
+// again, rather than trusting its own bookkeeping, and to detect and
+// repair a mount which was torn down outside of it, for example by a
+// reboot or an operator's manual unmount.
+//
+// A Handler which does not implement MountedChecker is checked by
+// inspecting the host's mount table instead, which is only accurate
+// for a Handler whose mount point is a real kernel mount. A Handler
+// which leaves something else at the mount point, such as a symlink
+// to a device, must implement this interface: a generic check would
+// otherwise always report it as not mounted and cause it to be
+// needlessly, and possibly unsafely, redone.
+type MountedChecker interface {
+	Mounted(ctx context.Context, path string) (bool, error)
+}
+
 // Transformer is an interface that can make changes to the mount based on
 // the previous mount state. This can be used to update the values of the
 // mount, such as with formatting, or for mount initialization that do not

--- a/core/mount/manager.go
+++ b/core/mount/manager.go
@@ -49,20 +49,23 @@ type Handler interface {
 }
 
 // MountedChecker is an optional interface a Handler may implement to
-// report whether the mount it manages at path is still in effect. A
-// manager which reuses a Handler's mounts across activations uses this
-// to verify a recorded mount is still live before handing it out
-// again, rather than trusting its own bookkeeping, and to detect and
-// repair a mount which was torn down outside of it, for example by a
-// reboot or an operator's manual unmount.
+// report whether the mount it manages at path is still in effect.
 //
-// A Handler which does not implement MountedChecker is checked by
-// inspecting the host's mount table instead, which is only accurate
-// for a Handler whose mount point is a real kernel mount. A Handler
-// which leaves something else at the mount point, such as a symlink
-// to a device, must implement this interface: a generic check would
-// otherwise always report it as not mounted and cause it to be
-// needlessly, and possibly unsafely, redone.
+// Managers can query whether a recorded mount is still live before
+// handing it out again. If the recorded mount is no longer available
+// (for example, an operator manually unmounted or a reboot occurred),
+// the manager can discard an incorrect activation record.
+//
+// Handlers which implement mount points as real kernel mounts may not
+// implement MountedChecker. Liveness of kernel mount points can be
+// determined by introspecting the host's mount table.
+//
+// Handlers that return something else at the mount point (such as
+// loopback's symlink to a device) must implement this interface.
+//
+// Managers may also invoke Mounted when creating an activation
+// record. If the Handler returns true here, the manager will not
+// invoke Mount.
 type MountedChecker interface {
 	Mounted(ctx context.Context, path string) (bool, error)
 }

--- a/core/mount/manager/backing.go
+++ b/core/mount/manager/backing.go
@@ -1,0 +1,375 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/containerd/errdefs"
+
+	"github.com/containerd/containerd/v2/core/mount"
+)
+
+// backingDir is the directory under the target root that holds the
+// mount points of mounted records.
+const backingDir = "b"
+
+// maxMounts is the largest chain position or system mount count this
+// schema supports: a position's index is encoded as a single byte.
+const maxMounts = math.MaxUint8
+
+// mountPointName is the directory used as the mount point within a
+// mounted record's directory. typeFileName records the mount type
+// alongside it.
+const (
+	mountPointName = "fs"
+	typeFileName   = "type"
+)
+
+// mountedRecord is a mount performed by the manager, shared by every
+// activation which describes the same mount within a namespace. point
+// and at are computed when the record is resolved, not measured after
+// mounting; see probeMounted for whether it is currently mounted.
+type mountedRecord struct {
+	id    uint64
+	mount mount.Mount
+	point string
+	at    *time.Time
+}
+
+// active returns the mounted record as an ActiveMount for reporting
+// through ActivationInfo.
+func (b mountedRecord) active() mount.ActiveMount {
+	return mount.ActiveMount{
+		Mount:      b.mount,
+		MountPoint: b.point,
+		MountedAt:  b.at,
+	}
+}
+
+// mountIdentity returns a digest uniquely identifying the kernel
+// mount described by m. Fields are length prefixed.
+func mountIdentity(m mount.Mount) []byte {
+	h := sha256.New()
+	var lenbuf [8]byte
+	write := func(s string) {
+		binary.BigEndian.PutUint64(lenbuf[:], uint64(len(s)))
+		h.Write(lenbuf[:])
+		h.Write([]byte(s))
+	}
+	write(m.Type)
+	write(m.Source)
+	write(m.Target)
+	binary.BigEndian.PutUint64(lenbuf[:], uint64(len(m.Options)))
+	h.Write(lenbuf[:])
+	for _, o := range m.Options {
+		write(o)
+	}
+	return h.Sum(nil)
+}
+
+// shareable reports whether m may be satisfied by an existing,
+// identical mounted record: only true when Source names a concrete
+// filesystem object, not a synthetic source like "tmpfs" or "none".
+func shareable(m mount.Mount) bool {
+	return filepath.IsAbs(m.Source)
+}
+
+// mountedKey encodes a mounted record id for use as a bolt bucket key.
+func mountedKey(id uint64) []byte {
+	b, _ := encodeID(id)
+	return b
+}
+
+// backingRoot returns the directory holding a mounted record's mount
+// point and type file.
+func (mm *mountManager) backingRoot(id uint64) string {
+	return filepath.Join(mm.targets.Name(), backingDir, strconv.FormatUint(id, 10))
+}
+
+// putMountedRecord writes a mounted record's mount parameters, point,
+// and approximate mount time.
+func putMountedRecord(bkt *bolt.Bucket, m mount.Mount, point string, at time.Time) error {
+	if err := bkt.Put(bucketKeyType, []byte(m.Type)); err != nil {
+		return err
+	}
+	if err := bkt.Put(bucketKeySource, []byte(m.Source)); err != nil {
+		return err
+	}
+	if err := bkt.Put(bucketKeyTarget, []byte(m.Target)); err != nil {
+		return err
+	}
+	if len(m.Options) > 0 {
+		if err := bkt.Put(bucketKeyOptions, []byte(strings.Join(m.Options, "\x00"))); err != nil {
+			return err
+		}
+	}
+	if err := bkt.Put(bucketKeyMountPoint, []byte(point)); err != nil {
+		return err
+	}
+	encoded, err := at.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	return bkt.Put(bucketKeyMountedAt, encoded)
+}
+
+// readMountedRecord reads a full mounted record.
+func readMountedRecord(id uint64, bkt *bolt.Bucket) (mountedRecord, error) {
+	b := mountedRecord{
+		id: id,
+		mount: mount.Mount{
+			Type:   string(bkt.Get(bucketKeyType)),
+			Source: string(bkt.Get(bucketKeySource)),
+			Target: string(bkt.Get(bucketKeyTarget)),
+		},
+		point: string(bkt.Get(bucketKeyMountPoint)),
+	}
+	if v := bkt.Get(bucketKeyOptions); len(v) > 0 {
+		b.mount.Options = strings.Split(string(v), "\x00")
+	}
+	if v := bkt.Get(bucketKeyMountedAt); len(v) > 0 {
+		var at time.Time
+		if err := at.UnmarshalBinary(v); err != nil {
+			return mountedRecord{}, err
+		}
+		b.at = &at
+	}
+	return b, nil
+}
+
+// getMountedRecord loads the mounted record with the given key from a
+// namespace bucket, returning false when it no longer exists.
+func getMountedRecord(nsbkt *bolt.Bucket, key []byte) (mountedRecord, bool, error) {
+	mtbkt := nsbkt.Bucket(bucketKeyMountTable)
+	if mtbkt == nil {
+		return mountedRecord{}, false, nil
+	}
+	bkt := mtbkt.Bucket(key)
+	if bkt == nil {
+		return mountedRecord{}, false, nil
+	}
+	id, _ := binary.Uvarint(key)
+	b, err := readMountedRecord(id, bkt)
+	if err != nil {
+		return mountedRecord{}, false, err
+	}
+	return b, true, nil
+}
+
+// resolvePosition resolves m, already fully rewritten, to a mounted
+// record within tx, creating one if no shareable record with this
+// identity already exists, and adds a reference from the named
+// activation at the given chain position. Callers must have already
+// confirmed name's activation bucket exists.
+func resolvePosition(tx *bolt.Tx, targetsName, namespace, name string, index int, m mount.Mount, start time.Time) (mountedRecord, error) {
+	v2bkt, err := tx.CreateBucketIfNotExists(bucketKeyV2)
+	if err != nil {
+		return mountedRecord{}, err
+	}
+	nsbkt, err := v2bkt.CreateBucketIfNotExists([]byte(namespace))
+	if err != nil {
+		return mountedRecord{}, err
+	}
+	mtbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyMountTable)
+	if err != nil {
+		return mountedRecord{}, err
+	}
+
+	if index < 0 || index > maxMounts {
+		return mountedRecord{}, fmt.Errorf("mount index %d out of range: %w", index, errdefs.ErrInvalidArgument)
+	}
+	mbkt := getSubBucket(nsbkt, bucketKeyActivations, []byte(name))
+	if mbkt == nil {
+		return mountedRecord{}, fmt.Errorf("mount %q: %w", name, errdefs.ErrNotFound)
+	}
+	abkt, err := mbkt.CreateBucketIfNotExists(bucketKeyActive)
+	if err != nil {
+		return mountedRecord{}, err
+	}
+	cbkt, err := abkt.CreateBucketIfNotExists([]byte{byte(index)})
+	if err != nil {
+		return mountedRecord{}, err
+	}
+
+	share := shareable(m)
+	var identity []byte
+	if share {
+		identity = mountIdentity(m)
+		xbkt := nsbkt.Bucket(bucketKeyMountIndex)
+		if xbkt != nil {
+			if k := xbkt.Get(identity); len(k) > 0 {
+				if bkt := mtbkt.Bucket(k); bkt != nil {
+					id, _ := binary.Uvarint(k)
+					existing, err := readMountedRecord(id, bkt)
+					if err != nil {
+						return mountedRecord{}, err
+					}
+					holdersbkt, err := bkt.CreateBucketIfNotExists(bucketKeyHolders)
+					if err != nil {
+						return mountedRecord{}, err
+					}
+					if err := holdersbkt.Put([]byte(name), nil); err != nil {
+						return mountedRecord{}, err
+					}
+					if err := cbkt.Put(bucketKeyMountID, k); err != nil {
+						return mountedRecord{}, err
+					}
+					return existing, nil
+				}
+				// Should not be reachable; drop the stale entry.
+				if err := xbkt.Delete(identity); err != nil {
+					return mountedRecord{}, err
+				}
+			}
+		}
+	}
+
+	id, err := v2bkt.NextSequence()
+	if err != nil {
+		return mountedRecord{}, err
+	}
+	key := mountedKey(id)
+	bkt, err := mtbkt.CreateBucket(key)
+	if err != nil {
+		return mountedRecord{}, err
+	}
+	point := filepath.Join(targetsName, backingDir, strconv.FormatUint(id, 10), mountPointName)
+	if err := putMountedRecord(bkt, m, point, start); err != nil {
+		return mountedRecord{}, err
+	}
+	holdersbkt, err := bkt.CreateBucket(bucketKeyHolders)
+	if err != nil {
+		return mountedRecord{}, err
+	}
+	if err := holdersbkt.Put([]byte(name), nil); err != nil {
+		return mountedRecord{}, err
+	}
+	if share {
+		xbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyMountIndex)
+		if err != nil {
+			return mountedRecord{}, err
+		}
+		if err := xbkt.Put(identity, key); err != nil {
+			return mountedRecord{}, err
+		}
+	}
+	if err := cbkt.Put(bucketKeyMountID, key); err != nil {
+		return mountedRecord{}, err
+	}
+
+	return mountedRecord{id: id, mount: m, point: point, at: &start}, nil
+}
+
+// releaseMountedRecords drops the named activation's references from
+// the given mounted records, removes those which lost their last
+// reference from the database, and returns them in unmount order.
+func releaseMountedRecords(tx *bolt.Tx, namespace, name string, ids []uint64) ([]mountedRecord, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	nsbkt := getBucket(tx, bucketKeyV2, []byte(namespace))
+	if nsbkt == nil {
+		return nil, nil
+	}
+	mtbkt := nsbkt.Bucket(bucketKeyMountTable)
+	if mtbkt == nil {
+		return nil, nil
+	}
+	xbkt := nsbkt.Bucket(bucketKeyMountIndex)
+
+	var released []mountedRecord
+	for _, id := range ids {
+		if id == 0 {
+			continue
+		}
+		key := mountedKey(id)
+		bkt := mtbkt.Bucket(key)
+		if bkt == nil {
+			continue
+		}
+		if holdersbkt := bkt.Bucket(bucketKeyHolders); holdersbkt != nil {
+			if err := holdersbkt.Delete([]byte(name)); err != nil {
+				return nil, err
+			}
+			if k, _ := holdersbkt.Cursor().First(); k != nil {
+				// Still used by another activation.
+				continue
+			}
+		}
+		b, err := readMountedRecord(id, bkt)
+		if err != nil {
+			return nil, err
+		}
+		if xbkt != nil && shareable(b.mount) {
+			if err := xbkt.Delete(mountIdentity(b.mount)); err != nil {
+				return nil, err
+			}
+		}
+		if err := mtbkt.DeleteBucket(key); err != nil {
+			return nil, err
+		}
+		released = append(released, b)
+	}
+
+	sortUnmountOrder(released)
+
+	return released, nil
+}
+
+// sortUnmountOrder orders mounted records for unmounting, highest id
+// first.
+func sortUnmountOrder(records []mountedRecord) {
+	sort.Slice(records, func(a, b int) bool {
+		return records[a].id > records[b].id
+	})
+}
+
+// activationUses returns the ids of the mounted records an activation
+// uses, in mount order.
+func activationUses(bkt *bolt.Bucket) []uint64 {
+	abkt := bkt.Bucket(bucketKeyActive)
+	if abkt == nil {
+		return nil
+	}
+	var ids []uint64
+	abkt.ForEachBucket(func(k []byte) error {
+		if v := abkt.Bucket(k).Get(bucketKeyMountID); len(v) > 0 {
+			id, _ := binary.Uvarint(v)
+			ids = append(ids, id)
+		}
+		return nil
+	})
+	return ids
+}
+
+// mountingKey returns the lock key used to serialize resolution and
+// mounting of activations which resolve to the same mount.
+func mountingKey(m mount.Mount) string {
+	return hex.EncodeToString(mountIdentity(m))
+}

--- a/core/mount/manager/backing.go
+++ b/core/mount/manager/backing.go
@@ -60,6 +60,8 @@ type mountedRecord struct {
 	mount mount.Mount
 	point string
 	at    *time.Time
+	// created is true when resolvePosition just minted this record.
+	created bool
 }
 
 // active returns the mounted record as an ActiveMount for reporting
@@ -283,7 +285,7 @@ func resolvePosition(tx *bolt.Tx, targetsName, namespace, name string, index int
 		return mountedRecord{}, err
 	}
 
-	return mountedRecord{id: id, mount: m, point: point, at: &start}, nil
+	return mountedRecord{id: id, mount: m, point: point, at: &start, created: true}, nil
 }
 
 // releaseMountedRecords drops the named activation's references from

--- a/core/mount/manager/buckets.go
+++ b/core/mount/manager/buckets.go
@@ -16,67 +16,148 @@
 
 // Package manager is used to manage mounts in a bolt database, normally
 // backed by a tempfs.
+//
+// The top level bucket name is the schema version. A structural,
+// backwards incompatible change to the schema is expressed by moving
+// to a new name rather than by migrating data within the old one:
+// "v2" is a distinct bucket from "v1", so a binary which only
+// understands "v1" neither reads nor writes anything under "v2". Each
+// creates its own bucket on first use.
+//
+// "v1" is read and released but never written or converted; see
+// v1.go. An older binary therefore always finds "v1" exactly as it
+// left it, minus whatever activations were released in the meantime,
+// so a rollback needs no compatibility code. Mounts recorded only
+// under "v2" are not something an older binary can restore, but the
+// database is expected to live on transient storage (normally a
+// tmpfs under the state directory) and every caller of Activate
+// treats an unrecognized name as not yet activated and activates it
+// again, so a rollback loses the record of those mounts without
+// corrupting anything.
+//
+// Every mount the manager performs is recorded once, as a mounted
+// record, and referenced by the activations using it: two activations
+// which describe the same mount use the same record and share the
+// underlying filesystem, so it stays mounted while either of them
+// uses it. This applies uniformly; a mount which cannot be shared with
+// another activation still gets its own record, it is simply never
+// looked up by another activation's mount parameters.
+//
+// An activation's entire chain of records is resolved and made
+// durable in a single write transaction, before anything is actually
+// mounted: mntpoint is computed rather than assigned once mounting
+// succeeds, and mntat is approximated as the time resolution ran
+// rather than measured after the fact. This lets the whole chain,
+// however long, cost exactly one write transaction to activate (two
+// if the name collides with a stale record left by a crash, since
+// deciding that requires probing the mounts it refers to first).
+//
+// mntpoint and mntat do not prove a mount is live: the manager checks
+// the mount itself before reusing a record (see probeMounted in
+// manager.go), repairing it in place if the check disagrees. Info and
+// List report the persisted record as-is; a stale one is caught by
+// Activate or a collection pass.
+//
+// Key names below use two vocabularies: this package's own, for an
+// activation and its chain, and the mount table's own (mnttable,
+// mntid, holders).
 /*
 Database schema
 
-	v1
+	v2
 	╘══*namespace*
-	   ├──mounts
+	   ├──activations
 	   │  ╘══*mount name*
 	   │     ├──id : <varuint64>                  - Unique ID for mount (auto incrementing)
 	   │     ├──createdat : <binary time>         - Created at
 	   │     ├──updatedat : <binary time>         - Updated at
 	   │     ├──lease : <string>                  - Lease
-	   │     ├──active
+	   │     ├──ensures : <string>                - NUL separated absolute paths created by a
+	   │     │                                      boundary mount's deferred mkdir or mkfs;
+	   │     │                                      omitted if it has none. Existing on disk
+	   │     │                                      means the ensure has already run
+	   │     ├──active                            - The whole chain, resolved in one transaction
 	   │     │  ╘══*order*
-	   │     │     ├──mountedat : <binary time>   - Mounted at
-	   │     │     ├──state : <enum>              - (0 - unmounted, 1 - filesystem, 2 - device, 3 - process)
-	   │     │     ├──type : <string>             - Mount type
-	   │     │     ├──source : <string>           - Mount source
-	   │     │     ├──target : <string>           - Mount target (relative to previous mount point)
-	   │     │     ├──mp : <string>               - Mount point for filesystem mount
-	   │     │     ├──mpg : <bool>                - Whether the mount point is auto generated (NOT USED)
-	   │     │     ├──dev : <string>              - Device active for this mount (NOT USED)
-	   │     │     ├──pid : <int>                 - Process created for this mount (NOT USED)
-	   │     │     └──options : <string>          - Comma separate options
+	   │     │     └──mntid : <varuint64>         - Mount table entry for this position in the chain
 	   │     ├──system
 	   │     │  ╘══*order*
 	   │     │     ├──type : <string>             - Mount type
 	   │     │     ├──source : <string>           - Mount source
 	   │     │     ├──target : <string>           - Mount target (relative to previous mount point)
-	   │     │     └──options : <string>          - Comma separate options
+	   │     │     └──options : <string>          - NUL separated options
 	   │     └──labels
 	   │        ╘══*key* : <string>               - Label value
-	   ├──leases
-	   │  ╘══*lease id*
-	   │     ╘══*mount name*: nil
-	   └──unmountq                                (CURRENTLY NOT USED, may remove)
-	      └──*mount name + auto-increment*
-	         ├──type : <string>                   - Mount type
-	         ├──target : <string>                 - Path to check && unmount
-	         ├──rm : <bool>                       - Whether to remove target after unmount
-	         ├──dev : <string>                    - Device to check before unmount
-	         ├──pid : <int>                       - Process to check and kill
-	         ├──target : <string>                 - Path to unmount
-	         ├──state : <enum>                    - (0 - unmounted, 1 - filesystem, 2 - device, 3 - process)
-	         └─ order : <int>                     - Order in which was mounted, unmount high to low
+	   ├──mnttable                                - Mounts actually performed by the manager
+	   │  ╘══*mount id (varuint64)*
+	   │     ├──type : <string>                   - Mount type
+	   │     ├──source : <string>                 - Mount source
+	   │     ├──target : <string>                 - Mount target
+	   │     ├──options : <string>                - NUL separated options
+	   │     ├──mntpoint : <string>               - Mount point, computed when resolved
+	   │     ├──mntat : <binary time>             - Approximate mount time
+	   │     └──holders
+	   │        ╘══*mount name* : nil             - Activations using this entry
+	   ├──mntindex                                - Dedup index over shareable mount table entries
+	   │  ╘══*mount identity digest* : <varuint64>
+	   └──leases
+	      ╘══*lease id*
+	         ╘══*mount name*: nil
+
+	v1                                            (deprecated: read and released only, see v1.go)
+	╘══*namespace*
+	   ├──mounts
+	   │  ╘══*mount name*
+	   │     ├──id : <varuint64>                  - Unique ID (auto incrementing)
+	   │     ├──createdat : <binary time>         - Created at
+	   │     ├──updatedat : <binary time>         - Updated at
+	   │     ├──lease : <string>                  - Lease
+	   │     ├──active                            - Absent if never completed
+	   │     │  ╘══*order*
+	   │     │     ├──type : <string>             - Mount type
+	   │     │     ├──mp : <string>               - Mount point
+	   │     │     └──mat : <binary time>         - Mount time
+	   │     ├──system
+	   │     │  ╘══*order*
+	   │     │     ├──type : <string>             - Mount type
+	   │     │     ├──source : <string>           - Mount source
+	   │     │     ├──target : <string>           - Mount target (relative to previous mount point)
+	   │     │     └──options : <string>          - NUL separated options
+	   │     └──labels
+	   │        ╘══*key* : <string>               - Label value
+	   └──leases
+	      ╘══*lease id*
+	         ╘══*mount name*: nil
 */
 package manager
 
 var (
-	bucketKeyID         = []byte("id")
-	bucketKeyMounts     = []byte("mounts")
-	bucketKeyLeases     = []byte("leases")
-	bucketKeyLease      = []byte("lease")
-	bucketKeyActive     = []byte("active")
-	bucketKeySystem     = []byte("system")
-	bucketKeyType       = []byte("type")
-	bucketKeySource     = []byte("source")
-	bucketKeyTarget     = []byte("target")
-	bucketKeyOptions    = []byte("options")
-	bucketKeyMountedAt  = []byte("mat")
-	bucketKeyMountPoint = []byte("mp")
-	bucketKeyLabels     = []byte("labels")
+	bucketKeyV2 = []byte("v2")
+	// bucketKeyV1 is the schema this package replaced. Read and
+	// released only, never written; see v1.go.
+	bucketKeyV1 = []byte("v1")
+
+	bucketKeyID          = []byte("id")
+	bucketKeyActivations = []byte("activations")
+	bucketKeyLeases      = []byte("leases")
+	bucketKeyLease       = []byte("lease")
+	// bucketKeyEnsureTargets holds the absolute path(s) a boundary
+	// mount's own deferred mkdir/mkfs produces, NUL separated.
+	bucketKeyEnsureTargets = []byte("ensures")
+	bucketKeyActive        = []byte("active")
+	bucketKeySystem        = []byte("system")
+	bucketKeyType          = []byte("type")
+	bucketKeySource        = []byte("source")
+	bucketKeyTarget        = []byte("target")
+	bucketKeyOptions       = []byte("options")
+	bucketKeyMountedAt     = []byte("mntat")
+	bucketKeyMountPoint    = []byte("mntpoint")
+	bucketKeyMountTable    = []byte("mnttable")
+	bucketKeyMountIndex    = []byte("mntindex")
+	bucketKeyMountID       = []byte("mntid")
+	bucketKeyHolders       = []byte("holders")
+	// bucketKeyLabels is shared with v1.go: boltutil.ReadLabels and
+	// boltutil.WriteLabels hardcode this exact spelling.
+	bucketKeyLabels = []byte("labels")
 
 	labelGCContainerBackRef = []byte("containerd.io/gc.bref.container")
 	labelGCContentBackRef   = []byte("containerd.io/gc.bref.content")

--- a/core/mount/manager/manager.go
+++ b/core/mount/manager/manager.go
@@ -554,9 +554,9 @@ func (mm *mountManager) staleCollision(ctx context.Context, namespace, name stri
 	for _, r := range refs {
 		if r.point == "" {
 			live = false
-			continue
+			break
 		}
-		ok, perr := probeMounted(ctx, mm.handlers[r.mtype], r.point)
+		ok, perr := probeMounted(ctx, mm.handlers[r.mtype], r.point, canObserveMountTableOS, true)
 		if perr != nil {
 			return true, isV1, false, perr
 		}
@@ -580,26 +580,16 @@ func (mm *mountManager) staleCollision(ctx context.Context, namespace, name stri
 	return true, isV1, live, nil
 }
 
-// probeMounted reports whether path, the mount point of a mounted
-// record, currently has that mount in effect. A handler which
-// implements mount.MountedChecker is asked directly; otherwise the
-// host's mount table is consulted, which is only accurate for a
-// system mount or a handler whose mount point really is a kernel
-// mount; see mount.MountedChecker's doc for why some handlers must
-// implement it instead of relying on this fallback.
-//
-// A path which does not exist at all is reported as not mounted
-// rather than as an error: this is the ordinary state of a mounted
-// record which has never been realized yet.
-//
-// On Windows, the fallback always reports false: mountinfo.Mounted
-// has no implementation there. This is not currently reachable in
-// practice, since nothing this package's own transforms produce on
-// Windows resolves to a managed position at all, but would matter for
-// a handler-less mount activated with WithTemporary, which does.
-func probeMounted(ctx context.Context, handler mount.Handler, path string) (bool, error) {
+// probeMounted reports whether path currently has its mount in
+// effect: via handler's MountedChecker if it implements one,
+// otherwise via the host's mount table if haveMountTable, or
+// assumeLive if not. A missing path is reported as not mounted.
+func probeMounted(ctx context.Context, handler mount.Handler, path string, haveMountTable, assumeLive bool) (bool, error) {
 	if mc, ok := handler.(mount.MountedChecker); ok {
 		return mc.Mounted(ctx, path)
+	}
+	if !haveMountTable {
+		return assumeLive, nil
 	}
 	live, err := mountinfo.Mounted(path)
 	if err != nil {
@@ -626,7 +616,13 @@ func (mm *mountManager) realizeMount(ctx context.Context, rec mountedRecord, han
 		defer mm.mounting.Unlock(key)
 	}
 
-	live, err := probeMounted(ctx, handler, rec.point)
+	for _, ensure := range ensures {
+		if err := ensure.run(ctx); err != nil {
+			return mount.ActiveMount{}, err
+		}
+	}
+
+	live, err := probeMounted(ctx, handler, rec.point, canObserveMountTableOS, !rec.created)
 	if err != nil {
 		return mount.ActiveMount{}, fmt.Errorf("failed to check mount %q: %w", rec.point, err)
 	}
@@ -640,12 +636,6 @@ func (mm *mountManager) realizeMount(ctx context.Context, rec mountedRecord, han
 
 	if err := mm.prepareRecordDir(rec.point, rec.mount.Type, handler == nil); err != nil {
 		return mount.ActiveMount{}, err
-	}
-
-	for _, ensure := range ensures {
-		if err := ensure.run(ctx); err != nil {
-			return mount.ActiveMount{}, err
-		}
 	}
 
 	if handler != nil {
@@ -708,21 +698,37 @@ func alreadyUnmounted(err error) bool {
 func (mm *mountManager) unmountRecords(ctx context.Context, records []mountedRecord) error {
 	var errs []error
 	for _, b := range records {
-		var err error
-		if h := mm.handlers[b.mount.Type]; h != nil {
-			err = h.Unmount(ctx, b.point)
-		} else {
-			err = mount.Unmount(b.point, 0)
-		}
-		if err != nil && !alreadyUnmounted(err) {
-			errs = append(errs, fmt.Errorf("failed to unmount %q: %w", b.point, err))
-			continue
-		}
-		if err := os.RemoveAll(mm.backingRoot(b.id)); err != nil && !os.IsNotExist(err) {
-			log.G(ctx).WithError(err).WithField("backing", b.id).Warn("failed to remove backing mount dir")
+		if err := mm.unmountRecord(ctx, b); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// unmountRecord unmounts and cleans up a single released record,
+// serializing on its identity with realizeMount.
+func (mm *mountManager) unmountRecord(ctx context.Context, b mountedRecord) error {
+	if shareable(b.mount) {
+		key := mountingKey(b.mount)
+		if err := mm.mounting.Lock(ctx, key); err != nil {
+			return err
+		}
+		defer mm.mounting.Unlock(key)
+	}
+
+	var err error
+	if h := mm.handlers[b.mount.Type]; h != nil {
+		err = h.Unmount(ctx, b.point)
+	} else {
+		err = mount.Unmount(b.point, 0)
+	}
+	if err != nil && !alreadyUnmounted(err) {
+		return fmt.Errorf("failed to unmount %q: %w", b.point, err)
+	}
+	if err := os.RemoveAll(mm.backingRoot(b.id)); err != nil && !os.IsNotExist(err) {
+		log.G(ctx).WithError(err).WithField("backing", b.id).Warn("failed to remove backing mount dir")
+	}
+	return nil
 }
 
 func encodeID(id uint64) ([]byte, error) {
@@ -1011,6 +1017,8 @@ func (mm *mountManager) StartCollection(ctx context.Context) (metadata.Collectio
 	// lock now and collection will unlock on cancel or finish
 	mm.rwlock.Lock()
 
+	mounted, haveMountTable := mm.snapshotMountTable(ctx)
+
 	tx, err := mm.db.Begin(true)
 	if err != nil {
 		mm.rwlock.Unlock()
@@ -1018,11 +1026,13 @@ func (mm *mountManager) StartCollection(ctx context.Context) (metadata.Collectio
 	}
 
 	return &collectionContext{
-		ctx:         ctx,
-		tx:          tx,
-		manager:     mm,
-		removed:     map[string]map[string]struct{}{},
-		remainingV1: map[uint64]struct{}{},
+		ctx:            ctx,
+		tx:             tx,
+		manager:        mm,
+		removed:        map[string]map[string]struct{}{},
+		remainingV1:    map[uint64]struct{}{},
+		mounted:        mounted,
+		haveMountTable: haveMountTable,
 	}, nil
 }
 
@@ -1035,6 +1045,12 @@ type collectionContext struct {
 	tx      *bolt.Tx
 	manager *mountManager
 	removed map[string]map[string]struct{}
+
+	// mounted is a snapshot of the host's mount table, taken once in
+	// StartCollection. haveMountTable is false when it cannot be
+	// trusted; see snapshotMountTable.
+	mounted        map[string]struct{}
+	haveMountTable bool
 
 	// Mounted records released during applyRemove; they need
 	// unmounting after the transaction commits.
@@ -1302,7 +1318,7 @@ func (cc *collectionContext) applyRemove() (map[uint64]struct{}, error) {
 				continue
 			}
 			namespace := string(nsk)
-			releasedV1, remainingV1, err := v1ApplyRemoveNamespace(cc.tx, namespace, v1bkt.Bucket(nsk), cc.removed[namespace])
+			releasedV1, remainingV1, err := v1ApplyRemoveNamespace(cc.ctx, cc.manager, cc.tx, namespace, v1bkt.Bucket(nsk), cc.removed[namespace], cc.mounted, cc.haveMountTable)
 			if err != nil {
 				return nil, err
 			}
@@ -1340,7 +1356,15 @@ func (cc *collectionContext) applyRemove() (map[uint64]struct{}, error) {
 				if removed != nil {
 					if _, ok := removed[string(msk)]; ok {
 						remove = append(remove, bytes.Clone(msk))
+						continue
 					}
+				}
+				live, err := activationLive(cc.ctx, cc.manager, nsbkt, msbkt.Bucket(msk), cc.mounted, cc.haveMountTable)
+				if err != nil {
+					return nil, err
+				}
+				if !live {
+					remove = append(remove, bytes.Clone(msk))
 				}
 			}
 

--- a/core/mount/manager/manager.go
+++ b/core/mount/manager/manager.go
@@ -28,8 +28,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
+	"github.com/moby/sys/mountinfo"
 	bolt "go.etcd.io/bbolt"
 
 	"github.com/containerd/errdefs"
@@ -88,9 +90,19 @@ func NewManager(db *bolt.DB, targetDir string, opts ...Opt) (mount.Manager, erro
 	if err := os.MkdirAll(targetDir, 0700); err != nil {
 		return nil, err
 	}
+	// Resolved so it matches the canonical paths the host mount table
+	// reports.
+	targetDir, err := filepath.EvalSymlinks(targetDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve target root %q: %w", targetDir, err)
+	}
 	tr, err := os.OpenRoot(targetDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open target root %q: %w", targetDir, err)
+	}
+	if err := tr.Mkdir(backingDir, 0700); err != nil && !os.IsExist(err) {
+		tr.Close()
+		return nil, fmt.Errorf("failed to create backing dir under %q: %w", targetDir, err)
 	}
 	rootMap := map[string]*os.Root{
 		tr.Name(): tr,
@@ -105,17 +117,30 @@ func NewManager(db *bolt.DB, targetDir string, opts ...Opt) (mount.Manager, erro
 		handlers: options.handlers,
 		rootMap:  rootMap,
 		activate: kmutex.New(),
+		mounting: kmutex.New(),
 	}, nil
 }
 
+// boltDB is the subset of *bolt.DB the manager uses.
+type boltDB interface {
+	Update(func(*bolt.Tx) error) error
+	View(func(*bolt.Tx) error) error
+	Begin(writable bool) (*bolt.Tx, error)
+	Close() error
+}
+
 type mountManager struct {
-	db       *bolt.DB
+	db       boltDB
 	targets  *os.Root
 	handlers map[string]mount.Handler
 	rootMap  map[string]*os.Root
 
 	rwlock   sync.RWMutex
 	activate kmutex.KeyedLocker
+	// mounting serializes resolution and mounting of activations which
+	// resolve to the same mount, keyed by mount identity, so that only
+	// one of them performs the underlying mount.
+	mounting kmutex.KeyedLocker
 }
 
 func (mm *mountManager) Close() error {
@@ -129,19 +154,24 @@ func (mm *mountManager) Close() error {
 	return errors.Join(errs...)
 }
 
+// activationKey combines a namespace and an activation name into one
+// key for mm.activate.
+func activationKey(namespace, name string) string {
+	return namespace + "|" + name
+}
+
 func (mm *mountManager) Activate(ctx context.Context, name string, mounts []mount.Mount, opts ...mount.ActivateOpt) (info mount.ActivationInfo, retErr error) {
 	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return mount.ActivationInfo{}, err
 	}
 
-	// Serialize concurrent activations of the same name to prevent a
-	// racing Activate from misidentifying an in-progress activation as
-	// a stale record and destroying it.
-	if err := mm.activate.Lock(ctx, name); err != nil {
+	// Serializes with a concurrent Activate or Deactivate of the same name.
+	key := activationKey(namespace, name)
+	if err := mm.activate.Lock(ctx, key); err != nil {
 		return mount.ActivationInfo{}, err
 	}
-	defer mm.activate.Unlock(name)
+	defer mm.activate.Unlock(key)
 
 	log.G(ctx).WithField("name", name).WithField("mounts", mounts).Debugf("activating mount")
 
@@ -151,6 +181,10 @@ func (mm *mountManager) Activate(ctx context.Context, name string, mounts []moun
 	for _, opt := range opts {
 		opt(&config)
 	}
+
+	// Transformers rewrite mounts in place; operate on a copy so the
+	// caller's own slice is untouched.
+	mounts = slices.Clone(mounts)
 
 	transforms := map[string]mount.Transformer{
 		"format": mountFormatter{},
@@ -172,46 +206,70 @@ func (mm *mountManager) Activate(ctx context.Context, name string, mounts []moun
 	if firstSystemMount == -1 {
 		return mount.ActivationInfo{}, errdefs.ErrNotImplemented
 	}
+	if firstSystemMount > maxMounts {
+		return mount.ActivationInfo{}, fmt.Errorf("too many mounts (%d): maximum %d: %w", firstSystemMount, maxMounts, errdefs.ErrInvalidArgument)
+	}
 
 	// Get read lock to block GC context from starting
 	mm.rwlock.RLock()
 	defer mm.rwlock.RUnlock()
 
-	var mid uint64
-	var staleMID uint64
+	found, isV1, live, err := mm.staleCollision(ctx, namespace, name)
+	if err != nil {
+		return mount.ActivationInfo{}, err
+	}
+	if found && live {
+		return mount.ActivationInfo{}, fmt.Errorf("mount %q: %w", name, errdefs.ErrAlreadyExists)
+	}
+
+	var (
+		mid uint64
+		// Records released while replacing a stale v2 activation;
+		// unmounted once the transaction below commits.
+		staleRecords []mountedRecord
+		// Set while replacing a stale v1 activation; unmounted once
+		// the transaction below commits.
+		staleV1 *v1Released
+
+		// Populated while resolving the chain below, for the realize
+		// step which follows the transaction.
+		records         = make([]mountedRecord, firstSystemMount)
+		posEnsures      = make([][]deferredEnsure, firstSystemMount)
+		boundaryEnsures []deferredEnsure
+		system          []mount.Mount
+	)
 
 	if err := mm.db.Update(func(tx *bolt.Tx) error {
-		v1bkt, err := tx.CreateBucketIfNotExists([]byte("v1"))
+		v2bkt, err := tx.CreateBucketIfNotExists(bucketKeyV2)
 		if err != nil {
 			return err
 		}
 
-		nsbkt, err := v1bkt.CreateBucketIfNotExists([]byte(namespace))
+		nsbkt, err := v2bkt.CreateBucketIfNotExists([]byte(namespace))
 		if err != nil {
 			return err
 		}
-		mbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyMounts)
+		mbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyActivations)
 		if err != nil {
 			return err
 		}
+
+		if isV1 {
+			positions, v1mid, releasedV1, err := v1Release(tx, namespace, name)
+			if err != nil {
+				return err
+			}
+			if releasedV1 {
+				staleV1 = &v1Released{positions: positions, mid: v1mid}
+			}
+		}
+
 		bkt, err := mbkt.CreateBucket([]byte(name))
 		if err != nil {
 			existing := mbkt.Bucket([]byte(name))
 			if existing == nil {
 				return err
 			}
-			// If the mount is fully activated, return already exists
-			// so the caller can reuse the existing mount.
-			if existing.Bucket(bucketKeyActive) != nil {
-				return fmt.Errorf("mount %q: %w", name, errdefs.ErrAlreadyExists)
-			}
-			// The mount bucket exists but was never fully activated
-			// (e.g., process crashed between creating the bucket and
-			// completing activation). Clean up the stale entry and
-			// proceed with a fresh activation. Save the old mount ID
-			// so the target directory can be cleaned up after the
-			// transaction commits.
-			staleMID = readID(existing)
 			if lid := existing.Get(bucketKeyLease); len(lid) > 0 {
 				if lsbkt := nsbkt.Bucket(bucketKeyLeases); lsbkt != nil {
 					if lbkt := lsbkt.Bucket(lid); lbkt != nil {
@@ -220,6 +278,10 @@ func (mm *mountManager) Activate(ctx context.Context, name string, mounts []moun
 						}
 					}
 				}
+			}
+			staleRecords, err = releaseMountedRecords(tx, namespace, name, activationUses(existing))
+			if err != nil {
+				return err
 			}
 			if err := mbkt.DeleteBucket([]byte(name)); err != nil {
 				return err
@@ -230,7 +292,7 @@ func (mm *mountManager) Activate(ctx context.Context, name string, mounts []moun
 			}
 		}
 
-		mid, err = v1bkt.NextSequence()
+		mid, err = v2bkt.NextSequence()
 		if err != nil {
 			return err
 		}
@@ -269,44 +331,112 @@ func (mm *mountManager) Activate(ctx context.Context, name string, mounts []moun
 			}
 		}
 
-		// TODO: Store mount information including mountpoint
-		// Setup mounts now with generated targets
+		var resolvedActive []mount.ActiveMount
+		for i, m := range mounts[:firstSystemMount] {
+			var chain []mount.Transformer
+			if mountConv != nil {
+				chain = mountConv[i]
+			}
+			rewritten, ensures, err := rewritePosition(ctx, chain, m, resolvedActive)
+			if err != nil {
+				return err
+			}
+			// A position with no Handler is mounted, probed, and
+			// unmounted at its own point, never Target's join of it.
+			if handlers[i] == nil && rewritten.Target != "" {
+				return fmt.Errorf("mount %d: target %q not supported without a handler: %w", i, rewritten.Target, errdefs.ErrInvalidArgument)
+			}
+			mounts[i] = rewritten
+			posEnsures[i] = ensures
+
+			rec, err := resolvePosition(tx, mm.targets.Name(), namespace, name, i, rewritten, start)
+			if err != nil {
+				return err
+			}
+			records[i] = rec
+			resolvedActive = append(resolvedActive, rec.active())
+		}
+
+		system = mounts[firstSystemMount:]
+		if mountConv != nil && firstSystemMount < len(mounts) {
+			rewritten, ensures, err := rewritePosition(ctx, mountConv[firstSystemMount][:plan.applyCount[firstSystemMount]], mounts[firstSystemMount], resolvedActive)
+			if err != nil {
+				return err
+			}
+			system = append([]mount.Mount{rewritten}, mounts[firstSystemMount+1:]...)
+			boundaryEnsures = ensures
+		}
+		// If no system mounts, add a bind mount if temporary
+		// TODO: Add config for whether to add the bind mount?
+		if config.Temporary && firstSystemMount > 0 {
+			system = append(system, mount.Mount{
+				Type:    "bind",
+				Source:  resolvedActive[firstSystemMount-1].MountPoint,
+				Options: []string{"rbind"},
+			})
+		}
+
+		if len(system) > 0 {
+			if len(system) > maxMounts {
+				return fmt.Errorf("too many system mounts (%d): maximum %d: %w", len(system), maxMounts, errdefs.ErrInvalidArgument)
+			}
+			sbkt, err := bkt.CreateBucket(bucketKeySystem)
+			if err != nil {
+				return err
+			}
+			for i, sm := range system {
+				cur, err := sbkt.CreateBucket([]byte{byte(i)})
+				if err != nil {
+					return err
+				}
+				if err = putSystemMount(cur, sm); err != nil {
+					return err
+				}
+			}
+		}
+
+		// Persist the boundary mount's ensure targets; see staleCollision.
+		if len(boundaryEnsures) > 0 {
+			var targets []string
+			for _, ensure := range boundaryEnsures {
+				targets = append(targets, ensure.targets...)
+			}
+			if err := bkt.Put(bucketKeyEnsureTargets, []byte(strings.Join(targets, "\x00"))); err != nil {
+				return err
+			}
+		}
 
 		return nil
 	}); err != nil {
 		return mount.ActivationInfo{}, err
 	}
 
-	// If a stale incomplete activation was found, clean up its target
-	// directory which may contain leftover mounts from before a crash.
-	if staleMID != 0 {
-		staleTarget := filepath.Join(mm.targets.Name(), strconv.FormatUint(staleMID, 10))
-		if err := unmountAll(ctx, staleTarget, mm.handlers); err != nil {
-			if os.IsNotExist(err) {
-				log.G(ctx).WithError(err).WithField("mountid", staleMID).Debug("stale activation target does not exist, skipping cleanup")
-			} else {
-				log.G(ctx).WithError(err).WithField("mountid", staleMID).Warn("failed to unmount stale activation target")
-			}
+	if len(staleRecords) > 0 {
+		if err := mm.unmountRecords(ctx, staleRecords); err != nil {
+			log.G(ctx).WithError(err).WithField("name", name).Warn("failed to clean up stale activation mounts")
+		}
+	}
+	if staleV1 != nil {
+		if err := mm.v1Unmount(ctx, staleV1.positions, staleV1.mid); err != nil {
+			log.G(ctx).WithError(err).WithField("name", name).Warn("failed to clean up stale v1 activation mounts")
 		}
 	}
 
 	defer func() {
-		// If error, rollback and remove by name
+		// This defer only has work to do once the transaction above
+		// commits: a failure inside it rolls the transaction back on
+		// its own and reaches here with nothing left to release.
 		if retErr != nil {
+			var orphaned []mountedRecord
 			if err := mm.db.Update(func(tx *bolt.Tx) error {
-				v1bkt := tx.Bucket([]byte("v1"))
-				if v1bkt == nil {
-					return fmt.Errorf("missing bucket: %w", errdefs.ErrUnknown)
-				}
-
-				nsbkt := v1bkt.Bucket([]byte(namespace))
+				nsbkt := getBucket(tx, bucketKeyV2, []byte(namespace))
 				if nsbkt == nil {
 					return fmt.Errorf("missing namespace %q bucket: %w", namespace, errdefs.ErrUnknown)
 				}
 
-				mbkt := nsbkt.Bucket(bucketKeyMounts)
+				mbkt := nsbkt.Bucket(bucketKeyActivations)
 				if mbkt == nil {
-					return fmt.Errorf("missing mounts bucket: %w", errdefs.ErrUnknown)
+					return fmt.Errorf("missing activations bucket: %w", errdefs.ErrUnknown)
 				}
 
 				if leased {
@@ -320,195 +450,279 @@ func (mm *mountManager) Activate(ctx context.Context, name string, mounts []moun
 							lsbkt.DeleteBucket([]byte(lid))
 						}
 					}
+				}
 
+				bkt := mbkt.Bucket([]byte(name))
+				if bkt == nil {
+					return nil
+				}
+
+				var err error
+				orphaned, err = releaseMountedRecords(tx, namespace, name, activationUses(bkt))
+				if err != nil {
+					return err
 				}
 
 				return mbkt.DeleteBucket([]byte(name))
 			}); err != nil {
 				log.G(ctx).WithError(err).WithField("name", name).Errorf("failed to rollback")
 			}
-		}
-	}()
-
-	targetName := strconv.FormatUint(mid, 10)
-	if err := mm.targets.Mkdir(targetName, 0700); err != nil {
-		return mount.ActivationInfo{}, err
-	}
-
-	var mounted []mount.ActiveMount
-	defer func() {
-		// If error, unmount all mounted
-		if retErr != nil {
-			for i, m := range mounted {
-				var err error
-				if h := handlers[i]; h != nil {
-					err = h.Unmount(ctx, m.MountPoint)
-				} else {
-					err = mount.Unmount(m.MountPoint, 0)
-				}
-				if err != nil {
-					log.G(ctx).WithError(err).WithField("MountPoint", m.MountPoint).Error("failed to cleanup mount after failed activation")
-				}
+			if err := mm.unmountRecords(ctx, orphaned); err != nil {
+				log.G(ctx).WithError(err).WithField("name", name).Error("failed to cleanup mounts after failed activation")
 			}
 		}
 	}()
 
-	// Ensure directory order for cleanup when rare case of large number of mounts,
-	// this allows cleanup logic to just scan directories on cleanup.
-	formatMP := "%d"
-	formatType := "%d-type"
-	if firstSystemMount > 100 {
-		formatMP = "%03d"
-		formatType = "%03d-type"
-	} else if firstSystemMount > 10 {
-		formatMP = "%02d"
-		formatType = "%02d-type"
-	}
-
-	for i, m := range mounts[:firstSystemMount] {
-		if mountConv != nil && mountConv[i] != nil {
-			for _, tr := range mountConv[i] {
-				newM, err := tr.Transform(ctx, m, mounted)
-				if err != nil {
-					return mount.ActivationInfo{}, err
-				}
-				m = newM
-			}
-			mounts[i] = m
-		}
-
-		// Use cleanup order for directory names
-		ci := firstSystemMount - i
-		// TODO: Go 1.25 use targetbase.WriteFile
-		if err := os.WriteFile(filepath.Join(mm.targets.Name(), targetName, fmt.Sprintf(formatType, ci)), []byte(m.Type), 0600); err != nil {
+	var active []mount.ActiveMount
+	for i, rec := range records {
+		am, err := mm.realizeMount(ctx, rec, handlers[i], posEnsures[i], active)
+		if err != nil {
 			return mount.ActivationInfo{}, err
 		}
-
-		mname := fmt.Sprintf(formatMP, ci)
-		var active mount.ActiveMount
-		if h := handlers[i]; h != nil {
-			active, err = h.Mount(ctx, m, filepath.Join(mm.targets.Name(), targetName, mname), mounted)
-			if err != nil {
-				return mount.ActivationInfo{}, fmt.Errorf("mount handler failed %v: %w", m, err)
-			}
-		} else {
-			if err := mm.targets.Mkdir(filepath.Join(targetName, mname), 0700); err != nil {
-				return mount.ActivationInfo{}, err
-			}
-			mp := filepath.Join(mm.targets.Name(), targetName, mname)
-			if err := m.Mount(mp); err != nil {
-				return mount.ActivationInfo{}, fmt.Errorf("mount failed %v: %w", m, err)
-			}
-			t := time.Now()
-			active = mount.ActiveMount{
-				Mount:      m,
-				MountPoint: mp,
-				MountedAt:  &t,
-			}
-		}
-		mounted = append(mounted, active)
+		active = append(active, am)
 	}
 
-	// If the first system mount has transforms, apply the ones the caller
-	// has not claimed. A claim can only be honored as a suffix of the
-	// chain: applyCount always covers at least every transform up to and
-	// including the last unclaimed one, since each depends on the last's
-	// output; see planActivation.
-	//
-	// firstSystemMount can reach len(mounts) when every mount is handled
-	// inside the manager (for example, every mount claimed via Temporary);
-	// there is then no system mount left to transform.
-	if mountConv != nil && firstSystemMount < len(mounts) {
-		for _, tr := range mountConv[firstSystemMount][:plan.applyCount[firstSystemMount]] {
-			newM, err := tr.Transform(ctx, mounts[firstSystemMount], mounted)
-			if err != nil {
-				return mount.ActivationInfo{}, err
-			}
-			mounts[firstSystemMount] = newM
+	for _, ensure := range boundaryEnsures {
+		if err := ensure.run(ctx); err != nil {
+			return mount.ActivationInfo{}, err
 		}
-	}
-	// If no system mounts, add a bind mount if temporary
-	// TODO: Add config for whether to add the bind mount?
-	if config.Temporary && firstSystemMount > 0 {
-		mounts = append(mounts, mount.Mount{
-			Type:    "bind",
-			Source:  mounted[firstSystemMount-1].MountPoint,
-			Options: []string{"rbind"},
-		})
 	}
 
 	info.Name = name
-	info.Active = mounted
-	info.System = mounts[firstSystemMount:]
+	info.Active = active
+	info.System = system
 	info.Labels = config.Labels
 
-	// Open another write transaction and update state, or another way to update state?
-	if err := mm.db.Update(func(tx *bolt.Tx) error {
-		v1bkt := tx.Bucket([]byte("v1"))
-		if v1bkt == nil {
-			return fmt.Errorf("missing v1 bucket: %w", errdefs.ErrUnknown)
+	return
+}
+
+// staleCollision reports whether an activation named name exists, in
+// either schema, and whether it is still live: every managed position
+// mounted, and, for v2, every recorded ensure target present.
+func (mm *mountManager) staleCollision(ctx context.Context, namespace, name string) (found, isV1, live bool, err error) {
+	type ref struct {
+		mtype string
+		point string
+	}
+	var (
+		refs          []ref
+		vacuousLive   bool
+		ensureTargets []string
+	)
+	if err := mm.db.View(func(tx *bolt.Tx) error {
+		if bkt := getBucket(tx, bucketKeyV2, []byte(namespace), bucketKeyActivations, []byte(name)); bkt != nil {
+			found = true
+			vacuousLive = true
+			if v := bkt.Get(bucketKeyEnsureTargets); len(v) > 0 {
+				ensureTargets = strings.Split(string(v), "\x00")
+			}
+			nsbkt := getBucket(tx, bucketKeyV2, []byte(namespace))
+			for _, id := range activationUses(bkt) {
+				b, ok, rerr := getMountedRecord(nsbkt, mountedKey(id))
+				if rerr != nil {
+					return rerr
+				}
+				if !ok {
+					// Should not be reachable; treat as stale.
+					refs = append(refs, ref{})
+					continue
+				}
+				refs = append(refs, ref{mtype: b.mount.Type, point: b.point})
+			}
+			return nil
 		}
 
-		nsbkt := v1bkt.Bucket([]byte(namespace))
-		if nsbkt == nil {
-			return fmt.Errorf("missing namespace %q bucket: %w", namespace, errdefs.ErrUnknown)
-		}
-
-		mbkt := nsbkt.Bucket(bucketKeyMounts)
-		if mbkt == nil {
-			return fmt.Errorf("missing mounts bucket: %w", errdefs.ErrUnknown)
-		}
-		bkt := mbkt.Bucket([]byte(name))
+		bkt := getBucket(tx, bucketKeyV1, []byte(namespace), v1KeyMounts, []byte(name))
 		if bkt == nil {
-			return fmt.Errorf("missing mount %q bucket: %w", name, errdefs.ErrUnknown)
+			return nil
 		}
-
-		abkt, err := bkt.CreateBucket(bucketKeyActive)
-		if err != nil {
-			return err
+		found = true
+		isV1 = true
+		vacuousLive = v1HasActive(bkt)
+		for _, p := range v1Positions(bkt) {
+			refs = append(refs, ref{mtype: p.mtype, point: p.point})
 		}
-
-		for i, active := range mounted {
-			// Error is i > uint8 max
-			cur, err := abkt.CreateBucket([]byte{byte(i)})
-			if err != nil {
-				return err
-			}
-			if err = putActiveMount(cur, active); err != nil {
-				return err
-			}
-
-		}
-
-		if err := boltutil.WriteTimestamps(bkt, start, time.Now()); err != nil {
-			return err
-		}
-
-		if len(info.System) > 0 {
-			if len(info.System) > 255 {
-				return fmt.Errorf("too many system mounts (%d): maximum 255", len(info.System))
-			}
-			sbkt, err := bkt.CreateBucket(bucketKeySystem)
-			if err != nil {
-				return err
-			}
-			for i, sm := range info.System {
-				cur, err := sbkt.CreateBucket([]byte{byte(i)})
-				if err != nil {
-					return err
-				}
-				if err = putSystemMount(cur, sm); err != nil {
-					return err
-				}
-			}
-		}
-
 		return nil
 	}); err != nil {
-		return mount.ActivationInfo{}, err
+		return false, false, false, err
+	}
+	if !found {
+		return false, false, false, nil
 	}
 
-	return
+	live = vacuousLive
+	for _, r := range refs {
+		if r.point == "" {
+			live = false
+			continue
+		}
+		ok, perr := probeMounted(ctx, mm.handlers[r.mtype], r.point)
+		if perr != nil {
+			return true, isV1, false, perr
+		}
+		if !ok {
+			live = false
+			break
+		}
+	}
+	for _, target := range ensureTargets {
+		if !live {
+			break
+		}
+		if _, err := os.Stat(target); err != nil {
+			if !os.IsNotExist(err) {
+				return true, isV1, false, err
+			}
+			live = false
+		}
+	}
+
+	return true, isV1, live, nil
+}
+
+// probeMounted reports whether path, the mount point of a mounted
+// record, currently has that mount in effect. A handler which
+// implements mount.MountedChecker is asked directly; otherwise the
+// host's mount table is consulted, which is only accurate for a
+// system mount or a handler whose mount point really is a kernel
+// mount; see mount.MountedChecker's doc for why some handlers must
+// implement it instead of relying on this fallback.
+//
+// A path which does not exist at all is reported as not mounted
+// rather than as an error: this is the ordinary state of a mounted
+// record which has never been realized yet.
+//
+// On Windows, the fallback always reports false: mountinfo.Mounted
+// has no implementation there. This is not currently reachable in
+// practice, since nothing this package's own transforms produce on
+// Windows resolves to a managed position at all, but would matter for
+// a handler-less mount activated with WithTemporary, which does.
+func probeMounted(ctx context.Context, handler mount.Handler, path string) (bool, error) {
+	if mc, ok := handler.(mount.MountedChecker); ok {
+		return mc.Mounted(ctx, path)
+	}
+	live, err := mountinfo.Mounted(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return live, nil
+}
+
+// realizeMount ensures rec's mount is in effect, mounting it if
+// needed, and returns it as an ActiveMount. active holds earlier
+// realized positions in the same chain; concurrent activations
+// resolving to the same identity serialize here. ensures always run,
+// even on a reused record, since mount identity excludes the
+// mkdir/mkfs options they validate or create.
+func (mm *mountManager) realizeMount(ctx context.Context, rec mountedRecord, handler mount.Handler, ensures []deferredEnsure, active []mount.ActiveMount) (mount.ActiveMount, error) {
+	if shareable(rec.mount) {
+		key := mountingKey(rec.mount)
+		if err := mm.mounting.Lock(ctx, key); err != nil {
+			return mount.ActiveMount{}, err
+		}
+		defer mm.mounting.Unlock(key)
+	}
+
+	live, err := probeMounted(ctx, handler, rec.point)
+	if err != nil {
+		return mount.ActiveMount{}, fmt.Errorf("failed to check mount %q: %w", rec.point, err)
+	}
+	if live {
+		log.G(ctx).WithFields(log.Fields{
+			"mounted":    rec.id,
+			"mountpoint": rec.point,
+		}).Debug("reusing mounted record")
+		return rec.active(), nil
+	}
+
+	if err := mm.prepareRecordDir(rec.point, rec.mount.Type, handler == nil); err != nil {
+		return mount.ActiveMount{}, err
+	}
+
+	for _, ensure := range ensures {
+		if err := ensure.run(ctx); err != nil {
+			return mount.ActiveMount{}, err
+		}
+	}
+
+	if handler != nil {
+		am, err := handler.Mount(ctx, rec.mount, rec.point, active)
+		if err != nil {
+			return mount.ActiveMount{}, fmt.Errorf("mount handler failed %v: %w", rec.mount, err)
+		}
+		return am, nil
+	}
+	if err := rec.mount.Mount(rec.point); err != nil {
+		return mount.ActiveMount{}, fmt.Errorf("mount failed %v: %w", rec.mount, err)
+	}
+
+	return rec.active(), nil
+}
+
+// prepareRecordDir creates the parent directory of point and a type
+// file recording mountType, and, if createMountPoint, the mount point
+// itself.
+func (mm *mountManager) prepareRecordDir(point, mountType string, createMountPoint bool) error {
+	rel, err := filepath.Rel(mm.targets.Name(), point)
+	if err != nil {
+		return fmt.Errorf("mount point %q outside target root: %w", point, err)
+	}
+	dir := filepath.Dir(rel)
+	if err := mm.targets.Mkdir(dir, 0700); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("failed to create mounted record dir: %w", err)
+	}
+	typePath := filepath.Join(dir, typeFileName)
+	f, err := mm.targets.OpenFile(typePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	_, werr := f.Write([]byte(mountType))
+	if werr == nil {
+		werr = f.Sync()
+	}
+	if cerr := f.Close(); werr == nil {
+		werr = cerr
+	}
+	if werr != nil {
+		return fmt.Errorf("failed to write type file %q: %w", typePath, werr)
+	}
+	if createMountPoint {
+		if err := mm.targets.Mkdir(rel, 0700); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create mount point: %w", err)
+		}
+	}
+	return nil
+}
+
+// alreadyUnmounted reports whether an unmount error means there was
+// nothing mounted at the path.
+func alreadyUnmounted(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOTDIR)
+}
+
+// unmountRecords unmounts and removes the directories of released
+// records, in the order given.
+func (mm *mountManager) unmountRecords(ctx context.Context, records []mountedRecord) error {
+	var errs []error
+	for _, b := range records {
+		var err error
+		if h := mm.handlers[b.mount.Type]; h != nil {
+			err = h.Unmount(ctx, b.point)
+		} else {
+			err = mount.Unmount(b.point, 0)
+		}
+		if err != nil && !alreadyUnmounted(err) {
+			errs = append(errs, fmt.Errorf("failed to unmount %q: %w", b.point, err))
+			continue
+		}
+		if err := os.RemoveAll(mm.backingRoot(b.id)); err != nil && !os.IsNotExist(err) {
+			log.G(ctx).WithError(err).WithField("backing", b.id).Warn("failed to remove backing mount dir")
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func encodeID(id uint64) ([]byte, error) {
@@ -522,52 +736,6 @@ func encodeID(id uint64) ([]byte, error) {
 		return nil, fmt.Errorf("failed encoding id = %v", id)
 	}
 	return idEncoded, nil
-}
-
-func readID(bkt *bolt.Bucket) uint64 {
-	id, _ := binary.Uvarint(bkt.Get(bucketKeyID))
-	return id
-}
-
-func putActiveMount(bkt *bolt.Bucket, active mount.ActiveMount) error {
-	if err := bkt.Put(bucketKeyType, []byte(active.Type)); err != nil {
-		return err
-	}
-
-	// TODO: Same if device?
-	if err := bkt.Put(bucketKeyMountPoint, []byte(active.MountPoint)); err != nil {
-		return err
-	}
-
-	mountedAt, err := active.MountedAt.MarshalBinary()
-	if err != nil {
-		return err
-	}
-	if err := bkt.Put(bucketKeyMountedAt, mountedAt); err != nil {
-		return err
-	}
-
-	// TODO: Add Source
-	// TODO: Add Target
-	// TODO: Add Options
-
-	return nil
-}
-
-func readActiveMount(bkt *bolt.Bucket) (mount.ActiveMount, error) {
-	var active mount.ActiveMount
-	active.Type = string(bkt.Get(bucketKeyType))
-	active.MountPoint = string(bkt.Get(bucketKeyMountPoint))
-	if v := bkt.Get(bucketKeyMountedAt); v != nil {
-		var mountedAt time.Time
-		if err := mountedAt.UnmarshalBinary(v); err != nil {
-			// TODO: Should this be skipped or otherwise logged and ignored?
-			return mount.ActiveMount{}, err
-		}
-		active.MountedAt = &mountedAt
-	}
-
-	return active, nil
 }
 
 func putSystemMount(bkt *bolt.Bucket, m mount.Mount) error {
@@ -600,17 +768,28 @@ func readSystemMount(bkt *bolt.Bucket) mount.Mount {
 	return m
 }
 
-func readActivationInfo(name string, bkt *bolt.Bucket) (mount.ActivationInfo, error) {
+// readActivationInfo builds the activation info for a mount, resolving
+// the mounted record for each position in its chain. nsbkt is the
+// namespace bucket holding the mounted records.
+func readActivationInfo(nsbkt *bolt.Bucket, name string, bkt *bolt.Bucket) (mount.ActivationInfo, error) {
 	info := mount.ActivationInfo{
 		Name: name,
 	}
 	if abkt := bkt.Bucket(bucketKeyActive); abkt != nil {
 		if err := abkt.ForEachBucket(func(k []byte) error {
-			active, err := readActiveMount(abkt.Bucket(k))
+			key := abkt.Bucket(k).Get(bucketKeyMountID)
+			if len(key) == 0 {
+				return nil
+			}
+			b, ok, err := getMountedRecord(nsbkt, key)
 			if err != nil {
 				return err
 			}
-			info.Active = append(info.Active, active)
+			if !ok {
+				// Should not be reachable; skip rather than fail.
+				return nil
+			}
+			info.Active = append(info.Active, b.active())
 			return nil
 		}); err != nil {
 			return mount.ActivationInfo{}, err
@@ -639,7 +818,11 @@ func getBucket(tx *bolt.Tx, keys ...[]byte) *bolt.Bucket {
 		return nil
 	}
 
-	for _, key := range keys[1:] {
+	return getSubBucket(bkt, keys[1:]...)
+}
+
+func getSubBucket(bkt *bolt.Bucket, keys ...[]byte) *bolt.Bucket {
+	for _, key := range keys {
 		bkt = bkt.Bucket(key)
 		if bkt == nil {
 			return nil
@@ -655,94 +838,77 @@ func (mm *mountManager) Deactivate(ctx context.Context, name string) error {
 		return err
 	}
 
+	// Serializes with a concurrent Activate of the same name.
+	key := activationKey(namespace, name)
+	if err := mm.activate.Lock(ctx, key); err != nil {
+		return err
+	}
+	defer mm.activate.Unlock(key)
+
+	// Get read lock to block GC context from starting
+	mm.rwlock.RLock()
+	defer mm.rwlock.RUnlock()
+
 	var (
-		mid       uint64
-		allActive []mount.ActiveMount
+		released []mountedRecord
+		v1pos    []v1Position
+		v1mid    uint64
+		isV1     bool
+		found    bool
 	)
 
-	// First in a single transaction, mark the mounts as deactivated
 	if err := mm.db.Update(func(tx *bolt.Tx) error {
-		v1bkt := tx.Bucket([]byte("v1"))
-		if v1bkt == nil {
-			return fmt.Errorf("missing v1 bucket: %w", errdefs.ErrNotFound)
-		}
+		bkt := getBucket(tx, bucketKeyV2, []byte(namespace), bucketKeyActivations, []byte(name))
+		if bkt != nil {
+			found = true
+			nsbkt := getBucket(tx, bucketKeyV2, []byte(namespace))
+			mbkt := nsbkt.Bucket(bucketKeyActivations)
 
-		nsbkt := v1bkt.Bucket([]byte(namespace))
-		if nsbkt == nil {
-			return fmt.Errorf("missing namespace %q bucket: %w", namespace, errdefs.ErrNotFound)
-		}
-
-		mbkt := nsbkt.Bucket(bucketKeyMounts)
-		if mbkt == nil {
-			return fmt.Errorf("missing mounts bucket: %w", errdefs.ErrNotFound)
-		}
-		bkt := mbkt.Bucket([]byte(name))
-		if bkt == nil {
-			return fmt.Errorf("missing mount %q bucket: %w", name, errdefs.ErrNotFound)
-		}
-
-		mid = readID(bkt)
-
-		lid := bkt.Get(bucketKeyLease)
-		if lid != nil {
-			lssbkt := nsbkt.Bucket(bucketKeyLeases)
-			if lssbkt != nil {
-				lsbkt := lssbkt.Bucket(lid)
-				if lsbkt != nil {
-					if err = lsbkt.Delete([]byte(name)); err != nil {
+			lid := bkt.Get(bucketKeyLease)
+			if len(lid) > 0 {
+				if lsbkt := getSubBucket(nsbkt, bucketKeyLeases, lid); lsbkt != nil {
+					if err := lsbkt.Delete([]byte(name)); err != nil {
 						return err
 					}
 				}
 			}
+
+			var err error
+			released, err = releaseMountedRecords(tx, namespace, name, activationUses(bkt))
+			if err != nil {
+				return err
+			}
+
+			return mbkt.DeleteBucket([]byte(name))
 		}
 
-		abkt := bkt.Bucket(bucketKeyActive)
-		if abkt != nil {
-			abkt.ForEachBucket(func(k []byte) error {
-				active, err := readActiveMount(abkt.Bucket(k))
-				if err != nil {
-					return err
-				}
-				allActive = append(allActive, active)
-				return nil
-			})
-		}
-
-		if err = mbkt.DeleteBucket([]byte(name)); err != nil {
+		positions, mid, ok, err := v1Release(tx, namespace, name)
+		if err != nil {
 			return err
 		}
-
-		// TODO: Is unmountq really needed or just delete?
-
+		if ok {
+			found = true
+			isV1 = true
+			v1pos = positions
+			v1mid = mid
+		}
 		return nil
 	}); err != nil {
 		return err
 	}
 
-	// TODO: Should this also be backgrounded, no much can do on failure to unmount
-	var mountErrors error
-	for _, active := range slices.Backward(allActive) {
-		var err error
-		if h := mm.handlers[active.Type]; h != nil {
-			err = h.Unmount(ctx, active.MountPoint)
-		} else {
-			err = mount.Unmount(active.MountPoint, 0)
-		}
-		if err != nil {
-			mountErrors = errors.Join(mountErrors, err)
-		}
-	}
-	if mountErrors != nil {
-		// Don't try to cleanup, GC will need to do the rest
-		return mountErrors
+	if !found {
+		return fmt.Errorf("mount %q: %w", name, errdefs.ErrNotFound)
 	}
 
-	// Run in background, GC would handle leftovers?
-	// Make configurable?
-	// TODO: In go 1.25, use mm.targets.RemoveAll()
-	if err := os.RemoveAll(filepath.Join(mm.targets.Name(), fmt.Sprintf("%d", mid))); err != nil {
-		// TODO: Only log here, cleanup would have to occur later
-		log.G(ctx).WithError(err).WithField("mountid", mid).Error("failed to cleanup mount target")
+	if isV1 {
+		return mm.v1Unmount(ctx, v1pos, v1mid)
+	}
+
+	// TODO: Should this also be backgrounded, not much can be done on failure to unmount
+	if err := mm.unmountRecords(ctx, released); err != nil {
+		// Don't try to cleanup, GC will need to do the rest
+		return err
 	}
 
 	return nil
@@ -753,19 +919,30 @@ func (mm *mountManager) Info(ctx context.Context, name string) (mount.Activation
 	if err != nil {
 		return mount.ActivationInfo{}, err
 	}
+
 	var info mount.ActivationInfo
 	if err := mm.db.View(func(tx *bolt.Tx) error {
-		bkt := getBucket(tx, []byte("v1"), []byte(namespace), bucketKeyMounts, []byte(name))
-		if bkt == nil {
-			return fmt.Errorf("mount %q %w", name, errdefs.ErrNotFound)
-		}
 		var err error
-		info, err = readActivationInfo(name, bkt)
+		info, err = infoFromTx(tx, namespace, name)
 		return err
 	}); err != nil {
 		return mount.ActivationInfo{}, err
 	}
 	return info, nil
+}
+
+// infoFromTx reads a single activation's info from either schema,
+// from an already open transaction.
+func infoFromTx(tx *bolt.Tx, namespace, name string) (mount.ActivationInfo, error) {
+	if nsbkt := getBucket(tx, bucketKeyV2, []byte(namespace)); nsbkt != nil {
+		if bkt := getSubBucket(nsbkt, bucketKeyActivations, []byte(name)); bkt != nil {
+			return readActivationInfo(nsbkt, name, bkt)
+		}
+	}
+	if bkt := getBucket(tx, bucketKeyV1, []byte(namespace), v1KeyMounts, []byte(name)); bkt != nil {
+		return v1ActivationInfo(name, bkt)
+	}
+	return mount.ActivationInfo{}, fmt.Errorf("mount %q %w", name, errdefs.ErrNotFound)
 }
 
 func (mm *mountManager) Update(context.Context, mount.ActivationInfo, ...string) (mount.ActivationInfo, error) {
@@ -780,22 +957,53 @@ func (mm *mountManager) List(ctx context.Context, filters ...string) ([]mount.Ac
 
 	var infos []mount.ActivationInfo
 	if err := mm.db.View(func(tx *bolt.Tx) error {
-		mbkt := getBucket(tx, []byte("v1"), []byte(namespace), bucketKeyMounts)
-		if mbkt == nil {
-			return nil
-		}
+		var err error
+		infos, err = listFromTx(tx, namespace)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return infos, nil
+}
 
-		return mbkt.ForEachBucket(func(k []byte) error {
-			info, err := readActivationInfo(string(k), mbkt.Bucket(k))
+// listFromTx reads every activation in a namespace, from both
+// schemas, from an already open transaction.
+func listFromTx(tx *bolt.Tx, namespace string) ([]mount.ActivationInfo, error) {
+	var infos []mount.ActivationInfo
+	seen := map[string]struct{}{}
+
+	if nsbkt := getBucket(tx, bucketKeyV2, []byte(namespace)); nsbkt != nil {
+		if mbkt := nsbkt.Bucket(bucketKeyActivations); mbkt != nil {
+			if err := mbkt.ForEachBucket(func(k []byte) error {
+				info, err := readActivationInfo(nsbkt, string(k), mbkt.Bucket(k))
+				if err != nil {
+					return err
+				}
+				infos = append(infos, info)
+				seen[string(k)] = struct{}{}
+				return nil
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if v1mbkt := getBucket(tx, bucketKeyV1, []byte(namespace), v1KeyMounts); v1mbkt != nil {
+		if err := v1mbkt.ForEachBucket(func(k []byte) error {
+			if _, ok := seen[string(k)]; ok {
+				return nil
+			}
+			info, err := v1ActivationInfo(string(k), v1mbkt.Bucket(k))
 			if err != nil {
 				return err
 			}
 			infos = append(infos, info)
 			return nil
-		})
-	}); err != nil {
-		return nil, err
+		}); err != nil {
+			return nil, err
+		}
 	}
+
 	return infos, nil
 }
 
@@ -805,14 +1013,16 @@ func (mm *mountManager) StartCollection(ctx context.Context) (metadata.Collectio
 
 	tx, err := mm.db.Begin(true)
 	if err != nil {
+		mm.rwlock.Unlock()
 		return nil, err
 	}
 
 	return &collectionContext{
-		ctx:     ctx,
-		tx:      tx,
-		manager: mm,
-		removed: map[string]map[string]struct{}{},
+		ctx:         ctx,
+		tx:          tx,
+		manager:     mm,
+		removed:     map[string]map[string]struct{}{},
+		remainingV1: map[uint64]struct{}{},
 	}, nil
 }
 
@@ -825,34 +1035,52 @@ type collectionContext struct {
 	tx      *bolt.Tx
 	manager *mountManager
 	removed map[string]map[string]struct{}
+
+	// Mounted records released during applyRemove; they need
+	// unmounting after the transaction commits.
+	released []mountedRecord
+	// v1 activations released during applyRemove; they need
+	// unmounting after the transaction commits, the same as released
+	// above but through v1Unmount instead of unmountRecords.
+	releasedV1 []v1Released
+	// The mid of every v1 activation, across every namespace, which
+	// survives applyRemove, so the v1 orphan directory scan in Finish
+	// does not mistake its directory for one nothing references.
+	remainingV1 map[uint64]struct{}
 }
 
 func (cc *collectionContext) All(fn func(gc.Node)) {
-	v1bkt := cc.tx.Bucket([]byte("v1"))
-	if v1bkt == nil {
-		return
-	}
-	nsc := v1bkt.Cursor()
-	for nsk, nsv := nsc.First(); nsk != nil; nsk, nsv = nsc.Next() {
-		if nsv != nil {
-			continue
-		}
-		mntsbkt := v1bkt.Bucket(nsk).Bucket(bucketKeyMounts)
-		if mntsbkt == nil {
-			continue
-		}
-		mc := mntsbkt.Cursor()
-		for mk, mv := mc.First(); mk != nil; mk, mv = mc.Next() {
-			if mv != nil {
+	if v2bkt := cc.tx.Bucket(bucketKeyV2); v2bkt != nil {
+		nsc := v2bkt.Cursor()
+		for nsk, nsv := nsc.First(); nsk != nil; nsk, nsv = nsc.Next() {
+			if nsv != nil {
 				continue
 			}
-			fn(gc.Node{
-				Type:      metadata.ResourceMount,
-				Namespace: string(nsk),
-				Key:       string(mk),
-			})
+			actbkt := v2bkt.Bucket(nsk).Bucket(bucketKeyActivations)
+			if actbkt == nil {
+				continue
+			}
+			mc := actbkt.Cursor()
+			for mk, mv := mc.First(); mk != nil; mk, mv = mc.Next() {
+				if mv != nil {
+					continue
+				}
+				fn(gc.Node{
+					Type:      metadata.ResourceMount,
+					Namespace: string(nsk),
+					Key:       string(mk),
+				})
+			}
 		}
 	}
+
+	v1All(cc.tx, func(namespace, name string) {
+		fn(gc.Node{
+			Type:      metadata.ResourceMount,
+			Namespace: namespace,
+			Key:       name,
+		})
+	})
 }
 
 func gcnode(t gc.ResourceType, ns, key string) gc.Node {
@@ -863,78 +1091,94 @@ func gcnode(t gc.ResourceType, ns, key string) gc.Node {
 	}
 }
 
+// scanBackRefLabels reports every gc.bref.* label on a mount's labels
+// bucket to bref, associating the resource it names with n.
+func scanBackRefLabels(lbkt *bolt.Bucket, ns string, n gc.Node, bref func(gc.Node, gc.Node)) {
+	if lbkt == nil {
+		return
+	}
+	lc := lbkt.Cursor()
+	for _, h := range []struct {
+		key     []byte
+		handler func([]byte, []byte)
+	}{
+		{
+			key: labelGCContainerBackRef,
+			handler: func(k, v []byte) {
+				if ks := string(k); ks != string(labelGCContainerBackRef) {
+					// Allow reference naming separated by . or /, ignore names
+					if ks[len(labelGCContainerBackRef)] != '.' && ks[len(labelGCContainerBackRef)] != '/' {
+						return
+					}
+				}
+
+				bref(gcnode(metadata.ResourceContainer, ns, string(v)), n)
+			},
+		},
+		{
+			key: labelGCContentBackRef,
+			handler: func(k, v []byte) {
+				if ks := string(k); ks != string(labelGCContentBackRef) {
+					// Allow reference naming separated by . or /, ignore names
+					if ks[len(labelGCContentBackRef)] != '.' && ks[len(labelGCContentBackRef)] != '/' {
+						return
+					}
+				}
+
+				bref(gcnode(metadata.ResourceContent, ns, string(v)), n)
+			},
+		},
+		{
+			key: labelGCImageBackRef,
+			handler: func(k, v []byte) {
+				if ks := string(k); ks != string(labelGCImageBackRef) {
+					// Allow reference naming separated by . or /, ignore names
+					if ks[len(labelGCImageBackRef)] != '.' && ks[len(labelGCImageBackRef)] != '/' {
+						return
+					}
+				}
+
+				bref(gcnode(metadata.ResourceImage, ns, string(v)), n)
+			},
+		},
+		{
+			key: labelGCSnapBackRef,
+			handler: func(k, v []byte) {
+				snapshotter := k[len(labelGCSnapBackRef):]
+				if i := bytes.IndexByte(snapshotter, '/'); i >= 0 {
+					snapshotter = snapshotter[:i]
+				}
+				bref(gcnode(metadata.ResourceSnapshot, ns, fmt.Sprintf("%s/%s", snapshotter, v)), n)
+			},
+		},
+		// TODO: Consider support for root/expire labels
+	} {
+		for k, v := lc.Seek(h.key); k != nil && bytes.HasPrefix(k, h.key); k, v = lc.Next() {
+			h.handler(k, v)
+		}
+	}
+}
+
 func (cc *collectionContext) ActiveWithBackRefs(ns string, fn func(gc.Node), bref func(gc.Node, gc.Node)) {
-	nsbkt := getBucket(cc.tx, []byte("v1"), []byte(ns), bucketKeyMounts)
-	if nsbkt != nil {
+	if nsbkt := getBucket(cc.tx, bucketKeyV2, []byte(ns), bucketKeyActivations); nsbkt != nil {
 		mc := nsbkt.Cursor()
 		for mk, mv := mc.First(); mk != nil; mk, mv = mc.Next() {
 			if mv != nil {
 				continue
 			}
 			n := gcnode(metadata.ResourceMount, ns, string(mk))
-			lbkt := nsbkt.Bucket(mk).Bucket(bucketKeyLabels)
-			if lbkt != nil {
-				lc := lbkt.Cursor()
-				for _, h := range []struct {
-					key     []byte
-					handler func([]byte, []byte)
-				}{
-					{
-						key: labelGCContainerBackRef,
-						handler: func(k, v []byte) {
-							if ks := string(k); ks != string(labelGCContainerBackRef) {
-								// Allow reference naming separated by . or /, ignore names
-								if ks[len(labelGCContainerBackRef)] != '.' && ks[len(labelGCContainerBackRef)] != '/' {
-									return
-								}
-							}
+			scanBackRefLabels(nsbkt.Bucket(mk).Bucket(bucketKeyLabels), ns, n, bref)
+		}
+	}
 
-							bref(gcnode(metadata.ResourceContainer, ns, string(v)), n)
-						},
-					},
-					{
-						key: labelGCContentBackRef,
-						handler: func(k, v []byte) {
-							if ks := string(k); ks != string(labelGCContentBackRef) {
-								// Allow reference naming separated by . or /, ignore names
-								if ks[len(labelGCContentBackRef)] != '.' && ks[len(labelGCContentBackRef)] != '/' {
-									return
-								}
-							}
-
-							bref(gcnode(metadata.ResourceContent, ns, string(v)), n)
-						},
-					},
-					{
-						key: labelGCImageBackRef,
-						handler: func(k, v []byte) {
-							if ks := string(k); ks != string(labelGCImageBackRef) {
-								// Allow reference naming separated by . or /, ignore names
-								if ks[len(labelGCImageBackRef)] != '.' && ks[len(labelGCImageBackRef)] != '/' {
-									return
-								}
-							}
-
-							bref(gcnode(metadata.ResourceImage, ns, string(v)), n)
-						},
-					},
-					{
-						key: labelGCSnapBackRef,
-						handler: func(k, v []byte) {
-							snapshotter := k[len(labelGCSnapBackRef):]
-							if i := bytes.IndexByte(snapshotter, '/'); i >= 0 {
-								snapshotter = snapshotter[:i]
-							}
-							bref(gcnode(metadata.ResourceSnapshot, ns, fmt.Sprintf("%s/%s", snapshotter, v)), n)
-						},
-					},
-					// TODO: Consider support for root/expire labels
-				} {
-					for k, v := lc.Seek(h.key); k != nil && bytes.HasPrefix(k, h.key); k, v = lc.Next() {
-						h.handler(k, v)
-					}
-				}
+	if nsbkt := getBucket(cc.tx, bucketKeyV1, []byte(ns), v1KeyMounts); nsbkt != nil {
+		mc := nsbkt.Cursor()
+		for mk, mv := mc.First(); mk != nil; mk, mv = mc.Next() {
+			if mv != nil {
+				continue
 			}
+			n := gcnode(metadata.ResourceMount, ns, string(mk))
+			scanBackRefLabels(nsbkt.Bucket(mk).Bucket(bucketKeyLabels), ns, n, bref)
 		}
 	}
 }
@@ -944,8 +1188,20 @@ func (cc *collectionContext) Active(ns string, fn func(gc.Node)) {
 }
 
 func (cc *collectionContext) Leased(ns, lease string, fn func(gc.Node)) {
-	bkt := getBucket(cc.tx, []byte("v1"), []byte(ns), []byte("leases"), []byte(lease))
-	if bkt != nil {
+	if bkt := getBucket(cc.tx, bucketKeyV2, []byte(ns), bucketKeyLeases, []byte(lease)); bkt != nil {
+		c := bkt.Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			fn(gc.Node{
+				Type:      metadata.ResourceMount,
+				Namespace: ns,
+				Key:       string(k),
+			})
+		}
+	}
+	// v1 activations report their own lease membership too, so one
+	// still in a live lease is not swept just for predating this
+	// schema.
+	if bkt := getBucket(cc.tx, bucketKeyV1, []byte(ns), v1KeyLeases, []byte(lease)); bkt != nil {
 		c := bkt.Cursor()
 		for k, _ := c.First(); k != nil; k, _ = c.Next() {
 			fn(gc.Node{
@@ -981,7 +1237,6 @@ func (cc *collectionContext) Cancel() (err error) {
 }
 
 func (cc *collectionContext) Finish() error {
-	// TODO: Get list of all remaining
 	remaining, err := cc.applyRemove()
 	if err != nil {
 		if rerr := cc.tx.Rollback(); rerr != nil {
@@ -995,8 +1250,23 @@ func (cc *collectionContext) Finish() error {
 		return err
 	}
 
+	// Mounted records released above are unmounted from their
+	// database records, exclude them from the orphan scan so they are
+	// not unmounted twice.
+	for _, b := range cc.released {
+		remaining[b.id] = struct{}{}
+	}
+	for _, v := range cc.releasedV1 {
+		cc.remainingV1[v.mid] = struct{}{}
+	}
+
 	// TODO: Consider using unmount q
-	cleanup, err := cc.getCleanupDirectories(remaining)
+	orphaned, err := cc.orphanBackingMounts(remaining)
+	if err != nil {
+		cc.manager.rwlock.Unlock()
+		return err
+	}
+	orphanedV1, err := v1OrphanDirs(cc.manager, cc.remainingV1)
 
 	cc.manager.rwlock.Unlock()
 
@@ -1004,39 +1274,81 @@ func (cc *collectionContext) Finish() error {
 		return err
 	}
 
-	return cleanupAll(cc.ctx, cleanup, cc.manager.handlers)
+	var errs []error
+	if err := cc.manager.unmountRecords(cc.ctx, cc.released); err != nil {
+		errs = append(errs, err)
+	}
+	if err := cc.manager.unmountRecords(cc.ctx, orphaned); err != nil {
+		errs = append(errs, err)
+	}
+	for _, v := range append(cc.releasedV1, orphanedV1...) {
+		if err := cc.manager.v1Unmount(cc.ctx, v.positions, v.mid); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
+// applyRemove deletes the activations marked for removal and releases
+// the references they held on their mounted records. It returns the
+// set of mounted record ids which are still referenced.
 func (cc *collectionContext) applyRemove() (map[uint64]struct{}, error) {
 	remaining := map[uint64]struct{}{}
-	v1bkt := cc.tx.Bucket([]byte("v1"))
-	if v1bkt == nil {
+
+	if v1bkt := cc.tx.Bucket(bucketKeyV1); v1bkt != nil {
+		nsc := v1bkt.Cursor()
+		for nsk, nsv := nsc.First(); nsk != nil; nsk, nsv = nsc.Next() {
+			if nsv != nil {
+				continue
+			}
+			namespace := string(nsk)
+			releasedV1, remainingV1, err := v1ApplyRemoveNamespace(cc.tx, namespace, v1bkt.Bucket(nsk), cc.removed[namespace])
+			if err != nil {
+				return nil, err
+			}
+			cc.releasedV1 = append(cc.releasedV1, releasedV1...)
+			for id := range remainingV1 {
+				cc.remainingV1[id] = struct{}{}
+			}
+		}
+	}
+
+	v2bkt := cc.tx.Bucket(bucketKeyV2)
+	if v2bkt == nil {
 		return remaining, nil
 	}
-	nsc := v1bkt.Cursor()
+	nsc := v2bkt.Cursor()
 	for nsk, nsv := nsc.First(); nsk != nil; nsk, nsv = nsc.Next() {
 		if nsv != nil {
 			continue
 		}
-		removed := cc.removed[string(nsk)]
-		nsbkt := v1bkt.Bucket(nsk)
-		msbkt := nsbkt.Bucket(bucketKeyMounts)
-		if msbkt == nil {
-			continue
-		}
-		lsbkt := nsbkt.Bucket(bucketKeyLeases)
-		msc := msbkt.Cursor()
-		for msk, msv := msc.First(); msk != nil; msk, msv = msc.Next() {
-			if msv != nil {
-				continue
-			}
-			mbkt := msbkt.Bucket(msk)
-			var remove bool
-			if removed != nil {
-				_, remove = removed[string(msk)]
+		namespace := string(nsk)
+		removed := cc.removed[namespace]
+		nsbkt := v2bkt.Bucket(nsk)
+		msbkt := nsbkt.Bucket(bucketKeyActivations)
+		if msbkt != nil {
+			lsbkt := nsbkt.Bucket(bucketKeyLeases)
+			// Collect first: releasing mounted records writes to
+			// sibling buckets, which must not happen while a cursor is
+			// open over the activations bucket.
+			var remove [][]byte
+			msc := msbkt.Cursor()
+			for msk, msv := msc.First(); msk != nil; msk, msv = msc.Next() {
+				if msv != nil {
+					continue
+				}
+				if removed != nil {
+					if _, ok := removed[string(msk)]; ok {
+						remove = append(remove, bytes.Clone(msk))
+					}
+				}
 			}
 
-			if remove {
+			for _, msk := range remove {
+				mbkt := msbkt.Bucket(msk)
+				if mbkt == nil {
+					continue
+				}
 				if lsbkt != nil {
 					lid := mbkt.Get(bucketKeyLease)
 					if len(lid) > 0 {
@@ -1049,19 +1361,47 @@ func (cc *collectionContext) applyRemove() (map[uint64]struct{}, error) {
 						}
 					}
 				}
-				msbkt.DeleteBucket(msk)
-			} else {
-				remaining[readID(mbkt)] = struct{}{}
+				released, err := releaseMountedRecords(cc.tx, namespace, string(msk), activationUses(mbkt))
+				if err != nil {
+					return nil, err
+				}
+				cc.released = append(cc.released, released...)
+				if err := msbkt.DeleteBucket(msk); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		// Everything still in the mount table is either used by a
+		// surviving activation or is one an in-flight activation
+		// already resolved, whether or not it has been realized yet.
+		if mtbkt := nsbkt.Bucket(bucketKeyMountTable); mtbkt != nil {
+			bc := mtbkt.Cursor()
+			for bk, bv := bc.First(); bk != nil; bk, bv = bc.Next() {
+				if bv != nil {
+					continue
+				}
+				id, _ := binary.Uvarint(bk)
+				remaining[id] = struct{}{}
 			}
 		}
 	}
 
+	sortUnmountOrder(cc.released)
+
 	return remaining, nil
 }
 
-func (cc *collectionContext) getCleanupDirectories(remaining map[uint64]struct{}) ([]string, error) {
-	fd, err := cc.manager.targets.Open(".")
+// orphanBackingMounts returns mounted records whose directory exists
+// under the target root but which no longer have a database record,
+// reconstructed from the type file written alongside each mount point.
+func (cc *collectionContext) orphanBackingMounts(remaining map[uint64]struct{}) ([]mountedRecord, error) {
+	root := filepath.Join(cc.manager.targets.Name(), backingDir)
+	fd, err := os.Open(root)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	defer fd.Close()
@@ -1071,7 +1411,7 @@ func (cc *collectionContext) getCleanupDirectories(remaining map[uint64]struct{}
 		return nil, err
 	}
 
-	cleanup := []string{}
+	var orphaned []mountedRecord
 	for _, d := range dirs {
 		id, err := strconv.ParseUint(d, 10, 64)
 		if err != nil {
@@ -1080,81 +1420,21 @@ func (cc *collectionContext) getCleanupDirectories(remaining map[uint64]struct{}
 		if _, ok := remaining[id]; ok {
 			continue
 		}
-		cleanup = append(cleanup, filepath.Join(cc.manager.targets.Name(), d))
-	}
-
-	return cleanup, nil
-}
-
-func cleanupAll(ctx context.Context, roots []string, handlers map[string]mount.Handler) error {
-	var errs []error
-	for _, root := range roots {
-		if err := unmountAll(ctx, root, handlers); err != nil {
-			errs = append(errs, fmt.Errorf("unmount all failed during cleanup up %s: %w", root, err))
+		b := mountedRecord{
+			id:    id,
+			point: filepath.Join(root, d, mountPointName),
+		}
+		if bs, err := os.ReadFile(filepath.Join(root, d, typeFileName)); err == nil {
+			b.mount.Type = string(bs)
+		} else if !os.IsNotExist(err) {
+			return nil, err
 		} else {
-			log.G(ctx).WithField("root", root).Debugf("unmounted")
+			log.G(cc.ctx).WithField("backing", id).Info("missing type file, attempting unmount with no handler")
 		}
-	}
-	return errors.Join(errs...)
-}
-
-func unmountAll(ctx context.Context, root string, handlers map[string]mount.Handler) error {
-	fd, err := os.Open(root)
-	if err != nil {
-		return err
+		orphaned = append(orphaned, b)
 	}
 
-	dirs, err := fd.Readdirnames(0)
-	fd.Close()
-	if err != nil {
-		return err
-	}
+	sortUnmountOrder(orphaned)
 
-	var mountErrs []error
-	for i := len(dirs) - 1; i >= 0; {
-		var (
-			d  = dirs[i]
-			mp string
-			h  mount.Handler
-		)
-		i--
-
-		if strings.HasSuffix(d, "-type") {
-			name := d[:len(d)-5]
-			if i >= 0 && dirs[i] == name {
-				i--
-			}
-			if b, rerr := os.ReadFile(filepath.Join(root, d)); rerr == nil {
-				h = handlers[string(b)]
-			} else {
-				return rerr
-			}
-			mp = filepath.Join(root, name)
-		} else {
-			mp = filepath.Join(root, d)
-			// If type file exists, continue and try again with "-type" file
-			if _, serr := os.Stat(mp + "-type"); serr == nil {
-				continue
-			} else if !os.IsNotExist(serr) {
-				return serr
-			} else {
-				log.G(ctx).WithField("mount", d).Infof("missing type file, attempting unmount with no handler")
-			}
-		}
-
-		if h != nil {
-			err = h.Unmount(ctx, mp)
-		} else {
-			err = mount.Unmount(mp, 0)
-		}
-		if err != nil {
-			// TODO: Ignore already unmounted
-			mountErrs = append(mountErrs, fmt.Errorf("failure unmounting %s: %w", d, err))
-		}
-	}
-	if len(mountErrs) > 0 {
-		return errors.Join(mountErrs...)
-	}
-
-	return os.RemoveAll(root)
+	return orphaned, nil
 }

--- a/core/mount/manager/manager.go
+++ b/core/mount/manager/manager.go
@@ -445,9 +445,9 @@ func (mm *mountManager) Activate(ctx context.Context, name string, mounts []moun
 						lbkt := lsbkt.Bucket([]byte(lid))
 						if lbkt != nil {
 							lbkt.Delete([]byte(name))
-						}
-						if k, _ := lbkt.Cursor().First(); k == nil {
-							lsbkt.DeleteBucket([]byte(lid))
+							if k, _ := lbkt.Cursor().First(); k == nil {
+								lsbkt.DeleteBucket([]byte(lid))
+							}
 						}
 					}
 				}

--- a/core/mount/manager/manager_test.go
+++ b/core/mount/manager/manager_test.go
@@ -205,6 +205,12 @@ func (h *errOnceHandler) Unmount(_ context.Context, mp string) error {
 	return nil
 }
 
+// Mounted reports h.mounted, the same bookkeeping Mount and Unmount keep.
+func (h *errOnceHandler) Mounted(_ context.Context, path string) (bool, error) {
+	_, ok := h.mounted[path]
+	return ok, nil
+}
+
 // TestGC tests the garbage collection features of the mount manager,
 // ensuring that mounts are properly cleaned up when no longer needed.
 func TestGC(t *testing.T) {
@@ -1739,6 +1745,95 @@ func TestActivateReusesRecordWithoutHandlerData(t *testing.T) {
 	require.NoError(t, m.Deactivate(ctx, "a"))
 	require.NoError(t, m.Deactivate(ctx, "b"))
 	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestProbeMountedAssumesLiveWhenMountTableUnobservable verifies that
+// a handler-less or checker-less mount falls back to assumeLive when
+// the host mount table cannot be consulted.
+func TestProbeMountedAssumesLiveWhenMountTableUnobservable(t *testing.T) {
+	ctx := context.Background()
+	live, err := probeMounted(ctx, nil, "/some/path/nothing/wrote", false, true)
+	require.NoError(t, err)
+	assert.True(t, live, "must assume live when told to and the mount table is unobservable")
+
+	live, err = probeMounted(ctx, nil, "/some/path/nothing/wrote", false, false)
+	require.NoError(t, err)
+	assert.False(t, live, "must not assume live for a brand new record even when the mount table is unobservable")
+}
+
+// TestActivateRunsEnsureForReusedSharedRecord verifies that a managed
+// position's own mkdir ensure runs even when it resolves to a record
+// another activation already mounted, since the mount identity does
+// not distinguish the mkdir options an activation used to get there.
+func TestActivateRunsEnsureForReusedSharedRecord(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	td := t.TempDir()
+	root := filepath.Join(td, "root")
+	require.NoError(t, os.MkdirAll(root, 0700))
+
+	db, err := bolt.Open(filepath.Join(td, "mounts.db"), 0600, nil)
+	require.NoError(t, err)
+	mountC := new(atomic.Int32)
+	m, err := NewManager(db, filepath.Join(td, "m"), WithAllowedRoot(root), WithMountHandler("vol", &noopHandler{mounts: mountC}))
+	require.NoError(t, err)
+	t.Cleanup(func() { m.(io.Closer).Close() })
+
+	dirA := filepath.Join(root, "a-dir")
+	dirB := filepath.Join(root, "b-dir")
+	vol := func(dir string) mount.Mount {
+		return mount.Mount{
+			Type:    "mkdir/vol",
+			Source:  testDevNull,
+			Options: []string{fmt.Sprintf("X-containerd.mkdir.path=%s", dir), "rw"},
+		}
+	}
+
+	_, err = m.Activate(ctx, "a", []mount.Mount{vol(dirA)})
+	require.NoError(t, err)
+	_, err = os.Stat(dirA)
+	require.NoError(t, err)
+
+	_, err = m.Activate(ctx, "b", []mount.Mount{vol(dirB)})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), mountC.Load(), "second activation must reuse the mount, not repeat it")
+	_, err = os.Stat(dirB)
+	assert.NoError(t, err, "a reused record must still run the reusing activation's own mkdir ensure")
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	require.NoError(t, m.Deactivate(ctx, "b"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestActivateReusedRecordValidatesConflictingMkdirRequest verifies
+// that reusing a shared record does not silently skip a conflicting
+// mkdir request: a second activation naming the same target with a
+// different mode must still hit apply's own validation.
+func TestActivateReusedRecordValidatesConflictingMkdirRequest(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	td := t.TempDir()
+	root := filepath.Join(td, "root")
+	require.NoError(t, os.MkdirAll(root, 0700))
+
+	db, err := bolt.Open(filepath.Join(td, "mounts.db"), 0600, nil)
+	require.NoError(t, err)
+	m, err := NewManager(db, filepath.Join(td, "m"), WithAllowedRoot(root), WithMountHandler("vol", &noopHandler{mounts: new(atomic.Int32)}))
+	require.NoError(t, err)
+	t.Cleanup(func() { m.(io.Closer).Close() })
+
+	dir := filepath.Join(root, "shared-dir")
+	volWithMode := func(mode string) mount.Mount {
+		return mount.Mount{
+			Type:    "mkdir/vol",
+			Source:  testDevNull,
+			Options: []string{fmt.Sprintf("X-containerd.mkdir.path=%s:%s", dir, mode), "rw"},
+		}
+	}
+
+	_, err = m.Activate(ctx, "a", []mount.Mount{volWithMode("700")})
+	require.NoError(t, err)
+
+	_, err = m.Activate(ctx, "b", []mount.Mount{volWithMode("755")})
+	assert.True(t, errdefs.IsNotImplemented(err), "a conflicting mkdir mode on a reused record must still be validated, got %v", err)
 }
 
 // TestPodGroupSharesOneMount verifies that a shared image mount at

--- a/core/mount/manager/manager_test.go
+++ b/core/mount/manager/manager_test.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -38,6 +40,25 @@ import (
 
 	bolt "go.etcd.io/bbolt"
 	bolterr "go.etcd.io/bbolt/errors"
+)
+
+// absSource returns a platform-absolute path, suitable for use as a
+// shareable mount's source in a test.
+func absSource(path string) string {
+	if runtime.GOOS != "windows" {
+		return path
+	}
+	return "C:" + filepath.FromSlash(path)
+}
+
+// Fake, never-really-mounted sources shared across many tests in this
+// file, each run through absSource so they remain absolute, and
+// therefore shareable, on every platform.
+var (
+	testDevNull   = absSource("/dev/null")
+	testDevZero   = absSource("/dev/zero")
+	testSharedImg = absSource("/images/shared.img")
+	testPodImg    = absSource("/images/pod.img")
 )
 
 func TestManager(t *testing.T) {
@@ -69,6 +90,10 @@ func TestManager(t *testing.T) {
 		m, err := NewManager(db, targetdir, opts...)
 		require.NoError(t, err)
 		t.Cleanup(func() { assert.NoError(t, m.(io.Closer).Close()) })
+		// Resolved the same way NewManager resolves it, so paths built
+		// from this match the manager's own.
+		targetdir, err = filepath.EvalSymlinks(targetdir)
+		require.NoError(t, err)
 		return m, targetdir
 	}
 
@@ -94,7 +119,7 @@ func TestManager(t *testing.T) {
 		assert.Equal(t, len(ainfo.System), 0)
 		assert.Equal(t, ainfo.Active[0].Source, sourcedir)
 		assert.Equal(t, ainfo.Active[0].Type, "bind")
-		assert.Equal(t, ainfo.Active[0].MountPoint, filepath.Join(targetdir, "1", "1"))
+		assert.Equal(t, ainfo.Active[0].MountPoint, filepath.Join(targetdir, backingDir, "2", mountPointName))
 	})
 
 	// try mounting
@@ -102,13 +127,29 @@ func TestManager(t *testing.T) {
 
 }
 
+// noopHandler is a Handler which does not touch the filesystem at
+// all, tracking which paths it considers mounted and implementing
+// mount.MountedChecker to report them.
 type noopHandler struct {
 	mounts *atomic.Int32
+
+	mu   sync.Mutex
+	live map[string]struct{}
+
+	// unmountAttempts, if set, counts every call to Unmount regardless
+	// of whether the path was known to be live.
+	unmountAttempts *atomic.Int32
 }
 
 func (h *noopHandler) Mount(ctx context.Context, m mount.Mount, mp string, _ []mount.ActiveMount) (mount.ActiveMount, error) {
 	now := time.Now()
 	h.mounts.Add(1)
+	h.mu.Lock()
+	if h.live == nil {
+		h.live = map[string]struct{}{}
+	}
+	h.live[mp] = struct{}{}
+	h.mu.Unlock()
 	return mount.ActiveMount{
 		Mount:      m,
 		MountedAt:  &now,
@@ -116,9 +157,26 @@ func (h *noopHandler) Mount(ctx context.Context, m mount.Mount, mp string, _ []m
 	}, nil
 }
 
-func (h *noopHandler) Unmount(context.Context, string) error {
-	h.mounts.Add(-1)
+// Unmount tolerates being asked to unmount a path it never mounted.
+func (h *noopHandler) Unmount(_ context.Context, mp string) error {
+	if h.unmountAttempts != nil {
+		h.unmountAttempts.Add(1)
+	}
+	h.mu.Lock()
+	_, wasLive := h.live[mp]
+	delete(h.live, mp)
+	h.mu.Unlock()
+	if wasLive {
+		h.mounts.Add(-1)
+	}
 	return nil
+}
+
+func (h *noopHandler) Mounted(_ context.Context, path string) (bool, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, ok := h.live[path]
+	return ok, nil
 }
 
 type errOnceHandler struct {
@@ -371,68 +429,109 @@ func TestActivateAlreadyExists(t *testing.T) {
 	assert.NoError(t, m.Deactivate(ctx, "task1"))
 }
 
+// TestActivateStaleIncomplete verifies that an activation whose chain
+// was resolved but never realized is detected as stale, replaced, and
+// its unrealized mounted record released.
 func TestActivateStaleIncomplete(t *testing.T) {
-	td := t.TempDir()
-	metadb := filepath.Join(td, "mounts.db")
-	targetdir := filepath.Join(td, "m")
-	db, err := bolt.Open(metadb, 0600, nil)
-	require.NoError(t, err)
 	ctx := namespaces.WithNamespace(context.Background(), "test")
-
-	// Simulate a stale incomplete activation by directly writing a bucket
-	// without the "active" sub-bucket (as if the process crashed mid-activation).
-	// Use mount ID 42 so we can verify the stale target directory gets cleaned up.
-	var staleMID uint64 = 42
-	err = db.Update(func(tx *bolt.Tx) error {
-		v1bkt, err := tx.CreateBucketIfNotExists([]byte("v1"))
-		if err != nil {
-			return err
-		}
-		nsbkt, err := v1bkt.CreateBucketIfNotExists([]byte("test"))
-		if err != nil {
-			return err
-		}
-		mbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyMounts)
-		if err != nil {
-			return err
-		}
-		// Create the mount bucket but don't add the "active" sub-bucket
-		bkt, err := mbkt.CreateBucket([]byte("task1"))
-		if err != nil {
-			return err
-		}
-		idb, err := encodeID(staleMID)
-		if err != nil {
-			return err
-		}
-		return bkt.Put(bucketKeyID, idb)
-	})
-	require.NoError(t, err)
-
-	// Create the stale target directory as if the process crashed after
-	// mkdir but before the second transaction.
-	staleTarget := filepath.Join(targetdir, fmt.Sprintf("%d", staleMID))
-	require.NoError(t, os.MkdirAll(staleTarget, 0700))
-
 	mountC := new(atomic.Int32)
-	m, err := NewManager(db, targetdir, WithMountHandler("noop", &noopHandler{mounts: mountC}))
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, m.(io.Closer).Close()) })
+	m, _ := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: mountC}))
+	mm := m.(*mountManager)
 
-	mounts := []mount.Mount{{Type: "noop"}}
+	stale := mount.Mount{Type: "noop", Source: testDevZero}
 
-	// Activation should succeed by cleaning up the stale entry
-	ainfo, err := m.Activate(ctx, "task1", mounts)
+	// Reproduce a resolved-but-never-realized record.
+	var staleMP string
+	require.NoError(t, mm.db.Update(func(tx *bolt.Tx) error {
+		v2bkt, err := tx.CreateBucketIfNotExists(bucketKeyV2)
+		if err != nil {
+			return err
+		}
+		nsbkt, err := v2bkt.CreateBucketIfNotExists([]byte("test"))
+		if err != nil {
+			return err
+		}
+		mbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyActivations)
+		if err != nil {
+			return err
+		}
+		if _, err := mbkt.CreateBucket([]byte("task1")); err != nil {
+			return err
+		}
+		rec, err := resolvePosition(tx, mm.targets.Name(), "test", "task1", 0, stale, time.Now())
+		if err != nil {
+			return err
+		}
+		staleMP = rec.point
+		return nil
+	}))
+	// The directory itself is created as part of realizing a mount;
+	// simulate having gotten that far too, still without ever calling
+	// the handler.
+	require.NoError(t, mm.prepareRecordDir(staleMP, stale.Type, true))
+
+	// Activating the same name must clean up the stale record.
+	ainfo, err := m.Activate(ctx, "task1", []mount.Mount{{Type: "noop", Source: testDevNull}})
 	require.NoError(t, err)
 	assert.Equal(t, "task1", ainfo.Name)
-	assert.Equal(t, 1, len(ainfo.Active))
+	require.Equal(t, 1, len(ainfo.Active))
 
-	// The stale target directory should have been cleaned up
-	_, err = os.Stat(staleTarget)
-	assert.True(t, os.IsNotExist(err), "stale target directory should be removed, but still exists")
+	assert.Equal(t, int32(1), mountC.Load(), "new mount made; stale record was never actually mounted")
+	_, err = os.Stat(filepath.Dir(staleMP))
+	assert.True(t, os.IsNotExist(err), "stale mounted record directory should be removed")
 
-	// Cleanup
 	assert.NoError(t, m.Deactivate(ctx, "task1"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestActivateStaleKeepsReferencedBackingMount verifies that replacing
+// a stale activation does not tear down a mount another activation is
+// using.
+func TestActivateStaleKeepsReferencedBackingMount(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: mountC}))
+	mm := m.(*mountManager)
+
+	shared := mount.Mount{Type: "noop", Source: testDevNull}
+	unique := mount.Mount{Type: "noop", Source: testDevZero}
+
+	keep, err := m.Activate(ctx, "keep", []mount.Mount{shared})
+	require.NoError(t, err)
+	mp := keep.Active[0].MountPoint
+	assert.Equal(t, int32(1), mountC.Load())
+
+	// A stale activation which uses the same mount as "keep", plus a
+	// second, unique mount of its own which was never realized.
+	var staleUniqueMP string
+	require.NoError(t, mm.db.Update(func(tx *bolt.Tx) error {
+		mbkt := getBucket(tx, bucketKeyV2, []byte("test"), bucketKeyActivations)
+		if _, err := mbkt.CreateBucket([]byte("task1")); err != nil {
+			return err
+		}
+		if _, err := resolvePosition(tx, mm.targets.Name(), "test", "task1", 0, shared, time.Now()); err != nil {
+			return err
+		}
+		rec, err := resolvePosition(tx, mm.targets.Name(), "test", "task1", 1, unique, time.Now())
+		if err != nil {
+			return err
+		}
+		staleUniqueMP = rec.point
+		return nil
+	}))
+	require.NoError(t, mm.prepareRecordDir(staleUniqueMP, unique.Type, true))
+
+	_, err = m.Activate(ctx, "task1", []mount.Mount{shared, unique})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), mountC.Load(), "shared mount must not be remounted; a mount is made for the unique one")
+	_, err = os.Stat(filepath.Dir(mp))
+	assert.NoError(t, err, "mount shared with another activation must survive stale cleanup")
+	_, err = os.Stat(filepath.Dir(staleUniqueMP))
+	assert.True(t, os.IsNotExist(err), "stale unique mounted record directory should be removed")
+
+	require.NoError(t, m.Deactivate(ctx, "keep"))
+	require.NoError(t, m.Deactivate(ctx, "task1"))
+	assert.Equal(t, int32(0), mountC.Load())
 }
 
 func TestInfo(t *testing.T) {
@@ -600,6 +699,17 @@ func TestActivateConcurrentSameName(t *testing.T) {
 	assert.NoError(t, m.Deactivate(ctx, "task1"))
 }
 
+// TestActivationKeyDistinguishesNamespaces verifies activationKey
+// doesn't collide across namespace/name boundaries.
+func TestActivationKeyDistinguishesNamespaces(t *testing.T) {
+	assert.NotEqual(t, activationKey("ns1", "name"), activationKey("ns2", "name"))
+	assert.Equal(t, activationKey("ns1", "name"), activationKey("ns1", "name"))
+
+	// A name containing the separator is still a distinct key from an
+	// unrelated name in the same namespace.
+	assert.NotEqual(t, activationKey("ns1", "a|b"), activationKey("ns1", "a"))
+}
+
 // TODO: Test deactivate
 // TODO: Test Sync
 
@@ -616,4 +726,1064 @@ func TestClose(t *testing.T) {
 	// Verify the underlying bolt DB is closed: a new transaction should fail.
 	_, err = db.Begin(false)
 	assert.ErrorIs(t, err, bolterr.ErrDatabaseNotOpen)
+}
+
+// mkTestManager builds a manager with the given handlers over a fresh
+// bolt database.
+func mkTestManager(t *testing.T, opts ...Opt) (mount.Manager, string) {
+	t.Helper()
+	td := t.TempDir()
+	db, err := bolt.Open(filepath.Join(td, "mounts.db"), 0600, nil)
+	require.NoError(t, err)
+	targetdir := filepath.Join(td, "m")
+	m, err := NewManager(db, targetdir, opts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { m.(io.Closer).Close() })
+	// Resolved the same way NewManager resolves it, so paths built
+	// from this match the manager's own (e.g. on macOS, where /tmp is
+	// itself a symlink).
+	targetdir, err = filepath.EvalSymlinks(targetdir)
+	require.NoError(t, err)
+	return m, targetdir
+}
+
+// TestNewManagerResolvesSymlinkedTargetDir verifies that NewManager
+// resolves symlinks in targetDir before opening it, so
+// mm.targets.Name() is always canonical.
+func TestNewManagerResolvesSymlinkedTargetDir(t *testing.T) {
+	td := t.TempDir()
+	real := filepath.Join(td, "real")
+	require.NoError(t, os.MkdirAll(real, 0700))
+	link := filepath.Join(td, "link")
+	require.NoError(t, os.Symlink(real, link))
+
+	db, err := bolt.Open(filepath.Join(td, "mounts.db"), 0600, nil)
+	require.NoError(t, err)
+	m, err := NewManager(db, link)
+	require.NoError(t, err)
+	t.Cleanup(func() { m.(io.Closer).Close() })
+
+	resolved, err := filepath.EvalSymlinks(real)
+	require.NoError(t, err)
+	assert.Equal(t, resolved, m.(*mountManager).targets.Name(),
+		"targets must be opened at the resolved path, not the symlink given to NewManager")
+}
+
+// TestBackingMount verifies that activations which describe the
+// same mount resolve to a single mount, and that the mount survives
+// until the last activation referencing it is deactivated.
+func TestBackingMount(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("vol", &noopHandler{mounts: mountC}))
+
+	vol := func() []mount.Mount {
+		return []mount.Mount{{
+			Type:    "vol",
+			Source:  testDevNull,
+			Options: []string{"rw"},
+		}}
+	}
+
+	aInfo, err := m.Activate(ctx, "a", vol())
+	require.NoError(t, err)
+	require.Len(t, aInfo.Active, 1)
+	mp := aInfo.Active[0].MountPoint
+	require.NotEmpty(t, mp)
+	assert.Equal(t, int32(1), mountC.Load(), "first activation mounts once")
+
+	bInfo, err := m.Activate(ctx, "b", vol())
+	require.NoError(t, err)
+	require.Len(t, bInfo.Active, 1)
+	assert.Equal(t, mp, bInfo.Active[0].MountPoint, "identical mount should be reused")
+	assert.Equal(t, int32(1), mountC.Load(), "identical mount should not be mounted twice")
+
+	// Info reports the same mount for both activations.
+	for _, name := range []string{"a", "b"} {
+		info, err := m.Info(ctx, name)
+		require.NoError(t, err)
+		require.Len(t, info.Active, 1)
+		assert.Equal(t, mp, info.Active[0].MountPoint)
+		assert.Equal(t, "vol", info.Active[0].Type)
+		assert.Equal(t, testDevNull, info.Active[0].Source)
+		assert.Equal(t, []string{"rw"}, info.Active[0].Options)
+	}
+
+	// Deactivating one activation must not disturb the other.
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	assert.Equal(t, int32(1), mountC.Load(), "mount stays while b references it")
+	_, err = os.Stat(filepath.Dir(mp))
+	assert.NoError(t, err, "mount point must remain while referenced")
+
+	require.NoError(t, m.Deactivate(ctx, "b"))
+	assert.Equal(t, int32(0), mountC.Load(), "mount released after last reference")
+	_, err = os.Stat(filepath.Dir(mp))
+	assert.True(t, os.IsNotExist(err), "mount point should be removed with the last reference")
+}
+
+// TestBackingMountDistinctParameters verifies that mounts which
+// differ in any parameter are not collapsed together.
+func TestBackingMountDistinctParameters(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		b    mount.Mount
+	}{
+		{
+			name: "Source",
+			b:    mount.Mount{Type: "vol", Source: testDevZero, Options: []string{"rw"}},
+		},
+		{
+			name: "Options",
+			b:    mount.Mount{Type: "vol", Source: testDevNull, Options: []string{"ro"}},
+		},
+		{
+			name: "OptionOrder",
+			b:    mount.Mount{Type: "vol", Source: testDevNull, Options: []string{"nodev", "rw"}},
+		},
+		{
+			name: "Target",
+			b:    mount.Mount{Type: "vol", Source: testDevNull, Target: "/t", Options: []string{"rw", "nodev"}},
+		},
+		{
+			name: "Type",
+			b:    mount.Mount{Type: "vol2", Source: testDevNull, Options: []string{"rw", "nodev"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := namespaces.WithNamespace(context.Background(), "test")
+			mountC := new(atomic.Int32)
+			m, _ := mkTestManager(t,
+				WithMountHandler("vol", &noopHandler{mounts: mountC}),
+				WithMountHandler("vol2", &noopHandler{mounts: mountC}))
+
+			a := mount.Mount{Type: "vol", Source: testDevNull, Options: []string{"rw", "nodev"}}
+
+			aInfo, err := m.Activate(ctx, "a", []mount.Mount{a})
+			require.NoError(t, err)
+			bInfo, err := m.Activate(ctx, "b", []mount.Mount{tc.b})
+			require.NoError(t, err)
+
+			assert.NotEqual(t, aInfo.Active[0].MountPoint, bInfo.Active[0].MountPoint)
+			assert.Equal(t, int32(2), mountC.Load(), "differing mounts must not be shared")
+
+			require.NoError(t, m.Deactivate(ctx, "a"))
+			require.NoError(t, m.Deactivate(ctx, "b"))
+			assert.Equal(t, int32(0), mountC.Load())
+		})
+	}
+}
+
+// TestBackingMountSyntheticSource verifies that filesystems
+// which synthesize their own contents are never shared. Two tmpfs
+// mounts with identical parameters are still two distinct
+// filesystems.
+func TestBackingMountSyntheticSource(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("tmpfs", &noopHandler{mounts: mountC}))
+
+	tmpfs := func() []mount.Mount {
+		return []mount.Mount{{
+			Type:    "tmpfs",
+			Source:  "tmpfs",
+			Options: []string{"size=1m"},
+		}}
+	}
+
+	aInfo, err := m.Activate(ctx, "a", tmpfs())
+	require.NoError(t, err)
+	bInfo, err := m.Activate(ctx, "b", tmpfs())
+	require.NoError(t, err)
+
+	assert.NotEqual(t, aInfo.Active[0].MountPoint, bInfo.Active[0].MountPoint)
+	assert.Equal(t, int32(2), mountC.Load(), "synthetic filesystems must not be shared")
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	assert.Equal(t, int32(1), mountC.Load())
+	require.NoError(t, m.Deactivate(ctx, "b"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestBackingMountNamespaces verifies that identical mounts in
+// different namespaces are not shared.
+func TestBackingMountNamespaces(t *testing.T) {
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("vol", &noopHandler{mounts: mountC}))
+
+	vol := []mount.Mount{{Type: "vol", Source: testDevNull, Options: []string{"rw"}}}
+
+	ctxA := namespaces.WithNamespace(context.Background(), "ns-a")
+	ctxB := namespaces.WithNamespace(context.Background(), "ns-b")
+
+	aInfo, err := m.Activate(ctxA, "a", vol)
+	require.NoError(t, err)
+	bInfo, err := m.Activate(ctxB, "a", vol)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, aInfo.Active[0].MountPoint, bInfo.Active[0].MountPoint)
+	assert.Equal(t, int32(2), mountC.Load(), "mounts must not be shared across namespaces")
+
+	require.NoError(t, m.Deactivate(ctxA, "a"))
+	assert.Equal(t, int32(1), mountC.Load())
+	require.NoError(t, m.Deactivate(ctxB, "a"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestBackingMountTransformed verifies that the mount identity is
+// computed from the mount as finally handed to the kernel, after any
+// transforms have run, and that later mounts in a chain resolve their
+// templates against the backing mount point.
+func TestBackingMountTransformed(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t,
+		WithMountHandler("blk", &noopHandler{mounts: mountC}),
+		WithMountHandler("upper", &noopHandler{mounts: mountC}))
+
+	chain := func(id string) []mount.Mount {
+		return []mount.Mount{
+			{
+				Type:    "format/blk",
+				Source:  testSharedImg,
+				Options: []string{"rw", "loop"},
+			},
+			{
+				Type:    "format/upper",
+				Source:  "{{ mount 0 }}/upper-" + id,
+				Options: []string{"rbind"},
+			},
+		}
+	}
+
+	aInfo, err := m.Activate(ctx, "a", chain("a"))
+	require.NoError(t, err)
+	require.Len(t, aInfo.Active, 2)
+	blkMP := aInfo.Active[0].MountPoint
+	assert.Equal(t, "blk", aInfo.Active[0].Type, "transform prefix must be peeled before mounting")
+	assert.Equal(t, blkMP+"/upper-a", aInfo.Active[1].Source)
+	assert.Equal(t, int32(2), mountC.Load())
+
+	bInfo, err := m.Activate(ctx, "b", chain("b"))
+	require.NoError(t, err)
+	require.Len(t, bInfo.Active, 2)
+
+	assert.Equal(t, blkMP, bInfo.Active[0].MountPoint,
+		"identical transformed mount must be reused")
+	assert.Equal(t, blkMP+"/upper-b", bInfo.Active[1].Source,
+		"dependent mount must resolve against the backing mount point")
+	assert.NotEqual(t, aInfo.Active[1].MountPoint, bInfo.Active[1].MountPoint,
+		"differing upper mounts must not be shared")
+	assert.Equal(t, int32(3), mountC.Load(), "only the upper mount is added")
+
+	// The backing image stays mounted while either chain uses it.
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	assert.Equal(t, int32(2), mountC.Load())
+	_, err = os.Stat(filepath.Dir(blkMP))
+	assert.NoError(t, err, "backing mount must survive while another chain uses it")
+
+	require.NoError(t, m.Deactivate(ctx, "b"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestActivateHonorsClaimedTransformSuffix verifies that a transform
+// claimed by the caller is left unapplied at the boundary mount once
+// resolved through the schema v2 write transaction.
+func TestActivateHonorsClaimedTransformSuffix(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+
+	ainfo, err := m.Activate(ctx, "a", []mount.Mount{
+		{Type: "format/mkdir/overlay", Source: testDevNull},
+	}, mount.WithAllowTransform("mkdir"))
+	require.NoError(t, err)
+	assert.Empty(t, ainfo.Active, "nothing here is handled by the manager")
+	require.Len(t, ainfo.System, 1)
+	assert.Equal(t, "mkdir/overlay", ainfo.System[0].Type,
+		"format must still be peeled, but the claimed mkdir left untouched for the caller")
+	assert.Equal(t, testDevNull, ainfo.System[0].Source,
+		"mkdir never ran, so its source is exactly as given")
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+}
+
+// TestActivateReplaysIncompleteBoundaryEnsure verifies that an
+// activation whose boundary mount's ensure target does not actually
+// exist is replaced, redoing the missing mkdir rather than reporting
+// success or already-exists.
+func TestActivateReplaysIncompleteBoundaryEnsure(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	td := t.TempDir()
+	root := filepath.Join(td, "root")
+	require.NoError(t, os.MkdirAll(root, 0700))
+
+	db, err := bolt.Open(filepath.Join(td, "mounts.db"), 0600, nil)
+	require.NoError(t, err)
+	m, err := NewManager(db, filepath.Join(td, "m"), WithAllowedRoot(root))
+	require.NoError(t, err)
+	t.Cleanup(func() { m.(io.Closer).Close() })
+
+	upper := filepath.Join(root, "upper")
+	mounts := []mount.Mount{
+		{
+			Type:   "mkdir/overlay",
+			Source: "overlay",
+			Options: []string{
+				fmt.Sprintf("X-containerd.mkdir.path=%s", upper),
+				"upperdir=" + upper,
+			},
+		},
+	}
+
+	ainfo, err := m.Activate(ctx, "a", mounts)
+	require.NoError(t, err)
+	require.Len(t, ainfo.System, 1)
+	_, err = os.Stat(upper)
+	require.NoError(t, err, "mkdir must have run on the first, uninterrupted Activate")
+
+	// Simulate the crash window: the ensure target was recorded but
+	// the mkdir which produces it never ran.
+	require.NoError(t, os.Remove(upper))
+
+	ainfo, err = m.Activate(ctx, "a", mounts)
+	require.NoError(t, err, "an activation whose ensure target does not exist must be replaced, not reported as already existing")
+	require.Len(t, ainfo.System, 1)
+
+	_, err = os.Stat(upper)
+	assert.NoError(t, err, "replacing the activation must redo its boundary mount's own mkdir, not skip straight back to success")
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+}
+
+// TestActivateSecondCallOnCompleteActivationAlreadyExists verifies
+// that once an activation's boundary mount ensure has actually
+// produced every recorded target, a second Activate for the same name
+// reports ErrAlreadyExists.
+func TestActivateSecondCallOnCompleteActivationAlreadyExists(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	td := t.TempDir()
+	root := filepath.Join(td, "root")
+	require.NoError(t, os.MkdirAll(root, 0700))
+
+	db, err := bolt.Open(filepath.Join(td, "mounts.db"), 0600, nil)
+	require.NoError(t, err)
+	m, err := NewManager(db, filepath.Join(td, "m"), WithAllowedRoot(root))
+	require.NoError(t, err)
+	t.Cleanup(func() { m.(io.Closer).Close() })
+
+	upper := filepath.Join(root, "upper")
+	mounts := []mount.Mount{
+		{
+			Type:   "mkdir/overlay",
+			Source: "overlay",
+			Options: []string{
+				fmt.Sprintf("X-containerd.mkdir.path=%s", upper),
+				"upperdir=" + upper,
+			},
+		},
+	}
+
+	_, err = m.Activate(ctx, "a", mounts)
+	require.NoError(t, err)
+
+	_, err = m.Activate(ctx, "a", mounts)
+	assert.True(t, errdefs.IsAlreadyExists(err), "expected ErrAlreadyExists, got %v", err)
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+}
+
+// TestActivateRejectsTargetWithoutHandler verifies that a managed
+// position with no Handler is rejected outright if it sets Target.
+func TestActivateRejectsTargetWithoutHandler(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+
+	_, err := m.Activate(ctx, "a", []mount.Mount{
+		{Type: "bind", Source: testDevNull, Target: "sub", Options: []string{"rbind"}},
+	}, mount.WithTemporary)
+	assert.True(t, errdefs.IsInvalidArgument(err), "expected ErrInvalidArgument, got %v", err)
+
+	_, err = m.Info(ctx, "a")
+	assert.True(t, errdefs.IsNotFound(err), "a rejected activation must not leave a record behind, got %v", err)
+}
+
+// TestActivateRollbackReleasesBackingReferences verifies that a failed
+// activation releases the references it took, without disturbing a
+// mount another activation is still using.
+func TestActivateRollbackReleasesBackingReferences(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t,
+		WithMountHandler("vol", &noopHandler{mounts: mountC}),
+		WithMountHandler("bad", &failHandler{}))
+
+	vol := mount.Mount{Type: "vol", Source: testDevNull, Options: []string{"rw"}}
+
+	okInfo, err := m.Activate(ctx, "ok", []mount.Mount{vol})
+	require.NoError(t, err)
+	mp := okInfo.Active[0].MountPoint
+	assert.Equal(t, int32(1), mountC.Load())
+
+	// A chain which reuses the same mount but then fails must leave
+	// the backing mount alone.
+	_, err = m.Activate(ctx, "fail", []mount.Mount{
+		vol,
+		{Type: "bad", Source: testDevZero},
+	})
+	require.Error(t, err)
+	assert.Equal(t, int32(1), mountC.Load(), "backing mount must survive the rollback")
+	_, err = os.Stat(filepath.Dir(mp))
+	assert.NoError(t, err)
+
+	// The failed activation must not be left behind.
+	_, err = m.Info(ctx, "fail")
+	assert.True(t, errdefs.IsNotFound(err), "expected ErrNotFound, got %v", err)
+
+	// Retrying the same name works, so the previous references were
+	// fully released.
+	_, err = m.Activate(ctx, "fail", []mount.Mount{vol})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), mountC.Load())
+
+	require.NoError(t, m.Deactivate(ctx, "ok"))
+	require.NoError(t, m.Deactivate(ctx, "fail"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestActivateRollbackUnmountsUnreferencedBacking verifies that a failed
+// activation unmounts the mounts it alone created.
+func TestActivateRollbackUnmountsUnreferencedBacking(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t,
+		WithMountHandler("vol", &noopHandler{mounts: mountC}),
+		WithMountHandler("bad", &failHandler{}))
+
+	_, err := m.Activate(ctx, "fail", []mount.Mount{
+		{Type: "vol", Source: testDevNull, Options: []string{"rw"}},
+		{Type: "bad", Source: testDevZero},
+	})
+	require.Error(t, err)
+	assert.Equal(t, int32(0), mountC.Load(), "mounts made by the failed activation must be undone")
+}
+
+// failHandler returns an error on every mount, used to force an
+// Activate failure in rollback tests.
+type failHandler struct{}
+
+func (failHandler) Mount(context.Context, mount.Mount, string, []mount.ActiveMount) (mount.ActiveMount, error) {
+	return mount.ActiveMount{}, fmt.Errorf("forced failure")
+}
+func (failHandler) Unmount(context.Context, string) error { return nil }
+
+// TestBackingMountGCRelease verifies that garbage collecting the
+// activations which reference a backing mount releases it exactly once.
+func TestBackingMountGCRelease(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("vol", &noopHandler{mounts: mountC}))
+
+	vol := []mount.Mount{{Type: "vol", Source: testDevNull, Options: []string{"rw"}}}
+
+	_, err := m.Activate(ctx, "a", vol)
+	require.NoError(t, err)
+	_, err = m.Activate(ctx, "b", vol)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), mountC.Load())
+
+	collect := func(names ...string) {
+		t.Helper()
+		cc, err := m.(interface {
+			StartCollection(context.Context) (metadata.CollectionContext, error)
+		}).StartCollection(ctx)
+		require.NoError(t, err)
+		for _, n := range names {
+			cc.Remove(gc.Node{Type: metadata.ResourceMount, Namespace: "test", Key: n})
+		}
+		require.NoError(t, cc.Finish())
+	}
+
+	// Removing one activation leaves the mount in place for the other.
+	collect("a")
+	assert.Equal(t, int32(1), mountC.Load(), "mount stays while b references it")
+
+	collect("b")
+	assert.Equal(t, int32(0), mountC.Load(), "mount released with the last reference")
+}
+
+// TestGCOrphanedBackingMount verifies that a mount directory left behind
+// without a database record, as happens when the process dies between
+// mounting and recording the mount, is unmounted by the collector.
+func TestGCOrphanedBackingMount(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	handler := &noopHandler{mounts: mountC}
+	m, targetdir := mkTestManager(t, WithMountHandler("vol", handler))
+
+	// Simulate a mounted record's directory left behind with no
+	// database record.
+	orphan := filepath.Join(targetdir, backingDir, "99")
+	orphanMP := filepath.Join(orphan, mountPointName)
+	require.NoError(t, os.MkdirAll(orphanMP, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(orphan, typeFileName), []byte("vol"), 0600))
+	mountC.Add(1)
+	handler.live = map[string]struct{}{orphanMP: {}}
+
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cc.Finish())
+
+	assert.Equal(t, int32(0), mountC.Load(), "orphaned mount should be unmounted with its handler")
+	_, err = os.Stat(orphan)
+	assert.True(t, os.IsNotExist(err), "orphaned backing mount directory should be removed")
+}
+
+// TestActivateConcurrentIdenticalMounts verifies that concurrent
+// activations which resolve to the same mount perform the underlying
+// mount exactly once.
+func TestActivateConcurrentIdenticalMounts(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	total := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("vol", &countingHandler{active: mountC, total: total}))
+
+	vol := []mount.Mount{{Type: "vol", Source: testDevNull, Options: []string{"rw"}}}
+
+	const n = 8
+	var wg sync.WaitGroup
+	mps := make([]string, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			info, err := m.Activate(ctx, fmt.Sprintf("task%d", i), vol)
+			errs[i] = err
+			if err == nil && len(info.Active) == 1 {
+				mps[i] = info.Active[0].MountPoint
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		require.NoError(t, errs[i])
+		assert.Equal(t, mps[0], mps[i], "all activations should share one mount point")
+	}
+	assert.Equal(t, int32(1), total.Load(), "identical mount should be mounted exactly once")
+	assert.Equal(t, int32(1), mountC.Load())
+
+	for i := 0; i < n; i++ {
+		require.NoError(t, m.Deactivate(ctx, fmt.Sprintf("task%d", i)))
+	}
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// countingHandler tracks both currently active mounts and the total
+// number of mount calls ever made. Like noopHandler, it implements
+// mount.MountedChecker itself since it leaves nothing on the
+// filesystem a generic check could ever find.
+type countingHandler struct {
+	active *atomic.Int32
+	total  *atomic.Int32
+
+	mu   sync.Mutex
+	live map[string]struct{}
+}
+
+func (h *countingHandler) Mount(_ context.Context, m mount.Mount, mp string, _ []mount.ActiveMount) (mount.ActiveMount, error) {
+	now := time.Now()
+	h.active.Add(1)
+	h.total.Add(1)
+	h.mu.Lock()
+	if h.live == nil {
+		h.live = map[string]struct{}{}
+	}
+	h.live[mp] = struct{}{}
+	h.mu.Unlock()
+	return mount.ActiveMount{Mount: m, MountedAt: &now, MountPoint: mp}, nil
+}
+
+// Unmount, like a real handler's, tolerates being asked to unmount a
+// path it never actually mounted: it only counts down for one it
+// knows about.
+func (h *countingHandler) Unmount(_ context.Context, mp string) error {
+	h.mu.Lock()
+	_, wasLive := h.live[mp]
+	delete(h.live, mp)
+	h.mu.Unlock()
+	if wasLive {
+		h.active.Add(-1)
+	}
+	return nil
+}
+
+func (h *countingHandler) Mounted(_ context.Context, path string) (bool, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, ok := h.live[path]
+	return ok, nil
+}
+
+// TestActivateAllMountsHandled covers a transformed chain in which every
+// mount is handled by the manager, leaving no system mount to convert.
+func TestActivateAllMountsHandled(t *testing.T) {
+	td := t.TempDir()
+	db, err := bolt.Open(filepath.Join(td, "mounts.db"), 0600, nil)
+	require.NoError(t, err)
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+
+	mountC := new(atomic.Int32)
+	m, err := NewManager(db, filepath.Join(td, "m"),
+		WithMountHandler("lower", &noopHandler{mounts: mountC}),
+		WithMountHandler("upper", &noopHandler{mounts: mountC}))
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, m.(io.Closer).Close()) })
+
+	// Both mounts carry a transform and both have a handler, so
+	// firstSystemMount is the length of the chain.
+	ainfo, err := m.Activate(ctx, "a", []mount.Mount{
+		{Type: "format/lower", Source: testDevNull},
+		{Type: "format/upper", Source: "{{ mount 0 }}/child"},
+	})
+	require.NoError(t, err)
+	require.Len(t, ainfo.Active, 2)
+	assert.Empty(t, ainfo.System, "nothing is left for the system to mount")
+	assert.Equal(t, ainfo.Active[0].MountPoint+"/child", ainfo.Active[1].Source,
+		"the second mount should resolve against the first")
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// countingDB wraps a *bolt.DB, counting write transactions so a test
+// can assert on how many Activate actually performs.
+type countingDB struct {
+	*bolt.DB
+	writes atomic.Int32
+}
+
+func (c *countingDB) Update(fn func(*bolt.Tx) error) error {
+	c.writes.Add(1)
+	return c.DB.Update(fn)
+}
+
+// TestActivateSingleWriteTransaction verifies that Activate performs
+// exactly one write transaction for a chain of managed mounts, no
+// matter how many positions it has.
+func TestActivateSingleWriteTransaction(t *testing.T) {
+	td := t.TempDir()
+	rawdb, err := bolt.Open(filepath.Join(td, "mounts.db"), 0600, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { rawdb.Close() })
+
+	mountC := new(atomic.Int32)
+	m, err := NewManager(rawdb, filepath.Join(td, "m"),
+		WithMountHandler("blk", &noopHandler{mounts: mountC}),
+		WithMountHandler("upper", &noopHandler{mounts: mountC}))
+	require.NoError(t, err)
+	t.Cleanup(func() { m.(io.Closer).Close() })
+	mm := m.(*mountManager)
+	cdb := &countingDB{DB: rawdb}
+	mm.db = cdb
+
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	_, err = m.Activate(ctx, "a", []mount.Mount{
+		{Type: "format/blk", Source: testSharedImg, Options: []string{"rw", "loop"}},
+		{Type: "format/upper", Source: "{{ mount 0 }}/upper", Options: []string{"rbind"}},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), cdb.writes.Load(), "Activate must perform exactly one write transaction")
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+}
+
+// TestActivateSingleWriteTransactionWithBoundaryEnsure verifies that
+// a boundary mount's own deferred mkdir/mkfs does not cost a second
+// write transaction.
+func TestActivateSingleWriteTransactionWithBoundaryEnsure(t *testing.T) {
+	td := t.TempDir()
+	root := filepath.Join(td, "root")
+	require.NoError(t, os.MkdirAll(root, 0700))
+	rawdb, err := bolt.Open(filepath.Join(td, "mounts.db"), 0600, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { rawdb.Close() })
+
+	m, err := NewManager(rawdb, filepath.Join(td, "m"), WithAllowedRoot(root))
+	require.NoError(t, err)
+	t.Cleanup(func() { m.(io.Closer).Close() })
+	mm := m.(*mountManager)
+	cdb := &countingDB{DB: rawdb}
+	mm.db = cdb
+
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	upper := filepath.Join(root, "upper")
+	ainfo, err := m.Activate(ctx, "a", []mount.Mount{
+		{
+			Type:   "mkdir/overlay",
+			Source: "overlay",
+			Options: []string{
+				fmt.Sprintf("X-containerd.mkdir.path=%s", upper),
+				"upperdir=" + upper,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, ainfo.System, 1)
+
+	assert.Equal(t, int32(1), cdb.writes.Load(), "a boundary mount's own deferred mkdir must not cost a second write transaction")
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+}
+
+// blockingHandler blocks inside Mount until release is closed, and
+// signals entered once it does.
+type blockingHandler struct {
+	total       atomic.Int32
+	entered     chan struct{}
+	enteredOnce sync.Once
+	release     chan struct{}
+
+	mu   sync.Mutex
+	live map[string]struct{}
+}
+
+func (h *blockingHandler) Mount(_ context.Context, m mount.Mount, mp string, _ []mount.ActiveMount) (mount.ActiveMount, error) {
+	h.total.Add(1)
+	h.enteredOnce.Do(func() { close(h.entered) })
+	<-h.release
+
+	now := time.Now()
+	h.mu.Lock()
+	if h.live == nil {
+		h.live = map[string]struct{}{}
+	}
+	h.live[mp] = struct{}{}
+	h.mu.Unlock()
+	return mount.ActiveMount{Mount: m, MountedAt: &now, MountPoint: mp}, nil
+}
+
+func (h *blockingHandler) Unmount(_ context.Context, mp string) error {
+	h.mu.Lock()
+	delete(h.live, mp)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *blockingHandler) Mounted(_ context.Context, path string) (bool, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, ok := h.live[path]
+	return ok, nil
+}
+
+type activateResult struct {
+	info mount.ActivationInfo
+	err  error
+}
+
+// TestRealizeMountWaitsForConcurrentIdentity verifies that an
+// activation which resolves to the same identity as one still in the
+// middle of mounting waits for it rather than observing a
+// not-yet-live record and mounting a second time.
+func TestRealizeMountWaitsForConcurrentIdentity(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	handler := &blockingHandler{entered: make(chan struct{}), release: make(chan struct{})}
+	m, _ := mkTestManager(t, WithMountHandler("vol", handler))
+
+	vol := mount.Mount{Type: "vol", Source: testDevNull, Options: []string{"rw"}}
+
+	aDone := make(chan activateResult, 1)
+	go func() {
+		info, err := m.Activate(ctx, "a", []mount.Mount{vol})
+		aDone <- activateResult{info, err}
+	}()
+
+	select {
+	case <-handler.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the first activation to start mounting")
+	}
+
+	// "b" resolves to the same identity while "a" is still inside
+	// Mount. It must block acquiring the identity lock in
+	// realizeMount, not proceed past a not-yet-live probe and mount
+	// a second time.
+	bDone := make(chan activateResult, 1)
+	go func() {
+		info, err := m.Activate(ctx, "b", []mount.Mount{vol})
+		bDone <- activateResult{info, err}
+	}()
+
+	// There is no event to synchronize on for "b" reaching the lock;
+	// give the scheduler a window. If "b" were not actually blocked,
+	// the assertion on total mounts below would still catch it.
+	time.Sleep(50 * time.Millisecond)
+
+	close(handler.release)
+
+	a := <-aDone
+	require.NoError(t, a.err)
+	b := <-bDone
+	require.NoError(t, b.err)
+
+	assert.Equal(t, int32(1), handler.total.Load(), "identical mount must be mounted exactly once")
+	assert.Equal(t, a.info.Active[0].MountPoint, b.info.Active[0].MountPoint)
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	require.NoError(t, m.Deactivate(ctx, "b"))
+}
+
+// TestDeactivateWaitsForConcurrentActivateSameName verifies that
+// Deactivate cannot release a name's activation while an Activate of
+// that same name is still in flight.
+func TestDeactivateWaitsForConcurrentActivateSameName(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	handler := &blockingHandler{entered: make(chan struct{}), release: make(chan struct{})}
+	m, _ := mkTestManager(t, WithMountHandler("vol", handler))
+
+	// Deliberately non-shareable (a relative/empty Source).
+	vol := mount.Mount{Type: "vol", Options: []string{"rw"}}
+
+	aDone := make(chan activateResult, 1)
+	go func() {
+		info, err := m.Activate(ctx, "a", []mount.Mount{vol})
+		aDone <- activateResult{info, err}
+	}()
+
+	select {
+	case <-handler.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Activate to start mounting")
+	}
+
+	deactivateDone := make(chan error, 1)
+	go func() {
+		deactivateDone <- m.Deactivate(ctx, "a")
+	}()
+
+	// Deactivate must block behind the activate lock, not race ahead
+	// while Activate is still mounting.
+	select {
+	case err := <-deactivateDone:
+		t.Fatalf("Deactivate returned (err=%v) while Activate was still mounting; the two were not serialized on the same name", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(handler.release)
+
+	a := <-aDone
+	require.NoError(t, a.err)
+
+	require.NoError(t, <-deactivateDone)
+	assert.Equal(t, int32(1), handler.total.Load(), "the mount Activate resolved before Deactivate could run must be the only one made")
+
+	_, err := m.Info(ctx, "a")
+	assert.True(t, errdefs.IsNotFound(err), "expected ErrNotFound after the deferred Deactivate finally ran, got %v", err)
+}
+
+// recordUses returns the ids of the mounted records the named
+// activation uses.
+func recordUses(t *testing.T, mm *mountManager, namespace, name string) []uint64 {
+	t.Helper()
+	var ids []uint64
+	require.NoError(t, mm.db.View(func(tx *bolt.Tx) error {
+		bkt := getBucket(tx, bucketKeyV2, []byte(namespace), bucketKeyActivations, []byte(name))
+		require.NotNil(t, bkt)
+		ids = activationUses(bkt)
+		return nil
+	}))
+	return ids
+}
+
+// TestRealizeMountRepairsInPlace verifies that a mounted record found
+// not live is repaired using its existing id and mount point rather
+// than by minting a new one.
+func TestRealizeMountRepairsInPlace(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	handler := &noopHandler{mounts: mountC}
+	m, _ := mkTestManager(t, WithMountHandler("vol", handler))
+	mm := m.(*mountManager)
+
+	vol := mount.Mount{Type: "vol", Source: testDevNull, Options: []string{"rw"}}
+
+	aInfo, err := m.Activate(ctx, "a", []mount.Mount{vol})
+	require.NoError(t, err)
+	mp := aInfo.Active[0].MountPoint
+	assert.Equal(t, int32(1), mountC.Load())
+	idsBefore := recordUses(t, mm, "test", "a")
+	require.Len(t, idsBefore, 1)
+
+	// Something outside this package tears the mount down without
+	// going through Deactivate: the manager's own bookkeeping still
+	// describes it, but it is no longer actually there.
+	handler.mu.Lock()
+	delete(handler.live, mp)
+	handler.mu.Unlock()
+	mountC.Add(-1)
+
+	// A second activation resolving to the same identity must find it
+	// is not live and repair it in place.
+	bInfo, err := m.Activate(ctx, "b", []mount.Mount{vol})
+	require.NoError(t, err)
+	assert.Equal(t, mp, bInfo.Active[0].MountPoint, "repair must reuse the same mount point, not allocate a new one")
+	assert.Equal(t, int32(1), mountC.Load(), "repair mounts exactly once")
+
+	idsAfter := recordUses(t, mm, "test", "b")
+	require.Len(t, idsAfter, 1)
+	assert.Equal(t, idsBefore[0], idsAfter[0], "repair must reuse the existing record id, never mint a new one")
+
+	// "a", having never been told anything changed, now correctly
+	// reports the record as live again too, since it was repaired at
+	// the same path under the same id.
+	info, err := m.Info(ctx, "a")
+	require.NoError(t, err)
+	assert.Equal(t, mp, info.Active[0].MountPoint)
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	assert.Equal(t, int32(1), mountC.Load(), "mount stays while b references it")
+	require.NoError(t, m.Deactivate(ctx, "b"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// rewritingHandler mounts by rewriting m.Source and reporting
+// MountData, the way a real handler such as erofs rewrites a source
+// into a loop or dm-verity device.
+type rewritingHandler struct {
+	mounts *atomic.Int32
+
+	mu   sync.Mutex
+	live map[string]struct{}
+}
+
+func (h *rewritingHandler) Mount(_ context.Context, m mount.Mount, mp string, _ []mount.ActiveMount) (mount.ActiveMount, error) {
+	now := time.Now()
+	h.mounts.Add(1)
+	h.mu.Lock()
+	if h.live == nil {
+		h.live = map[string]struct{}{}
+	}
+	h.live[mp] = struct{}{}
+	h.mu.Unlock()
+	m.Source = "rewritten:" + m.Source
+	return mount.ActiveMount{
+		Mount:      m,
+		MountedAt:  &now,
+		MountPoint: mp,
+		MountData:  map[string]string{"handler": "rewritingHandler"},
+	}, nil
+}
+
+func (h *rewritingHandler) Unmount(_ context.Context, mp string) error {
+	h.mu.Lock()
+	_, wasLive := h.live[mp]
+	delete(h.live, mp)
+	h.mu.Unlock()
+	if wasLive {
+		h.mounts.Add(-1)
+	}
+	return nil
+}
+
+func (h *rewritingHandler) Mounted(_ context.Context, mp string) (bool, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, ok := h.live[mp]
+	return ok, nil
+}
+
+// TestActivateReportsHandlerRewrittenMount verifies that Activate
+// reports the Mount and MountData a Handler's own Mount call returns,
+// not the pre-resolution record.
+func TestActivateReportsHandlerRewrittenMount(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	handler := &rewritingHandler{mounts: mountC}
+	m, _ := mkTestManager(t, WithMountHandler("vol", handler))
+
+	ainfo, err := m.Activate(ctx, "a", []mount.Mount{{Type: "vol", Source: testDevNull, Options: []string{"rw"}}})
+	require.NoError(t, err)
+	require.Len(t, ainfo.Active, 1)
+	assert.Equal(t, "rewritten:"+testDevNull, ainfo.Active[0].Source, "Activate must report the handler's own rewritten mount")
+	assert.Equal(t, map[string]string{"handler": "rewritingHandler"}, ainfo.Active[0].MountData)
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestActivateReusesRecordWithoutHandlerData verifies that an
+// activation which reuses an already-mounted shared record, never
+// calling Mount itself, reports the persisted record rather than
+// handler data from an activation it did not make.
+func TestActivateReusesRecordWithoutHandlerData(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	handler := &rewritingHandler{mounts: mountC}
+	m, _ := mkTestManager(t, WithMountHandler("vol", handler))
+
+	vol := mount.Mount{Type: "vol", Source: testDevNull, Options: []string{"rw"}}
+	aInfo, err := m.Activate(ctx, "a", []mount.Mount{vol})
+	require.NoError(t, err)
+	require.Len(t, aInfo.Active, 1)
+	assert.Equal(t, "rewritten:"+testDevNull, aInfo.Active[0].Source)
+
+	bInfo, err := m.Activate(ctx, "b", []mount.Mount{vol})
+	require.NoError(t, err)
+	require.Len(t, bInfo.Active, 1)
+	assert.Equal(t, int32(1), mountC.Load(), "second activation must reuse the mount, not repeat it")
+	assert.Equal(t, testDevNull, bInfo.Active[0].Source, "a reused record reports its persisted source, not another activation's handler result")
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	require.NoError(t, m.Deactivate(ctx, "b"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestPodGroupSharesOneMount verifies that a shared image mount at
+// the bottom of each container's chain is mounted exactly once no
+// matter how many containers reference it.
+func TestPodGroupSharesOneMount(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t,
+		WithMountHandler("image", &noopHandler{mounts: mountC}),
+		WithMountHandler("dir", &noopHandler{mounts: mountC}))
+
+	chain := func(container string) []mount.Mount {
+		return []mount.Mount{
+			{
+				Type:    "format/image",
+				Source:  testPodImg,
+				Options: []string{"rw", "loop"},
+			},
+			{
+				Type:    "format/dir",
+				Source:  "{{ mount 0 }}/upper-" + container,
+				Options: []string{"rbind"},
+			},
+		}
+	}
+
+	const n = 3
+	var mps []string
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("container%d", i)
+		info, err := m.Activate(ctx, name, chain(name))
+		require.NoError(t, err)
+		require.Len(t, info.Active, 2)
+		mps = append(mps, info.Active[0].MountPoint)
+		assert.Equal(t, info.Active[0].MountPoint+"/upper-"+name, info.Active[1].Source)
+	}
+
+	for i := 1; i < n; i++ {
+		assert.Equal(t, mps[0], mps[i], "every container must share the same image mount point")
+	}
+	assert.Equal(t, int32(1+n), mountC.Load(), "one shared image mount, plus one unique directory mount per container")
+
+	for i := 0; i < n; i++ {
+		require.NoError(t, m.Deactivate(ctx, fmt.Sprintf("container%d", i)))
+	}
+	assert.Equal(t, int32(0), mountC.Load())
 }

--- a/core/mount/manager/mkdir.go
+++ b/core/mount/manager/mkdir.go
@@ -64,7 +64,7 @@ func (h *mkdir) rewrite(m mount.Mount) (mount.Mount, deferredEnsure, error) {
 			if !isPath {
 				return mount.Mount{}, deferredEnsure{}, fmt.Errorf("invalid mkdir option %q: %w", o, errdefs.ErrInvalidArgument)
 			}
-			parts := strings.SplitN(value, ":", 4)
+			parts := splitMkdirPathValue(value)
 			var (
 				dir      string
 				mode     os.FileMode = 0700

--- a/core/mount/manager/mkdir.go
+++ b/core/mount/manager/mkdir.go
@@ -37,16 +37,32 @@ type mkdir struct {
 	rootMap map[string]*os.Root
 }
 
-func (h *mkdir) Transform(ctx context.Context, m mount.Mount, _ []mount.ActiveMount) (mount.Mount, error) {
+// mkdirAction is one X-containerd.mkdir.* option, parsed but not yet
+// applied to the filesystem.
+type mkdirAction struct {
+	root    *os.Root
+	subpath string
+	dir     string // original, unresolved-relative path, for error messages
+	mode    os.FileMode
+	uid     int
+	gid     int
+	luid    int
+	lgid    int
+}
 
+// rewrite parses m's mkdir options into the mount value the kernel
+// will see, and a deferredEnsure that creates the directories those
+// options describe.
+func (h *mkdir) rewrite(m mount.Mount) (mount.Mount, deferredEnsure, error) {
 	var options []string
+	var actions []mkdirAction
 	for _, o := range m.Options {
 		if mkdirOption, isMkdir := strings.CutPrefix(o, prefixMkdir); isMkdir {
 			// Format is X-containerd.mkdir.path=value[:mode[:uid:gid]]
 
 			value, isPath := strings.CutPrefix(mkdirOption, "path=")
 			if !isPath {
-				return mount.Mount{}, fmt.Errorf("invalid mkdir option %q: %w", o, errdefs.ErrInvalidArgument)
+				return mount.Mount{}, deferredEnsure{}, fmt.Errorf("invalid mkdir option %q: %w", o, errdefs.ErrInvalidArgument)
 			}
 			parts := strings.SplitN(value, ":", 4)
 			var (
@@ -61,11 +77,11 @@ func (h *mkdir) Transform(ctx context.Context, m mount.Mount, _ []mount.ActiveMo
 			case 4:
 				gid, err = strconv.Atoi(parts[3])
 				if err != nil {
-					return mount.Mount{}, fmt.Errorf("invalid gid %q: %w", parts[3], errdefs.ErrInvalidArgument)
+					return mount.Mount{}, deferredEnsure{}, fmt.Errorf("invalid gid %q: %w", parts[3], errdefs.ErrInvalidArgument)
 				}
 				uid, err = strconv.Atoi(parts[2])
 				if err != nil {
-					return mount.Mount{}, fmt.Errorf("invalid uid %q: %w", parts[2], errdefs.ErrInvalidArgument)
+					return mount.Mount{}, deferredEnsure{}, fmt.Errorf("invalid uid %q: %w", parts[2], errdefs.ErrInvalidArgument)
 				}
 				fallthrough
 			case 2:
@@ -74,16 +90,16 @@ func (h *mkdir) Transform(ctx context.Context, m mount.Mount, _ []mount.ActiveMo
 				if err == nil {
 					mode = os.FileMode(p)
 					if mode != mode&os.ModePerm {
-						return mount.Mount{}, fmt.Errorf("invalid mode %o", p)
+						return mount.Mount{}, deferredEnsure{}, fmt.Errorf("invalid mode %o", p)
 					}
 				} else {
-					return mount.Mount{}, fmt.Errorf("invalid mode %s: %w", parts[1], err)
+					return mount.Mount{}, deferredEnsure{}, fmt.Errorf("invalid mode %s: %w", parts[1], err)
 				}
 				fallthrough
 			case 1:
 				dir = parts[0]
 			default:
-				return mount.Mount{}, fmt.Errorf("invalid mkdir option %q: %w", o, errdefs.ErrInvalidArgument)
+				return mount.Mount{}, deferredEnsure{}, fmt.Errorf("invalid mkdir option %q: %w", o, errdefs.ErrInvalidArgument)
 			}
 
 			var r *os.Root
@@ -98,35 +114,85 @@ func (h *mkdir) Transform(ctx context.Context, m mount.Mount, _ []mount.ActiveMo
 				}
 			}
 			if r == nil {
-				return mount.Mount{}, fmt.Errorf("no root %q configured for mkdir: %w", dir, errdefs.ErrNotImplemented)
+				return mount.Mount{}, deferredEnsure{}, fmt.Errorf("no root %q configured for mkdir: %w", dir, errdefs.ErrNotImplemented)
 			}
 
-			if st, err := r.Stat(subpath); err == nil {
-				if st.Mode()&os.ModePerm != mode {
-					// TODO: Chmod support added in go1.25
-					return mount.Mount{}, fmt.Errorf("chmod not supported yet for mkdir handler: %w", errdefs.ErrNotImplemented)
-				}
-				// TODO: check ownership, chown support added in go1.25
-			} else if os.IsNotExist(err) {
-				// TODO: MkdirAll added in go1.25
-				if err := r.Mkdir(subpath, mode); err != nil {
-					return mount.Mount{}, fmt.Errorf("failed to create directory %q: %w", dir, err)
-				}
-				if luid != -1 && (luid != uid || lgid != gid) {
-					// TODO: Chown support added in go1.25
-					//if err := r.Chown(subpath, uid, gid); err != nil {
-					//	return fmt.Errorf("failed to chown directory %q: %w", m.Source, err)
-					//}
-					return mount.Mount{}, fmt.Errorf("chown not supported yet for mkdir handler: %w", errdefs.ErrNotImplemented)
-				}
-			} else {
-				return mount.Mount{}, fmt.Errorf("failed to stat %q: %w", dir, err)
-			}
+			actions = append(actions, mkdirAction{
+				root:    r,
+				subpath: subpath,
+				dir:     dir,
+				mode:    mode,
+				uid:     uid,
+				gid:     gid,
+				luid:    luid,
+				lgid:    lgid,
+			})
 		} else {
 			options = append(options, o)
 		}
 	}
 	m.Options = options
 
-	return m, nil
+	targets := make([]string, len(actions))
+	for i, a := range actions {
+		target, err := filepath.Abs(filepath.Join(a.root.Name(), a.subpath))
+		if err != nil {
+			return mount.Mount{}, deferredEnsure{}, fmt.Errorf("failed to resolve absolute path for %q: %w", a.dir, err)
+		}
+		targets[i] = target
+	}
+	ensure := deferredEnsure{
+		targets: targets,
+		run: func(ctx context.Context) error {
+			for _, a := range actions {
+				if err := a.apply(); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	return m, ensure, nil
+}
+
+// apply creates a's directory if it does not already exist. An
+// existing directory whose mode disagrees is reported rather than
+// changed, matching the historical behavior: chown and chmod support
+// for an already existing directory are not yet implemented.
+func (a mkdirAction) apply() error {
+	if st, err := a.root.Stat(a.subpath); err == nil {
+		if st.Mode()&os.ModePerm != a.mode {
+			// TODO: Chmod support added in go1.25
+			return fmt.Errorf("chmod not supported yet for mkdir handler: %w", errdefs.ErrNotImplemented)
+		}
+		// TODO: check ownership, chown support added in go1.25
+	} else if os.IsNotExist(err) {
+		// TODO: MkdirAll added in go1.25
+		if err := a.root.Mkdir(a.subpath, a.mode); err != nil {
+			return fmt.Errorf("failed to create directory %q: %w", a.dir, err)
+		}
+		if a.luid != -1 && (a.luid != a.uid || a.lgid != a.gid) {
+			// TODO: Chown support added in go1.25
+			//if err := a.root.Chown(a.subpath, a.uid, a.gid); err != nil {
+			//	return fmt.Errorf("failed to chown directory %q: %w", a.dir, err)
+			//}
+			return fmt.Errorf("chown not supported yet for mkdir handler: %w", errdefs.ErrNotImplemented)
+		}
+	} else {
+		return fmt.Errorf("failed to stat %q: %w", a.dir, err)
+	}
+	return nil
+}
+
+// Transform implements mount.Transformer by running rewrite and its
+// ensure together.
+func (h *mkdir) Transform(ctx context.Context, m mount.Mount, _ []mount.ActiveMount) (mount.Mount, error) {
+	rewritten, ensure, err := h.rewrite(m)
+	if err != nil {
+		return rewritten, err
+	}
+	if err := ensure.run(ctx); err != nil {
+		return mount.Mount{}, err
+	}
+	return rewritten, nil
 }

--- a/core/mount/manager/mkdir.go
+++ b/core/mount/manager/mkdir.go
@@ -146,31 +146,54 @@ func (h *mkdir) rewrite(m mount.Mount) (mount.Mount, deferredEnsure, error) {
 }
 
 // apply creates a's directory if it does not already exist. An
-// existing directory whose mode disagrees is reported rather than
-// changed, matching the historical behavior: chown and chmod support
-// for an already existing directory are not yet implemented.
+// existing path is accepted only if it is already a directory with
+// matching permissions.
 func (a mkdirAction) apply() error {
-	if st, err := a.root.Stat(a.subpath); err == nil {
-		if st.Mode()&os.ModePerm != a.mode {
-			// TODO: Chmod support added in go1.25
-			return fmt.Errorf("chmod not supported yet for mkdir handler: %w", errdefs.ErrNotImplemented)
+	st, err := a.root.Stat(a.subpath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to stat %q: %w", a.dir, err)
 		}
-		// TODO: check ownership, chown support added in go1.25
-	} else if os.IsNotExist(err) {
-		// TODO: MkdirAll added in go1.25
-		if err := a.root.Mkdir(a.subpath, a.mode); err != nil {
+		return a.create()
+	}
+	return a.validate(st)
+}
+
+// create makes a's directory, tolerating a concurrent boundary ensure
+// for the same target having just created it first.
+func (a mkdirAction) create() error {
+	// TODO: MkdirAll added in go1.25
+	if err := a.root.Mkdir(a.subpath, a.mode); err != nil {
+		if !os.IsExist(err) {
 			return fmt.Errorf("failed to create directory %q: %w", a.dir, err)
 		}
-		if a.luid != -1 && (a.luid != a.uid || a.lgid != a.gid) {
-			// TODO: Chown support added in go1.25
-			//if err := a.root.Chown(a.subpath, a.uid, a.gid); err != nil {
-			//	return fmt.Errorf("failed to chown directory %q: %w", a.dir, err)
-			//}
-			return fmt.Errorf("chown not supported yet for mkdir handler: %w", errdefs.ErrNotImplemented)
+		st, err := a.root.Stat(a.subpath)
+		if err != nil {
+			return fmt.Errorf("failed to stat %q: %w", a.dir, err)
 		}
-	} else {
-		return fmt.Errorf("failed to stat %q: %w", a.dir, err)
+		return a.validate(st)
 	}
+	if a.luid != -1 && (a.luid != a.uid || a.lgid != a.gid) {
+		// TODO: Chown support added in go1.25
+		//if err := a.root.Chown(a.subpath, a.uid, a.gid); err != nil {
+		//	return fmt.Errorf("failed to chown directory %q: %w", a.dir, err)
+		//}
+		return fmt.Errorf("chown not supported yet for mkdir handler: %w", errdefs.ErrNotImplemented)
+	}
+	return nil
+}
+
+// validate reports whether st, describing something already at a's
+// target, satisfies a's directory and mode requirements.
+func (a mkdirAction) validate(st os.FileInfo) error {
+	if !st.IsDir() {
+		return fmt.Errorf("mkdir target %q exists and is not a directory: %w", a.dir, errdefs.ErrFailedPrecondition)
+	}
+	if st.Mode()&os.ModePerm != a.mode {
+		// TODO: Chmod support added in go1.25
+		return fmt.Errorf("chmod not supported yet for mkdir handler: %w", errdefs.ErrNotImplemented)
+	}
+	// TODO: check ownership, chown support added in go1.25
 	return nil
 }
 

--- a/core/mount/manager/mkdir.go
+++ b/core/mount/manager/mkdir.go
@@ -102,19 +102,9 @@ func (h *mkdir) rewrite(m mount.Mount) (mount.Mount, deferredEnsure, error) {
 				return mount.Mount{}, deferredEnsure{}, fmt.Errorf("invalid mkdir option %q: %w", o, errdefs.ErrInvalidArgument)
 			}
 
-			var r *os.Root
-			var subpath string
-
-			for path, root := range h.rootMap {
-				if strings.HasPrefix(dir, path) {
-					r = root
-					subpath = strings.TrimPrefix(dir, path)
-					subpath, _ = filepath.Rel("/", subpath)
-					break
-				}
-			}
-			if r == nil {
-				return mount.Mount{}, deferredEnsure{}, fmt.Errorf("no root %q configured for mkdir: %w", dir, errdefs.ErrNotImplemented)
+			r, subpath, err := resolveRoot(h.rootMap, dir, "mkdir")
+			if err != nil {
+				return mount.Mount{}, deferredEnsure{}, err
 			}
 
 			actions = append(actions, mkdirAction{

--- a/core/mount/manager/mkdir_linux_test.go
+++ b/core/mount/manager/mkdir_linux_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log/logtest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/containerd/v2/core/mount"
@@ -124,4 +125,63 @@ func TestMkdirHandlerTargetIsRoot(t *testing.T) {
 
 	_, err = mh.Transform(ctx, m, nil)
 	require.NoError(t, err)
+}
+
+// TestMkdirHandlerTargetNotADirectory verifies that mkdir rejects an
+// existing target which is not a directory.
+func TestMkdirHandlerTargetNotADirectory(t *testing.T) {
+	ctx := logtest.WithT(context.Background(), t)
+	ctx = namespaces.WithNamespace(ctx, "test")
+	td := t.TempDir()
+
+	root := filepath.Join(td, "root")
+	require.NoError(t, os.MkdirAll(root, 0775))
+
+	testmode := os.FileMode(0751)
+	target := filepath.Join(root, "notadir")
+	require.NoError(t, os.WriteFile(target, nil, testmode))
+
+	r, err := os.OpenRoot(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+	mh := mkdir{rootMap: map[string]*os.Root{root: r}}
+
+	m := mount.Mount{
+		Type:   "mkdir/overlay",
+		Source: "overlay",
+		Options: []string{
+			fmt.Sprintf("X-containerd.mkdir.path=%s:%o", target, testmode),
+		},
+	}
+
+	_, err = mh.Transform(ctx, m, nil)
+	require.Error(t, err)
+	assert.True(t, errdefs.IsFailedPrecondition(err), "expected ErrFailedPrecondition, got %v", err)
+}
+
+// TestMkdirActionCreateToleratesConcurrentCreation verifies that
+// create does not fail when a concurrent boundary ensure for the same
+// target creates the directory first: Mkdir's own EEXIST is validated
+// like an already-existing target, not treated as a hard failure.
+func TestMkdirActionCreateToleratesConcurrentCreation(t *testing.T) {
+	td := t.TempDir()
+	root := filepath.Join(td, "root")
+	require.NoError(t, os.MkdirAll(root, 0775))
+
+	testmode := os.FileMode(0751)
+	target := filepath.Join(root, "concurrent")
+	require.NoError(t, os.MkdirAll(target, testmode))
+
+	r, err := os.OpenRoot(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	a := mkdirAction{
+		root:    r,
+		subpath: "concurrent",
+		dir:     target,
+		mode:    testmode,
+		luid:    -1,
+	}
+	assert.NoError(t, a.create(), "losing the mkdir race to a concurrent ensure must not fail apply")
 }

--- a/core/mount/manager/mkdir_linux_test.go
+++ b/core/mount/manager/mkdir_linux_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log/logtest"
+	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
@@ -94,4 +95,33 @@ func TestMkdirHandler(t *testing.T) {
 	} else if !errdefs.IsNotImplemented(err) {
 		t.Fatal(err)
 	}
+}
+
+// TestMkdirHandlerTargetIsRoot verifies that mkdir can target the
+// configured root directory itself.
+func TestMkdirHandlerTargetIsRoot(t *testing.T) {
+	ctx := logtest.WithT(context.Background(), t)
+	ctx = namespaces.WithNamespace(ctx, "test")
+	td := t.TempDir()
+
+	testmode := os.FileMode(0751)
+	root := filepath.Join(td, "root")
+	require.NoError(t, os.MkdirAll(root, 0775))
+	require.NoError(t, os.Chmod(root, testmode))
+
+	r, err := os.OpenRoot(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+	mh := mkdir{rootMap: map[string]*os.Root{root: r}}
+
+	m := mount.Mount{
+		Type:   "mkdir/overlay",
+		Source: "overlay",
+		Options: []string{
+			fmt.Sprintf("X-containerd.mkdir.path=%s:%o", root, testmode),
+		},
+	}
+
+	_, err = mh.Transform(ctx, m, nil)
+	require.NoError(t, err)
 }

--- a/core/mount/manager/mkdir_other.go
+++ b/core/mount/manager/mkdir_other.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import "strings"
+
+// splitMkdirPathValue splits value, an X-containerd.mkdir.path
+// option's value, into its colon-separated path/mode/uid/gid parts.
+func splitMkdirPathValue(value string) []string {
+	return strings.SplitN(value, ":", 4)
+}

--- a/core/mount/manager/mkdir_other_test.go
+++ b/core/mount/manager/mkdir_other_test.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSplitMkdirPathValue verifies that splitMkdirPathValue splits on
+// every colon.
+func TestSplitMkdirPathValue(t *testing.T) {
+	assert.Equal(t, []string{"/a/b"}, splitMkdirPathValue("/a/b"))
+	assert.Equal(t, []string{"/a/b", "700"}, splitMkdirPathValue("/a/b:700"))
+	assert.Equal(t, []string{"/a/b", "700", "1000", "1000"}, splitMkdirPathValue("/a/b:700:1000:1000"))
+}

--- a/core/mount/manager/mkdir_windows.go
+++ b/core/mount/manager/mkdir_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// splitMkdirPathValue splits value, an X-containerd.mkdir.path
+// option's value, into its colon-separated path/mode/uid/gid parts,
+// without splitting a drive letter's own colon out of the path.
+func splitMkdirPathValue(value string) []string {
+	vol := filepath.VolumeName(value)
+	parts := strings.SplitN(value[len(vol):], ":", 4)
+	parts[0] = vol + parts[0]
+	return parts
+}

--- a/core/mount/manager/mkdir_windows_test.go
+++ b/core/mount/manager/mkdir_windows_test.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSplitMkdirPathValue verifies that splitMkdirPathValue does not
+// split a drive letter's own colon out of the path.
+func TestSplitMkdirPathValue(t *testing.T) {
+	assert.Equal(t, []string{`C:\Users\foo`}, splitMkdirPathValue(`C:\Users\foo`))
+	assert.Equal(t, []string{`C:\Users\foo`, "700"}, splitMkdirPathValue(`C:\Users\foo:700`))
+	assert.Equal(t, []string{`C:\Users\foo`, "700", "1000", "1000"}, splitMkdirPathValue(`C:\Users\foo:700:1000:1000`))
+	// No volume name: behaves like the non-Windows split.
+	assert.Equal(t, []string{`\Users\foo`, "700"}, splitMkdirPathValue(`\Users\foo:700`))
+}

--- a/core/mount/manager/mkfs.go
+++ b/core/mount/manager/mkfs.go
@@ -149,19 +149,30 @@ func ensureMkfsImage(ctx context.Context, r *os.Root, subpath, source string, si
 		return fmt.Errorf("unsupported filesystem %q: %w", fs, errdefs.ErrInvalidArgument)
 	}
 
-	f, err := r.OpenFile(subpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
+	// Formatted at a sibling temp path and renamed into place, so
+	// subpath only ever exists once fully formatted.
+	tmpSubpath := subpath + ".tmp"
+	f, err := r.OpenFile(tmpSubpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
 	if err != nil {
 		return fmt.Errorf("failed to create file %q: %w", source, err)
 	}
+	removeTmp := true
+	defer func() {
+		if !removeTmp {
+			return
+		}
+		// Best effort; a leftover temp file is harmless.
+		if err := r.Remove(tmpSubpath); err != nil && !os.IsNotExist(err) {
+			log.G(ctx).WithError(err).WithField("path", tmpSubpath).Warn("failed to remove mkfs temp file")
+		}
+	}()
 
-	// Absolute, since createWritableImage runs mkfs.* as a subprocess
-	// without setting its working directory.
-	imgPath, err := filepath.Abs(filepath.Join(r.Name(), subpath))
+	tmpImgPath, err := filepath.Abs(filepath.Join(r.Name(), tmpSubpath))
 	if err != nil {
 		f.Close()
 		return fmt.Errorf("failed to resolve absolute path for %q: %w", source, err)
 	}
-	createArgs = append(createArgs, imgPath)
+	createArgs = append(createArgs, tmpImgPath)
 
 	err = f.Truncate(size)
 	f.Close()
@@ -172,6 +183,11 @@ func ensureMkfsImage(ctx context.Context, r *os.Root, subpath, source string, si
 	if err := createWritableImage(ctx, binary, createArgs...); err != nil {
 		return fmt.Errorf("failed format %q: %w", source, err)
 	}
+
+	if err := r.Rename(tmpSubpath, subpath); err != nil {
+		return fmt.Errorf("failed to publish formatted image %q: %w", source, err)
+	}
+	removeTmp = false
 
 	return nil
 }

--- a/core/mount/manager/mkfs.go
+++ b/core/mount/manager/mkfs.go
@@ -39,19 +39,9 @@ type mkfs struct {
 // will see, and a deferredEnsure that creates and formats the backing
 // file those options describe.
 func (t *mkfs) rewrite(m mount.Mount) (mount.Mount, deferredEnsure, error) {
-	var r *os.Root
-	var subpath string
-
-	for path, root := range t.rootMap {
-		if strings.HasPrefix(m.Source, path) {
-			r = root
-			subpath = strings.TrimPrefix(m.Source, path)
-			subpath, _ = filepath.Rel("/", subpath)
-			break
-		}
-	}
-	if r == nil {
-		return m, deferredEnsure{}, fmt.Errorf("no root %q configured for mkfs: %w", m.Source, errdefs.ErrNotImplemented)
+	r, subpath, err := resolveRoot(t.rootMap, m.Source, "mkfs")
+	if err != nil {
+		return m, deferredEnsure{}, err
 	}
 
 	var (

--- a/core/mount/manager/mkfs.go
+++ b/core/mount/manager/mkfs.go
@@ -35,7 +35,10 @@ type mkfs struct {
 	rootMap map[string]*os.Root
 }
 
-func (t *mkfs) Transform(ctx context.Context, m mount.Mount, a []mount.ActiveMount) (mount.Mount, error) {
+// rewrite parses m's mkfs options into the mount value the kernel
+// will see, and a deferredEnsure that creates and formats the backing
+// file those options describe.
+func (t *mkfs) rewrite(m mount.Mount) (mount.Mount, deferredEnsure, error) {
 	var r *os.Root
 	var subpath string
 
@@ -48,12 +51,8 @@ func (t *mkfs) Transform(ctx context.Context, m mount.Mount, a []mount.ActiveMou
 		}
 	}
 	if r == nil {
-		err := fmt.Errorf("no root %q configured for mkfs: %w", m.Source, errdefs.ErrNotImplemented)
-		log.G(ctx).WithError(err).Debugf("skipping mkfs")
-		return m, err
+		return m, deferredEnsure{}, fmt.Errorf("no root %q configured for mkfs: %w", m.Source, errdefs.ErrNotImplemented)
 	}
-
-	log.G(ctx).Debugf("transforming mkfs mount: %+v", m)
 
 	var (
 		size int64
@@ -73,14 +72,14 @@ func (t *mkfs) Transform(ctx context.Context, m mount.Mount, a []mount.ActiveMou
 				var err error
 				size, err = units.RAMInBytes(value)
 				if err != nil {
-					return mount.Mount{}, fmt.Errorf("bad option %s: %w", key, err)
+					return mount.Mount{}, deferredEnsure{}, fmt.Errorf("bad option %s: %w", key, err)
 				}
 			case "fs":
 				fs = value
 			case "uuid":
 				id = value
 			default:
-				return mount.Mount{}, fmt.Errorf("unknown mount option %s: %w", key, errdefs.ErrInvalidArgument)
+				return mount.Mount{}, deferredEnsure{}, fmt.Errorf("unknown mount option %s: %w", key, errdefs.ErrInvalidArgument)
 			}
 
 		} else {
@@ -89,54 +88,97 @@ func (t *mkfs) Transform(ctx context.Context, m mount.Mount, a []mount.ActiveMou
 	}
 	m.Options = options
 	if size == 0 {
-		return mount.Mount{}, fmt.Errorf("mkfs requires mkfs.size option: %w", errdefs.ErrInvalidArgument)
+		return mount.Mount{}, deferredEnsure{}, fmt.Errorf("mkfs requires mkfs.size option: %w", errdefs.ErrInvalidArgument)
 	}
 
+	// Absolute, since createWritableImage runs mkfs.* as a subprocess
+	// without setting its working directory.
+	imgPath, err := filepath.Abs(filepath.Join(r.Name(), subpath))
+	if err != nil {
+		return mount.Mount{}, deferredEnsure{}, fmt.Errorf("failed to resolve absolute path for %q: %w", m.Source, err)
+	}
+
+	source := m.Source
+	ensure := deferredEnsure{
+		targets: []string{imgPath},
+		run: func(ctx context.Context) error {
+			return ensureMkfsImage(ctx, r, subpath, source, size, fs, id)
+		},
+	}
+	return m, ensure, nil
+}
+
+// Transform implements mount.Transformer by running rewrite and its
+// ensure together.
+func (t *mkfs) Transform(ctx context.Context, m mount.Mount, _ []mount.ActiveMount) (mount.Mount, error) {
+	log.G(ctx).Debugf("transforming mkfs mount: %+v", m)
+	rewritten, ensure, err := t.rewrite(m)
+	if err != nil {
+		log.G(ctx).WithError(err).Debugf("skipping mkfs")
+		return rewritten, err
+	}
+	if err := ensure.run(ctx); err != nil {
+		return mount.Mount{}, err
+	}
+	return rewritten, nil
+}
+
+// ensureMkfsImage creates and formats the backing file at subpath if
+// it does not already exist. An existing file is assumed already
+// formatted.
+func ensureMkfsImage(ctx context.Context, r *os.Root, subpath, source string, size int64, fs, id string) error {
 	if _, err := r.Stat(subpath); err == nil {
-		// Check magic number
-	} else if os.IsNotExist(err) {
-		createArgs := []string{"-q"}
-
-		// TODO: Pre-resolve the binaries to absolute path on startup for supported fs types
-		var binary string
-
-		// Check fs
-		switch fs {
-		case "ext2", "ext3", "ext4":
-			binary = fmt.Sprintf("mkfs.%s", fs)
-			if id != "" {
-				createArgs = append(createArgs, []string{"-U", id}...)
-			}
-		case "xfs":
-			binary = "mkfs.xfs"
-			if id != "" {
-				createArgs = append(createArgs, []string{"-m", fmt.Sprintf("uuid=%s", id)}...)
-			}
-		default:
-			return mount.Mount{}, fmt.Errorf("unsupported filesystem %q: %w", fs, errdefs.ErrInvalidArgument)
-		}
-
-		f, err := r.OpenFile(subpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
-		if err != nil {
-			return mount.Mount{}, fmt.Errorf("failed to create file %q: %w", m.Source, err)
-		}
-
-		createArgs = append(createArgs, f.Name())
-
-		err = f.Truncate(size)
-		f.Close()
-		if err != nil {
-			return mount.Mount{}, fmt.Errorf("failed to truncate file %q: %w", m.Source, err)
-		}
-
-		if err := createWritableImage(ctx, binary, createArgs...); err != nil {
-			return mount.Mount{}, fmt.Errorf("failed format %q: %w", m.Source, err)
-		}
-	} else {
-		return mount.Mount{}, fmt.Errorf("failed to stat %q: %w", m.Source, err)
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat %q: %w", source, err)
 	}
 
-	return m, nil
+	createArgs := []string{"-q"}
+
+	// TODO: Pre-resolve the binaries to absolute path on startup for supported fs types
+	var binary string
+
+	// Check fs
+	switch fs {
+	case "ext2", "ext3", "ext4":
+		binary = fmt.Sprintf("mkfs.%s", fs)
+		if id != "" {
+			createArgs = append(createArgs, []string{"-U", id}...)
+		}
+	case "xfs":
+		binary = "mkfs.xfs"
+		if id != "" {
+			createArgs = append(createArgs, []string{"-m", fmt.Sprintf("uuid=%s", id)}...)
+		}
+	default:
+		return fmt.Errorf("unsupported filesystem %q: %w", fs, errdefs.ErrInvalidArgument)
+	}
+
+	f, err := r.OpenFile(subpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
+	if err != nil {
+		return fmt.Errorf("failed to create file %q: %w", source, err)
+	}
+
+	// Absolute, since createWritableImage runs mkfs.* as a subprocess
+	// without setting its working directory.
+	imgPath, err := filepath.Abs(filepath.Join(r.Name(), subpath))
+	if err != nil {
+		f.Close()
+		return fmt.Errorf("failed to resolve absolute path for %q: %w", source, err)
+	}
+	createArgs = append(createArgs, imgPath)
+
+	err = f.Truncate(size)
+	f.Close()
+	if err != nil {
+		return fmt.Errorf("failed to truncate file %q: %w", source, err)
+	}
+
+	if err := createWritableImage(ctx, binary, createArgs...); err != nil {
+		return fmt.Errorf("failed format %q: %w", source, err)
+	}
+
+	return nil
 }
 
 func createWritableImage(ctx context.Context, binary string, args ...string) error {

--- a/core/mount/manager/mkfs.go
+++ b/core/mount/manager/mkfs.go
@@ -114,12 +114,17 @@ func (t *mkfs) Transform(ctx context.Context, m mount.Mount, _ []mount.ActiveMou
 }
 
 // ensureMkfsImage creates and formats the backing file at subpath if
-// it does not already exist. An existing file is assumed already
-// formatted.
+// it does not already exist. An existing regular file is assumed
+// already formatted; an existing path of any other type is rejected.
 func ensureMkfsImage(ctx context.Context, r *os.Root, subpath, source string, size int64, fs, id string) error {
-	if _, err := r.Stat(subpath); err == nil {
+	st, err := r.Stat(subpath)
+	if err == nil {
+		if !st.Mode().IsRegular() {
+			return fmt.Errorf("mkfs backing file %q exists and is not a regular file: %w", source, errdefs.ErrFailedPrecondition)
+		}
 		return nil
-	} else if !os.IsNotExist(err) {
+	}
+	if !os.IsNotExist(err) {
 		return fmt.Errorf("failed to stat %q: %w", source, err)
 	}
 

--- a/core/mount/manager/mkfs_test.go
+++ b/core/mount/manager/mkfs_test.go
@@ -93,5 +93,46 @@ func TestEnsureMkfsImagePassesAbsolutePath(t *testing.T) {
 	require.NotEmpty(t, fields)
 	imgPath := fields[len(fields)-1]
 	assert.True(t, filepath.IsAbs(imgPath), "path passed to mkfs.ext4 must be absolute, got %q", imgPath)
-	assert.Equal(t, filepath.Join(root, "img"), imgPath)
+	assert.Equal(t, filepath.Join(root, "img.tmp"), imgPath)
+}
+
+// TestEnsureMkfsImagePublishesAtomically verifies that the final
+// backing file path exists only once mkfs.* has succeeded, with no
+// leftover temp file either way.
+func TestEnsureMkfsImagePublishesAtomically(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on a #!/bin/sh fake mkfs.ext4, not runnable on Windows")
+	}
+
+	td := t.TempDir()
+	root := filepath.Join(td, "root")
+	require.NoError(t, os.MkdirAll(root, 0700))
+	r, err := os.OpenRoot(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	bin := filepath.Join(td, "bin")
+	require.NoError(t, os.MkdirAll(bin, 0700))
+	failing := filepath.Join(bin, "mkfs.ext4")
+	require.NoError(t, os.WriteFile(failing, []byte("#!/bin/sh\nexit 1\n"), 0700))
+	t.Setenv("PATH", bin)
+
+	final := filepath.Join(root, "img")
+	tmp := final + ".tmp"
+
+	err = ensureMkfsImage(context.Background(), r, "img", "img", 4096, "ext4", "")
+	require.Error(t, err, "a failing mkfs.ext4 must surface as an error")
+	_, statErr := os.Stat(final)
+	assert.True(t, os.IsNotExist(statErr), "the final path must not exist after a failed format")
+	_, statErr = os.Stat(tmp)
+	assert.True(t, os.IsNotExist(statErr), "the temp file must be cleaned up after a failed format, not left orphaned")
+
+	succeeding := "#!/bin/sh\nexit 0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(bin, "mkfs.ext4"), []byte(succeeding), 0700))
+
+	require.NoError(t, ensureMkfsImage(context.Background(), r, "img", "img", 4096, "ext4", ""))
+	_, statErr = os.Stat(final)
+	assert.NoError(t, statErr, "a succeeding mkfs.ext4 must be published to the final path")
+	_, statErr = os.Stat(tmp)
+	assert.True(t, os.IsNotExist(statErr), "the temp file must not survive a successful publish")
 }

--- a/core/mount/manager/mkfs_test.go
+++ b/core/mount/manager/mkfs_test.go
@@ -1,0 +1,97 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/containerd/errdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureMkfsImageExistingDirectory verifies that ensureMkfsImage
+// rejects an existing directory at the backing file path.
+func TestEnsureMkfsImageExistingDirectory(t *testing.T) {
+	td := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(td, "existing"), 0700))
+
+	r, err := os.OpenRoot(td)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	err = ensureMkfsImage(context.Background(), r, "existing", "existing", 0, "ext4", "")
+	require.Error(t, err)
+	assert.True(t, errdefs.IsFailedPrecondition(err), "expected ErrFailedPrecondition, got %v", err)
+}
+
+// TestEnsureMkfsImageExistingRegularFile verifies that an existing
+// regular file is accepted as an already-formatted image.
+func TestEnsureMkfsImageExistingRegularFile(t *testing.T) {
+	td := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(td, "existing"), []byte("not really a filesystem"), 0600))
+
+	r, err := os.OpenRoot(td)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	require.NoError(t, ensureMkfsImage(context.Background(), r, "existing", "existing", 0, "ext4", ""))
+}
+
+// TestEnsureMkfsImagePassesAbsolutePath verifies that the path handed
+// to the mkfs.* subprocess is always absolute, even when the
+// configured root is relative.
+func TestEnsureMkfsImagePassesAbsolutePath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on a #!/bin/sh fake mkfs.ext4, not runnable on Windows")
+	}
+
+	td := t.TempDir()
+	root := filepath.Join(td, "root")
+	require.NoError(t, os.MkdirAll(root, 0700))
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	relRoot, err := filepath.Rel(wd, root)
+	require.NoError(t, err)
+
+	r, err := os.OpenRoot(relRoot)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	argsFile := filepath.Join(td, "args")
+	bin := filepath.Join(td, "bin")
+	require.NoError(t, os.MkdirAll(bin, 0700))
+	script := "#!/bin/sh\necho \"$@\" > " + argsFile + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(bin, "mkfs.ext4"), []byte(script), 0700))
+	t.Setenv("PATH", bin)
+
+	require.NoError(t, ensureMkfsImage(context.Background(), r, "img", "img", 4096, "ext4", ""))
+
+	recorded, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	fields := strings.Fields(string(recorded))
+	require.NotEmpty(t, fields)
+	imgPath := fields[len(fields)-1]
+	assert.True(t, filepath.IsAbs(imgPath), "path passed to mkfs.ext4 must be absolute, got %q", imgPath)
+	assert.Equal(t, filepath.Join(root, "img"), imgPath)
+}

--- a/core/mount/manager/reconcile.go
+++ b/core/mount/manager/reconcile.go
@@ -1,0 +1,152 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/moby/sys/mountinfo"
+
+	"github.com/containerd/log"
+
+	"github.com/containerd/containerd/v2/core/mount"
+)
+
+// This file reconciles the activations a database records against the
+// mounts actually in effect, the direction neither GC's own reference
+// counting nor the orphan directory scans in manager.go/v1.go cover:
+// an activation whose write transaction committed but which never got
+// (or no longer has) the mounts it describes, because the process
+// died in between, or because something outside this package tore a
+// mount down. Every collection pass releases what it finds, exactly
+// as if a caller had deactivated it: a name recorded but not actually
+// mounted is otherwise reported by Info and List, and blocks Activate
+// with ErrAlreadyExists, indefinitely, until something reactivates it.
+//
+// canObserveMountTableOS is false exactly where the host's mount
+// table cannot be trusted to distinguish "not mounted" from "cannot
+// tell" at all: on Windows, mountinfo's own fallback silently reports
+// every path as unmounted rather than erroring (see probeMounted's
+// doc). A handler-less mount is never reconciled while this is false;
+// a Handler is always checked directly, on any platform, since
+// mount.MountedChecker's contract does not depend on this.
+const canObserveMountTableOS = runtime.GOOS != "windows"
+
+// snapshotMountTable reads every mount currently under mm.targets,
+// once, for an entire collection pass to share. The returned bool is
+// false when the result cannot be trusted at all, in which case the
+// map is always nil; see reconcileLive.
+func (mm *mountManager) snapshotMountTable(ctx context.Context) (map[string]struct{}, bool) {
+	if !canObserveMountTableOS {
+		return nil, false
+	}
+	// mm.targets.Name() is already canonical; see NewManager.
+	infos, err := mountinfo.GetMounts(mountinfo.PrefixFilter(mm.targets.Name()))
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("failed to read host mount table; handler-less mounts will not be reconciled this pass")
+		return nil, false
+	}
+	mounted := make(map[string]struct{}, len(infos))
+	for _, info := range infos {
+		mounted[info.Mountpoint] = struct{}{}
+	}
+	return mounted, true
+}
+
+// reconcileLive reports whether path is actually mounted: via
+// handler's MountedChecker if it implements one, otherwise against
+// mounted, or assumed live if haveMountTable is false.
+func reconcileLive(ctx context.Context, handler mount.Handler, path string, mounted map[string]struct{}, haveMountTable bool) (bool, error) {
+	if mc, ok := handler.(mount.MountedChecker); ok {
+		return mc.Mounted(ctx, path)
+	}
+	if !haveMountTable {
+		return true, nil
+	}
+	if _, ok := mounted[path]; ok {
+		return true, nil
+	}
+	// A v1 position may still carry the unresolved spelling a pre-v2
+	// binary wrote it with; mounted only ever holds resolved paths.
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		_, ok := mounted[resolved]
+		return ok, nil
+	}
+	return false, nil
+}
+
+// activationLive reports whether every position in a v2 activation's
+// chain is actually mounted, and every recorded ensure target exists.
+func activationLive(ctx context.Context, mm *mountManager, nsbkt, bkt *bolt.Bucket, mounted map[string]struct{}, haveMountTable bool) (bool, error) {
+	if v := bkt.Get(bucketKeyEnsureTargets); len(v) > 0 {
+		for target := range strings.SplitSeq(string(v), "\x00") {
+			if _, err := os.Stat(target); err != nil {
+				if !os.IsNotExist(err) {
+					return false, err
+				}
+				return false, nil
+			}
+		}
+	}
+	ids := activationUses(bkt)
+	if len(ids) == 0 {
+		return true, nil
+	}
+	for _, id := range ids {
+		b, ok, err := getMountedRecord(nsbkt, mountedKey(id))
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			// Should not be reachable; treat as not live.
+			return false, nil
+		}
+		live, err := reconcileLive(ctx, mm.handlers[b.mount.Type], b.point, mounted, haveMountTable)
+		if err != nil {
+			return false, err
+		}
+		if !live {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// v1ActivationLive reports whether every position in a v1
+// activation's chain is actually mounted. No active bucket at all
+// means the activation was interrupted and is never live.
+func v1ActivationLive(ctx context.Context, mm *mountManager, bkt *bolt.Bucket, mounted map[string]struct{}, haveMountTable bool) (bool, error) {
+	if !v1HasActive(bkt) {
+		return false, nil
+	}
+	for _, p := range v1Positions(bkt) {
+		live, err := reconcileLive(ctx, mm.handlers[p.mtype], p.point, mounted, haveMountTable)
+		if err != nil {
+			return false, err
+		}
+		if !live {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/core/mount/manager/reconcile_test.go
+++ b/core/mount/manager/reconcile_test.go
@@ -1,0 +1,508 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/containerd/errdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/v2/core/metadata"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// startCollection is a small helper: every test in this file needs
+// the same type assertion mkTestManager's return value requires to
+// reach StartCollection at all.
+func startCollection(t *testing.T, m mount.Manager, ctx context.Context) metadata.CollectionContext {
+	t.Helper()
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	return cc
+}
+
+// TestReconcileRemovesUnrealizedActivation verifies that an activation
+// whose write transaction committed but which was never actually
+// mounted is released by a collection pass.
+func TestReconcileRemovesUnrealizedActivation(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: mountC}))
+	mm := m.(*mountManager)
+
+	stale := mount.Mount{Type: "noop", Source: testDevZero}
+	require.NoError(t, mm.db.Update(func(tx *bolt.Tx) error {
+		v2bkt, err := tx.CreateBucketIfNotExists(bucketKeyV2)
+		if err != nil {
+			return err
+		}
+		nsbkt, err := v2bkt.CreateBucketIfNotExists([]byte("test"))
+		if err != nil {
+			return err
+		}
+		mbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyActivations)
+		if err != nil {
+			return err
+		}
+		if _, err := mbkt.CreateBucket([]byte("task1")); err != nil {
+			return err
+		}
+		_, err = resolvePosition(tx, mm.targets.Name(), "test", "task1", 0, stale, time.Now())
+		return err
+	}))
+
+	require.NoError(t, startCollection(t, m, ctx).Finish())
+
+	_, err := m.Info(ctx, "task1")
+	assert.True(t, errdefs.IsNotFound(err), "an activation never actually mounted must be reconciled away, got %v", err)
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestReconcileRemovesUnrealizedActivationNoHandler verifies the same
+// crash window as TestReconcileRemovesUnrealizedActivation, but for a
+// position with no Handler, unmounted directly with mount.Unmount.
+func TestReconcileRemovesUnrealizedActivationNoHandler(t *testing.T) {
+	if !canObserveMountTableOS {
+		t.Skip("this handler-less position's fallback is the host mount table, which is not observable on this platform (see canObserveMountTableOS); it is correctly assumed live instead, covered by TestReconcileLiveAssumedWhenMountTableUnobservable")
+	}
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+	mm := m.(*mountManager)
+
+	stale := mount.Mount{Type: "bind", Source: testDevZero}
+	require.NoError(t, mm.db.Update(func(tx *bolt.Tx) error {
+		v2bkt, err := tx.CreateBucketIfNotExists(bucketKeyV2)
+		if err != nil {
+			return err
+		}
+		nsbkt, err := v2bkt.CreateBucketIfNotExists([]byte("test"))
+		if err != nil {
+			return err
+		}
+		mbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyActivations)
+		if err != nil {
+			return err
+		}
+		if _, err := mbkt.CreateBucket([]byte("task1")); err != nil {
+			return err
+		}
+		_, err = resolvePosition(tx, mm.targets.Name(), "test", "task1", 0, stale, time.Now())
+		return err
+	}))
+
+	require.NoError(t, startCollection(t, m, ctx).Finish())
+
+	_, err := m.Info(ctx, "task1")
+	assert.True(t, errdefs.IsNotFound(err), "an activation never actually mounted must be reconciled away, got %v", err)
+}
+
+// TestReconcileRemovesActivationMissingBoundaryEnsure verifies that
+// reconciliation releases an activation whose boundary mount's own
+// deferred mkdir/mkfs never produced its recorded ensure target.
+func TestReconcileRemovesActivationMissingBoundaryEnsure(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+	mm := m.(*mountManager)
+
+	missing := filepath.Join(t.TempDir(), "never-created")
+	require.NoError(t, mm.db.Update(func(tx *bolt.Tx) error {
+		v2bkt, err := tx.CreateBucketIfNotExists(bucketKeyV2)
+		if err != nil {
+			return err
+		}
+		nsbkt, err := v2bkt.CreateBucketIfNotExists([]byte("test"))
+		if err != nil {
+			return err
+		}
+		mbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyActivations)
+		if err != nil {
+			return err
+		}
+		bkt, err := mbkt.CreateBucket([]byte("a"))
+		if err != nil {
+			return err
+		}
+		return bkt.Put(bucketKeyEnsureTargets, []byte(missing))
+	}))
+
+	require.NoError(t, startCollection(t, m, ctx).Finish())
+
+	_, err := m.Info(ctx, "a")
+	assert.True(t, errdefs.IsNotFound(err), "an activation whose boundary mount's ensure target does not exist must be reconciled away, got %v", err)
+}
+
+// TestReconcileRemovesPartiallyRealizedActivation verifies that an
+// activation with a mixed chain -- one position mounted, the next
+// never reached -- is released in full, unmounting the live position.
+func TestReconcileRemovesPartiallyRealizedActivation(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	handler := &noopHandler{mounts: mountC}
+	m, _ := mkTestManager(t, WithMountHandler("noop", handler))
+	mm := m.(*mountManager)
+
+	base := mount.Mount{Type: "noop", Source: testDevNull}
+
+	var basePoint string
+	require.NoError(t, mm.db.Update(func(tx *bolt.Tx) error {
+		v2bkt, err := tx.CreateBucketIfNotExists(bucketKeyV2)
+		if err != nil {
+			return err
+		}
+		nsbkt, err := v2bkt.CreateBucketIfNotExists([]byte("test"))
+		if err != nil {
+			return err
+		}
+		mbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyActivations)
+		if err != nil {
+			return err
+		}
+		if _, err := mbkt.CreateBucket([]byte("a")); err != nil {
+			return err
+		}
+		rec0, err := resolvePosition(tx, mm.targets.Name(), "test", "a", 0, base, time.Now())
+		if err != nil {
+			return err
+		}
+		basePoint = rec0.point
+		top := mount.Mount{Type: "noop", Source: rec0.point + "/upper"}
+		_, err = resolvePosition(tx, mm.targets.Name(), "test", "a", 1, top, time.Now())
+		return err
+	}))
+
+	// The process got as far as mounting the base before dying; the
+	// second position was never realized at all.
+	handler.live = map[string]struct{}{basePoint: {}}
+	mountC.Store(1)
+
+	require.NoError(t, startCollection(t, m, ctx).Finish())
+
+	_, err := m.Info(ctx, "a")
+	assert.True(t, errdefs.IsNotFound(err), "a partially realized activation must be reconciled away entirely, got %v", err)
+	assert.Equal(t, int32(0), mountC.Load(), "the position which really was mounted must be unmounted too")
+}
+
+// TestReconcileLeavesLiveActivationUntouched is the critical negative
+// case: a fully live activation must survive a collection pass
+// completely unchanged, not merely avoid being unmounted.
+func TestReconcileLeavesLiveActivationUntouched(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: mountC}))
+
+	ainfo, err := m.Activate(ctx, "a", []mount.Mount{{Type: "noop", Source: testDevNull}})
+	require.NoError(t, err)
+	mp := ainfo.Active[0].MountPoint
+
+	require.NoError(t, startCollection(t, m, ctx).Finish())
+
+	info, err := m.Info(ctx, "a")
+	require.NoError(t, err, "a fully live activation must survive reconciliation")
+	require.Len(t, info.Active, 1)
+	assert.Equal(t, mp, info.Active[0].MountPoint)
+	assert.Equal(t, int32(1), mountC.Load())
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// opaqueHandler performs a mount that never appears in the host mount
+// table, and implements no mount.MountedChecker.
+type opaqueHandler struct {
+	mounts *atomic.Int32
+}
+
+func (h *opaqueHandler) Mount(_ context.Context, m mount.Mount, mp string, _ []mount.ActiveMount) (mount.ActiveMount, error) {
+	h.mounts.Add(1)
+	now := time.Now()
+	return mount.ActiveMount{Mount: m, MountedAt: &now, MountPoint: mp}, nil
+}
+
+func (h *opaqueHandler) Unmount(_ context.Context, _ string) error {
+	h.mounts.Add(-1)
+	return nil
+}
+
+// opaqueHandlerAlwaysLive implements mount.MountedChecker, always
+// reporting live.
+type opaqueHandlerAlwaysLive struct{ opaqueHandler }
+
+func (h *opaqueHandlerAlwaysLive) Mounted(_ context.Context, _ string) (bool, error) {
+	return true, nil
+}
+
+// TestReconcileTrustsMountedChecker verifies that a Handler's own
+// mount.MountedChecker answer is authoritative and is not
+// second-guessed against the host mount table.
+func TestReconcileTrustsMountedChecker(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	handler := &opaqueHandlerAlwaysLive{opaqueHandler{mounts: new(atomic.Int32)}}
+	m, _ := mkTestManager(t, WithMountHandler("opaque", handler))
+	mm := m.(*mountManager)
+
+	opq := mount.Mount{Type: "opaque", Source: testDevNull}
+	require.NoError(t, mm.db.Update(func(tx *bolt.Tx) error {
+		v2bkt, err := tx.CreateBucketIfNotExists(bucketKeyV2)
+		if err != nil {
+			return err
+		}
+		nsbkt, err := v2bkt.CreateBucketIfNotExists([]byte("test"))
+		if err != nil {
+			return err
+		}
+		mbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyActivations)
+		if err != nil {
+			return err
+		}
+		if _, err := mbkt.CreateBucket([]byte("a")); err != nil {
+			return err
+		}
+		_, err = resolvePosition(tx, mm.targets.Name(), "test", "a", 0, opq, time.Now())
+		return err
+	}))
+
+	require.NoError(t, startCollection(t, m, ctx).Finish())
+
+	info, err := m.Info(ctx, "a")
+	require.NoError(t, err, "a handler reporting itself always live must never be reconciled away, even though nothing was ever really mounted")
+	require.Len(t, info.Active, 1)
+}
+
+// TestReconcileOmittingCheckerFallsBackToHostMountTable verifies that
+// a Handler which does not implement mount.MountedChecker is checked
+// against the host mount table and reconciled away if absent from it.
+func TestReconcileOmittingCheckerFallsBackToHostMountTable(t *testing.T) {
+	if !canObserveMountTableOS {
+		t.Skip("this Handler's fallback is the host mount table, which is not observable on this platform (see canObserveMountTableOS); it is correctly assumed live instead, covered by TestReconcileLiveAssumedWhenMountTableUnobservable")
+	}
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("opaque", &opaqueHandler{mounts: mountC}))
+
+	ainfo, err := m.Activate(ctx, "a", []mount.Mount{{Type: "opaque", Source: testDevNull}})
+	require.NoError(t, err)
+	require.Len(t, ainfo.Active, 1)
+
+	require.NoError(t, startCollection(t, m, ctx).Finish())
+
+	_, err = m.Info(ctx, "a")
+	assert.True(t, errdefs.IsNotFound(err),
+		"a handler with no MountedChecker and no real kernel mount to show for it must be reconciled away, got %v", err)
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// blockingUnmountHandler blocks inside Unmount until release is
+// closed, signaling entered once it does.
+type blockingUnmountHandler struct {
+	entered     chan struct{}
+	enteredOnce sync.Once
+	release     chan struct{}
+}
+
+func (h *blockingUnmountHandler) Mount(_ context.Context, m mount.Mount, mp string, _ []mount.ActiveMount) (mount.ActiveMount, error) {
+	now := time.Now()
+	return mount.ActiveMount{Mount: m, MountedAt: &now, MountPoint: mp}, nil
+}
+
+func (h *blockingUnmountHandler) Unmount(_ context.Context, _ string) error {
+	h.enteredOnce.Do(func() { close(h.entered) })
+	<-h.release
+	return nil
+}
+
+func (h *blockingUnmountHandler) Mounted(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+
+// TestReconcileUnmountSerializesWithConcurrentActivate verifies that
+// unmounting a record reconciliation released does not run
+// concurrently with a fresh Activate resolving to the same identity.
+func TestReconcileUnmountSerializesWithConcurrentActivate(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	handler := &blockingUnmountHandler{entered: make(chan struct{}), release: make(chan struct{})}
+	m, _ := mkTestManager(t, WithMountHandler("vol", handler))
+	mm := m.(*mountManager)
+
+	vol := mount.Mount{Type: "vol", Source: testDevNull, Options: []string{"rw"}}
+
+	require.NoError(t, mm.db.Update(func(tx *bolt.Tx) error {
+		v2bkt, err := tx.CreateBucketIfNotExists(bucketKeyV2)
+		if err != nil {
+			return err
+		}
+		nsbkt, err := v2bkt.CreateBucketIfNotExists([]byte("test"))
+		if err != nil {
+			return err
+		}
+		mbkt, err := nsbkt.CreateBucketIfNotExists(bucketKeyActivations)
+		if err != nil {
+			return err
+		}
+		if _, err := mbkt.CreateBucket([]byte("a")); err != nil {
+			return err
+		}
+		_, err = resolvePosition(tx, mm.targets.Name(), "test", "a", 0, vol, time.Now())
+		return err
+	}))
+
+	cc := startCollection(t, m, ctx)
+
+	finishDone := make(chan error, 1)
+	go func() { finishDone <- cc.Finish() }()
+
+	select {
+	case <-handler.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconciliation's unmount to start")
+	}
+
+	// "b" resolves to the same identity while "a"'s unmount is in flight.
+	bDone := make(chan activateResult, 1)
+	go func() {
+		info, err := m.Activate(ctx, "b", []mount.Mount{vol})
+		bDone <- activateResult{info, err}
+	}()
+
+	select {
+	case <-bDone:
+		t.Fatal("Activate must wait for the identity lock while a released record sharing it is still being unmounted")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(handler.release)
+
+	require.NoError(t, <-finishDone)
+	b := <-bDone
+	require.NoError(t, b.err)
+	require.Len(t, b.info.Active, 1)
+
+	require.NoError(t, m.Deactivate(ctx, "b"))
+}
+
+// TestReconcileWaitsForInFlightActivate verifies that StartCollection
+// cannot observe an activation mid-realization.
+func TestReconcileWaitsForInFlightActivate(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	handler := &blockingHandler{entered: make(chan struct{}), release: make(chan struct{})}
+	m, _ := mkTestManager(t, WithMountHandler("blk", handler))
+
+	activateDone := make(chan activateResult, 1)
+	go func() {
+		info, err := m.Activate(ctx, "a", []mount.Mount{{Type: "blk", Source: testDevNull}})
+		activateDone <- activateResult{info, err}
+	}()
+
+	select {
+	case <-handler.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Activate to start mounting")
+	}
+
+	collectDone := make(chan error, 1)
+	go func() {
+		cc := startCollection(t, m, ctx)
+		collectDone <- cc.Finish()
+	}()
+
+	select {
+	case <-collectDone:
+		t.Fatal("StartCollection must block while Activate holds the rwlock across resolving and realizing its chain")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(handler.release)
+
+	a := <-activateDone
+	require.NoError(t, a.err)
+	require.NoError(t, <-collectDone)
+
+	// The activation must have survived: reconciliation must never
+	// have observed it mid-realization.
+	info, err := m.Info(ctx, "a")
+	require.NoError(t, err)
+	require.Len(t, info.Active, 1)
+	assert.Equal(t, a.info.Active[0].MountPoint, info.Active[0].MountPoint)
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+}
+
+// TestReconcileLiveAssumedWhenMountTableUnobservable verifies that a
+// handler-less mount is assumed live when haveMountTable is false.
+func TestReconcileLiveAssumedWhenMountTableUnobservable(t *testing.T) {
+	ctx := context.Background()
+	live, err := reconcileLive(ctx, nil, "/some/path/nothing/wrote", nil, false)
+	require.NoError(t, err)
+	assert.True(t, live, "a handler-less mount must be assumed live, never deleted, when the mount table cannot be trusted at all")
+}
+
+// TestReconcileLiveResolvesUnresolvedV1Path verifies that an
+// unresolved v1 path still matches its canonical mount table entry.
+// /proc stands in for a real mount reached through a symlink.
+func TestReconcileLiveResolvesUnresolvedV1Path(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("relies on /proc, specific to Linux")
+	}
+
+	real, err := filepath.EvalSymlinks("/proc")
+	require.NoError(t, err)
+
+	link := filepath.Join(t.TempDir(), "link")
+	require.NoError(t, os.Symlink(real, link))
+
+	mounted := map[string]struct{}{real: {}}
+	live, err := reconcileLive(context.Background(), nil, link, mounted, true)
+	require.NoError(t, err)
+	assert.True(t, live, "a v1 position's unresolved path must still match the canonical mount table entry")
+}
+
+// TestSnapshotMountTableFindsMountUnderTargets verifies that
+// snapshotMountTable finds a mount under mm.targets. /proc stands in
+// for a mount genuinely under the target directory, without needing
+// root; NewManager is what guarantees mm.targets.Name() is canonical
+// (see TestNewManagerResolvesSymlinkedTargetDir).
+func TestSnapshotMountTableFindsMountUnderTargets(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("relies on /proc, specific to Linux")
+	}
+
+	real, err := filepath.EvalSymlinks("/proc")
+	require.NoError(t, err)
+
+	r, err := os.OpenRoot(real)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	mm := &mountManager{targets: r}
+	mounted, haveMountTable := mm.snapshotMountTable(context.Background())
+	require.True(t, haveMountTable)
+	_, ok := mounted[real]
+	assert.True(t, ok, "a mount under the target directory must be found")
+}

--- a/core/mount/manager/transformer.go
+++ b/core/mount/manager/transformer.go
@@ -19,7 +19,11 @@ package manager
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 
 	"github.com/containerd/containerd/v2/core/mount"
@@ -32,6 +36,32 @@ const (
 	prefixMkdir = "X-containerd.mkdir."
 	prefixMkfs  = "X-containerd.mkfs."
 )
+
+// resolveRoot returns the *os.Root in roots whose key is the longest
+// path dir is under, and dir's path relative to it ("." if dir is the
+// root itself). what names the caller in the error when nothing
+// matches.
+func resolveRoot(roots map[string]*os.Root, dir, what string) (*os.Root, string, error) {
+	var bestPath, bestRel string
+	var best *os.Root
+	for path, root := range roots {
+		rel, err := filepath.Rel(path, dir)
+		if err != nil {
+			continue
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			// dir is not under path at all.
+			continue
+		}
+		if best == nil || len(path) > len(bestPath) {
+			best, bestPath, bestRel = root, path, rel
+		}
+	}
+	if best == nil {
+		return nil, "", fmt.Errorf("no root %q configured for %s: %w", dir, what, errdefs.ErrNotImplemented)
+	}
+	return best, bestRel, nil
+}
 
 type typeTransformer struct {
 	mount.Transformer

--- a/core/mount/manager/transformer.go
+++ b/core/mount/manager/transformer.go
@@ -18,6 +18,9 @@ package manager
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/containerd/log"
 
 	"github.com/containerd/containerd/v2/core/mount"
 )
@@ -36,7 +39,68 @@ type typeTransformer struct {
 	mountType string
 }
 
+// deferredEnsure is an impure side effect deferred until run is
+// called. targets are the absolute path(s) run produces.
+type deferredEnsure struct {
+	targets []string
+	run     func(context.Context) error
+}
+
 func (t typeTransformer) Transform(ctx context.Context, m mount.Mount, a []mount.ActiveMount) (mount.Mount, error) {
 	m.Type = t.mountType
 	return t.Transformer.Transform(ctx, m, a)
+}
+
+// rewritePosition applies chain, a position's pending transforms, to
+// m. mkfs and mkdir return their impure work as a deferredEnsure
+// instead of performing it immediately; every other transformer runs
+// in full.
+func rewritePosition(ctx context.Context, chain []mount.Transformer, m mount.Mount, resolved []mount.ActiveMount) (mount.Mount, []deferredEnsure, error) {
+	var ensures []deferredEnsure
+	for _, elem := range chain {
+		tt, ok := elem.(typeTransformer)
+		if !ok {
+			rewritten, err := elem.Transform(ctx, m, resolved)
+			if err != nil {
+				return mount.Mount{}, nil, err
+			}
+			m = rewritten
+			continue
+		}
+		m.Type = tt.mountType
+		switch tr := tt.Transformer.(type) {
+		case mountFormatter:
+			rewritten, err := tr.Transform(ctx, m, resolved)
+			if err != nil {
+				return mount.Mount{}, nil, err
+			}
+			m = rewritten
+		case *mkfs:
+			rewritten, ensure, err := tr.rewrite(m)
+			if err != nil {
+				return mount.Mount{}, nil, err
+			}
+			m = rewritten
+			if ensure.run != nil {
+				ensures = append(ensures, ensure)
+			}
+		case *mkdir:
+			rewritten, ensure, err := tr.rewrite(m)
+			if err != nil {
+				return mount.Mount{}, nil, err
+			}
+			m = rewritten
+			if ensure.run != nil {
+				ensures = append(ensures, ensure)
+			}
+		default:
+			log.G(ctx).WithField("transform_type", fmt.Sprintf("%T", tr)).Warn("transform has no pure rewrite, running it in full")
+			rewritten, err := tt.Transform(ctx, m, resolved)
+			if err != nil {
+				return mount.Mount{}, nil, err
+			}
+			m = rewritten
+		}
+	}
+	return m, ensures, nil
 }

--- a/core/mount/manager/transformer_test.go
+++ b/core/mount/manager/transformer_test.go
@@ -1,0 +1,153 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/containerd/errdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openTestRoot opens root as an *os.Root, creating it first, and
+// registers it to close when the test ends.
+func openTestRoot(t *testing.T, root string) *os.Root {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(root, 0700))
+	r, err := os.OpenRoot(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+	return r
+}
+
+// TestResolveRootPathBoundary verifies that a root only matches a
+// path under it, not one which merely shares a textual prefix.
+func TestResolveRootPathBoundary(t *testing.T) {
+	td := t.TempDir()
+	base := filepath.Join(td, "base")
+	r := openTestRoot(t, base)
+	roots := map[string]*os.Root{base: r}
+
+	_, _, err := resolveRoot(roots, base+"2/img.raw", "test")
+	assert.True(t, errdefs.IsNotImplemented(err),
+		"a path sharing only a textual prefix with the root must not match, got %v", err)
+
+	root, subpath, err := resolveRoot(roots, filepath.Join(base, "img.raw"), "test")
+	require.NoError(t, err)
+	assert.Same(t, r, root)
+	assert.Equal(t, "img.raw", subpath)
+
+	root, subpath, err = resolveRoot(roots, base, "test")
+	require.NoError(t, err)
+	assert.Same(t, r, root)
+	assert.Equal(t, ".", subpath)
+}
+
+// TestResolveRootLongestMatch verifies that a path under two nested
+// roots resolves against the longer, more specific one.
+func TestResolveRootLongestMatch(t *testing.T) {
+	td := t.TempDir()
+	outer := filepath.Join(td, "outer")
+	inner := filepath.Join(outer, "inner")
+	rOuter := openTestRoot(t, outer)
+	rInner := openTestRoot(t, inner)
+
+	roots := map[string]*os.Root{
+		outer: rOuter,
+		inner: rInner,
+	}
+
+	dir := filepath.Join(inner, "x")
+	// Repeated since map iteration order is randomized per range.
+	for range 20 {
+		root, subpath, err := resolveRoot(roots, dir, "test")
+		require.NoError(t, err)
+		assert.Same(t, rInner, root, "the longer, more specific root must win")
+		assert.Equal(t, "x", subpath)
+	}
+}
+
+// TestResolveRootNoMatch verifies that a path under no configured
+// root is reported as errdefs.ErrNotImplemented.
+func TestResolveRootNoMatch(t *testing.T) {
+	td := t.TempDir()
+	base := filepath.Join(td, "base")
+	r := openTestRoot(t, base)
+	roots := map[string]*os.Root{base: r}
+
+	_, _, err := resolveRoot(roots, filepath.Join(td, "elsewhere"), "mkfs")
+	assert.True(t, errdefs.IsNotImplemented(err), "expected ErrNotImplemented, got %v", err)
+	assert.ErrorContains(t, err, "mkfs")
+}
+
+// TestResolveRootTrailingSeparator verifies that a configured root
+// with a trailing separator still matches.
+func TestResolveRootTrailingSeparator(t *testing.T) {
+	td := t.TempDir()
+	base := filepath.Join(td, "base")
+	r := openTestRoot(t, base)
+	roots := map[string]*os.Root{base + string(filepath.Separator): r}
+
+	root, subpath, err := resolveRoot(roots, filepath.Join(base, "img.raw"), "test")
+	require.NoError(t, err)
+	assert.Same(t, r, root)
+	assert.Equal(t, "img.raw", subpath)
+}
+
+// TestResolveRootIsFilesystemRoot verifies that a configured root
+// which is the root of the whole filesystem matches and resolves a
+// correct subpath.
+func TestResolveRootIsFilesystemRoot(t *testing.T) {
+	fsRoot := string(filepath.Separator)
+	if runtime.GOOS == "windows" {
+		fsRoot = `C:\`
+	}
+	r, err := os.OpenRoot(fsRoot)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+	roots := map[string]*os.Root{fsRoot: r}
+
+	dir := filepath.Join(fsRoot, "a", "b")
+	root, subpath, err := resolveRoot(roots, dir, "test")
+	require.NoError(t, err)
+	assert.Same(t, r, root)
+	assert.Equal(t, filepath.Join("a", "b"), subpath)
+
+	root, subpath, err = resolveRoot(roots, fsRoot, "test")
+	require.NoError(t, err)
+	assert.Same(t, r, root)
+	assert.Equal(t, ".", subpath)
+}
+
+// TestResolveRootTrailingSeparatorMatchesRootItself verifies that a
+// configured root with a trailing separator matches dir when dir is
+// that same root spelled without one.
+func TestResolveRootTrailingSeparatorMatchesRootItself(t *testing.T) {
+	td := t.TempDir()
+	base := filepath.Join(td, "base")
+	r := openTestRoot(t, base)
+	roots := map[string]*os.Root{base + string(filepath.Separator): r}
+
+	root, subpath, err := resolveRoot(roots, base, "test")
+	require.NoError(t, err)
+	assert.Same(t, r, root)
+	assert.Equal(t, ".", subpath)
+}

--- a/core/mount/manager/v1.go
+++ b/core/mount/manager/v1.go
@@ -1,0 +1,433 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/containerd/log"
+
+	"github.com/containerd/containerd/v2/core/metadata/boltutil"
+	"github.com/containerd/containerd/v2/core/mount"
+)
+
+// This file is the entirety of what this package still knows about
+// "v1", the schema it replaced: how to read an activation, release
+// one, and see one from garbage collection. Nothing here migrates
+// "v1" data into a "v2" record; a "v1" activation is read from and
+// unmounted at the mount point it already has, never given a "v2"
+// identity or moved under backingDir.
+//
+// Every access goes through tx.Bucket or getBucket, never
+// CreateBucketIfNotExists, so a database or namespace with no "v1"
+// data never gains a "v1" bucket just from being read.
+//
+// Releasing a "v1" activation deletes its own entry, never anything
+// else's. A rollback to a binary which only understands "v1" finds it
+// exactly as left, minus whatever this package released.
+//
+// "v1" mounts are never deduplicated against one another or against a
+// "v2" mount: shareable requires a source, and "v1" never recorded
+// one (only type and mount point), so shareable already reports false
+// for every "v1" mount without this package special casing it.
+
+// v1's own key names, matching exactly what a "v1" binary wrote to
+// disk. Not shared with buckets.go's "v2" keys.
+var (
+	v1KeyID         = []byte("id")
+	v1KeyMounts     = []byte("mounts")
+	v1KeyLeases     = []byte("leases")
+	v1KeyLease      = []byte("lease")
+	v1KeyActive     = []byte("active")
+	v1KeySystem     = []byte("system")
+	v1KeyType       = []byte("type")
+	v1KeySource     = []byte("source")
+	v1KeyTarget     = []byte("target")
+	v1KeyOptions    = []byte("options")
+	v1KeyMountedAt  = []byte("mat")
+	v1KeyMountPoint = []byte("mp")
+)
+
+// v1Position is one position in a v1 activation's mount chain, in the
+// shape that schema recorded it.
+type v1Position struct {
+	mtype string
+	point string
+	at    *time.Time
+}
+
+// v1ReadID reads the numeric id a v1 activation was created with.
+func v1ReadID(bkt *bolt.Bucket) uint64 {
+	id, _ := binary.Uvarint(bkt.Get(v1KeyID))
+	return id
+}
+
+// v1HasActive reports whether a v1 activation bucket recorded a mount
+// chain, complete or not.
+func v1HasActive(bkt *bolt.Bucket) bool {
+	return bkt.Bucket(v1KeyActive) != nil
+}
+
+// v1Positions reads a v1 activation's mount chain, base first. Returns
+// nil both when there is no active bucket and when it is empty; use
+// v1HasActive to tell those apart.
+func v1Positions(bkt *bolt.Bucket) []v1Position {
+	abkt := bkt.Bucket(v1KeyActive)
+	if abkt == nil {
+		return nil
+	}
+	var positions []v1Position
+	abkt.ForEachBucket(func(k []byte) error {
+		cur := abkt.Bucket(k)
+		p := v1Position{
+			mtype: string(cur.Get(v1KeyType)),
+			point: string(cur.Get(v1KeyMountPoint)),
+		}
+		if v := cur.Get(v1KeyMountedAt); len(v) > 0 {
+			var at time.Time
+			if err := at.UnmarshalBinary(v); err == nil {
+				p.at = &at
+			}
+		}
+		positions = append(positions, p)
+		return nil
+	})
+	return positions
+}
+
+// v1SystemMounts reads a v1 activation's system mounts: the mounts
+// left for the caller to perform.
+func v1SystemMounts(bkt *bolt.Bucket) ([]mount.Mount, error) {
+	sbkt := bkt.Bucket(v1KeySystem)
+	if sbkt == nil {
+		return nil, nil
+	}
+	var system []mount.Mount
+	if err := sbkt.ForEachBucket(func(k []byte) error {
+		cur := sbkt.Bucket(k)
+		m := mount.Mount{
+			Type:   string(cur.Get(v1KeyType)),
+			Source: string(cur.Get(v1KeySource)),
+			Target: string(cur.Get(v1KeyTarget)),
+		}
+		if v := cur.Get(v1KeyOptions); len(v) > 0 {
+			m.Options = strings.Split(string(v), "\x00")
+		}
+		system = append(system, m)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return system, nil
+}
+
+// v1ActivationInfo builds ActivationInfo for a v1 activation: Active
+// from its mount chain, System from the mounts it left for the caller
+// to perform. An interrupted activation, with no active bucket, is
+// reported with an empty Active list rather than as an error.
+func v1ActivationInfo(name string, bkt *bolt.Bucket) (mount.ActivationInfo, error) {
+	info := mount.ActivationInfo{Name: name}
+	for _, p := range v1Positions(bkt) {
+		info.Active = append(info.Active, mount.ActiveMount{
+			Mount:      mount.Mount{Type: p.mtype},
+			MountPoint: p.point,
+			MountedAt:  p.at,
+		})
+	}
+	system, err := v1SystemMounts(bkt)
+	if err != nil {
+		return mount.ActivationInfo{}, err
+	}
+	info.System = system
+	lbls, err := boltutil.ReadLabels(bkt)
+	if err != nil {
+		return mount.ActivationInfo{}, err
+	}
+	info.Labels = lbls
+	return info, nil
+}
+
+// v1Release deletes a v1 activation and its lease membership, if any,
+// and returns the mount chain it described for the caller to unmount.
+// It reports found=false if there is no v1 activation by this name.
+func v1Release(tx *bolt.Tx, namespace, name string) (positions []v1Position, mid uint64, found bool, err error) {
+	nsbkt := getBucket(tx, bucketKeyV1, []byte(namespace))
+	if nsbkt == nil {
+		return nil, 0, false, nil
+	}
+	mbkt := nsbkt.Bucket(v1KeyMounts)
+	if mbkt == nil {
+		return nil, 0, false, nil
+	}
+	bkt := mbkt.Bucket([]byte(name))
+	if bkt == nil {
+		return nil, 0, false, nil
+	}
+
+	mid = v1ReadID(bkt)
+	positions = v1Positions(bkt)
+
+	if lid := bkt.Get(v1KeyLease); len(lid) > 0 {
+		if lsbkt := nsbkt.Bucket(v1KeyLeases); lsbkt != nil {
+			if lbkt := lsbkt.Bucket(lid); lbkt != nil {
+				if err := lbkt.Delete([]byte(name)); err != nil {
+					return nil, 0, false, err
+				}
+				if k, _ := lbkt.Cursor().First(); k == nil {
+					if err := lsbkt.DeleteBucket(lid); err != nil {
+						return nil, 0, false, err
+					}
+				}
+			}
+		}
+	}
+
+	if err := mbkt.DeleteBucket([]byte(name)); err != nil {
+		return nil, 0, false, err
+	}
+
+	// mbkt, nsbkt and bucketKeyV1 are left in place even once empty.
+	return positions, mid, true, nil
+}
+
+// v1Unmount unmounts a v1 activation's mount chain in reverse order
+// and removes its target directory. Tolerates finding nothing there.
+// The target directory is only removed once every position unmounted
+// cleanly.
+func (mm *mountManager) v1Unmount(ctx context.Context, positions []v1Position, mid uint64) error {
+	var errs []error
+	for _, p := range slices.Backward(positions) {
+		var err error
+		if h := mm.handlers[p.mtype]; h != nil {
+			err = h.Unmount(ctx, p.point)
+		} else {
+			err = mount.Unmount(p.point, 0)
+		}
+		if err != nil && !alreadyUnmounted(err) {
+			errs = append(errs, fmt.Errorf("failed to unmount %q: %w", p.point, err))
+		}
+	}
+	if len(errs) == 0 {
+		if err := os.RemoveAll(filepath.Join(mm.targets.Name(), strconv.FormatUint(mid, 10))); err != nil && !os.IsNotExist(err) {
+			log.G(ctx).WithError(err).WithField("mountid", mid).Warn("failed to remove v1 mount target directory")
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// v1All reports every v1 activation in tx to fn, including one
+// interrupted before it completed.
+func v1All(tx *bolt.Tx, fn func(namespace, name string)) {
+	v1bkt := tx.Bucket(bucketKeyV1)
+	if v1bkt == nil {
+		return
+	}
+	nsc := v1bkt.Cursor()
+	for nsk, nsv := nsc.First(); nsk != nil; nsk, nsv = nsc.Next() {
+		if nsv != nil {
+			continue
+		}
+		mbkt := v1bkt.Bucket(nsk).Bucket(v1KeyMounts)
+		if mbkt == nil {
+			continue
+		}
+		mc := mbkt.Cursor()
+		for mk, mv := mc.First(); mk != nil; mk, mv = mc.Next() {
+			if mv != nil {
+				continue
+			}
+			fn(string(nsk), string(mk))
+		}
+	}
+}
+
+// v1Released describes one v1 activation removed, whether by
+// v1ApplyRemoveNamespace or by the v1 orphan directory scan, carrying
+// what v1Unmount needs to finish the job once the caller's
+// transaction, if any, commits.
+type v1Released struct {
+	positions []v1Position
+	mid       uint64
+}
+
+// v1ApplyRemoveNamespace deletes the v1 activations in namespace ns
+// marked for removal in removed, mirroring applyRemove's own v2 walk
+// in shape: every activation still in nsbkt afterward, not just the
+// ones this releases, has its mid collected, since the orphan
+// directory scan which runs once the caller's transaction commits
+// needs to know about every v1 activation which survives, not only
+// the ones touched here, to avoid mistaking a live one's directory
+// for one nothing references any more.
+//
+// A name in removed which does not name a v1 activation in this
+// namespace, whether because it never did or because it names a v2
+// one instead, is silently ignored: applyRemove calls this once per
+// namespace with the same removed set it uses for v2, rather than
+// sorting it into schemas first. A v1 and a v2 activation which
+// happen to share a name are unrelated resources, reachable at all
+// only via a rollback to a v1 binary and forward again.
+func v1ApplyRemoveNamespace(tx *bolt.Tx, ns string, nsbkt *bolt.Bucket, removed map[string]struct{}) (released []v1Released, remainingMids map[uint64]struct{}, err error) {
+	remainingMids = map[uint64]struct{}{}
+	mbkt := nsbkt.Bucket(v1KeyMounts)
+	if mbkt == nil {
+		return nil, remainingMids, nil
+	}
+
+	// Collect first: releasing an activation writes to sibling
+	// buckets (its lease membership), which must not happen while a
+	// cursor is open over the mounts bucket.
+	var remove [][]byte
+	if len(removed) > 0 {
+		mc := mbkt.Cursor()
+		for mk, mv := mc.First(); mk != nil; mk, mv = mc.Next() {
+			if mv != nil {
+				continue
+			}
+			if _, ok := removed[string(mk)]; ok {
+				remove = append(remove, bytes.Clone(mk))
+			}
+		}
+	}
+
+	for _, mk := range remove {
+		positions, mid, ok, err := v1Release(tx, ns, string(mk))
+		if err != nil {
+			return nil, nil, err
+		}
+		if ok {
+			released = append(released, v1Released{positions: positions, mid: mid})
+		}
+	}
+
+	// Whatever is left was not marked for removal and survives;
+	// collect its mid for the orphan directory scan to exclude.
+	mc := mbkt.Cursor()
+	for mk, mv := mc.First(); mk != nil; mk, mv = mc.Next() {
+		if mv != nil {
+			continue
+		}
+		remainingMids[v1ReadID(mbkt.Bucket(mk))] = struct{}{}
+	}
+
+	return released, remainingMids, nil
+}
+
+// v1OrphanDirs returns v1 mount chains found on disk with no
+// surviving database record in any namespace. remainingMids must be
+// the union of every namespace's surviving v1 mids.
+func v1OrphanDirs(mm *mountManager, remainingMids map[uint64]struct{}) ([]v1Released, error) {
+	fd, err := mm.targets.Open(".")
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	dirs, err := fd.Readdirnames(0)
+	if err != nil {
+		return nil, err
+	}
+
+	var orphaned []v1Released
+	for _, d := range dirs {
+		if d == backingDir {
+			continue
+		}
+		mid, err := strconv.ParseUint(d, 10, 64)
+		if err != nil {
+			continue
+		}
+		if _, ok := remainingMids[mid]; ok {
+			continue
+		}
+
+		positions, err := v1OrphanPositions(mm, d)
+		if err != nil {
+			return nil, err
+		}
+		orphaned = append(orphaned, v1Released{positions: positions, mid: mid})
+	}
+
+	return orphaned, nil
+}
+
+// v1OrphanPositions reconstructs a v1 activation's mount chain from
+// the type file left alongside each mount point, named "<n>-type" for
+// position n. v1 numbered a chain of N positions ci = N-i, so sorting
+// numerically descending on n recovers mount order, base first.
+func v1OrphanPositions(mm *mountManager, dir string) ([]v1Position, error) {
+	full := filepath.Join(mm.targets.Name(), dir)
+	fd, err := os.Open(full)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer fd.Close()
+
+	entries, err := fd.Readdirnames(0)
+	if err != nil {
+		return nil, err
+	}
+
+	type numbered struct {
+		n    int
+		name string
+	}
+	var found []numbered
+	for _, e := range entries {
+		name, ok := strings.CutSuffix(e, "-type")
+		if !ok {
+			continue
+		}
+		n, err := strconv.Atoi(name)
+		if err != nil {
+			// Not one of v1's own "<n>-type" files; tolerate it
+			// defensively rather than fail the whole scan over it.
+			continue
+		}
+		found = append(found, numbered{n: n, name: name})
+	}
+	sort.Slice(found, func(a, b int) bool { return found[a].n > found[b].n })
+
+	var positions []v1Position
+	for _, e := range found {
+		mtype, err := os.ReadFile(filepath.Join(full, e.name+"-type"))
+		if err != nil {
+			return nil, err
+		}
+		positions = append(positions, v1Position{
+			mtype: string(mtype),
+			point: filepath.Join(full, e.name),
+		})
+	}
+
+	return positions, nil
+}

--- a/core/mount/manager/v1.go
+++ b/core/mount/manager/v1.go
@@ -278,42 +278,38 @@ type v1Released struct {
 }
 
 // v1ApplyRemoveNamespace deletes the v1 activations in namespace ns
-// marked for removal in removed, mirroring applyRemove's own v2 walk
-// in shape: every activation still in nsbkt afterward, not just the
-// ones this releases, has its mid collected, since the orphan
-// directory scan which runs once the caller's transaction commits
-// needs to know about every v1 activation which survives, not only
-// the ones touched here, to avoid mistaking a live one's directory
-// for one nothing references any more.
-//
-// A name in removed which does not name a v1 activation in this
-// namespace, whether because it never did or because it names a v2
-// one instead, is silently ignored: applyRemove calls this once per
-// namespace with the same removed set it uses for v2, rather than
-// sorting it into schemas first. A v1 and a v2 activation which
-// happen to share a name are unrelated resources, reachable at all
-// only via a rollback to a v1 binary and forward again.
-func v1ApplyRemoveNamespace(tx *bolt.Tx, ns string, nsbkt *bolt.Bucket, removed map[string]struct{}) (released []v1Released, remainingMids map[uint64]struct{}, err error) {
+// marked in removed or found no longer mounted, and returns the mid
+// of every v1 activation which survives.
+func v1ApplyRemoveNamespace(ctx context.Context, mm *mountManager, tx *bolt.Tx, ns string, nsbkt *bolt.Bucket, removed map[string]struct{}, mounted map[string]struct{}, haveMountTable bool) (released []v1Released, remainingMids map[uint64]struct{}, err error) {
 	remainingMids = map[uint64]struct{}{}
 	mbkt := nsbkt.Bucket(v1KeyMounts)
 	if mbkt == nil {
 		return nil, remainingMids, nil
 	}
 
-	// Collect first: releasing an activation writes to sibling
-	// buckets (its lease membership), which must not happen while a
-	// cursor is open over the mounts bucket.
-	var remove [][]byte
-	if len(removed) > 0 {
-		mc := mbkt.Cursor()
-		for mk, mv := mc.First(); mk != nil; mk, mv = mc.Next() {
-			if mv != nil {
-				continue
-			}
-			if _, ok := removed[string(mk)]; ok {
-				remove = append(remove, bytes.Clone(mk))
-			}
+	// Collected first, before any cursor-invalidating writes.
+	var remove, keep [][]byte
+	mc := mbkt.Cursor()
+	for mk, mv := mc.First(); mk != nil; mk, mv = mc.Next() {
+		if mv != nil {
+			continue
 		}
+		if _, ok := removed[string(mk)]; ok {
+			remove = append(remove, bytes.Clone(mk))
+			continue
+		}
+		// Not marked for removal by the caller; reconcile it against
+		// the mount table snapshot regardless, the same as applyRemove
+		// does for v2 (see reconcile.go).
+		live, lerr := v1ActivationLive(ctx, mm, mbkt.Bucket(mk), mounted, haveMountTable)
+		if lerr != nil {
+			return nil, nil, lerr
+		}
+		if !live {
+			remove = append(remove, bytes.Clone(mk))
+			continue
+		}
+		keep = append(keep, bytes.Clone(mk))
 	}
 
 	for _, mk := range remove {
@@ -326,13 +322,7 @@ func v1ApplyRemoveNamespace(tx *bolt.Tx, ns string, nsbkt *bolt.Bucket, removed 
 		}
 	}
 
-	// Whatever is left was not marked for removal and survives;
-	// collect its mid for the orphan directory scan to exclude.
-	mc := mbkt.Cursor()
-	for mk, mv := mc.First(); mk != nil; mk, mv = mc.Next() {
-		if mv != nil {
-			continue
-		}
+	for _, mk := range keep {
 		remainingMids[v1ReadID(mbkt.Bucket(mk))] = struct{}{}
 	}
 

--- a/core/mount/manager/v1_test.go
+++ b/core/mount/manager/v1_test.go
@@ -1,0 +1,862 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/errdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/v2/core/metadata"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/pkg/gc"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// v1Active is one position in a v1 activation's mount chain: type and
+// mount point only.
+type v1Active struct {
+	typ string
+	mp  string
+	at  time.Time
+}
+
+// v1Activation describes one activation to seed under the "v1" bucket
+// name. A nil active slice produces an activation with no active
+// bucket at all, matching one interrupted before completion.
+type v1Activation struct {
+	name   string
+	lease  string
+	labels map[string]string
+	active []v1Active
+	system []mount.Mount
+}
+
+// seedV1 writes activations directly under the "v1" bucket, using
+// v1's own key names, to build fixtures for tests in this file.
+func seedV1(t *testing.T, db boltDB, namespace string, activations ...v1Activation) {
+	t.Helper()
+	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		oldbkt, err := tx.CreateBucketIfNotExists([]byte("v1"))
+		if err != nil {
+			return err
+		}
+		nsbkt, err := oldbkt.CreateBucketIfNotExists([]byte(namespace))
+		if err != nil {
+			return err
+		}
+		mbkt, err := nsbkt.CreateBucketIfNotExists(v1KeyMounts)
+		if err != nil {
+			return err
+		}
+
+		var lsbkt *bolt.Bucket
+		for i, a := range activations {
+			bkt, err := mbkt.CreateBucket([]byte(a.name))
+			if err != nil {
+				return err
+			}
+			idb, err := encodeID(uint64(i + 1))
+			if err != nil {
+				return err
+			}
+			if err := bkt.Put(v1KeyID, idb); err != nil {
+				return err
+			}
+
+			if a.lease != "" {
+				if err := bkt.Put(v1KeyLease, []byte(a.lease)); err != nil {
+					return err
+				}
+				if lsbkt == nil {
+					lsbkt, err = nsbkt.CreateBucketIfNotExists(v1KeyLeases)
+					if err != nil {
+						return err
+					}
+				}
+				lbkt, err := lsbkt.CreateBucketIfNotExists([]byte(a.lease))
+				if err != nil {
+					return err
+				}
+				if err := lbkt.Put([]byte(a.name), nil); err != nil {
+					return err
+				}
+			}
+
+			if len(a.labels) > 0 {
+				lblbkt, err := bkt.CreateBucket(bucketKeyLabels)
+				if err != nil {
+					return err
+				}
+				for k, v := range a.labels {
+					if err := lblbkt.Put([]byte(k), []byte(v)); err != nil {
+						return err
+					}
+				}
+			}
+
+			if a.active != nil {
+				abkt, err := bkt.CreateBucket(v1KeyActive)
+				if err != nil {
+					return err
+				}
+				for j, act := range a.active {
+					cur, err := abkt.CreateBucket([]byte{byte(j)})
+					if err != nil {
+						return err
+					}
+					if err := cur.Put(v1KeyType, []byte(act.typ)); err != nil {
+						return err
+					}
+					if err := cur.Put(v1KeyMountPoint, []byte(act.mp)); err != nil {
+						return err
+					}
+					atb, err := act.at.MarshalBinary()
+					if err != nil {
+						return err
+					}
+					if err := cur.Put(v1KeyMountedAt, atb); err != nil {
+						return err
+					}
+				}
+			}
+
+			if len(a.system) > 0 {
+				sbkt, err := bkt.CreateBucket(v1KeySystem)
+				if err != nil {
+					return err
+				}
+				for j, sm := range a.system {
+					cur, err := sbkt.CreateBucket([]byte{byte(j)})
+					if err != nil {
+						return err
+					}
+					if err := cur.Put(v1KeyType, []byte(sm.Type)); err != nil {
+						return err
+					}
+					if err := cur.Put(v1KeySource, []byte(sm.Source)); err != nil {
+						return err
+					}
+					if err := cur.Put(v1KeyTarget, []byte(sm.Target)); err != nil {
+						return err
+					}
+					if len(sm.Options) > 0 {
+						if err := cur.Put(v1KeyOptions, []byte(strings.Join(sm.Options, "\x00"))); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+		return nil
+	}))
+}
+
+// assertV1Present asserts whether the bucket name of the schema this
+// package replaced is still present in db.
+func assertV1Present(t *testing.T, db boltDB, present bool, msgAndArgs ...any) {
+	t.Helper()
+	require.NoError(t, db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket([]byte("v1"))
+		if present {
+			assert.NotNil(t, bkt, msgAndArgs...)
+		} else {
+			assert.Nil(t, bkt, msgAndArgs...)
+		}
+		return nil
+	}))
+}
+
+// TestV1Info verifies that a v1 activation is readable through Info
+// exactly as it was recorded: v1 never implemented Source or Options,
+// so neither is ever populated for one, unlike a v2 activation.
+func TestV1Info(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: new(atomic.Int32)}))
+	mm := m.(*mountManager)
+
+	at := time.Now().Truncate(time.Second)
+	seedV1(t, mm.db, "test", v1Activation{
+		name: "old",
+		labels: map[string]string{
+			"containerd.io/gc.bref.container": "c1",
+			"custom-label":                    "value1",
+		},
+		active: []v1Active{
+			{typ: "noop", mp: "/legacy/lower", at: at},
+			{typ: "noop", mp: "/legacy/upper", at: at},
+		},
+		system: []mount.Mount{
+			{Type: "bind", Source: "/legacy/upper", Target: "/", Options: []string{"rbind", "ro"}},
+		},
+	})
+
+	info, err := m.Info(ctx, "old")
+	require.NoError(t, err)
+	assert.Equal(t, "old", info.Name)
+	require.Len(t, info.Active, 2)
+	assert.Equal(t, "noop", info.Active[0].Type)
+	assert.Equal(t, "/legacy/lower", info.Active[0].MountPoint)
+	assert.Empty(t, info.Active[0].Source, "v1 never recorded source")
+	assert.Empty(t, info.Active[0].Options, "v1 never recorded options")
+	require.NotNil(t, info.Active[0].MountedAt)
+	assert.Equal(t, at.Unix(), info.Active[0].MountedAt.Unix())
+	assert.Equal(t, "noop", info.Active[1].Type)
+	assert.Equal(t, "/legacy/upper", info.Active[1].MountPoint)
+	assert.Equal(t, "c1", info.Labels["containerd.io/gc.bref.container"])
+	assert.Equal(t, "value1", info.Labels["custom-label"])
+
+	// v1 recorded system mounts in full, unlike active ones above:
+	// Info must report them, not silently drop the mounts the caller
+	// is responsible for performing.
+	require.Len(t, info.System, 1)
+	assert.Equal(t, "bind", info.System[0].Type)
+	assert.Equal(t, "/legacy/upper", info.System[0].Source)
+	assert.Equal(t, "/", info.System[0].Target)
+	assert.Equal(t, []string{"rbind", "ro"}, info.System[0].Options)
+
+	// Reading it must not have touched v1 at all.
+	assertV1Present(t, mm.db, true)
+}
+
+// TestV1InfoIncomplete verifies that a v1 activation interrupted
+// before it completed, which never created an active bucket, is
+// reported through Info with an empty Active list rather than an
+// error, exactly as v1's own native Info always reported one.
+func TestV1InfoIncomplete(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+	mm := m.(*mountManager)
+
+	seedV1(t, mm.db, "test", v1Activation{name: "gone", active: nil})
+
+	info, err := m.Info(ctx, "gone")
+	require.NoError(t, err)
+	assert.Equal(t, "gone", info.Name)
+	assert.Empty(t, info.Active)
+}
+
+// TestV1List verifies that List reports activations from both
+// schemas together.
+func TestV1List(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: new(atomic.Int32)}))
+	mm := m.(*mountManager)
+
+	seedV1(t, mm.db, "test", v1Activation{
+		name:   "old",
+		active: []v1Active{{typ: "noop", mp: "/legacy/old", at: time.Now()}},
+	})
+
+	_, err := m.Activate(ctx, "new", []mount.Mount{{Type: "noop", Source: "/dev/null"}})
+	require.NoError(t, err)
+
+	infos, err := m.List(ctx)
+	require.NoError(t, err)
+	names := make([]string, len(infos))
+	for i, info := range infos {
+		names[i] = info.Name
+	}
+	assert.ElementsMatch(t, []string{"old", "new"}, names)
+
+	require.NoError(t, m.Deactivate(ctx, "new"))
+}
+
+// TestV1CollisionPrecedence verifies that a name existing in both
+// schemas at once is resolved consistently in favor of the v2
+// activation by both Info and List, without disturbing the v1 namesake.
+func TestV1CollisionPrecedence(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: mountC}))
+	mm := m.(*mountManager)
+
+	ainfo, err := m.Activate(ctx, "a", []mount.Mount{{Type: "noop", Source: "/dev/null"}})
+	require.NoError(t, err)
+	liveMP := ainfo.Active[0].MountPoint
+
+	seedV1(t, mm.db, "test", v1Activation{
+		name:   "a",
+		active: []v1Active{{typ: "noop", mp: "/legacy/a", at: time.Now()}},
+	})
+
+	info, err := m.Info(ctx, "a")
+	require.NoError(t, err)
+	require.Len(t, info.Active, 1)
+	assert.Equal(t, liveMP, info.Active[0].MountPoint, "Info must prefer the v2 activation")
+
+	infos, err := m.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, infos, 1, "List must not report the v1 namesake alongside the v2 activation")
+	assert.Equal(t, liveMP, infos[0].Active[0].MountPoint)
+
+	// The v1 namesake is untouched: Activate never looked at it, since
+	// a live v2 activation by this name already existed.
+	assertV1Present(t, mm.db, true)
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestV1Deactivate verifies that Deactivate releases a v1 activation:
+// it unmounts its recorded chain and removes its target directory,
+// the same as it always did before this schema existed.
+func TestV1Deactivate(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	unmounts := new(atomic.Int32)
+	handler := &noopHandler{mounts: mountC, unmountAttempts: unmounts}
+	m, targetdir := mkTestManager(t, WithMountHandler("noop", handler))
+	mm := m.(*mountManager)
+
+	target := filepath.Join(targetdir, "1")
+	require.NoError(t, os.MkdirAll(target, 0700))
+
+	seedV1(t, mm.db, "test", v1Activation{
+		name: "old",
+		active: []v1Active{
+			{typ: "noop", mp: filepath.Join(target, "0"), at: time.Now()},
+			{typ: "noop", mp: filepath.Join(target, "1"), at: time.Now()},
+		},
+	})
+
+	require.NoError(t, m.Deactivate(ctx, "old"))
+
+	assert.Equal(t, int32(2), unmounts.Load(), "unmount attempted once per position")
+	assert.Equal(t, int32(0), mountC.Load(), "the fixture was never actually mounted through the handler")
+	_, err := os.Stat(target)
+	assert.True(t, os.IsNotExist(err), "the v1 activation's target directory should be removed")
+
+	_, err = m.Info(ctx, "old")
+	assert.True(t, errdefs.IsNotFound(err), "expected ErrNotFound, got %v", err)
+	assertV1Present(t, mm.db, true, "the v1 bucket itself, now with no activations left in it, is left in place")
+}
+
+// ebusyHandler always fails to unmount with syscall.EBUSY, standing
+// in for a filesystem which is still busy underneath the mount point
+// v1Unmount is trying to remove.
+type ebusyHandler struct{}
+
+func (ebusyHandler) Mount(_ context.Context, m mount.Mount, mp string, _ []mount.ActiveMount) (mount.ActiveMount, error) {
+	return mount.ActiveMount{Mount: m, MountPoint: mp}, nil
+}
+
+func (ebusyHandler) Unmount(_ context.Context, _ string) error {
+	return syscall.EBUSY
+}
+
+// TestV1UnmountLeavesDirectoryOnFailedUnmount verifies that a v1
+// activation's target directory survives a failed unmount.
+func TestV1UnmountLeavesDirectoryOnFailedUnmount(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, targetdir := mkTestManager(t, WithMountHandler("noop", ebusyHandler{}))
+	mm := m.(*mountManager)
+
+	target := filepath.Join(targetdir, "1")
+	require.NoError(t, os.MkdirAll(target, 0700))
+
+	seedV1(t, mm.db, "test", v1Activation{
+		name:   "old",
+		active: []v1Active{{typ: "noop", mp: filepath.Join(target, "0"), at: time.Now()}},
+	})
+
+	err := m.Deactivate(ctx, "old")
+	require.Error(t, err)
+
+	_, statErr := os.Stat(target)
+	assert.NoError(t, statErr, "the target directory must survive a failed unmount, not be removed out from under a still-mounted filesystem")
+}
+
+// TestV1DeactivateNotFound verifies that Deactivate reports
+// ErrNotFound for a name which exists in neither schema.
+func TestV1DeactivateNotFound(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+
+	err := m.Deactivate(ctx, "nonexistent")
+	assert.True(t, errdefs.IsNotFound(err), "expected ErrNotFound, got %v", err)
+}
+
+// TestActivateReportsLiveV1AlreadyExists verifies that Activate
+// reports ErrAlreadyExists, without touching anything, for a name
+// whose v1 activation is still actually mounted.
+func TestActivateReportsLiveV1AlreadyExists(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	handler := &noopHandler{mounts: mountC}
+	m, _ := mkTestManager(t, WithMountHandler("noop", handler))
+	mm := m.(*mountManager)
+
+	mp := "/legacy/live"
+	seedV1(t, mm.db, "test", v1Activation{
+		name:   "old",
+		active: []v1Active{{typ: "noop", mp: mp, at: time.Now()}},
+	})
+	// Simulate the v1 mount still actually being in effect.
+	handler.live = map[string]struct{}{mp: {}}
+
+	_, err := m.Activate(ctx, "old", []mount.Mount{{Type: "noop", Source: "/dev/null"}})
+	assert.True(t, errdefs.IsAlreadyExists(err), "expected ErrAlreadyExists, got: %v", err)
+	assertV1Present(t, mm.db, true)
+
+	info, err := m.Info(ctx, "old")
+	require.NoError(t, err)
+	assert.Equal(t, mp, info.Active[0].MountPoint, "the v1 activation must be untouched")
+}
+
+// TestActivateReplacesDeadV1 verifies that Activate treats a v1
+// activation whose recorded mount is no longer actually mounted as
+// stale, releasing and unmounting it before creating a fresh v2
+// activation under the same name.
+func TestActivateReplacesDeadV1(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	handler := &noopHandler{mounts: mountC}
+	m, targetdir := mkTestManager(t, WithMountHandler("noop", handler))
+	mm := m.(*mountManager)
+
+	target := filepath.Join(targetdir, "1")
+	require.NoError(t, os.MkdirAll(target, 0700))
+	mp := filepath.Join(target, "0")
+
+	seedV1(t, mm.db, "test", v1Activation{
+		name:   "old",
+		active: []v1Active{{typ: "noop", mp: mp, at: time.Now()}},
+	})
+	// Not marked live on the handler: this position is not actually
+	// mounted, matching wreckage left behind by a pre-upgrade crash.
+
+	ainfo, err := m.Activate(ctx, "old", []mount.Mount{{Type: "noop", Source: "/dev/null"}})
+	require.NoError(t, err)
+	require.Len(t, ainfo.Active, 1)
+	assert.Equal(t, int32(1), mountC.Load(), "a fresh v2 mount was made")
+
+	_, err = os.Stat(target)
+	assert.True(t, os.IsNotExist(err), "the dead v1 activation's target directory should be removed")
+	assertV1Present(t, mm.db, true, "the v1 bucket itself is left in place, now with this activation released from it")
+
+	require.NoError(t, m.Deactivate(ctx, "old"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestActivateReplacesIncompleteV1 verifies that a v1 activation
+// interrupted before it completed, which never created an active
+// bucket, is treated as stale unconditionally, without needing
+// anything to probe, exactly as an equivalent v2 activation would be.
+func TestActivateReplacesIncompleteV1(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: mountC}))
+	mm := m.(*mountManager)
+
+	seedV1(t, mm.db, "test", v1Activation{name: "gone", active: nil})
+
+	ainfo, err := m.Activate(ctx, "gone", []mount.Mount{{Type: "noop", Source: "/dev/null"}})
+	require.NoError(t, err)
+	require.Len(t, ainfo.Active, 1)
+
+	require.NoError(t, m.Deactivate(ctx, "gone"))
+	assert.Equal(t, int32(0), mountC.Load())
+}
+
+// TestV1GCAll verifies that every v1 activation is reported by All,
+// including one interrupted before it completed, exactly as v1's own
+// native collector always reported it: unconditionally, without
+// filtering by completeness.
+func TestV1GCAll(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+	mm := m.(*mountManager)
+
+	seedV1(t, mm.db, "test",
+		v1Activation{name: "complete", active: []v1Active{{typ: "noop", mp: "/legacy/a", at: time.Now()}}},
+		v1Activation{name: "incomplete", active: nil},
+	)
+
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	defer cc.Cancel()
+
+	var all []string
+	cc.All(func(n gc.Node) { all = append(all, n.Key) })
+	assert.ElementsMatch(t, []string{"complete", "incomplete"}, all)
+}
+
+// TestV1GCRemove verifies that removing a v1 activation through
+// garbage collection releases and unmounts it.
+func TestV1GCRemove(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	unmounts := new(atomic.Int32)
+	m, targetdir := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: mountC, unmountAttempts: unmounts}))
+	mm := m.(*mountManager)
+
+	target := filepath.Join(targetdir, "1")
+	require.NoError(t, os.MkdirAll(target, 0700))
+
+	seedV1(t, mm.db, "test", v1Activation{
+		name:   "old",
+		active: []v1Active{{typ: "noop", mp: filepath.Join(target, "0"), at: time.Now()}},
+	})
+
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	cc.Remove(gc.Node{Type: metadata.ResourceMount, Namespace: "test", Key: "old"})
+	require.NoError(t, cc.Finish())
+
+	assert.Equal(t, int32(1), unmounts.Load())
+	_, err = os.Stat(target)
+	assert.True(t, os.IsNotExist(err))
+	_, err = m.Info(ctx, "old")
+	assert.True(t, errdefs.IsNotFound(err))
+}
+
+// TestV1GCBackRefKeepsAlive verifies that a v1 activation's own
+// gc.bref labels are honored by ActiveWithBackRefs.
+func TestV1GCBackRefKeepsAlive(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+	mm := m.(*mountManager)
+
+	seedV1(t, mm.db, "test", v1Activation{
+		name:   "old",
+		labels: map[string]string{"containerd.io/gc.bref.container": "c1"},
+		active: []v1Active{{typ: "noop", mp: "/legacy/old", at: time.Now()}},
+	})
+
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	defer cc.Cancel()
+
+	ccb := cc.(interface {
+		ActiveWithBackRefs(string, func(gc.Node), func(gc.Node, gc.Node))
+	})
+	var brefs []string
+	ccb.ActiveWithBackRefs("test", func(gc.Node) {}, func(n, ref gc.Node) {
+		if n.Type == metadata.ResourceContainer && n.Key == "c1" {
+			brefs = append(brefs, ref.Key)
+		}
+	})
+	assert.Contains(t, brefs, "old")
+}
+
+// TestV1GCLeasedKeepsAlive verifies that a v1 activation's own lease
+// membership is honored by Leased, the same as a v2 activation's.
+func TestV1GCLeasedKeepsAlive(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+	mm := m.(*mountManager)
+
+	seedV1(t, mm.db, "test", v1Activation{
+		name:   "old",
+		lease:  "L",
+		active: []v1Active{{typ: "noop", mp: "/legacy/old", at: time.Now()}},
+	})
+
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	defer cc.Cancel()
+
+	ccl := cc.(interface {
+		Leased(string, string, func(gc.Node))
+	})
+	var leased []string
+	ccl.Leased("test", "L", func(n gc.Node) { leased = append(leased, n.Key) })
+	assert.Contains(t, leased, "old")
+}
+
+// TestV1OrphanDirs verifies that a v1 activation's target directory
+// left behind with no database record at all is reaped by garbage
+// collection.
+func TestV1OrphanDirs(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	handler := &noopHandler{mounts: mountC}
+	m, targetdir := mkTestManager(t, WithMountHandler("noop", handler))
+
+	orphan := filepath.Join(targetdir, "42")
+	require.NoError(t, os.MkdirAll(orphan, 0700))
+	// v1 never wrote position "0": a chain of N positions is numbered
+	// N down to 1 (see v1OrphanPositions), so a lone position is "1".
+	mp0 := filepath.Join(orphan, "1")
+	require.NoError(t, os.WriteFile(filepath.Join(orphan, "1-type"), []byte("noop"), 0600))
+	require.NoError(t, os.MkdirAll(mp0, 0700))
+	mountC.Add(1)
+	handler.live = map[string]struct{}{mp0: {}}
+
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cc.Finish())
+
+	assert.Equal(t, int32(0), mountC.Load(), "the orphaned v1 mount should be unmounted with its handler")
+	_, err = os.Stat(orphan)
+	assert.True(t, os.IsNotExist(err), "the orphaned v1 target directory should be removed")
+}
+
+// orderRecordingHandler records the mount point Unmount is called
+// with, in call order.
+type orderRecordingHandler struct {
+	mu    sync.Mutex
+	order []string
+}
+
+func (h *orderRecordingHandler) Mount(_ context.Context, m mount.Mount, mp string, _ []mount.ActiveMount) (mount.ActiveMount, error) {
+	return mount.ActiveMount{Mount: m, MountPoint: mp}, nil
+}
+
+func (h *orderRecordingHandler) Unmount(_ context.Context, mp string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.order = append(h.order, mp)
+	return nil
+}
+
+// TestV1OrphanDirsUnmountsTopFirst verifies that a multi-position v1
+// activation found orphaned on disk is unmounted top of the chain
+// first and base last, sorting numerically rather than lexically on
+// position number (11 positions exercises the "10"/"11" ordering case).
+func TestV1OrphanDirsUnmountsTopFirst(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	handler := &orderRecordingHandler{}
+	m, targetdir := mkTestManager(t, WithMountHandler("noop", handler))
+
+	const n = 11
+	orphan := filepath.Join(targetdir, "77")
+	require.NoError(t, os.MkdirAll(orphan, 0700))
+	// dir "1" is the top of the chain, mounted last; dir "n" is the base.
+	var wantOrder []string
+	for i := 1; i <= n; i++ {
+		mp := filepath.Join(orphan, strconv.Itoa(i))
+		require.NoError(t, os.WriteFile(filepath.Join(orphan, strconv.Itoa(i)+"-type"), []byte("noop"), 0600))
+		require.NoError(t, os.MkdirAll(mp, 0700))
+		wantOrder = append(wantOrder, mp)
+	}
+
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cc.Finish())
+
+	assert.Equal(t, wantOrder, handler.order,
+		"top of the chain (lowest n) must be unmounted first, base (highest n) last")
+	_, err = os.Stat(orphan)
+	assert.True(t, os.IsNotExist(err), "the orphaned v1 target directory should be removed")
+}
+
+// TestV1OrphanDirsSkipsBackingDir verifies that the v1 orphan
+// directory scan never mistakes v2's own backingDir for a v1 target
+// directory left behind with no record.
+func TestV1OrphanDirsSkipsBackingDir(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, _ := mkTestManager(t, WithMountHandler("vol", &noopHandler{mounts: mountC}))
+
+	// A real v2 mount, whose directory lives under backingDir.
+	_, err := m.Activate(ctx, "a", []mount.Mount{{Type: "vol", Source: "/dev/null", Options: []string{"rw"}}})
+	require.NoError(t, err)
+
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cc.Finish())
+
+	// The v2 mount must have survived: the v1 orphan scan must not
+	// have swept backingDir out from under it.
+	assert.Equal(t, int32(1), mountC.Load())
+
+	require.NoError(t, m.Deactivate(ctx, "a"))
+}
+
+// TestV1AndV2IDsCanCollideNumerically verifies that a v1 activation
+// and a v2 mounted record which happen to share the same numeric id
+// do not interfere with one another.
+func TestV1AndV2IDsCanCollideNumerically(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	m, targetdir := mkTestManager(t, WithMountHandler("vol", &noopHandler{mounts: mountC}))
+	mm := m.(*mountManager)
+
+	ainfo, err := m.Activate(ctx, "new", []mount.Mount{{Type: "vol", Source: "/dev/null", Options: []string{"rw"}}})
+	require.NoError(t, err)
+	v2MP := ainfo.Active[0].MountPoint
+
+	// Extract the v2 record's own numeric id from its mount point and
+	// seed a v1 activation with that same id.
+	id := filepath.Base(filepath.Dir(v2MP))
+	require.NoError(t, mm.db.Update(func(tx *bolt.Tx) error {
+		oldbkt, err := tx.CreateBucketIfNotExists([]byte("v1"))
+		if err != nil {
+			return err
+		}
+		nsbkt, err := oldbkt.CreateBucketIfNotExists([]byte("test"))
+		if err != nil {
+			return err
+		}
+		mbkt, err := nsbkt.CreateBucketIfNotExists(v1KeyMounts)
+		if err != nil {
+			return err
+		}
+		bkt, err := mbkt.CreateBucket([]byte("old"))
+		if err != nil {
+			return err
+		}
+		idNum, err := strconv.ParseUint(id, 10, 64)
+		if err != nil {
+			return err
+		}
+		idb, err := encodeID(idNum)
+		if err != nil {
+			return err
+		}
+		if err := bkt.Put(v1KeyID, idb); err != nil {
+			return err
+		}
+		abkt, err := bkt.CreateBucket(v1KeyActive)
+		if err != nil {
+			return err
+		}
+		cur, err := abkt.CreateBucket([]byte{0})
+		if err != nil {
+			return err
+		}
+		if err := cur.Put(v1KeyType, []byte("vol")); err != nil {
+			return err
+		}
+		if err := cur.Put(v1KeyMountPoint, []byte("/legacy/old")); err != nil {
+			return err
+		}
+		atb, err := time.Now().MarshalBinary()
+		if err != nil {
+			return err
+		}
+		return cur.Put(v1KeyMountedAt, atb)
+	}))
+	require.Equal(t, filepath.Join(targetdir, backingDir, id, mountPointName), v2MP,
+		"sanity check on the path this test parsed the id out of")
+
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	cc.Remove(gc.Node{Type: metadata.ResourceMount, Namespace: "test", Key: "old"})
+	require.NoError(t, cc.Finish())
+
+	// The v1 activation is gone, but the v2 one, despite sharing its
+	// numeric id, must be completely unaffected.
+	_, err = m.Info(ctx, "old")
+	assert.True(t, errdefs.IsNotFound(err))
+	info, err := m.Info(ctx, "new")
+	require.NoError(t, err)
+	assert.Equal(t, v2MP, info.Active[0].MountPoint)
+	assert.Equal(t, int32(1), mountC.Load())
+
+	require.NoError(t, m.Deactivate(ctx, "new"))
+}
+
+// TestV1NeverModified verifies that a full v2 activate, deactivate and
+// garbage collection cycle leaves an unrelated v1 activation, and the
+// "v1" bucket itself, completely unchanged.
+func TestV1NeverModified(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: new(atomic.Int32)}))
+	mm := m.(*mountManager)
+
+	seedV1(t, mm.db, "test", v1Activation{
+		name:   "untouched",
+		lease:  "L",
+		labels: map[string]string{"containerd.io/gc.bref.container": "c1"},
+		active: []v1Active{{typ: "noop", mp: "/legacy/untouched", at: time.Now()}},
+	})
+
+	var before []byte
+	require.NoError(t, mm.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket([]byte("v1"))
+		require.NotNil(t, bkt)
+		var err error
+		before, err = dumpBucket(bkt)
+		return err
+	}))
+
+	_, err := m.Activate(ctx, "unrelated", []mount.Mount{{Type: "noop", Source: "/dev/null"}})
+	require.NoError(t, err)
+	require.NoError(t, m.Deactivate(ctx, "unrelated"))
+
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cc.Finish())
+
+	var after []byte
+	require.NoError(t, mm.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket([]byte("v1"))
+		require.NotNil(t, bkt)
+		var err error
+		after, err = dumpBucket(bkt)
+		return err
+	}))
+
+	assert.Equal(t, before, after, "v1 must be byte for byte unchanged")
+}
+
+// dumpBucket serializes a bucket's full contents, recursively, into a
+// deterministic byte string for comparison.
+func dumpBucket(bkt *bolt.Bucket) ([]byte, error) {
+	var buf []byte
+	c := bkt.Cursor()
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		buf = append(buf, k...)
+		buf = append(buf, 0)
+		if v != nil {
+			buf = append(buf, v...)
+			buf = append(buf, 0, 0)
+			continue
+		}
+		sub, err := dumpBucket(bkt.Bucket(k))
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, sub...)
+		buf = append(buf, 0, 0)
+	}
+	return buf, nil
+}

--- a/core/mount/manager/v1_test.go
+++ b/core/mount/manager/v1_test.go
@@ -542,6 +542,68 @@ func TestV1GCRemove(t *testing.T) {
 	assert.True(t, errdefs.IsNotFound(err))
 }
 
+// TestV1Reconciled verifies that a v1 activation whose recorded mount
+// is not actually in effect is released by garbage collection even
+// when nothing asks for it to be removed.
+func TestV1Reconciled(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	mountC := new(atomic.Int32)
+	unmounts := new(atomic.Int32)
+	m, targetdir := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: mountC, unmountAttempts: unmounts}))
+	mm := m.(*mountManager)
+
+	target := filepath.Join(targetdir, "1")
+	require.NoError(t, os.MkdirAll(target, 0700))
+
+	seedV1(t, mm.db, "test", v1Activation{
+		name:   "dead",
+		active: []v1Active{{typ: "noop", mp: filepath.Join(target, "0"), at: time.Now()}},
+	})
+	cc, err := m.(interface {
+		StartCollection(context.Context) (metadata.CollectionContext, error)
+	}).StartCollection(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cc.Finish())
+
+	assert.Equal(t, int32(1), unmounts.Load())
+	_, err = os.Stat(target)
+	assert.True(t, os.IsNotExist(err))
+	_, err = m.Info(ctx, "dead")
+	assert.True(t, errdefs.IsNotFound(err))
+}
+
+// TestV1ReconciledIncomplete verifies that a v1 activation interrupted
+// before it ever completed, with no active bucket at all, is released
+// by reconciliation.
+func TestV1ReconciledIncomplete(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+	mm := m.(*mountManager)
+
+	seedV1(t, mm.db, "test", v1Activation{name: "gone", active: nil})
+
+	require.NoError(t, startCollection(t, m, ctx).Finish())
+
+	_, err := m.Info(ctx, "gone")
+	assert.True(t, errdefs.IsNotFound(err), "an incomplete v1 activation must be reconciled away, got %v", err)
+}
+
+// TestV1ReconciledEmptyActiveIsLive verifies that an active bucket
+// which exists but has no positions in it is treated as live, not
+// reconciled away like an activation with no active bucket at all.
+func TestV1ReconciledEmptyActiveIsLive(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	m, _ := mkTestManager(t)
+	mm := m.(*mountManager)
+
+	seedV1(t, mm.db, "test", v1Activation{name: "here", active: []v1Active{}})
+
+	require.NoError(t, startCollection(t, m, ctx).Finish())
+
+	_, err := m.Info(ctx, "here")
+	require.NoError(t, err, "an activation with an empty but present active bucket must not be reconciled away")
+}
+
 // TestV1GCBackRefKeepsAlive verifies that a v1 activation's own
 // gc.bref labels are honored by ActiveWithBackRefs.
 func TestV1GCBackRefKeepsAlive(t *testing.T) {
@@ -797,14 +859,19 @@ func TestV1AndV2IDsCanCollideNumerically(t *testing.T) {
 // "v1" bucket itself, completely unchanged.
 func TestV1NeverModified(t *testing.T) {
 	ctx := namespaces.WithNamespace(context.Background(), "test")
-	m, _ := mkTestManager(t, WithMountHandler("noop", &noopHandler{mounts: new(atomic.Int32)}))
+	handler := &noopHandler{mounts: new(atomic.Int32)}
+	m, _ := mkTestManager(t, WithMountHandler("noop", handler))
 	mm := m.(*mountManager)
 
+	// Marked live on the handler: reconciliation must leave a
+	// still-mounted v1 activation alone.
+	mp := "/legacy/untouched"
+	handler.live = map[string]struct{}{mp: {}}
 	seedV1(t, mm.db, "test", v1Activation{
 		name:   "untouched",
 		lease:  "L",
 		labels: map[string]string{"containerd.io/gc.bref.container": "c1"},
-		active: []v1Active{{typ: "noop", mp: "/legacy/untouched", at: time.Now()}},
+		active: []v1Active{{typ: "noop", mp: mp, at: time.Now()}},
 	})
 
 	var before []byte

--- a/plugins/mount/manager.go
+++ b/plugins/mount/manager.go
@@ -17,7 +17,6 @@
 package mount
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -25,12 +24,10 @@ import (
 
 	bolt "go.etcd.io/bbolt"
 
-	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 
 	"github.com/containerd/containerd/v2/core/metadata"
-	"github.com/containerd/containerd/v2/core/metadata/boltutil"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/mount/manager"
 	"github.com/containerd/containerd/v2/plugins"
@@ -97,30 +94,6 @@ func init() {
 			if err != nil {
 				db.Close()
 				return nil, fmt.Errorf("failed to create mount manager: %w", err)
-			}
-
-			//TODO: IF has sync
-			if sync, ok := mm.(interface{ Sync(context.Context) error }); ok {
-
-				// Start transaction and then background sync with mount state,
-				// ensure startup waits until ready to continue
-				tx, err := db.Begin(true)
-				if err != nil {
-					db.Close()
-					return nil, fmt.Errorf("failed to open database for write: %w", err)
-				}
-				ctx := boltutil.WithTransaction(ic.Context, tx)
-
-				ready := ic.RegisterReadiness()
-				go func() {
-					defer ready()
-					if err := sync.Sync(ctx); err == nil {
-						tx.Commit()
-					} else {
-						log.G(ctx).WithError(err).Errorf("failed to sync mounts")
-						tx.Rollback()
-					}
-				}()
 			}
 
 			if collector, ok := mm.(metadata.Collector); ok {


### PR DESCRIPTION
# mount/manager: schema v2, one record per mount

## Issues fixed

- **Duplicate mounts of an identical filesystem.** `main` has no dedup at
  all: every activation of the same mount (same image, same options)
  performs its own independent mount. For a read-only layer that's wasted
  work; for a shared writable image (e.g. one ext4 block device several
  containers write into) it's actively corrupting, since two independent
  read-write mounts of the same filesystem will corrupt it. This change
  deduplicates and reference-counts identical mounts so there is exactly one
  real mount no matter how many activations use it.
- **Persisted mount state can silently go stale.** `main` decides whether an
  activation already exists and is usable purely by checking whether a
  bucket its own bookkeeping wrote is present, never by checking whether the
  mount it describes is actually still there. A reboot, or an unmount that
  happens outside this package, leaves that bookkeeping believing a mount
  exists when it no longer does; on `main` this can surface as
  `ErrAlreadyExists`, or `Info`, for a mount that isn't really there anymore.
  This change always checks the mount directly before trusting it, and
  repairs it in place when it's found to disagree with what's recorded.

## What this does

Every mount the manager actually performs is now recorded once, as a
"mounted record" (`core/mount/manager/backing.go`), keyed by a digest of its
final (post-transform) type/source/target/options. An activation's chain no
longer stores mounts inline; each position just points at the mounted record
it uses. Two activations that resolve to the same record share it and it
stays mounted as long as either uses it; one that can't be shared (e.g.
tmpfs) still gets its own record, so there's one code path either way.

## Design points worth flagging for review

- **One write transaction per `Activate`, instead of two.** `main` always
  performs exactly two, regardless of chain length: one to create the
  activation, and a second, after every mount in the chain is performed, to
  record the results and mark it complete. This change resolves the whole
  chain — every position's final mount value and the record it uses — in
  the first transaction and needs no second one, since mount point and
  mount time are computed as part of resolving rather than measured
  afterward. Only possible because `mkfs`/`mkdir` were split into a pure
  part (computes the resulting mount, safe to run inside a transaction) and
  an impure part (creates the file/directory, deferred until after the
  transaction commits). See `rewritePosition` in `transformer.go`.
- **Records are never trusted, only checked.** Because mount point and mount
  time are now computed rather than measured, they can't double as a
  liveness signal the way `main`'s bookkeeping does, so nothing here relies
  on persisted state for that: whether a record is actually mounted is
  always checked directly (`probeMounted` in `manager.go`), via the new
  `mount.MountedChecker` optional interface if the handler implements it, or
  the host's mount table otherwise. A record found not to be mounted is
  repaired in place, reusing its existing id and mount point, rather than
  minted fresh.
- **New public interface: `mount.MountedChecker`** (`core/mount/manager.go`).
  Optional, type-asserted, same pattern as `metadata.Collector` etc. Needed
  because a handler's mount point isn't always a real kernel mount — the
  loopback handler's is a symlink to a device — so a generic mount-table
  check would always report it as dead. Implemented on `LoopbackHandler`
  (`core/mount/loopback_handler_linux.go`) via `LOOP_GET_STATUS64`.
- **Claimed transforms are honored through the write transaction, not just
  in planning.** `main` already computes `applyCount` — how much of the
  boundary mount's transform chain the caller has claimed and the manager
  must leave unapplied (`planActivation` in `plan.go`) — but nothing in this
  package's schema v2 predecessor called through `resolvePosition`/
  `rewritePosition` with it sliced; it applied the whole chain regardless of
  what the plan says. Fixed by slicing `mountConv[firstSystemMount]` to
  `plan.applyCount[firstSystemMount]` at the one place it's applied, with an
  end to end regression test (`TestActivateHonorsClaimedTransformSuffix`) in
  addition to `plan_test.go`'s existing unit coverage of `planActivation`
  itself.

## Schema

Top level bucket moves from `"v1"` to `"v2"` (structural change, not
compatible in place: an old record stores its mount inline, a new one only
ever points at a mounted record). Unlike a typical schema bump, `"v1"` is
never converted into `"v2"`: it is left exactly where it is, and this
package only ever reads it and, when a caller asks, releases it
(`core/mount/manager/v1.go`). `Info`, `List`, `Deactivate`, garbage
collection, and the check `Activate` uses to tell an existing activation
apart from stale wreckage, all consult `"v1"` as a fallback whenever `"v2"`
has nothing by that name.

Reading in place rather than converting was chosen specifically to avoid a
hybrid state: a converted record would carry a `"v2"` identity (a mounted
record id, implying the `backingDir`-based layout every other `"v2"` record
uses) while still describing a mount point wherever `"v1"` originally put
it, since `"v1"` never used `backingDir`. Every place that distinction
would have to be threaded through — cleanup, orphan scanning, the dedup
index — is instead simply unaware `"v1"` exists at all: a mounted record is
now always one this schema created itself, at exactly the path its id
implies.

This makes rollback to a pre-v2 binary safe unconditionally, not just
before this package's first write: `"v1"` is never mutated by a `"v2"`
binary at all, so there is nothing for a rollback to have missed.

`"v1"` mounts are never deduplicated against one another or against a
`"v2"` mount: dedup requires a source, and `"v1"` never recorded one, so
this falls out of the existing shareability check without needing to
special case it.

This is intentionally temporary: `v1.go`'s package doc marks it removable
in 2.7. 2.6 is the next LTS, so `"v1"` support needs to survive it; 2.7 is
the next release after that free to make a breaking change. Not this
release, 2.4: introducing and removing it in the same release would leave
no window for anyone to actually upgrade through it.

`"v1"`'s original layout is documented alongside `"v2"`'s in the schema
diagram in `buckets.go`, marked deprecated, since this package still reads
it even though it never writes it. `"v1"`'s own key constants (`v1Key*`)
live in `v1.go` rather than `buckets.go`, decoupled from `"v2"`'s: sharing
them would let a future `"v2"` rename silently change how `"v1"` is read.

`"v2"`'s own bucket keys are renamed for their first appearance in any
release — the last point at which this is free, since `"v1"`'s are frozen
forever by definition. The bucket of activations was called `mounts`,
reading as the same concept as the bucket of mounted records, `mounted`,
under two different names; it becomes `activations`.
`mounted`/`mountedindex`/`uses`/`usedby`/`mp`/`mat` become
`mnttable`/`mntindex`/`mntid`/`holders`/`mntpoint`/`mntat`, consistently
using `mnt` as Linux itself does (`mnt_id`, `/proc/self/mountinfo`'s
`Mountpoint`) for one mount shared across several references (see
`sget()`). `active`, `system` and `labels` are kept as is, matching
`ActivationInfo`'s own field names.

Two bugs were found in `"v1"` handling while addressing review feedback,
both fixed and both caught only because a new regression test was added
for each (see Testing below):

- **The orphan directory scan unmounted a chain backwards.**
  `v1OrphanPositions` sorted position directories lexically ("1", "10",
  "11", "2", ...) and read them in that order as though it were mount
  order. `"v1"` numbered a chain of N positions `ci = N-i`, so recovering
  mount order requires sorting numerically descending, not lexically
  ascending; a chain found orphaned on disk (no database record at all)
  was unmounted base first, top last, opposite of every other unmount
  path in this package. Silent because the only existing test seeded a
  single position, where no ordering bug is observable.
- **`Info`/`List` silently dropped a `"v1"` activation's `System` mounts.**
  `"v1"` recorded a system mount in full (type, source, target, options),
  the same as `"v2"` does, but `v1ActivationInfo` never read that bucket
  back. The existing test asserted the empty result as correct.

## Testing

- Unit and root-requiring tests (`-test.root`) pass, including new tests
  added:
  - `TestActivateSingleWriteTransaction` (exactly one write transaction per
    `Activate`)
  - `TestActivateHonorsClaimedTransformSuffix` (a caller's claimed transform
    stays unapplied at the boundary mount once resolved through the write
    transaction, not just in `planActivation`)
  - `TestRealizeMountWaitsForConcurrentIdentity` (a second activation blocks
    on and reuses a mount still being made rather than double-mounting)
  - `TestRealizeMountRepairsInPlace` (same id/path survive a repair)
  - `TestPodGroupSharesOneMount` (N activations, one shared mount)
  - `v1_test.go`: `"v1"` activations reading correctly through `Info`/`List`
    (including one interrupted before it completed, and one whose name
    collides with a live `"v2"` activation), now including a `System`
    round trip; `Activate` reporting `ErrAlreadyExists` for a still-live
    `"v1"` activation and replacing a dead one; `"v1"` activations
    participating correctly in garbage collection, including `gc.bref`
    backreferences, lease membership, and orphaned target directories,
    now including `TestV1OrphanDirsUnmountsTopFirst` (11 positions, past
    both of `"v1"`'s own zero-padding width changes, unmounted with a
    handler that records call order); a `"v1"` id and a `"v2"` id which
    happen to collide numerically (independent counters) not interfering
    with one another; a full `"v2"` activate/deactivate/collect cycle
    leaving `"v1"` byte for byte unchanged.
- `-race -count=2` clean on `core/mount/manager`, with and without root.
- `make check`: 24 issues vs. `main`'s own baseline of 25 at the same tip
  (one fewer, not regressed).
- Builds, vets, and compiles its test binary under `GOOS=windows`. Test
  mount sources which need to be absolute (to exercise dedup) are built
  with a small `absSource` helper rather than hardcoded as Unix-style
  literals, since `filepath.IsAbs` requires a volume name on Windows.

## Commits

Single commit: `mount/manager: move to schema v2, back every mount with one
record` — the schema/dedup/transaction-count rework described above.

Previously two commits; the first, a standalone fix for a panic reachable
when every mount in a chain is handled by the manager, was dropped: `main`
already fixes the identical panic, as part of a more thorough series
(`8ba69faf0`, `00967ecf0`, `0b641f009`) that also extracted activation
planning into `plan.go` and added support for a caller to claim a transform
by name (`WithAllowTransform`) rather than only via the `"format/*"` mount
type convention. This series's boundary-mount transform application now
builds on that extraction; see the `applyCount` point
above.
