### PR TITLE
mount/manager: fix panic on temporary activation with no system mounts

### DIFF
--- a/core/mount/manager/manager.go
+++ b/core/mount/manager/manager.go
@@ -472,8 +472,10 @@ func (mm *mountManager) Activate(ctx context.Context, name string, mounts []moun
 		mounted = append(mounted, active)
 	}
 
-	// If first system mount is converted, fill in the format
-	if mountConv != nil {
+	// If first system mount is converted, fill in the format. When all
+	// mounts were performed (e.g. a temporary activation whose final mount
+	// carries a transform prefix), there is no system mount to transform.
+	if mountConv != nil && firstSystemMount < len(mounts) {
 		for _, tr := range mountConv[firstSystemMount] {
 			newM, err := tr.Transform(ctx, mounts[firstSystemMount], mounted)
 			if err != nil {

--- a/core/mount/manager/manager_test.go
+++ b/core/mount/manager/manager_test.go
@@ -617,3 +617,36 @@ func TestClose(t *testing.T) {
 	_, err = db.Begin(false)
 	assert.ErrorIs(t, err, bolterr.ErrDatabaseNotOpen)
 }
+
+func TestActivateTemporaryAllHandled(t *testing.T) {
+	td := t.TempDir()
+	metadb := filepath.Join(td, "mounts.db")
+	targetdir := filepath.Join(td, "m")
+	db, err := bolt.Open(metadb, 0600, nil)
+	require.NoError(t, err)
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+
+	mountC := new(atomic.Int32)
+	m, err := NewManager(db, targetdir, WithMountHandler("noop", &noopHandler{mounts: mountC}))
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, m.(io.Closer).Close()) })
+
+	// A temporary activation performs every mount, including a final mount
+	// whose type carries a transform prefix (as returned e.g. by the erofs
+	// snapshotter). All mounts being handled must not panic when applying
+	// the transforms for the first system mount, since there is none.
+	mounts := []mount.Mount{
+		{Type: "noop"},
+		{Type: "format/noop", Source: "{{ mount 0 }}"},
+	}
+
+	info, err := m.Activate(ctx, "tmp1", mounts, mount.WithTemporary)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(info.Active))
+	// The temporary bind mount to access the mounted filesystem root is
+	// the only system mount.
+	require.Equal(t, 1, len(info.System))
+	assert.Equal(t, "bind", info.System[0].Type)
+
+	assert.NoError(t, m.Deactivate(ctx, "tmp1"))
+}


### PR DESCRIPTION

`Manager.Activate` panics with an index out of range when a temporary activation is requested for a mount set whose final mount carries a transform prefix.

With `WithTemporary`, every mount in the set advances `firstSystemMount` to `i + 1`, so after the loop `firstSystemMount == len(mounts)`. If any mount had a transform prefix (which allocates `mountConv` with
`len(mounts)` entries), the transform-application block then indexes `mountConv[firstSystemMount]` out of range.

This is reachable from outside the daemon: the erofs snapshotter returns mount sets ending in a `format/mkdir/overlay` mount, and a client calling the mounts gRPC service (`io.containerd.grpc.v1.mounts`) with
`Activate(..., WithTemporary)` on such a set kills the whole containerd daemon — the gRPC handler path has no panic recovery:

```
panic: runtime error: index out of range [2] with length 2

goroutine ... [running]:
github.com/containerd/containerd/v2/core/mount/manager.(*mountManager).Activate(...)
        core/mount/manager/manager.go:477
github.com/containerd/containerd/v2/plugins/services/mounts.(*service).Activate(...)
        plugins/services/mounts/service.go:75
github.com/containerd/containerd/api/services/mounts/v1._Mounts_Activate_Handler.func1(...)
```

We hit this while prototyping a dockerd-side consumer of erofs snapshots that resolves the snapshotter's templated mounts through the mounts service.

The fix guards the transform application on a system mount existing: when all mounts were performed by the manager, there is nothing to transform, and the temporary bind mount added just below is the only system mount
(`info.System = mounts[firstSystemMount:]` already handles the boundary correctly).

Includes a regression test (`TestActivateTemporaryAllHandled`) using the existing fake handlers; it panics without the fix and passes with it.

This patch was developed with AI assistance (Claude); it has been reviewed, tested, and is submitted under the DCO by the human author.
