### PR TITLE
vendor: github.com/containerd/platforms v1.0.0-rc.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/nri v0.12.2
 	github.com/containerd/otelttrpc v0.1.0
-	github.com/containerd/platforms v1.0.0-rc.4
+	github.com/containerd/platforms v1.0.0-rc.5
 	github.com/containerd/plugin v1.1.0
 	github.com/containerd/ttrpc v1.2.9
 	github.com/containerd/typeurl/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/containerd/nri v0.12.2 h1:piA7h2QUm0m3+e994qWFPYwnoXXwAphwDc1Ydx1eWi4
 github.com/containerd/nri v0.12.2/go.mod h1:o6Pz0I/iks9g2KlH3WdgvFtc9rB7k0aeoZCAH01xOGk=
 github.com/containerd/otelttrpc v0.1.0 h1:UOX68eVTE8H/T45JveIg+I22Ev2aFj4qPITCmXsskjw=
 github.com/containerd/otelttrpc v0.1.0/go.mod h1:XhoA2VvaGPW1clB2ULwrBZfXVuEWuyOd2NUD1IM0yTg=
-github.com/containerd/platforms v1.0.0-rc.4 h1:M42JrUT4zfZTqtkUwkr0GzmUWbfyO5VO0Q5b3op97T4=
-github.com/containerd/platforms v1.0.0-rc.4/go.mod h1:lKlMXyLybmBedS/JJm11uDofzI8L2v0J2ZbYvNsbq1A=
+github.com/containerd/platforms v1.0.0-rc.5 h1:vXd569rDrz8LeMXzAnBsy6LADV5YtsD8oyaRarxdmSU=
+github.com/containerd/platforms v1.0.0-rc.5/go.mod h1:lKlMXyLybmBedS/JJm11uDofzI8L2v0J2ZbYvNsbq1A=
 github.com/containerd/plugin v1.1.0 h1:O+7lczNJVMy8rz0YNx3xGB8tTf5qY4i5abF041Ew19U=
 github.com/containerd/plugin v1.1.0/go.mod h1:qBTum+A8lJ6lO44A19Eo7y1OlcLj4OWFH1DA/vnHmcc=
 github.com/containerd/ttrpc v1.2.9 h1:ha0ak962T0s3CA/RoZ6S6xiWZQF24GrBaEpiGX1uihg=

--- a/vendor/github.com/containerd/platforms/platform_windows_compat.go
+++ b/vendor/github.com/containerd/platforms/platform_windows_compat.go
@@ -87,19 +87,26 @@ func checkWindowsHostAndContainerCompat(host, ctr windowsOSVersion) bool {
 		return host.Build == ctr.Build
 	}
 
-	// Find the latest LTSC version that is earlier than the host version.
-	// This is the earliest version of container that the host can run.
+	// Find the floor of the compatible container range. Per the Windows stable
+	// ABI policy, every host from LTSC N up to (but not including) LTSC N+1 can
+	// run containers from LTSC N-1 up to the host build.
 	//
-	// If the host version is an LTSC, then it supports compatibility with
-	// everything from the previous LTSC up to itself, so we want supportedLTSCRelease
-	// to be the previous entry.
+	// So we find the largest LTSC <= host.Build, then step one entry back to
+	// get the floor. If host.Build is past the latest LTSC in the list
+	// (e.g. a 26200 host, which is in the WS2025 generation), the floor is
+	// still the previous LTSC (20348), not the latest LTSC itself.
 	//
-	// If no match is found, then we know that the host is LTSC2022 exactly,
-	// since we already checked that it's not less than LTSC2022.
+	// If host is the very first LTSC (or no entry matches, which is impossible
+	// here since we already checked host.Build >= ltsc2022), use that LTSC as
+	// the floor.
 	var supportedLTSCRelease uint16 = ltsc2022
 	for i := len(compatLTSCReleases) - 1; i >= 0; i-- {
-		if host.Build > compatLTSCReleases[i] {
-			supportedLTSCRelease = compatLTSCReleases[i]
+		if host.Build >= compatLTSCReleases[i] {
+			if i == 0 {
+				supportedLTSCRelease = compatLTSCReleases[i]
+			} else {
+				supportedLTSCRelease = compatLTSCReleases[i-1]
+			}
 			break
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -248,7 +248,7 @@ github.com/containerd/nri/types/v1
 ## explicit; go 1.21
 github.com/containerd/otelttrpc
 github.com/containerd/otelttrpc/internal
-# github.com/containerd/platforms v1.0.0-rc.4
+# github.com/containerd/platforms v1.0.0-rc.5
 ## explicit; go 1.24
 github.com/containerd/platforms
 # github.com/containerd/plugin v1.1.0


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/53397

### vendor: github.com/containerd/platforms v1.0.0-rc.5

- Fix WS2022 compat on hosts past the latest LTSC

full diff: https://github.com/containerd/platforms/compare/v1.0.0-rc.4...v1.0.0-rc.5