### PR TITLE
Remove shim.Command form pkg

### DIFF
--- a/core/runtime/v2/binary.go
+++ b/core/runtime/v2/binary.go
@@ -64,11 +64,9 @@ type binary struct {
 }
 
 func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ *shim, err error) {
-	// containerd daemon is the intended caller of client.Command; the deprecation
-	// targets external callers.
-	cmd, err := client.Command( //nolint:staticcheck // SA1019
+	cmd, err := command(
 		ctx,
-		&client.CommandConfig{
+		&commandConfig{
 			ID:           b.bundle.ID,
 			RuntimePath:  b.runtime,
 			GRPCAddress:  b.containerdAddress,
@@ -165,10 +163,8 @@ func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 		bundlePath = b.bundle.Path
 	}
 
-	// containerd daemon is the intended caller of client.Command; the deprecation
-	// targets external callers.
-	cmd, err := client.Command(ctx, //nolint:staticcheck // SA1019
-		&client.CommandConfig{
+	cmd, err := command(ctx,
+		&commandConfig{
 			ID:           b.bundle.ID,
 			RuntimePath:  b.runtime,
 			BundlePath:   b.bundle.Path,
@@ -220,7 +216,7 @@ func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 
 // shimCallError builds an error for a failed shim binary invocation.
 //
-// client.Command is run via exec.CommandContext, which kills the process
+// command is run via exec.CommandContext, which kills the process
 // once ctx is done. On Windows that kill is TerminateProcess(handle, 1),
 // which is indistinguishable from the shim genuinely calling os.Exit(1),
 // and os/exec reports the wait status in preference to the context error.

--- a/core/runtime/v2/command.go
+++ b/core/runtime/v2/command.go
@@ -1,0 +1,159 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	bootapi "github.com/containerd/containerd/api/runtime/bootstrap/v1"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
+	"github.com/containerd/containerd/v2/pkg/protobuf/types"
+	"github.com/containerd/containerd/v2/version"
+	"github.com/containerd/log"
+)
+
+// Environment variables passed to the shim binary.
+//
+// TODO: Remove in a future release in favor of Bootstrap protocol.
+const (
+	ttrpcAddressEnv = "TTRPC_ADDRESS"
+	grpcAddressEnv  = "GRPC_ADDRESS"
+	namespaceEnv    = "NAMESPACE"
+	maxVersionEnv   = "MAX_SHIM_VERSION"
+)
+
+type commandConfig struct {
+	ID           string
+	RuntimePath  string
+	BundlePath   string
+	GRPCAddress  string
+	TTRPCAddress string
+	WorkDir      string
+	Args         []string
+	Opts         *types.Any
+	Env          []string
+	LogLevel     log.Level
+	Action       string // Either "start" or "delete"
+	SocketDir    string
+}
+
+// command returns the shim command with the provided args and configuration.
+//
+// It is used to invoke the shim binary for "start" and "delete" actions during the
+// shim lifecycle, and encodes launch internals: backwards compatibility with older
+// shim models and the new Bootstrap protocol used by 2.3+ shims.
+func command(ctx context.Context, config *commandConfig) (*exec.Cmd, error) {
+	ns, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return nil, err
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Remove in a future release in favor of Bootstrap protocol.
+	args := []string{
+		"-namespace", ns,
+		"-address", config.GRPCAddress,
+		"-publish-binary", self,
+		"-id", config.ID,
+	}
+	if config.BundlePath != "" {
+		args = append(args, "-bundle", config.BundlePath)
+	}
+	switch config.LogLevel {
+	case log.DebugLevel, log.TraceLevel:
+		args = append(args, "-debug")
+	}
+	if config.Action == "" {
+		return nil, errors.New("action must be specified in commandConfig")
+	}
+
+	args = append(args, config.Action)
+
+	if len(config.Args) > 0 {
+		args = append(args, config.Args...)
+	}
+
+	cmd := exec.CommandContext(ctx, config.RuntimePath, args...)
+	cmd.Dir = config.WorkDir
+	cmd.Env = append(
+		os.Environ(),
+		"GOMAXPROCS=2",
+		fmt.Sprintf("%s=2", maxVersionEnv),
+		// TODO: Remove in a future release in favor of Bootstrap protocol.
+		fmt.Sprintf("%s=%s", ttrpcAddressEnv, config.TTRPCAddress),
+		fmt.Sprintf("%s=%s", grpcAddressEnv, config.GRPCAddress),
+		fmt.Sprintf("%s=%s", namespaceEnv, ns),
+	)
+	if len(config.Env) > 0 {
+		cmd.Env = append(cmd.Env, config.Env...)
+	}
+	cmd.SysProcAttr = getSysProcAttr()
+
+	// Special path when upgrading from 1.7 shims to 2.x containerd.
+	// v1 shims would fail if passed wrong stdin data.
+	// TODO: Remove in a future release in favor of Bootstrap protocol.
+	execName := filepath.Base(config.RuntimePath)
+	if strings.Contains(execName, "shim-runc-v1") || strings.Contains(execName, "shim-runhcs-v1") {
+		if config.Opts != nil {
+			d, err := proto.Marshal(config.Opts)
+			if err != nil {
+				return nil, err
+			}
+			cmd.Stdin = bytes.NewReader(d)
+		}
+	} else if config.Action == "start" {
+		// Use the new Bootstrap protocol for all newer shims.
+		params := bootapi.BootstrapParams{
+			InstanceID:             config.ID,
+			Namespace:              ns,
+			LogLevel:               bootapi.LogLevelFromString(config.LogLevel.String()),
+			ContainerdVersion:      version.Version,
+			ContainerdGrpcAddress:  config.GRPCAddress,
+			ContainerdTtrpcAddress: config.TTRPCAddress,
+			ContainerdBinary:       self,
+		}
+		if config.SocketDir != "" {
+			params.SocketDir = &config.SocketDir
+		}
+
+		if config.Opts != nil {
+			if err := params.AddExtension(config.Opts); err != nil {
+				return nil, fmt.Errorf("unable to add runtime options extensions: %w", err)
+			}
+		}
+
+		data, err := proto.Marshal(&params)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal bootstrap params: %w", err)
+		}
+
+		cmd.Stdin = bytes.NewReader(data)
+	}
+
+	return cmd, nil
+}

--- a/core/runtime/v2/command_unix.go
+++ b/core/runtime/v2/command_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import "syscall"
+
+func getSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/core/runtime/v2/command_windows.go
+++ b/core/runtime/v2/command_windows.go
@@ -1,0 +1,23 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import "syscall"
+
+func getSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -118,8 +118,6 @@ var (
 const (
 	ttrpcAddressEnv = "TTRPC_ADDRESS"
 	grpcAddressEnv  = "GRPC_ADDRESS"
-	namespaceEnv    = "NAMESPACE"
-	maxVersionEnv   = "MAX_SHIM_VERSION"
 )
 
 func parseFlags() {

--- a/pkg/shim/util.go
+++ b/pkg/shim/util.go
@@ -17,14 +17,12 @@
 package shim
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -32,131 +30,11 @@ import (
 	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl/v2"
 
-	bootapi "github.com/containerd/containerd/api/runtime/bootstrap/v1"
 	"github.com/containerd/containerd/v2/pkg/atomicfile"
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/containerd/containerd/v2/pkg/protobuf/types"
-	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
 )
-
-type CommandConfig struct {
-	ID           string
-	RuntimePath  string
-	BundlePath   string
-	GRPCAddress  string
-	TTRPCAddress string
-	WorkDir      string
-	Args         []string
-	Opts         *types.Any
-	Env          []string
-	LogLevel     log.Level
-	Action       string // Either "start" or "delete"
-	SocketDir    string
-}
-
-// Command returns the shim command with the provided args and configuration.
-//
-// Deprecated: this function is internal to the containerd daemon, which uses it to
-// invoke the shim binary for "start" and "delete" actions during the shim lifecycle.
-// It encodes daemon-specific launch internals — backwards compatibility with older shim
-// models and the new Bootstrap protocol used by 2.3+ shims — and is not intended for use
-// by external callers. It will be moved into the core containerd runtime package in the future.
-func Command(ctx context.Context, config *CommandConfig) (*exec.Cmd, error) {
-	ns, err := namespaces.NamespaceRequired(ctx)
-	if err != nil {
-		return nil, err
-	}
-	self, err := os.Executable()
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Remove in a future release in favor of Bootstrap protocol.
-	args := []string{
-		"-namespace", ns,
-		"-address", config.GRPCAddress,
-		"-publish-binary", self,
-		"-id", config.ID,
-	}
-	if config.BundlePath != "" {
-		args = append(args, "-bundle", config.BundlePath)
-	}
-	switch config.LogLevel {
-	case log.DebugLevel, log.TraceLevel:
-		args = append(args, "-debug")
-	}
-	if config.Action == "" {
-		return nil, errors.New("action must be specified in CommandConfig")
-	}
-
-	args = append(args, config.Action)
-
-	if len(config.Args) > 0 {
-		args = append(args, config.Args...)
-	}
-
-	cmd := exec.CommandContext(ctx, config.RuntimePath, args...)
-	cmd.Dir = config.WorkDir
-	cmd.Env = append(
-		os.Environ(),
-		"GOMAXPROCS=2",
-		fmt.Sprintf("%s=2", maxVersionEnv),
-		// TODO: Remove in a future release in favor of Bootstrap protocol.
-		fmt.Sprintf("%s=%s", ttrpcAddressEnv, config.TTRPCAddress),
-		fmt.Sprintf("%s=%s", grpcAddressEnv, config.GRPCAddress),
-		fmt.Sprintf("%s=%s", namespaceEnv, ns),
-	)
-	if len(config.Env) > 0 {
-		cmd.Env = append(cmd.Env, config.Env...)
-	}
-	cmd.SysProcAttr = getSysProcAttr()
-
-	// Special path when upgrading from 1.7 shims to 2.x containerd.
-	// v1 shims would fail if passed wrong stdin data.
-	// TODO: Remove in a future release in favor of Bootstrap protocol.
-	execName := filepath.Base(config.RuntimePath)
-	if strings.Contains(execName, "shim-runc-v1") || strings.Contains(execName, "shim-runhcs-v1") {
-		if config.Opts != nil {
-			d, err := proto.Marshal(config.Opts)
-			if err != nil {
-				return nil, err
-			}
-			cmd.Stdin = bytes.NewReader(d)
-		}
-	} else if config.Action == "start" {
-		// Use the new Bootstrap protocol for all newer shims.
-		params := bootapi.BootstrapParams{
-			InstanceID:             config.ID,
-			Namespace:              ns,
-			LogLevel:               bootapi.LogLevelFromString(config.LogLevel.String()),
-			ContainerdVersion:      version.Version,
-			ContainerdGrpcAddress:  config.GRPCAddress,
-			ContainerdTtrpcAddress: config.TTRPCAddress,
-			ContainerdBinary:       self,
-		}
-		if config.SocketDir != "" {
-			params.SocketDir = &config.SocketDir
-		}
-
-		if config.Opts != nil {
-			if err := params.AddExtension(config.Opts); err != nil {
-				return nil, fmt.Errorf("unable to add runtime options extensions: %w", err)
-			}
-		}
-
-		data, err := proto.Marshal(&params)
-		if err != nil {
-			return nil, fmt.Errorf("unable to marshal bootstrap params: %w", err)
-		}
-
-		cmd.Stdin = bytes.NewReader(data)
-	}
-
-	return cmd, nil
-}
 
 // BinaryName returns the shim binary name from the runtime name,
 // empty string returns means runtime name is invalid

--- a/pkg/shim/util_unix.go
+++ b/pkg/shim/util_unix.go
@@ -50,12 +50,6 @@ const (
 	protoUnix        = "unix"
 )
 
-func getSysProcAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{
-		Setpgid: true,
-	}
-}
-
 // AdjustOOMScore sets the OOM score for the process to the parents OOM score +1
 // to ensure that they parent has a lower* score than the shim
 // if not already at the maximum OOM Score

--- a/pkg/shim/util_windows.go
+++ b/pkg/shim/util_windows.go
@@ -21,17 +21,12 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"syscall"
 	"time"
 
 	winio "github.com/Microsoft/go-winio"
 )
 
 const shimBinaryFormat = "containerd-shim-%s-%s.exe"
-
-func getSysProcAttr() *syscall.SysProcAttr {
-	return nil
-}
 
 // AnonReconnectDialer connects to a named pipe that should already exist.
 // It fails immediately if the pipe is not found, rather than retrying.


### PR DESCRIPTION
`shim.Command` is used by the daemon and not intended for public use.
It was previously deprecated, this PR moves it to `runtime/v2` where it belongs.

Deprecation PR: https://github.com/containerd/containerd/pull/13319

```release-note
Remove deprecated shim.Command from pkg
```