### PR TITLE
feat(shim): implement Go stack dump for Windows shims

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -378,6 +378,7 @@ func dumpStacks(writeToFile bool) {
 	if writeToFile {
 		name, err := stackdump.WriteFile("containerd", buf)
 		if err != nil {
+			log.L.WithError(err).Warn("failed to write goroutine stack dump")
 			return
 		}
 		log.L.WithField("path", name).Info("goroutine stack dump written")

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	_ "github.com/containerd/containerd/v2/core/metrics" // import containerd build info
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/containerd/v2/internal/stackdump"
 	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/errdefs"
@@ -372,28 +372,14 @@ func setLogFormat(config *srvconfig.Config) error {
 }
 
 func dumpStacks(writeToFile bool) {
-	var (
-		buf       []byte
-		stackSize int
-	)
-	bufferLen := 16384
-	for stackSize == len(buf) {
-		buf = make([]byte, bufferLen)
-		stackSize = runtime.Stack(buf, true)
-		bufferLen *= 2
-	}
-	buf = buf[:stackSize]
+	buf := stackdump.Dump()
 	log.L.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
 
 	if writeToFile {
-		// Also write to file to aid gathering diagnostics
-		name := filepath.Join(os.TempDir(), fmt.Sprintf("containerd.%d.stacks.log", os.Getpid()))
-		f, err := os.Create(name)
+		name, err := stackdump.WriteFile("containerd", buf)
 		if err != nil {
 			return
 		}
-		defer f.Close()
-		f.WriteString(string(buf))
-		log.L.Infof("goroutine stack dump written to %s", name)
+		log.L.WithField("path", name).Info("goroutine stack dump written")
 	}
 }

--- a/cmd/containerd/command/main_windows.go
+++ b/cmd/containerd/command/main_windows.go
@@ -18,17 +18,15 @@ package command
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"unsafe"
 
 	"github.com/Microsoft/go-winio/pkg/etw"
 	"github.com/Microsoft/go-winio/pkg/etwlogrus"
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/containerd/containerd/v2/cmd/containerd/server"
+	"github.com/containerd/containerd/v2/internal/stackdump"
 	"github.com/containerd/log"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows"
 )
 
 var (
@@ -63,33 +61,13 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 	return done
 }
 
+// setupDumpStacks dumps stacks whenever this process's stackdump event is
+// signaled. Windows has no SIGUSR1 to trap, so the named event from
+// internal/stackdump stands in for it.
 func setupDumpStacks() {
-	// Windows does not support signals like *nix systems. So instead of
-	// trapping on SIGUSR1 to dump stacks, we wait on a Win32 event to be
-	// signaled. ACL'd to builtin administrators and local system
-	event := "Global\\stackdump-" + fmt.Sprint(os.Getpid())
-	ev, _ := windows.UTF16PtrFromString(event)
-	sd, err := windows.SecurityDescriptorFromString("D:P(A;;GA;;;BA)(A;;GA;;;SY)")
-	if err != nil {
-		log.L.Errorf("failed to get security descriptor for debug stackdump event %s: %s", event, err.Error())
-		return
+	if err := stackdump.Notify(func() { dumpStacks(true) }); err != nil {
+		log.L.WithError(err).Error("failed to set up debug stackdump event, stack dumps unavailable")
 	}
-	var sa windows.SecurityAttributes
-	sa.Length = uint32(unsafe.Sizeof(sa))
-	sa.InheritHandle = 1
-	sa.SecurityDescriptor = sd
-	h, err := windows.CreateEvent(&sa, 0, 0, ev)
-	if h == 0 || err != nil {
-		log.L.Errorf("failed to create debug stackdump event %s: %s", event, err.Error())
-		return
-	}
-	go func() {
-		log.L.Debugf("Stackdump - waiting signal at %s", event)
-		for {
-			windows.WaitForSingleObject(h, windows.INFINITE)
-			dumpStacks(true)
-		}
-	}()
 }
 
 func etwCallback(sourceID guid.GUID, state etw.ProviderState, level etw.Level, matchAnyKeyword uint64, matchAllKeyword uint64, filterData uintptr) {

--- a/internal/stackdump/event_windows.go
+++ b/internal/stackdump/event_windows.go
@@ -1,0 +1,96 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package stackdump
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"unsafe"
+
+	"github.com/containerd/log"
+	"golang.org/x/sys/windows"
+)
+
+// eventSecurityDescriptor grants full access to builtin administrators and local
+// system only, on a DACL protected from inheritance. Signaling the event makes a
+// privileged process dump its internals to disk, so an unprivileged one must not
+// be able to reach it.
+const eventSecurityDescriptor = "D:P(A;;GA;;;BA)(A;;GA;;;SY)"
+
+// EventName returns the name of the Win32 event that triggers a stack dump in
+// the process with the given pid.
+//
+// The daemon and every shim use this same scheme, so one tool can trigger a dump
+// in any of them. PIDs are unique machine-wide, so the pid alone is enough to
+// keep two processes from contending for a name.
+func EventName(pid int) string {
+	return `Global\stackdump-` + strconv.Itoa(pid)
+}
+
+// Notify calls fn every time this process's stack dump event is signaled, for
+// example from PowerShell:
+//
+//	[System.Threading.EventWaitHandle]::OpenExisting("Global\stackdump-$targetPid").Set()
+//
+// Substitute the target's pid for $targetPid. PowerShell's own $PID is an
+// automatic variable holding the pid of the session, not of the process to dump.
+//
+// fn runs on a dedicated goroutine that lives for the life of the process, so a
+// slow fn delays later requests but nothing else.
+//
+// Callers should report an error and carry on: losing the debug facility is not a
+// reason to fail startup.
+func Notify(fn func()) error {
+	return notify(EventName(os.Getpid()), fn)
+}
+
+// notify is the body of Notify with the event name supplied explicitly, so
+// tests can use a name that does not collide with the running process's own.
+func notify(event string, fn func()) error {
+	ev, err := windows.UTF16PtrFromString(event)
+	if err != nil {
+		return fmt.Errorf("encoding event name %s: %w", event, err)
+	}
+	sd, err := windows.SecurityDescriptorFromString(eventSecurityDescriptor)
+	if err != nil {
+		return fmt.Errorf("building security descriptor for event %s: %w", event, err)
+	}
+	var sa windows.SecurityAttributes
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	// Deliberately not inheritable. An inherited handle carries the access
+	// rights it was created with, so a child process could signal dumps
+	// without the DACL above ever being consulted again.
+	sa.InheritHandle = 0
+	sa.SecurityDescriptor = sd
+
+	// Auto-reset and initially non-signaled: each signaling wakes exactly one
+	// dump, and no dump is queued before anyone asks for one.
+	h, err := windows.CreateEvent(&sa, 0, 0, ev)
+	if h == 0 || err != nil {
+		return fmt.Errorf("creating event %s: %w", event, err)
+	}
+
+	go func() {
+		log.L.WithField("event", event).Debug("waiting for stackdump signal")
+		for {
+			windows.WaitForSingleObject(h, windows.INFINITE)
+			fn()
+		}
+	}()
+	return nil
+}

--- a/internal/stackdump/event_windows_test.go
+++ b/internal/stackdump/event_windows_test.go
@@ -1,0 +1,147 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package stackdump
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// Long enough to survive a stalled CI runner: it only elapses when the test
+	// is already failing, so generosity here costs nothing.
+	waitTimeout   = 10 * time.Second
+	retryInterval = 50 * time.Millisecond
+)
+
+// eventCounter keeps event names unique across tests in this package.
+var eventCounter atomic.Uint64
+
+func TestEventName(t *testing.T) {
+	// External tooling signals this name to trigger a dump, and the containerd
+	// daemon and its shims must agree on it, so it is a compatibility contract.
+	if got, want := EventName(1234), `Global\stackdump-1234`; got != want {
+		t.Fatalf("EventName(1234) = %q; want %q", got, want)
+	}
+}
+
+// startNotify registers a watcher on a uniquely named event and returns a
+// handle for signaling it.
+//
+// Creating an event in the Global\ namespace needs SeCreateGlobalPrivilege and
+// the event's DACL admits only builtin administrators and local system, so an
+// unelevated run cannot exercise this. That is the behavior under test, not a
+// failure of it, so skip rather than fail.
+func startNotify(t *testing.T, fn func()) windows.Handle {
+	t.Helper()
+	name := fmt.Sprintf(`Global\stackdump-test-%d-%d`, os.Getpid(), eventCounter.Add(1))
+	if err := notify(name, fn); err != nil {
+		if !isElevationError(err) {
+			t.Fatalf("notify(%s) error = %v", name, err)
+		}
+		t.Skipf("cannot create stackdump event %s, test requires elevation: %v", name, err)
+	}
+	n, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		t.Fatalf("failed to encode event name %s: %v", name, err)
+	}
+	h, err := windows.OpenEvent(windows.EVENT_MODIFY_STATE|windows.SYNCHRONIZE, false, n)
+	if err != nil {
+		if !isElevationError(err) {
+			t.Fatalf("failed to open stackdump event %s: %v", name, err)
+		}
+		t.Skipf("cannot open stackdump event %s, test requires elevation: %v", name, err)
+	}
+	t.Cleanup(func() { windows.CloseHandle(h) })
+	return h
+}
+
+// isElevationError reports whether err is the failure an unelevated run
+// produces. Skipping on anything else would hide the regressions these tests
+// exist to catch: ERROR_FILE_NOT_FOUND, for one, means no event was created.
+func isElevationError(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD)
+}
+
+func TestNotifyRunsCallbackPerSignal(t *testing.T) {
+	calls := make(chan struct{}, 8)
+	h := startNotify(t, func() { calls <- struct{}{} })
+
+	// The event is auto-reset, so each signaling must produce exactly one call.
+	for i := range 3 {
+		if err := windows.SetEvent(h); err != nil {
+			t.Fatalf("SetEvent() error = %v", err)
+		}
+		select {
+		case <-calls:
+		case <-time.After(waitTimeout):
+			t.Fatalf("callback was not run after signaling the event (iteration %d)", i)
+		}
+		select {
+		case <-calls:
+			t.Fatalf("callback ran more than once for a single signaling (iteration %d)", i)
+		case <-time.After(retryInterval):
+		}
+	}
+}
+
+// TestNotifyKeepsServingAfterSlowCallback covers the containerd daemon's usage,
+// where the callback writes a stack dump to disk before returning: a slow
+// callback must delay later requests, not end them.
+func TestNotifyKeepsServingAfterSlowCallback(t *testing.T) {
+	calls := make(chan struct{}, 8)
+	var first atomic.Bool
+	h := startNotify(t, func() {
+		if first.CompareAndSwap(false, true) {
+			time.Sleep(2 * retryInterval)
+		}
+		calls <- struct{}{}
+	})
+
+	if err := windows.SetEvent(h); err != nil {
+		t.Fatalf("SetEvent() error = %v", err)
+	}
+	select {
+	case <-calls:
+	case <-time.After(waitTimeout):
+		t.Fatal("callback was not run after signaling the event")
+	}
+
+	if err := windows.SetEvent(h); err != nil {
+		t.Fatalf("SetEvent() error = %v", err)
+	}
+	select {
+	case <-calls:
+	case <-time.After(waitTimeout):
+		t.Fatal("watcher stopped serving requests after a slow callback")
+	}
+}
+
+func TestNotifyRejectsInvalidEventName(t *testing.T) {
+	// A NUL byte cannot be encoded into a UTF-16 name, so notify must report
+	// the failure rather than start a watcher on nothing.
+	if err := notify("Global\\stackdump\x00bad", func() {}); err == nil {
+		t.Fatal("notify() with an invalid event name = nil; want an error")
+	}
+}

