### PR TITLE
remotes/docker: add tls_groups host configuration

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -22,12 +22,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -54,6 +56,8 @@ type hostConfig struct {
 	skipVerify  *bool
 
 	dialTimeout *time.Duration
+
+	tlsGroups []tls.CurveID
 
 	header http.Header
 
@@ -168,7 +172,8 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 		rhosts := make([]docker.RegistryHost, len(hosts))
 		for i, host := range hosts {
 			// Allow setting for each host as well
-			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil
+			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil ||
+				host.skipVerify != nil || len(host.tlsGroups) > 0
 			explicitTLS := tlsConfigured || explicitTLSFromHost
 
 			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 {
@@ -285,6 +290,10 @@ func updateTLSConfigFromHost(tlsConfig *tls.Config, host *hostConfig) error {
 		tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 	}
 
+	if len(host.tlsGroups) > 0 {
+		tlsConfig.CurvePreferences = host.tlsGroups
+	}
+
 	return nil
 }
 
@@ -374,6 +383,10 @@ type hostFileConfig struct {
 	// a connect to complete.
 	DialTimeout string `toml:"dial_timeout"`
 
+	// TLSGroups is the list of TLS key exchange groups allowed
+	// when negotiating TLS with this host. Set on the client's tls.Config.
+	TLSGroups []string `toml:"tls_groups"`
+
 	// TODO: Credentials: helper? name? username? alternate domain? token?
 }
 
@@ -419,6 +432,16 @@ func parseHostsFile(baseDir string, b []byte) ([]hostConfig, error) {
 	hosts = append(hosts, parsed)
 
 	return hosts, nil
+}
+
+var tlsGroupNames = map[string]tls.CurveID{
+	"P-256":              tls.CurveP256,
+	"P-384":              tls.CurveP384,
+	"P-521":              tls.CurveP521,
+	"X25519":             tls.X25519,
+	"X25519MLKEM768":     tls.X25519MLKEM768,
+	"SecP256r1MLKEM768":  tls.SecP256r1MLKEM768,
+	"SecP384r1MLKEM1024": tls.SecP384r1MLKEM1024,
 }
 
 func parseHostConfig(server string, baseDir string, config hostFileConfig) (hostConfig, error) {
@@ -542,6 +565,15 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 			return hostConfig{}, err
 		}
 		result.dialTimeout = &dialTimeout
+	}
+
+	for _, name := range config.TLSGroups {
+		group, ok := tlsGroupNames[name]
+		if !ok {
+			return hostConfig{}, fmt.Errorf("unknown TLS group %q, valid groups: %s", name, strings.Join(slices.Sorted(maps.Keys(tlsGroupNames)), ", "))
+		}
+
+		result.tlsGroups = append(result.tlsGroups, group)
 	}
 
 	return result, nil

--- a/core/remotes/docker/config/hosts_test.go
+++ b/core/remotes/docker/config/hosts_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -123,6 +124,9 @@ ca = "/etc/path/default"
 
 [host."https://dial-timeout.registry"]
   dial_timeout = "3s"
+
+[host."https://tls-groups.registry"]
+  tls_groups = ["X25519MLKEM768", "P-256"]
 `
 
 	var tb, fb = true, false
@@ -214,6 +218,13 @@ ca = "/etc/path/default"
 			path:         "/v2",
 			capabilities: allCaps,
 			dialTimeout:  &dialTimeout,
+		},
+		{
+			scheme:       "https",
+			host:         "tls-groups.registry",
+			path:         "/v2",
+			capabilities: allCaps,
+			tlsGroups:    []tls.CurveID{tls.X25519MLKEM768, tls.CurveP256},
 		},
 		{
 			scheme:       "https",
@@ -510,6 +521,17 @@ func TestHTTPFallback(t *testing.T) {
 	}
 }
 
+func TestInvalidTLSGroup(t *testing.T) {
+	const testtoml = `
+[host."https://example.com"]
+	tls_groups = ["NotAGroup"]
+`
+	_, err := parseHostsFile("", []byte(testtoml))
+	if err == nil {
+		t.Fatalf("expected error for unknown TLS group")
+	}
+}
+
 func compareRegistryHost(j, k docker.RegistryHost) bool {
 	if j.Scheme != k.Scheme {
 		return false
@@ -587,6 +609,10 @@ func compareHostConfig(j, k hostConfig) bool {
 			return false
 		}
 	} else if j.dialTimeout != nil || k.dialTimeout != nil {
+		return false
+	}
+
+	if !slices.Equal(j.tlsGroups, k.tlsGroups) {
 		return false
 	}
 

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -373,6 +373,19 @@ A shorter timeout helps reduce delays when falling back to the original registry
 dial_timeout = "1s"
 ```
 
+## tls_groups field
+
+`tls_groups` restricts the set of TLS key exchange groups offered when
+negotiating TLS with this host. Go selects among the listed groups using its
+internal preference order; the order of the list is ignored. When not set,
+Go's default key exchange groups are used. Supported values are `P-256`,
+`P-384`, `P-521`, `X25519`, `X25519MLKEM768`, `SecP256r1MLKEM768`, and
+`SecP384r1MLKEM1024`.
+
+```toml
+tls_groups = ["X25519MLKEM768", "X25519", "P-256"]
+```
+
 ## host field(s) (in the toml table format)
 
 `[host]."https://namespace"` and `[host]."http://namespace"` entries in the


### PR DESCRIPTION
Adds a `tls_groups` field to the `hosts.toml` registry host configuration for controlling which TLS key exchange groups are negotiated per host (sets `tls.Config.CurvePreferences`). 

```toml
[host."https://registry.example.com"]
  tls_groups = ["X25519MLKEM768", "X25519", "P-256"]
```

Supported values: P-256, P-384, P-521, X25519, X25519MLKEM768,
SecP256r1MLKEM768, SecP384r1MLKEM1024.

Includes tests and a new section in docs/hosts.md.

Closes #13663