### PR TITLE
internal/cri/server: remove remaining uses of k8s.io/utils

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,6 @@ require (
 	k8s.io/cri-streaming v0.36.3
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/streaming v0.36.3
-	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	tags.cncf.io/container-device-interface v1.1.1-0.20260720132747-49ac08dcf160
 )
 
@@ -152,6 +151,7 @@ require (
 	k8s.io/api v0.36.3 // indirect
 	k8s.io/component-base v0.36.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20260319004828-5883c5ee87b9 // indirect
+	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect

--- a/internal/cri/server/streaming.go
+++ b/internal/cri/server/streaming.go
@@ -26,8 +26,42 @@ import (
 	streaming "k8s.io/cri-streaming/pkg/streaming"
 	remotecommand "k8s.io/cri-streaming/pkg/streaming/remotecommand"
 	"k8s.io/streaming/pkg/runtime"
-	executil "k8s.io/utils/exec"
 )
+
+// exitError is an interface that presents an API similar to os.ProcessState, which is
+// what exitError from os/exec is. This is designed to make testing a bit easier and
+// probably loses some of the cross-platform properties of the underlying library.
+//
+// exitError matches [k8s.io/utils/exec.ExitError], which is used by
+// [remotecommand.ServeExec] to distinguish a command exiting with a non-zero
+// status from an error executing the command.
+//
+// FIXME(thaJeztah): define this contract in k8s.io/cri-streaming instead.
+// ServeExec only requires Exited and ExitStatus, so the upstream interface
+// could be reduced to those methods in addition to error.
+//
+// - https://github.com/kubernetes/cri-streaming/blob/v0.36.3/pkg/streaming/remotecommand/exec.go#L48-L64
+// - https://github.com/kubernetes/utils/blob/28399d86e0b55e612b83ad94dc6bac8e5de2a5ac/exec/exec.go#L83-L91
+type exitError interface {
+	error
+	fmt.Stringer
+	Exited() bool
+	ExitStatus() int
+}
+
+// codeExitError is an implementation of exitError consisting of an error object
+// and an exit code (the upper bits of os.exec.ExitStatus).
+type codeExitError struct {
+	error
+	code int
+}
+
+func (e codeExitError) String() string  { return e.Error() }
+func (e codeExitError) Exited() bool    { return true }   // Exited is to check if the process has finished
+func (e codeExitError) ExitStatus() int { return e.code } // ExitStatus is for checking the error code
+
+// FIXME(thaJeztah): assert against remotecommand.ExitError once k8s.io/cri-streaming defines the exit-error contract.
+var _ exitError = (*codeExitError)(nil)
 
 type streamRuntime struct {
 	c *criService
@@ -37,8 +71,8 @@ func newStreamRuntime(c *criService) streaming.Runtime {
 	return &streamRuntime{c: c}
 }
 
-// Exec executes a command inside the container. executil.ExitError is returned if the command
-// returns non-zero exit code.
+// Exec executes a command inside the container. An exitError is returned if
+// the command exits with a non-zero status.
 func (s *streamRuntime) Exec(ctx context.Context, containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser,
 	tty bool, resize <-chan remotecommand.TerminalSize) error {
 	exitCode, err := s.c.execInContainer(ctrdutil.WithNamespace(ctx), containerID, execOptions{
@@ -55,9 +89,9 @@ func (s *streamRuntime) Exec(ctx context.Context, containerID string, cmd []stri
 	if *exitCode == 0 {
 		return nil
 	}
-	return &executil.CodeExitError{
-		Err:  fmt.Errorf("error executing command %v, exit code %d", cmd, *exitCode),
-		Code: int(*exitCode),
+	return &codeExitError{
+		error: fmt.Errorf("error executing command %v, exit code %d", cmd, *exitCode),
+		code:  int(*exitCode),
 	}
 }
 


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/13997#issuecomment-5362111790


k8s.io/utils/exec.CodeExitError was the only remaining direct use of k8s.io/utils. Replace it with a local error type implementing the same interface. The streaming server uses this interface to distinguish commands terminating with a non-zero exit status from errors executing the command, and to propagate the exit status to the client.

Add a FIXME to define this error contract in k8s.io/cri-streaming, where it is consumed, instead of requiring runtime implementations to implicitly match k8s.io/utils/exec.ExitError.


☝️ for the above; currently the interface is defined in utils (producer side) https://github.com/kubernetes/utils/blob/28399d86e0b55e612b83ad94dc6bac8e5de2a5ac/exec/exec.go#L83-L91

But it _should_ be defined on the receiver side, because that's where it's part of the contract;
https://github.com/kubernetes/cri-streaming/blob/v0.36.3/pkg/streaming/remotecommand/exec.go#L48-L64


That interface must be documented as part of the contract (to avoid a 500 internal server error for expected cases); the interface can be simplified to only the parts needed;

```go
type ExitError interface {
    error
    Exited() bool
    ExitStatus() int
}
```

BUT! It ... could .. even be more elegant. Instead of defining a Kubernetes-specific `ExitStatus()`, k8s.io/cri-streaming could define an interface stdlib:

```go
type ExitError interface {
    error
    ExitCode() int
}
```

That interface would be satisfied by `*os/exec.ExitError` (through `*os.ProcessState`), and implementations could just return a `*exec.ExitError` directly without wrapping; and k8s.io/cri-streaming could have a small utility to match either; quick draw-up;

```go
// ExitError is returned by Runtime.Exec when the command terminated with a
// non-zero exit code.
//
// *os/exec.ExitError implements ExitError.
type ExitError interface {
	error
	ExitCode() int
}
```

```go
type legacyExitError interface {
	error
	Exited() bool
	ExitStatus() int
}

func exitCode(err error) (int, bool) {
	var exitErr ExitError
	if errors.As(err, &exitErr) {
		return exitErr.ExitCode(), true
	}

	var exitErrLegacy legacyExitError
	if errors.As(err, &exitErrLegacy) && exitErrLegacy.Exited() {
		return exitErrLegacy.ExitStatus(), true
	}

	return 0, false
}
```

And document it;

```go
// Exec executes a command in a container.
//
// If the command terminates with a non-zero exit code, Exec should return an
// ExitError. In particular, *os/exec.ExitError satisfies this contract.
Exec(...) error
```