--- a/internal/stackdump/stackdump.go
+++ b/internal/stackdump/stackdump.go
@@ -1,0 +1,65 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package stackdump captures goroutine stack dumps for diagnostics.
+//
+// Callers wire up their own SIGUSR1 handling on unix. Windows has no
+// user-defined signal, so this package also provides the named Win32 event that
+// stands in for it, shared by the daemon and its shims so one tool can trigger a
+// dump in any containerd process.
+package stackdump
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// Dump returns a snapshot of the stacks of every goroutine in this process.
+func Dump() []byte {
+	var (
+		buf       []byte
+		stackSize int
+	)
+	bufferLen := 16384
+	// runtime.Stack truncates to the buffer it is given and reports how much it
+	// wrote, so a full buffer means the dump may have been cut short.
+	for stackSize == len(buf) {
+		buf = make([]byte, bufferLen)
+		stackSize = runtime.Stack(buf, true)
+		bufferLen *= 2
+	}
+	return buf[:stackSize]
+}
+
+// WriteFile writes buf to "<prefix>.<pid>.stacks.log" in the system temp
+// directory and returns the path it wrote.
+//
+// Stacks are worth reading precisely when a process's log output may not be, so
+// the dump also goes where diagnostics collection can retrieve it.
+func WriteFile(prefix string, buf []byte) (string, error) {
+	name := filepath.Join(os.TempDir(), fmt.Sprintf("%s.%d.stacks.log", prefix, os.Getpid()))
+	f, err := os.Create(name)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	if _, err := f.Write(buf); err != nil {
+		return "", err
+	}
+	return name, nil
+}

