### PR TITLE
cri: refuse to overwrite an existing checkpoint archive

### DIFF
--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -301,25 +301,47 @@ func (c *criService) CheckpointContainer(ctx context.Context, r *runtime.Checkpo
 
 	// write final tarball of all content
 	tar := archive.Diff(ctx, "", cpPath)
+	defer tar.Close()
 
-	outFile, err := os.OpenFile(r.Location, os.O_RDWR|os.O_CREATE, 0o600)
-	if err != nil {
-		return nil, err
-	}
-	defer outFile.Close()
-	_, err = io.Copy(outFile, tar)
-	if err != nil {
-		return nil, err
-	}
-	if err := tar.Close(); err != nil {
+	if err := writeCheckpointArchive(r.Location, tar); err != nil {
 		return nil, err
 	}
 
 	containerCheckpointTimer.WithValues(i.Runtime.Name).UpdateSince(start)
 
-	log.G(ctx).Infof("Wrote checkpoint archive to %s for %s", outFile.Name(), container.ID)
+	log.G(ctx).Infof("Wrote checkpoint archive to %s for %s", r.Location, container.ID)
 
 	return &runtime.CheckpointContainerResponse{}, nil
+}
+
+// writeCheckpointArchive writes the checkpoint archive read from content to
+// location.
+//
+// location is created exclusively, so an existing file is never overwritten.
+// A partial archive is removed when the write fails, so a retry is not blocked
+// by the remains of the attempt that failed.
+func writeCheckpointArchive(location string, content io.Reader) (retErr error) {
+	outFile, err := os.OpenFile(location, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to create checkpoint archive: %w", err)
+	}
+	defer func() {
+		_ = outFile.Close()
+		if retErr != nil {
+			_ = os.Remove(location)
+		}
+	}()
+
+	if _, err := io.Copy(outFile, content); err != nil {
+		return fmt.Errorf("failed to write checkpoint archive %s: %w", location, err)
+	}
+	// Close explicitly rather than leaving it to the deferred Close: a write
+	// error reported only when the last buffered data is flushed would
+	// otherwise be discarded, and a truncated archive reported as a success.
+	if err := outFile.Close(); err != nil {
+		return fmt.Errorf("failed to write checkpoint archive %s: %w", location, err)
+	}
+	return nil
 }
 
 func withCheckpointOpts(rt, rootDir string) client.CheckpointTaskOpts {

--- a/internal/cri/server/container_checkpoint_linux_test.go
+++ b/internal/cri/server/container_checkpoint_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -221,4 +222,66 @@ func TestCheckpointContainerDisabled(t *testing.T) {
 	if !strings.Contains(err.Error(), "criu support is disabled by configuration") {
 		t.Errorf("expected error containing 'criu support is disabled by configuration', got: %v", err)
 	}
+}
+
+func TestWriteCheckpointArchive(t *testing.T) {
+	dir := t.TempDir()
+	location := filepath.Join(dir, "checkpoint.tar")
+
+	require.NoError(t, writeCheckpointArchive(location, strings.NewReader("archive")))
+
+	data, err := os.ReadFile(location)
+	require.NoError(t, err)
+	assert.Equal(t, "archive", string(data))
+
+	info, err := os.Stat(location)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+// A location that is already taken is left untouched. Overwriting it would
+// destroy an archive that is still wanted, and the leftover tail of a larger
+// one would ride along in the export unnoticed.
+func TestWriteCheckpointArchiveRefusesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	location := filepath.Join(dir, "checkpoint.tar")
+	require.NoError(t, os.WriteFile(location, []byte("a previous archive"), 0o600))
+
+	err := writeCheckpointArchive(location, strings.NewReader("archive"))
+	assert.ErrorIs(t, err, os.ErrExist)
+
+	data, err := os.ReadFile(location)
+	require.NoError(t, err)
+	assert.Equal(t, "a previous archive", string(data))
+}
+
+// containerd writes this file as root, so a symlink at location must not be
+// followed to its target.
+func TestWriteCheckpointArchiveRefusesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	location := filepath.Join(dir, "checkpoint.tar")
+	require.NoError(t, os.WriteFile(target, []byte("not the checkpoint"), 0o600))
+	require.NoError(t, os.Symlink(target, location))
+
+	err := writeCheckpointArchive(location, strings.NewReader("archive"))
+	assert.ErrorIs(t, err, os.ErrExist)
+
+	data, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "not the checkpoint", string(data))
+}
+
+// A failed write must not leave a partial archive behind: with exclusive
+// creation it would block every later attempt at the same location.
+func TestWriteCheckpointArchiveRemovesPartialArchive(t *testing.T) {
+	dir := t.TempDir()
+	location := filepath.Join(dir, "checkpoint.tar")
+
+	readErr := errors.New("read failed")
+	err := writeCheckpointArchive(location, iotest.ErrReader(readErr))
+	assert.ErrorIs(t, err, readErr)
+
+	_, statErr := os.Stat(location)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "partial archive should be removed")
 }


### PR DESCRIPTION
## What this PR does

`CheckpointContainer` opens the caller-supplied `r.Location` with
`O_RDWR|O_CREATE` and streams the tarball into it, so an existing file is
overwritten in place rather than replaced. When the file that was already there
is larger, its tail survives past the end of the new archive.

Nothing reports this. Both GNU tar and `archive/tar` stop at the end-of-archive
marker, so the export reads back as a valid checkpoint — it extracts to exactly
the right content, with matching checksums — while silently carrying the tail of
whatever was there before. The only visible symptom is that the file never
shrinks:

```
$ ls -l /tmp/test.tar          # 200M placeholder
-rw------- 200000000
$ crictl checkpoint --export=/tmp/test.tar <container>
$ ls -l /tmp/test.tar          # still 200M; the archive itself is ~40M
-rw------- 200000000
```

## What changed

Refuse rather than overwrite, per review feedback. The kubelet derives a unique
name for every checkpoint request, so a name that is already taken means either
a caller reusing a path or two requests racing for the same one, and in both
cases destroying an archive that is still wanted is worse than failing the
request.

- Create the destination with `O_WRONLY|O_CREATE|O_EXCL`.
- Remove the partial archive when the write fails, so a retry is not blocked by
  the remains of the attempt that failed.

## Behaviour change

Direct CRI callers that reuse a fixed export path now get an error instead of a
silent overwrite. The kubelet is unaffected since it derives a unique name per
request, and `contrib/checkpoint/checkpoint-restore-cri-disable-test.sh` already
does `rm -f` before its one successful export, so it keeps passing. Worth
keeping in mind for the 2.2/2.1 backports.

## Tests

- `TestWriteCheckpointArchive` — writes to a fresh location, mode `0600`.
- `TestWriteCheckpointArchiveRefusesExistingFile` — an existing file is left
  byte-for-byte untouched and the error is `os.ErrExist`.
- `TestWriteCheckpointArchiveRefusesSymlink` — a symlink at the destination is
  not followed and its target is left untouched.
- `TestWriteCheckpointArchiveRemovesPartialArchive` — a failed write leaves no
  file behind, so the next attempt at the same location is not blocked.