### PR TITLE
cri: support to specify snapshot rwlayer path for overlayfs

### DIFF
--- a/core/snapshots/benchsuite/benchmark_test.go
+++ b/core/snapshots/benchsuite/benchmark_test.go
@@ -83,7 +83,7 @@ func BenchmarkOverlay(b *testing.B) {
 		b.Skip("overlay root dir must be provided")
 	}
 
-	snapshotter, err := overlay.NewSnapshotter(overlayRootPath)
+	snapshotter, err := overlay.NewSnapshotter(overlayRootPath, "")
 	assert.Nil(b, err, "failed to create overlay snapshotter")
 
 	defer func() {

--- a/core/snapshots/snapshotter.go
+++ b/core/snapshots/snapshotter.go
@@ -44,6 +44,9 @@ const (
 	// LabelSnapshotDiffID is set by the unpacker on the extraction Prepare to
 	// the uncompressed digest (diffID) of the layer being unpacked.
 	LabelSnapshotDiffID = "containerd.io/snapshot/diff-id"
+	// LabelSnapshotSplit is a snapshot label that instructs a snapshotter to place the
+	// snapshot's writable layer outside the default snapshot root (implementation-specific).
+	LabelSnapshotSplit = "containerd.io/snapshot/split"
 
 	// LabelSnapshotUIDMapping is the label used for UID mappings
 	LabelSnapshotUIDMapping = "containerd.io/snapshot/uidmapping"

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -37,6 +37,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
@@ -307,6 +308,9 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 	if err != nil {
 		return "", err
 	}
+	snapShotLabel := make(map[string]string)
+	snapShotLabel[snapshots.LabelSnapshotSplit] = "true"
+	sOpts = append(sOpts, snapshots.WithLabels(snapshots.FilterInheritedLabels(snapShotLabel)))
 
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{
@@ -374,7 +378,7 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 	}
 
 	containerLabels := util.BuildLabels(r.containerConfig.Labels, r.imageConfig.Labels, crilabels.ContainerKindContainer)
-
+	containerLabels[snapshots.LabelSnapshotSplit] = "true"
 	// TODO the sandbox in the cache should hold this info
 	runtimeName, runtimeOption, err := c.runtimeInfo(r.ctx, r.sandboxID)
 	if err != nil {

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -184,8 +184,12 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 	}
 
 	sandboxLabels := ctrdutil.BuildLabels(config.Labels, imageSpec.Config.Labels, crilabels.ContainerKindSandbox)
-
-	snapshotterOpt := []snapshots.Opt{snapshots.WithLabels(snapshots.FilterInheritedLabels(config.Annotations))}
+	labels = snapshots.FilterInheritedLabels(config.Annotations)
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[snapshots.LabelSnapshotSplit] = "true"
+	snapshotterOpt := []snapshots.Opt{snapshots.WithLabels(labels)}
 	extraSOpts, err := sandboxSnapshotterOpts(config)
 	if err != nil {
 		return cin, err

--- a/plugins/snapshots/overlay/overlay.go
+++ b/plugins/snapshots/overlay/overlay.go
@@ -20,6 +20,7 @@ package overlay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,6 +34,7 @@ import (
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/log"
+	"golang.org/x/sys/unix"
 )
 
 // upperdirKey is a key of an optional label to each snapshot.
@@ -107,6 +109,7 @@ func WithSlowChown(config *SnapshotterConfig) error {
 
 type snapshotter struct {
 	root          string
+	rwPath        string
 	ms            MetaStore
 	asyncRemove   bool
 	upperdirLabel bool
@@ -118,7 +121,7 @@ type snapshotter struct {
 // NewSnapshotter returns a Snapshotter which uses overlayfs. The overlayfs
 // diffs are stored under the provided root. A metadata file is stored under
 // the root.
-func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
+func NewSnapshotter(root string, rwPath string, opts ...Opt) (snapshots.Snapshotter, error) {
 	var config SnapshotterConfig
 	for _, opt := range opts {
 		if err := opt(&config); err != nil {
@@ -129,6 +132,12 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
 	}
+	if rwPath != "" {
+		if err := os.MkdirAll(rwPath, 0700); err != nil {
+			return nil, err
+		}
+	}
+
 	supportsDType, err := fs.SupportsDType(root)
 	if err != nil {
 		return nil, err
@@ -145,6 +154,12 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 
 	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
 		return nil, err
+	}
+
+	if rwPath != "" {
+		if err := os.Mkdir(filepath.Join(rwPath, "snapshots"), 0700); err != nil && !os.IsExist(err) {
+			return nil, err
+		}
 	}
 
 	if !hasOption(config.mountOptions, "userxattr") {
@@ -166,6 +181,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 
 	return &snapshotter{
 		root:          root,
+		rwPath:        rwPath,
 		ms:            config.ms,
 		asyncRemove:   config.asyncRemove,
 		upperdirLabel: config.upperdirLabel,
@@ -317,6 +333,17 @@ func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 	})
 }
 
+func unmountBind(target string) error {
+	err := unix.Unmount(target, unix.MNT_DETACH)
+	if err != nil {
+		if errors.Is(err, unix.EINVAL) {
+			return nil
+		}
+		return fmt.Errorf("unmount %q failed: %w", target, err)
+	}
+	return nil
+}
+
 // Remove abandons the snapshot identified by key. The snapshot will
 // immediately become unavailable and unrecoverable. Disk space will
 // be freed up on the next call to `Cleanup`.
@@ -335,6 +362,16 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		}
 	}()
 	return o.ms.WithTransaction(ctx, true, func(ctx context.Context) error {
+		id, info, _, err := storage.GetInfo(ctx, key)
+		if err != nil {
+			return err
+		}
+		if _, split := info.Labels[snapshots.LabelSnapshotSplit]; split {
+			path := filepath.Join(filepath.Join(o.root, "snapshots"), id)
+			if err := unmountBind(path); err != nil {
+				return err
+			}
+		}
 		_, _, err = storage.Remove(ctx, key)
 		if err != nil {
 			return fmt.Errorf("failed to remove snapshot %s: %w", key, err)
@@ -418,6 +455,24 @@ func (o *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, erro
 	}
 
 	cleanup := []string{}
+
+	if o.rwPath != "" {
+		snapshotSplitDir := filepath.Join(o.rwPath, "snapshots")
+		if sfd, err := os.Open(snapshotSplitDir); err == nil {
+			defer sfd.Close()
+			dirsSplit, err := sfd.Readdirnames(0)
+			if err != nil {
+				return nil, err
+			}
+			for _, sd := range dirsSplit {
+				if _, ok := ids[sd]; ok {
+					continue
+				}
+				cleanup = append(cleanup, filepath.Join(snapshotSplitDir, sd))
+			}
+		}
+	}
+
 	for _, d := range dirs {
 		if _, ok := ids[d]; ok {
 			continue
@@ -430,9 +485,9 @@ func (o *snapshotter) getCleanupDirectories(ctx context.Context) ([]string, erro
 
 func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ []mount.Mount, err error) {
 	var (
-		s        storage.Snapshot
-		td, path string
-		info     snapshots.Info
+		s                storage.Snapshot
+		td, path, rwPath string
+		info             snapshots.Info
 	)
 
 	defer func() {
@@ -440,6 +495,13 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 			if td != "" {
 				if err1 := os.RemoveAll(td); err1 != nil {
 					log.G(ctx).WithError(err1).Warn("failed to cleanup temp snapshot directory")
+				}
+			}
+			if rwPath != "" {
+				_ = unmountBind(path)
+				if err1 := os.RemoveAll(rwPath); err1 != nil {
+					log.G(ctx).WithError(err1).WithField("path", rwPath).Error("failed to reclaim snapshot directory, directory may need removal")
+					err = fmt.Errorf("failed to remove path: %v: %w", err1, err)
 				}
 			}
 			if path != "" {
@@ -453,10 +515,6 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 
 	if err := o.ms.WithTransaction(ctx, true, func(ctx context.Context) (err error) {
 		snapshotDir := filepath.Join(o.root, "snapshots")
-		td, err = o.prepareDirectory(ctx, snapshotDir, kind)
-		if err != nil {
-			return fmt.Errorf("failed to create prepare snapshot dir: %w", err)
-		}
 
 		s, err = storage.CreateSnapshot(ctx, kind, key, parent, opts...)
 		if err != nil {
@@ -514,18 +572,56 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 			}
 		}
 
-		if mappedUID != -1 && mappedGID != -1 {
-			if err := os.Lchown(filepath.Join(td, "fs"), mappedUID, mappedGID); err != nil {
-				return fmt.Errorf("failed to chown: %w", err)
+		createTempDir := func(tempParent, finalDest string) (tmpDir string, err error) {
+			tmpDir, err = os.MkdirTemp(tempParent, "new-")
+			if err != nil {
+				return "", fmt.Errorf("failed to create temp dir: %w", err)
 			}
+
+			defer func() {
+				if err != nil {
+					_ = os.RemoveAll(tmpDir)
+				}
+			}()
+
+			if err = o.prepareDirectory(ctx, tmpDir, snapshotDir, kind); err != nil {
+				return "", fmt.Errorf("failed to create prepare snapshot dir: %w", err)
+			}
+
+			if mappedUID != -1 && mappedGID != -1 {
+				if err := os.Lchown(filepath.Join(tmpDir, "fs"), mappedUID, mappedGID); err != nil {
+					return "", fmt.Errorf("failed to chown: %w", err)
+				}
+			}
+			if err = os.Rename(tmpDir, finalDest); err != nil {
+				return "", fmt.Errorf("failed to rename: %w", err)
+			}
+			return tmpDir, nil
 		}
 
+		_, split := info.Labels[snapshots.LabelSnapshotSplit]
+		if split && o.rwPath != "" {
+			path = filepath.Join(snapshotDir, s.ID)
+			if err = os.MkdirAll(path, 0700); err != nil {
+				return err
+			}
+			rwPath = o.snapshotRWPath(s.ID)
+			tempParent := filepath.Join(o.rwPath, "snapshots")
+			if _, err = createTempDir(tempParent, rwPath); err != nil {
+				return err
+			}
+			if err := bindMount(rwPath, path, false); err != nil {
+				_ = os.RemoveAll(rwPath)
+				return err
+			}
+			return nil
+		}
 		path = filepath.Join(snapshotDir, s.ID)
-		if err = os.Rename(td, path); err != nil {
-			return fmt.Errorf("failed to rename: %w", err)
+		td, err = createTempDir(snapshotDir, path)
+		if err != nil {
+			return err
 		}
 		td = ""
-
 		return nil
 	}); err != nil {
 		return nil, err
@@ -533,23 +629,26 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 	return o.mounts(s, info), nil
 }
 
-func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
-	td, err := os.MkdirTemp(snapshotDir, "new-")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp dir: %w", err)
-	}
-
+func (o *snapshotter) prepareDirectory(ctx context.Context, td string, snapshotDir string, kind snapshots.Kind) error {
 	if err := os.Mkdir(filepath.Join(td, "fs"), 0755); err != nil {
-		return td, err
+		return err
 	}
 
 	if kind == snapshots.KindActive {
 		if err := os.Mkdir(filepath.Join(td, "work"), 0711); err != nil {
-			return td, err
+			return err
 		}
 	}
 
-	return td, nil
+	return nil
+}
+
+func bindMount(source, target string, recursive bool) error {
+	flags := uintptr(unix.MS_BIND)
+	if recursive {
+		flags |= unix.MS_REC
+	}
+	return unix.Mount(source, target, "", flags, "")
 }
 
 func (o *snapshotter) mounts(s storage.Snapshot, info snapshots.Info) []mount.Mount {
@@ -619,6 +718,10 @@ func (o *snapshotter) mounts(s storage.Snapshot, info snapshots.Info) []mount.Mo
 
 func (o *snapshotter) upperPath(id string) string {
 	return filepath.Join(o.root, "snapshots", id, "fs")
+}
+
+func (o *snapshotter) snapshotRWPath(id string) string {
+	return filepath.Join(o.rwPath, "snapshots", id)
 }
 
 func (o *snapshotter) workPath(id string) string {

--- a/plugins/snapshots/overlay/overlay_test.go
+++ b/plugins/snapshots/overlay/overlay_test.go
@@ -39,7 +39,7 @@ import (
 
 func newSnapshotterWithOpts(opts ...Opt) testsuite.SnapshotterFunc {
 	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
-		snapshotter, err := NewSnapshotter(root, opts...)
+		snapshotter, err := NewSnapshotter(root, "", opts...)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -58,7 +58,7 @@ func TestOverlayConfiguredIndexNotOverridden(t *testing.T) {
 	if !supportsIndex() {
 		t.Skip("kernel does not expose the overlay index parameter")
 	}
-	sn, err := NewSnapshotter(t.TempDir(), WithMountOptions([]string{"index=on", "nfs_export=on"}))
+	sn, err := NewSnapshotter(t.TempDir(), "", WithMountOptions([]string{"index=on", "nfs_export=on"}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/snapshots/overlay/plugin/plugin.go
+++ b/plugins/snapshots/overlay/plugin/plugin.go
@@ -51,6 +51,9 @@ type Config struct {
 
 	// MountOptions are options used for the overlay mount (not used on bind mounts)
 	MountOptions []string `toml:"mount_options"`
+	// RwPath, if set, is an alternate base directory used for writable snapshot data when
+	// the snapshot is created with the split label.
+	RwPath string `toml:"rw_path"`
 }
 
 func init() {
@@ -69,6 +72,10 @@ func init() {
 			root := ic.Properties[plugins.PropertyRootDir]
 			if config.RootPath != "" {
 				root = config.RootPath
+			}
+			var rwPath string
+			if config.RwPath != "" {
+				rwPath = config.RwPath
 			}
 
 			var oOpts []overlay.Opt
@@ -103,7 +110,7 @@ func init() {
 			}
 
 			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
-			return overlay.NewSnapshotter(root, oOpts...)
+			return overlay.NewSnapshotter(root, rwPath, oOpts...)
 		},
 	})
 }


### PR DESCRIPTION
fix https://github.com/containerd/containerd/issues/13978
set rw_path 
```
  [plugins.'io.containerd.snapshotter.v1.overlayfs']
    rw_path = '/var/lib/rw'
```

```
❯ crictl  exec -it  1c8d sh
/ # echo 001 > hello
/ # exit

root in /home/nmx/pods via 🐹 v1.26.3 took 12s 
❯ find /var/lib/rw -name hello
/var/lib/rw/snapshots/28/fs/hello


❯ ls /var/lib/rw/snapshots/    (dir 27 28 is snapshot's rwlayer )
27  28

root in /home/nmx/pods via 🐹 v1.26.3 
❯ ls /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/
1  2  27  28  3


✦ ❯ cat /proc/self/mountinfo |grep snapshots/28
2141 92 253:0 /var/lib/rw/snapshots/28 /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/28 rw,relatime shared:1 - xfs /dev/mapper/newstartos-root rw,attr2,inode64,noquota
2179 26 0:76 / /run/containerd/io.containerd.runtime.v2.task/k8s.io/1c8d8c8e4e5d7ead220c81c79c0c3c66c66371c1988987b8df6f673cce77d32a/rootfs rw,relatime shared:1071 - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/28/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/28/work
2183 1213 0:76 / /run/containerd/io.containerd.runtime.v2.task/k8s.io/1c8d8c8e4e5d7ead220c81c79c0c3c66c66371c1988987b8df6f673cce77d32a/rootfs rw,relatime shared:1071 - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/28/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/28/work



````
bind  mount "/var/lib/rw/snapshots/28" to  "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/28"
If this is not done,  will frequently encounter issues with large numbers of image layers.
