### PR TITLE
fix: fix incorrect restart=always restart logic

### DIFF
--- a/core/runtime/restart/restart.go
+++ b/core/runtime/restart/restart.go
@@ -116,13 +116,17 @@ func (rp *Policy) MaximumRetryCount() int {
 
 // Reconcile reconciles the restart policy of a container.
 func Reconcile(status containerd.Status, labels map[string]string) bool {
+	explicitlyStopped, _ := strconv.ParseBool(labels[ExplicitlyStoppedLabel])
+	if explicitlyStopped {
+		return false
+	}
 	rp, err := NewPolicy(labels[PolicyLabel])
 	if err != nil {
 		log.L.WithError(err).Error("policy reconcile")
 		return false
 	}
 	switch rp.Name() {
-	case "", "always":
+	case "always", "unless-stopped":
 		return true
 	case "on-failure":
 		restartCount, err := strconv.Atoi(labels[CountLabel])
@@ -131,11 +135,6 @@ func Reconcile(status containerd.Status, labels map[string]string) bool {
 			return false
 		}
 		if status.ExitStatus != 0 && (rp.maximumRetryCount == 0 || restartCount < rp.maximumRetryCount) {
-			return true
-		}
-	case "unless-stopped":
-		explicitlyStopped, _ := strconv.ParseBool(labels[ExplicitlyStoppedLabel])
-		if !explicitlyStopped {
 			return true
 		}
 	}

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -42,6 +43,7 @@ import (
 	. "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	coreimages "github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/runtime/restart"
 	"github.com/containerd/containerd/v2/integration/failpoint"
 	"github.com/containerd/containerd/v2/integration/images"
 	"github.com/containerd/containerd/v2/pkg/archive"
@@ -173,6 +175,120 @@ func TestTaskUpdate(t *testing.T) {
 	}
 
 	<-statusC
+}
+
+func TestContainerRestartPolicyAlways(t *testing.T) {
+	t.Parallel()
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var (
+		ctx, cancel = testContext(t)
+		id          = t.Name()
+	)
+	defer cancel()
+
+	image, err := client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cOpts []NewContainerOpts
+
+	policy, err := restart.NewPolicy("always")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cOpts = append(cOpts, restart.WithPolicy(policy))
+	cOpts = append(cOpts, WithNewSnapshot(id, image))
+	cOpts = append(cOpts, WithNewSpec(oci.WithImageConfig(image), withProcessArgs("sleep", "1d")))
+	container, err := client.NewContainer(ctx, id, cOpts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer container.Delete(ctx, WithSnapshotCleanup)
+
+	task, err := container.NewTask(ctx, empty())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		task, err := container.Task(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		task.Delete(ctx)
+	}()
+
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := task.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateStatusLabel(ctx, container, Running); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := task.Kill(ctx, unix.SIGKILL); err != nil {
+		t.Fatal(err)
+	}
+
+	<-statusC
+	// should be longer than interval (10 seconds) time
+	time.Sleep(time.Second * 12)
+	newTask, err := container.Task(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newStatus, err := newTask.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newStatus.Status != Running {
+		t.Errorf("expected status %s but get %s", Running, newStatus.Status)
+	}
+
+	// update  restart label and kill task
+	if err := updateExplicitlyStoppedLabel(ctx, container, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := newTask.Kill(ctx, unix.SIGKILL); err != nil {
+		t.Fatal(err)
+	}
+	// should be longer than interval (10 seconds) time
+	time.Sleep(time.Second * 12)
+	newTask, err = container.Task(ctx, nil)
+
+	newStatus, err = newTask.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newStatus.Status != Stopped {
+		t.Errorf("expected status %s but get %s", Stopped, newStatus.Status)
+	}
+}
+
+func updateExplicitlyStoppedLabel(ctx context.Context, container Container, explicitlyStopped bool) error {
+	opt := WithAdditionalContainerLabels(map[string]string{
+		restart.ExplicitlyStoppedLabel: strconv.FormatBool(explicitlyStopped),
+	})
+	return container.Update(ctx, UpdateContainerOpts(opt))
+}
+
+// UpdateStatusLabel updates the "containerd.io/restart.status"
+// label of the container according to the value of restart desired status.
+func updateStatusLabel(ctx context.Context, container Container, status ProcessStatus) error {
+	opt := WithAdditionalContainerLabels(map[string]string{
+		restart.StatusLabel: string(status),
+	})
+	return container.Update(ctx, UpdateContainerOpts(opt))
 }
 
 func TestShimInCgroup(t *testing.T) {

--- a/plugins/restart/monitor.go
+++ b/plugins/restart/monitor.go
@@ -60,6 +60,8 @@ func init() {
 			m := &monitor{
 				client: client,
 			}
+			// This function is executed exactly once.
+			m.resetAlwaysContainerExplicitlyStoppedLabel()
 			go m.run(tomlext.ToStdTime(ic.Config.(*Config).Interval))
 			return m, nil
 		},
@@ -85,6 +87,44 @@ type change interface {
 
 type monitor struct {
 	client *containerd.Client
+}
+
+// Reset restart.ExplicitlyStoppedLabel to false for containers whose restart policy is "always".
+// This ensures "always" containers are eligible to restart even if they were previously explicitly stopped.
+func (m *monitor) resetAlwaysContainerExplicitlyStoppedLabel() {
+	ns, err := m.client.NamespaceService().List(context.Background())
+	if err != nil {
+		log.G(context.Background()).WithError(err).Errorf("failed to get container namespace")
+		return
+	}
+	for _, name := range ns {
+		ctx := namespaces.WithNamespace(context.Background(), name)
+		containers, err := m.client.Containers(ctx, fmt.Sprintf("labels.%q", restart.StatusLabel))
+		if err != nil {
+			log.G(ctx).WithError(err).Error("failed to get containers")
+			continue
+		}
+		for _, c := range containers {
+			labels, err := c.Labels(ctx)
+			if err != nil {
+				log.G(ctx).WithError(err).Errorf("failed to get container %s label", c.ID())
+				continue
+			}
+			rp, err := restart.NewPolicy(labels[restart.PolicyLabel])
+			if err != nil {
+				log.G(ctx).WithError(err).Error("failed to parse restart policy")
+				continue
+			}
+			if rp.Name() == "always" {
+				explicitlyStopped, _ := strconv.ParseBool(labels[restart.ExplicitlyStoppedLabel])
+				if explicitlyStopped {
+					if err := resetContainerExplicitlyStoppedLabel(ctx, c); err != nil {
+						log.G(ctx).WithError(err).Error("failed to reset explicitly-stopped label")
+					}
+				}
+			}
+		}
+	}
 }
 
 func (m *monitor) run(interval time.Duration) {
@@ -126,6 +166,13 @@ func (m *monitor) reconcile(ctx context.Context) error {
 	}
 	wgNSLoop.Wait()
 	return nil
+}
+
+func resetContainerExplicitlyStoppedLabel(ctx context.Context, container containerd.Container) error {
+	opt := containerd.WithAdditionalContainerLabels(map[string]string{
+		restart.ExplicitlyStoppedLabel: strconv.FormatBool(false),
+	})
+	return container.Update(ctx, containerd.UpdateContainerOpts(opt))
 }
 
 func (m *monitor) monitor(ctx context.Context) ([]change, error) {


### PR DESCRIPTION
Continue the work from PR #6966.
fix https://github.com/containerd/nerdctl/issues/5153

Currently, when running a container with `nerdctl run -d --restart=always busybox sh -c "top"`,
and then performing `nerdctl stop` on it, containerd still restarts the container after a few seconds.
This is inconsistent with Docker behavior and not the desired outcome.

For containers with `--restart=always` policy:
After manually stopping the container via `nerdctl stop <id>`, containerd should not  restart it,
until the containerd daemon itself gets restarted. This change aligns the behavior with Docker.
ping  @AkihiroSuda  @mxpv @dmcgowan

```release-note
Avoid immediately restarting containers with restart=always policy after they are explicitly stopped
```