--- a/internal/stackdump/stackdump.go
+++ b/internal/stackdump/stackdump.go
@@ -51,14 +51,37 @@ func Dump() []byte {
 //
 // Stacks are worth reading precisely when a process's log output may not be, so
 // the dump also goes where diagnostics collection can retrieve it.
+//
+// The file is owner-only because a dump exposes the internals of a process that
+// usually runs as root. That is a unix guarantee: Go's file mode reaches Windows
+// only as FILE_ATTRIBUTE_READONLY, and not even that for a writable mode, so
+// there the file simply inherits the temp directory's ACL.
 func WriteFile(prefix string, buf []byte) (string, error) {
 	name := filepath.Join(os.TempDir(), fmt.Sprintf("%s.%d.stacks.log", prefix, os.Getpid()))
-	f, err := os.Create(name)
+
+	// Write a fresh file and rename it into place rather than opening name
+	// directly. The temp directory is shared and the name is predictable, so
+	// opening it would follow a symlink planted there and truncate whatever it
+	// points at, with the privileges of a process that usually runs as root.
+	// CreateTemp opens with O_EXCL and mode 0600, and the rename replaces any
+	// symlink sitting at name instead of writing through it.
+	f, err := os.CreateTemp(filepath.Dir(name), filepath.Base(name)+".")
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	tmp := f.Name()
+	defer func() {
+		f.Close()
+		os.Remove(tmp) // no-op once the rename below has succeeded
+	}()
+
 	if _, err := f.Write(buf); err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(tmp, name); err != nil {
 		return "", err
 	}
 	return name, nil

--- a/internal/stackdump/stackdump_test.go
+++ b/internal/stackdump/stackdump_test.go
@@ -1,0 +1,157 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package stackdump
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestDump(t *testing.T) {
+	buf := Dump()
+	if len(buf) == 0 {
+		t.Fatal("Dump() returned no data")
+	}
+	got := string(buf)
+	if !strings.Contains(got, "goroutine ") {
+		t.Fatalf("Dump() does not look like a stack dump:\n%s", got)
+	}
+	// The dump covers all goroutines, so the calling test must appear in it.
+	if !strings.Contains(got, "TestDump") {
+		t.Fatalf("Dump() does not contain the calling goroutine:\n%s", got)
+	}
+}
+
+// TestDumpGrowsBufferBeyondInitialSize parks enough goroutines that the dump
+// cannot fit in the initial 16KiB buffer, covering the grow loop. A truncated
+// dump is worse than useless during an incident, so this is the behavior that
+// matters most in Dump.
+func TestDumpGrowsBufferBeyondInitialSize(t *testing.T) {
+	const parked = 400
+
+	release := make(chan struct{})
+	var running, done sync.WaitGroup
+	running.Add(parked)
+	done.Add(parked)
+	for range parked {
+		go func() {
+			defer done.Done()
+			running.Done()
+			<-release
+		}()
+	}
+	running.Wait()
+	defer func() {
+		close(release)
+		done.Wait()
+	}()
+
+	buf := Dump()
+	if len(buf) <= 16384 {
+		t.Fatalf("Dump() returned %d bytes; expected the buffer to grow past the initial 16384", len(buf))
+	}
+	// Every parked goroutine must be present, not just enough to overflow.
+	if got := strings.Count(string(buf), "TestDumpGrowsBufferBeyondInitialSize.func"); got < parked {
+		t.Fatalf("Dump() contains %d parked goroutines; want at least %d (dump was truncated)", got, parked)
+	}
+	if n := runtime.NumGoroutine(); n < parked {
+		t.Fatalf("only %d goroutines running; test did not set up as expected", n)
+	}
+}
+
+// setTempDir points os.TempDir at dir for the duration of the test.
+//
+// os.TempDir consults TMPDIR on unix and TMP/TEMP on Windows, but Windows routes
+// through GetTempPath2, which ignores both for a process running as SYSTEM. Skip
+// rather than assert against a directory the override never reached.
+func setTempDir(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("TMPDIR", dir)
+	t.Setenv("TMP", dir)
+	t.Setenv("TEMP", dir)
+	if got := os.TempDir(); got != dir {
+		t.Skipf("os.TempDir() is %q, not the %q this test set", got, dir)
+	}
+}
+
+func TestWriteFile(t *testing.T) {
+	dir := t.TempDir()
+	setTempDir(t, dir)
+
+	want := []byte("goroutine 1 [running]:\nmain.main()\n")
+	name, err := WriteFile("test-prefix", want)
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	wantName := filepath.Join(dir, fmt.Sprintf("test-prefix.%d.stacks.log", os.Getpid()))
+	if name != wantName {
+		t.Fatalf("WriteFile() = %q; want %q", name, wantName)
+	}
+	got, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("failed to read back %s: %v", name, err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("file contents = %q; want %q", got, want)
+	}
+}
+
+// TestWriteFileOverwrites covers a second dump in the same process: the file is
+// named per-pid, so it must be replaced rather than appended to or left stale.
+func TestWriteFileOverwrites(t *testing.T) {
+	setTempDir(t, t.TempDir())
+
+	if _, err := WriteFile("test-prefix", []byte("first dump, the longer one")); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	want := []byte("second")
+	name, err := WriteFile("test-prefix", want)
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	got, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("failed to read back %s: %v", name, err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("file contents = %q; want %q", got, want)
+	}
+}
+
+func TestWriteFileReturnsErrorOnUnwritableDir(t *testing.T) {
+	// Point the temp dir at a path that cannot hold files so the caller's
+	// error handling is exercised rather than a silent failure.
+	notADir := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(notADir, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	setTempDir(t, notADir)
+
+	name, err := WriteFile("test-prefix", []byte("dump"))
+	if err == nil {
+		t.Fatalf("WriteFile() = %q, nil; want an error", name)
+	}
+	if name != "" {
+		t.Fatalf("WriteFile() returned path %q alongside an error; want \"\"", name)
+	}
+}

--- a/internal/stackdump/stackdump_test.go
+++ b/internal/stackdump/stackdump_test.go
@@ -138,6 +138,42 @@ func TestWriteFileOverwrites(t *testing.T) {
 	}
 }
 
+// TestWriteFileDoesNotFollowSymlink covers a symlink planted at the dump's
+// predictable path in a shared temp directory. Writing through it would let an
+// unprivileged user choose a file for a root process to truncate.
+func TestWriteFileDoesNotFollowSymlink(t *testing.T) {
+	dir := t.TempDir()
+	setTempDir(t, dir)
+
+	victim := filepath.Join(t.TempDir(), "victim")
+	const sentinel = "untouched"
+	if err := os.WriteFile(victim, []byte(sentinel), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(dir, fmt.Sprintf("test-prefix.%d.stacks.log", os.Getpid()))
+	if err := os.Symlink(victim, target); err != nil {
+		t.Skipf("cannot create symlinks here: %v", err)
+	}
+
+	name, err := WriteFile("test-prefix", []byte("dump"))
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != sentinel {
+		t.Fatalf("wrote through the symlink: target now contains %q", got)
+	}
+	// The dump must still land at the documented path.
+	if b, err := os.ReadFile(name); err != nil || string(b) != "dump" {
+		t.Fatalf("dump not written to %s: %q, %v", name, b, err)
+	}
+}
+
 func TestWriteFileReturnsErrorOnUnwritableDir(t *testing.T) {
 	// Point the temp dir at a path that cannot hold files so the caller's
 	// error handling is exercised rather than a silent failure.

--- a/internal/stackdump/stackdump_unix_test.go
+++ b/internal/stackdump/stackdump_unix_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package stackdump
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestWriteFilePermissions pins the dump file to owner-only. A goroutine dump
+// exposes the internals of a process that usually runs as root, and the file
+// lands in a world-readable temp directory.
+func TestWriteFilePermissions(t *testing.T) {
+	setTempDir(t, t.TempDir())
+
+	// os.WriteFile applies the umask, so clear it for the duration.
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+
+	name, err := WriteFile("test-prefix", []byte("dump"))
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	fi, err := os.Stat(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Fatalf("stack dump file mode = %04o; want 0600", got)
+	}
+}

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -502,6 +502,7 @@ func serve(ctx context.Context, server *ttrpc.Server, signals chan os.Signal, sh
 func dumpStacks(logger *log.Entry) {
 	buf := stackdump.Dump()
 	logger.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
+	writeStackDump(logger, buf)
 }
 
 type server interface {

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/containerd/api/types"
 
 	"github.com/containerd/containerd/v2/core/events"
+	"github.com/containerd/containerd/v2/internal/stackdump"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
@@ -499,17 +500,7 @@ func serve(ctx context.Context, server *ttrpc.Server, signals chan os.Signal, sh
 }
 
 func dumpStacks(logger *log.Entry) {
-	var (
-		buf       []byte
-		stackSize int
-	)
-	bufferLen := 16384
-	for stackSize == len(buf) {
-		buf = make([]byte, bufferLen)
-		stackSize = runtime.Stack(buf, true)
-		bufferLen *= 2
-	}
-	buf = buf[:stackSize]
+	buf := stackdump.Dump()
 	logger.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
 }
 

--- a/pkg/shim/shim_unix.go
+++ b/pkg/shim/shim_unix.go
@@ -49,6 +49,11 @@ func setupDumpStacks(dump chan<- os.Signal) {
 	signal.Notify(dump, syscall.SIGUSR1)
 }
 
+// writeStackDump is a no-op on unix, where a dump goes to the log only. The
+// Windows build also writes a file because its log pipe drops writes while no
+// reader is attached.
+func writeStackDump(_ *log.Entry, _ []byte) {}
+
 func serveListener(path string, fd uintptr) (net.Listener, error) {
 	var (
 		l   net.Listener

--- a/pkg/shim/shim_windows.go
+++ b/pkg/shim/shim_windows.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	winio "github.com/Microsoft/go-winio"
+	"github.com/containerd/containerd/v2/internal/stackdump"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
@@ -62,12 +63,44 @@ func subreaper() error {
 	return nil
 }
 
-// setupDumpStacks is currently not implemented for Windows.
-// Windows doesn't have SIGUSR1, so stack dumping would need to use
-// a different mechanism (e.g., a named event or debug console).
-func setupDumpStacks(_ chan<- os.Signal) {
-	// No-op on Windows - SIGUSR1 doesn't exist
-	// Future: could implement using Windows events or console signals
+// dumpStacksSignal is delivered on the dump channel when the stackdump event is
+// signaled. The value is arbitrary and only has to be an os.Signal: Windows
+// raises no such signal, and the dump loop ignores a signal's identity.
+const dumpStacksSignal = syscall.Signal(0xa)
+
+// setupDumpStacks requests a goroutine stack dump on the dump channel whenever
+// this shim's stackdump event is signaled.
+//
+// Windows has no SIGUSR1 to trap, so the named event from internal/stackdump
+// stands in for it. Requests go onto the same channel the unix build wires
+// SIGUSR1 to, so both platforms share one dump loop.
+func setupDumpStacks(dump chan<- os.Signal) {
+	err := stackdump.Notify(func() {
+		select {
+		case dump <- dumpStacksSignal:
+		default:
+			// Never block the watcher: a request is already queued and will
+			// report the same state, so dropping this one loses nothing.
+		}
+	})
+	if err != nil {
+		log.L.WithError(err).Error("failed to set up debug stackdump event, stack dumps unavailable")
+	}
+}
+
+// writeStackDump persists a stack dump alongside the shim's log output.
+//
+// The shim's log here is a named pipe that drops writes when containerd is not
+// attached (see reconnectingLogWriter) — the very situation a hand-triggered dump
+// is meant to diagnose — so the log alone is not somewhere a dump can be relied
+// on to land.
+func writeStackDump(logger *log.Entry, buf []byte) {
+	name, err := stackdump.WriteFile("containerd-shim", buf)
+	if err != nil {
+		logger.WithError(err).Warn("failed to write goroutine stack dump")
+		return
+	}
+	logger.WithField("path", name).Info("goroutine stack dump written")
 }
 
 // serveListener creates a named pipe listener for Windows at the given path.

--- a/pkg/shim/shim_windows_test.go
+++ b/pkg/shim/shim_windows_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -32,8 +33,10 @@ import (
 	"time"
 
 	winio "github.com/Microsoft/go-winio"
+	"github.com/containerd/containerd/v2/internal/stackdump"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/log"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -566,9 +569,45 @@ func TestNewServer(t *testing.T) {
 }
 
 func TestSetupDumpStacks(t *testing.T) {
-	// setupDumpStacks is a no-op on Windows; it must return without panicking
-	// or blocking on the supplied channel.
+	// setupDumpStacks must return without panicking or blocking on the
+	// supplied channel, and must leave this process's stackdump event in place.
 	setupDumpStacks(make(chan os.Signal, 1))
+
+	// The event is ACL'd to builtin administrators and local system, so an
+	// unelevated run cannot open it. That is the behavior under test, not a
+	// failure of it.
+	name := stackdump.EventName(os.Getpid())
+	n, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		t.Fatalf("failed to encode event name %s: %v", name, err)
+	}
+	h, err := windows.OpenEvent(windows.EVENT_MODIFY_STATE|windows.SYNCHRONIZE, false, n)
+	if err != nil {
+		// Skip only what an unelevated run produces; ERROR_FILE_NOT_FOUND here
+		// would mean setupDumpStacks never created the event, which is the
+		// regression this test exists to catch.
+		if !errors.Is(err, windows.ERROR_ACCESS_DENIED) && !errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD) {
+			t.Fatalf("stackdump event %s was not created: %v", name, err)
+		}
+		t.Skipf("cannot open stackdump event %s, test requires elevation: %v", name, err)
+	}
+	windows.CloseHandle(h)
+}
+
+func TestWriteStackDump(t *testing.T) {
+	t.Setenv("TMP", t.TempDir())
+
+	want := []byte("goroutine 1 [running]:\nmain.main()\n")
+	writeStackDump(log.L, want)
+
+	name := filepath.Join(os.TempDir(), fmt.Sprintf("containerd-shim.%d.stacks.log", os.Getpid()))
+	got, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("stack dump file %s was not written: %v", name, err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("stack dump file contents = %q; want %q", got, want)
+	}
 }
 
 func TestReapReturnsOnContextCancel(t *testing.T) {


### PR DESCRIPTION
This change refactors the containerd server code into a shared utility for Windows Go stack dumps via event (Windows has no SIGUSR1 to trap).

Additionally this hardens permissions around the file written to tmp directory with the stack dump down to 0x600 (previously default). Pre-existing permissions but called out by agent review as an opportunity to harden here since the server process is usually ran elevated and the file lands predictability.