### PR TITLE
Bump go-runc to 1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/go-cni v1.1.13
 	github.com/containerd/go-dmverity v0.1.0
-	github.com/containerd/go-runc v1.1.0
+	github.com/containerd/go-runc v1.2.0
 	github.com/containerd/imgcrypt/v2 v2.0.3
 	github.com/containerd/log v0.1.0
 	github.com/containerd/nri v0.12.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/containerd/go-cni v1.1.13 h1:eFSGOKlhoYNxpJ51KRIMHZNlg5UgocXEIEBGkY7H
 github.com/containerd/go-cni v1.1.13/go.mod h1:nTieub0XDRmvCZ9VI/SBG6PyqT95N4FIhxsauF1vSBI=
 github.com/containerd/go-dmverity v0.1.0 h1:aqnpBRI6mmscya/XqvknZ4wQNJnXzx6lKxPa7Q71hDo=
 github.com/containerd/go-dmverity v0.1.0/go.mod h1:vYevYgfeVF244IpQCKshXLvyKoRHwoVrFG0HV6GrUrs=
-github.com/containerd/go-runc v1.1.0 h1:OX4f+/i2y5sUT7LhmcJH7GYrjjhHa1QI4e8yO0gGleA=
-github.com/containerd/go-runc v1.1.0/go.mod h1:xJv2hFF7GvHtTJd9JqTS2UVxMkULUYw4JN5XAUZqH5U=
+github.com/containerd/go-runc v1.2.0 h1:2bR2WFllv1e6NkGqdxv4vq6yjn20rn0A3Ya1Szo5zJg=
+github.com/containerd/go-runc v1.2.0/go.mod h1:fnxllTlO2iROsGzcfY1P2IfFW4bGpt7CIMKhgj1s1Xk=
 github.com/containerd/imgcrypt/v2 v2.0.3 h1:yM6//IOTtca9TpxPP8prJqLDuidbF/VhUQujLw7UQ3w=
 github.com/containerd/imgcrypt/v2 v2.0.3/go.mod h1:Sjfd3uOiBWtb1dUo1yS5Z/ZxdfMU7MpBr2pzs9HoRDs=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/vendor/github.com/containerd/go-runc/command_linux.go
+++ b/vendor/github.com/containerd/go-runc/command_linux.go
@@ -25,15 +25,21 @@ import (
 )
 
 func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
+	return r.commandWithCustomLogFile(context, "", args...)
+}
+
+func (r *Runc) commandWithCustomLogFile(context context.Context, logFile string, args ...string) *exec.Cmd {
 	command := r.Command
 	if command == "" {
 		command = DefaultCommand
 	}
-	cmd := exec.CommandContext(context, command, append(r.args(), args...)...)
+	cmd := exec.CommandContext(context, command, append(r.args(logFile), args...)...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: r.Setpgid,
 	}
 	cmd.Env = filterEnv(os.Environ(), "NOTIFY_SOCKET") // NOTIFY_SOCKET introduces a special behavior in runc but should only be set if invoked from systemd
+	cmd.Env = append(cmd.Env, extraEnv(context)...)
+	cmd.Dir = r.WorkDir
 	if r.PdeathSignal != 0 {
 		cmd.SysProcAttr.Pdeathsig = r.PdeathSignal
 	}

--- a/vendor/github.com/containerd/go-runc/command_other.go
+++ b/vendor/github.com/containerd/go-runc/command_other.go
@@ -25,11 +25,16 @@ import (
 )
 
 func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
+	return r.commandWithCustomLogFile(context, "", args...)
+}
+
+func (r *Runc) commandWithCustomLogFile(context context.Context, logFile string, args ...string) *exec.Cmd {
 	command := r.Command
 	if command == "" {
 		command = DefaultCommand
 	}
-	cmd := exec.CommandContext(context, command, append(r.args(), args...)...)
-	cmd.Env = os.Environ()
+	cmd := exec.CommandContext(context, command, append(r.args(logFile), args...)...)
+	cmd.Env = append(os.Environ(), extraEnv(context)...)
+	cmd.Dir = r.WorkDir
 	return cmd
 }

--- a/vendor/github.com/containerd/go-runc/console.go
+++ b/vendor/github.com/containerd/go-runc/console.go
@@ -19,146 +19,26 @@
 package runc
 
 import (
-	"fmt"
-	"net"
-	"os"
-	"path/filepath"
-
 	"github.com/containerd/console"
-	"golang.org/x/sys/unix"
 )
 
 // NewConsoleSocket creates a new unix socket at the provided path to accept a
 // pty master created by runc for use by the container
 func NewConsoleSocket(path string) (*Socket, error) {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return nil, err
-	}
-	addr, err := net.ResolveUnixAddr("unix", abs)
-	if err != nil {
-		return nil, err
-	}
-	l, err := net.ListenUnix("unix", addr)
-	if err != nil {
-		return nil, err
-	}
-	return &Socket{
-		l: l,
-	}, nil
+	return newSocket(path)
 }
 
 // NewTempConsoleSocket returns a temp console socket for use with a container
 // On Close(), the socket is deleted
 func NewTempConsoleSocket() (*Socket, error) {
-	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
-	dir, err := os.MkdirTemp(runtimeDir, "pty")
-	if err != nil {
-		return nil, err
-	}
-	abs, err := filepath.Abs(filepath.Join(dir, "pty.sock"))
-	if err != nil {
-		return nil, err
-	}
-	addr, err := net.ResolveUnixAddr("unix", abs)
-	if err != nil {
-		return nil, err
-	}
-	l, err := net.ListenUnix("unix", addr)
-	if err != nil {
-		return nil, err
-	}
-	if runtimeDir != "" {
-		if err := os.Chmod(abs, 0o755|os.ModeSticky); err != nil {
-			return nil, err
-		}
-	}
-	return &Socket{
-		l:     l,
-		rmdir: true,
-	}, nil
-}
-
-// Socket is a unix socket that accepts the pty master created by runc
-type Socket struct {
-	rmdir bool
-	l     *net.UnixListener
-}
-
-// Path returns the path to the unix socket on disk
-func (c *Socket) Path() string {
-	return c.l.Addr().String()
-}
-
-// recvFd waits for a file descriptor to be sent over the given AF_UNIX
-// socket. The file name of the remote file descriptor will be recreated
-// locally (it is sent as non-auxiliary data in the same payload).
-func recvFd(socket *net.UnixConn) (*os.File, error) {
-	const MaxNameLen = 4096
-	oobSpace := unix.CmsgSpace(4)
-
-	name := make([]byte, MaxNameLen)
-	oob := make([]byte, oobSpace)
-
-	n, oobn, _, _, err := socket.ReadMsgUnix(name, oob)
-	if err != nil {
-		return nil, err
-	}
-
-	if n >= MaxNameLen || oobn != oobSpace {
-		return nil, fmt.Errorf("recvfd: incorrect number of bytes read (n=%d oobn=%d)", n, oobn)
-	}
-
-	// Truncate.
-	name = name[:n]
-	oob = oob[:oobn]
-
-	scms, err := unix.ParseSocketControlMessage(oob)
-	if err != nil {
-		return nil, err
-	}
-	if len(scms) != 1 {
-		return nil, fmt.Errorf("recvfd: number of SCMs is not 1: %d", len(scms))
-	}
-	scm := scms[0]
-
-	fds, err := unix.ParseUnixRights(&scm)
-	if err != nil {
-		return nil, err
-	}
-	if len(fds) != 1 {
-		return nil, fmt.Errorf("recvfd: number of fds is not 1: %d", len(fds))
-	}
-	fd := uintptr(fds[0])
-
-	return os.NewFile(fd, string(name)), nil
+	return newTempSocket("pty", "pty.sock")
 }
 
 // ReceiveMaster blocks until the socket receives the pty master
 func (c *Socket) ReceiveMaster() (console.Console, error) {
-	conn, err := c.l.Accept()
-	if err != nil {
-		return nil, err
-	}
-	defer conn.Close()
-	uc, ok := conn.(*net.UnixConn)
-	if !ok {
-		return nil, fmt.Errorf("received connection which was not a unix socket")
-	}
-	f, err := recvFd(uc)
+	f, err := c.receive()
 	if err != nil {
 		return nil, err
 	}
 	return console.ConsoleFromFile(f)
-}
-
-// Close closes the unix socket
-func (c *Socket) Close() error {
-	err := c.l.Close()
-	if c.rmdir {
-		if rerr := os.RemoveAll(filepath.Dir(c.Path())); err == nil {
-			err = rerr
-		}
-	}
-	return err
 }

--- a/vendor/github.com/containerd/go-runc/env.go
+++ b/vendor/github.com/containerd/go-runc/env.go
@@ -1,0 +1,42 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+import "context"
+
+type extraEnvKey struct{}
+
+// WithExtraEnv returns a context which adds the given "KEY=VALUE" entries to the
+// environment of every runc invocation made with it. Entries are appended after
+// the inherited environment, so they replace inherited variables of the same
+// name, and repeated calls accumulate.
+func WithExtraEnv(ctx context.Context, env ...string) context.Context {
+	if len(env) == 0 {
+		return ctx
+	}
+	// Copy: the existing array may be shared with sibling contexts.
+	old := extraEnv(ctx)
+	merged := make([]string, 0, len(old)+len(env))
+	merged = append(merged, old...)
+	merged = append(merged, env...)
+	return context.WithValue(ctx, extraEnvKey{}, merged)
+}
+
+func extraEnv(ctx context.Context) []string {
+	env, _ := ctx.Value(extraEnvKey{}).([]string)
+	return env
+}

--- a/vendor/github.com/containerd/go-runc/events.go
+++ b/vendor/github.com/containerd/go-runc/events.go
@@ -30,11 +30,12 @@ type Event struct {
 
 // Stats is statistical information from the runc process
 type Stats struct {
-	Cpu     Cpu                `json:"cpu"` //revive:disable
-	Memory  Memory             `json:"memory"`
-	Pids    Pids               `json:"pids"`
-	Blkio   Blkio              `json:"blkio"`
-	Hugetlb map[string]Hugetlb `json:"hugetlb"`
+	Cpu               Cpu                 `json:"cpu"` //revive:disable
+	Memory            Memory              `json:"memory"`
+	Pids              Pids                `json:"pids"`
+	Blkio             Blkio               `json:"blkio"`
+	Hugetlb           map[string]Hugetlb  `json:"hugetlb"`
+	NetworkInterfaces []*NetworkInterface `json:"network_interfaces"`
 }
 
 // Hugetlb represents the detailed hugetlb component of the statistics data
@@ -112,4 +113,18 @@ type Memory struct {
 	Kernel    MemoryEntry       `json:"kernel,omitempty"`
 	KernelTCP MemoryEntry       `json:"kernelTCP,omitempty"`
 	Raw       map[string]uint64 `json:"raw,omitempty"`
+}
+
+type NetworkInterface struct {
+	// Name is the name of the network interface.
+	Name string
+
+	RxBytes   uint64
+	RxPackets uint64
+	RxErrors  uint64
+	RxDropped uint64
+	TxBytes   uint64
+	TxPackets uint64
+	TxErrors  uint64
+	TxDropped uint64
 }

--- a/vendor/github.com/containerd/go-runc/pidfd.go
+++ b/vendor/github.com/containerd/go-runc/pidfd.go
@@ -1,0 +1,54 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+import (
+	"os"
+)
+
+// NewPidfdSocket creates a new unix socket at the provided path to accept the
+// pidfd of the process runc creates.
+//
+// Requires runc v1.2.0 or newer and a v5.3 or newer kernel.
+func NewPidfdSocket(path string) (*Socket, error) {
+	return newSocket(path)
+}
+
+// NewTempPidfdSocket returns a temp socket to accept the pidfd of the process
+// runc creates. On Close(), the socket is deleted.
+//
+// Requires runc v1.2.0 or newer and a v5.3 or newer kernel.
+func NewTempPidfdSocket() (*Socket, error) {
+	return newTempSocket("pidfd", "pidfd.sock")
+}
+
+// ReceivePidfd blocks until the socket receives the pidfd of the process runc
+// created. The pidfd refers to the container's init process for create and run,
+// and to the exec'd process for exec.
+//
+// The pidfd is sent while the process is being set up, which is before `runc
+// create` returns and before the container's start fifo is opened, so it is
+// safe to receive it before starting the container.
+//
+// It is the caller's responsibility to close the returned file. The pidfd can
+// be used to signal or wait on the process without the pid reuse races that
+// come with a raw pid, e.g. with unix.PidfdSendSignal.
+func (c *Socket) ReceivePidfd() (*os.File, error) {
+	return c.receive()
+}

--- a/vendor/github.com/containerd/go-runc/runc.go
+++ b/vendor/github.com/containerd/go-runc/runc.go
@@ -59,10 +59,16 @@ const (
 var DefaultCommand = "runc"
 
 // Runc is the client to the runc cli
+//
+// Fields here apply to every invocation. For per-invocation settings see the
+// Opts types and WithExtraEnv.
 type Runc struct {
 	// Command overrides the name of the runc binary. If empty, DefaultCommand
 	// is used.
-	Command   string
+	Command string
+	// WorkDir sets the working directory of the runc process. If empty, the
+	// working directory of the calling process is used.
+	WorkDir   string
 	Root      string
 	Debug     bool
 	Log       string
@@ -126,18 +132,28 @@ type ConsoleSocket interface {
 	Path() string
 }
 
+// PidfdSocket handles the path of the socket which receives the pidfd of the
+// process runc creates.
+type PidfdSocket interface {
+	Path() string
+}
+
 // CreateOpts holds all the options information for calling runc with supported options
 type CreateOpts struct {
 	IO
 	// PidFile is a path to where a pid file should be created
 	PidFile       string
 	ConsoleSocket ConsoleSocket
-	Detach        bool
-	NoPivot       bool
-	NoNewKeyring  bool
-	ExtraFiles    []*os.File
-	Started       chan<- int
-	ExtraArgs     []string
+	// PidfdSocket receives a pidfd referencing the container's init process,
+	// which lets the caller signal or wait on it without racing against pid
+	// reuse. Requires runc v1.2.0 or newer.
+	PidfdSocket  PidfdSocket
+	Detach       bool
+	NoPivot      bool
+	NoNewKeyring bool
+	ExtraFiles   []*os.File
+	Started      chan<- int
+	ExtraArgs    []string
 }
 
 func (o *CreateOpts) args() (out []string, err error) {
@@ -150,6 +166,9 @@ func (o *CreateOpts) args() (out []string, err error) {
 	}
 	if o.ConsoleSocket != nil {
 		out = append(out, "--console-socket", o.ConsoleSocket.Path())
+	}
+	if o.PidfdSocket != nil {
+		out = append(out, "--pidfd-socket", o.PidfdSocket.Path())
 	}
 	if o.NoPivot {
 		out = append(out, "--no-pivot")
@@ -228,16 +247,24 @@ func (r *Runc) Start(context context.Context, id string) error {
 // ExecOpts holds optional settings when starting an exec process with runc
 type ExecOpts struct {
 	IO
+	LogFile       string
 	PidFile       string
 	ConsoleSocket ConsoleSocket
-	Detach        bool
-	Started       chan<- int
-	ExtraArgs     []string
+	// PidfdSocket receives a pidfd referencing the exec'd process, which lets
+	// the caller signal or wait on it without racing against pid reuse.
+	// Requires runc v1.2.0 or newer.
+	PidfdSocket PidfdSocket
+	Detach      bool
+	Started     chan<- int
+	ExtraArgs   []string
 }
 
 func (o *ExecOpts) args() (out []string, err error) {
 	if o.ConsoleSocket != nil {
 		out = append(out, "--console-socket", o.ConsoleSocket.Path())
+	}
+	if o.PidfdSocket != nil {
+		out = append(out, "--pidfd-socket", o.PidfdSocket.Path())
 	}
 	if o.Detach {
 		out = append(out, "--detach")
@@ -280,7 +307,7 @@ func (r *Runc) Exec(context context.Context, id string, spec specs.Process, opts
 		return err
 	}
 	args = append(args, oargs...)
-	cmd := r.command(context, append(args, id)...)
+	cmd := r.commandWithCustomLogFile(context, opts.LogFile, append(args, id)...)
 	if opts.IO != nil {
 		opts.Set(cmd)
 	}
@@ -750,7 +777,7 @@ func parseVersion(data []byte) (Version, error) {
 // Availability:
 //
 //   - runc:  supported since runc v1.1.0
-//   - crun:  https://github.com/containers/crun/issues/1177
+//   - crun:  supported since crun v1.8.6
 //   - youki: https://github.com/containers/youki/issues/815
 func (r *Runc) Features(context context.Context) (*features.Features, error) {
 	data, err := r.cmdOutput(r.command(context, "features"), false, nil)
@@ -765,7 +792,7 @@ func (r *Runc) Features(context context.Context) (*features.Features, error) {
 	return &feat, nil
 }
 
-func (r *Runc) args() (out []string) {
+func (r *Runc) args(logFile string) (out []string) {
 	if r.Root != "" {
 		out = append(out, "--root", r.Root)
 	}
@@ -773,7 +800,12 @@ func (r *Runc) args() (out []string) {
 		out = append(out, "--debug")
 	}
 	if r.Log != "" {
-		out = append(out, "--log", r.Log)
+		if logFile == "" {
+			out = append(out, "--log", r.Log)
+		}
+	}
+	if logFile != "" {
+		out = append(out, "--log", logFile)
 	}
 	if r.LogFormat != none {
 		out = append(out, "--log-format", string(r.LogFormat))

--- a/vendor/github.com/containerd/go-runc/socket.go
+++ b/vendor/github.com/containerd/go-runc/socket.go
@@ -1,0 +1,152 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// Socket is a unix socket that accepts a file descriptor sent by runc, such as
+// the pty master for the container's console or the pidfd of the process runc
+// creates.
+type Socket struct {
+	rmdir bool
+	l     *net.UnixListener
+}
+
+// newSocket creates a new unix socket listening at the provided path.
+func newSocket(path string) (*Socket, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	addr, err := net.ResolveUnixAddr("unix", abs)
+	if err != nil {
+		return nil, err
+	}
+	l, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		return nil, err
+	}
+	return &Socket{
+		l: l,
+	}, nil
+}
+
+// newTempSocket creates a unix socket named name inside a new temp directory
+// created with the provided prefix. The directory is removed on Close().
+func newTempSocket(prefix, name string) (*Socket, error) {
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	dir, err := os.MkdirTemp(runtimeDir, prefix)
+	if err != nil {
+		return nil, err
+	}
+	s, err := newSocket(filepath.Join(dir, name))
+	if err != nil {
+		os.RemoveAll(dir)
+		return nil, err
+	}
+	s.rmdir = true
+	if runtimeDir != "" {
+		if err := os.Chmod(s.Path(), 0o755|os.ModeSticky); err != nil {
+			s.Close()
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+// Path returns the path to the unix socket on disk
+func (c *Socket) Path() string {
+	return c.l.Addr().String()
+}
+
+// Close closes the unix socket
+func (c *Socket) Close() error {
+	err := c.l.Close()
+	if c.rmdir {
+		if rerr := os.RemoveAll(filepath.Dir(c.Path())); err == nil {
+			err = rerr
+		}
+	}
+	return err
+}
+
+// receive blocks until the socket receives a file descriptor
+func (c *Socket) receive() (*os.File, error) {
+	conn, err := c.l.Accept()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return nil, fmt.Errorf("received connection which was not a unix socket")
+	}
+	return recvFd(uc)
+}
+
+// recvFd waits for a file descriptor to be sent over the given AF_UNIX
+// socket. The file name of the remote file descriptor will be recreated
+// locally (it is sent as non-auxiliary data in the same payload).
+func recvFd(socket *net.UnixConn) (*os.File, error) {
+	const MaxNameLen = 4096
+	oobSpace := unix.CmsgSpace(4)
+
+	name := make([]byte, MaxNameLen)
+	oob := make([]byte, oobSpace)
+
+	n, oobn, _, _, err := socket.ReadMsgUnix(name, oob)
+	if err != nil {
+		return nil, err
+	}
+
+	if n >= MaxNameLen || oobn != oobSpace {
+		return nil, fmt.Errorf("recvfd: incorrect number of bytes read (n=%d oobn=%d)", n, oobn)
+	}
+
+	// Truncate.
+	name = name[:n]
+	oob = oob[:oobn]
+
+	scms, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return nil, err
+	}
+	if len(scms) != 1 {
+		return nil, fmt.Errorf("recvfd: number of SCMs is not 1: %d", len(scms))
+	}
+	scm := scms[0]
+
+	fds, err := unix.ParseUnixRights(&scm)
+	if err != nil {
+		return nil, err
+	}
+	if len(fds) != 1 {
+		return nil, fmt.Errorf("recvfd: number of fds is not 1: %d", len(fds))
+	}
+	fd := uintptr(fds[0])
+
+	return os.NewFile(fd, string(name)), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -217,8 +217,8 @@ github.com/containerd/go-dmverity/pkg/dm
 github.com/containerd/go-dmverity/pkg/keyring
 github.com/containerd/go-dmverity/pkg/utils
 github.com/containerd/go-dmverity/pkg/verity
-# github.com/containerd/go-runc v1.1.0
-## explicit; go 1.18
+# github.com/containerd/go-runc v1.2.0
+## explicit; go 1.21
 github.com/containerd/go-runc
 # github.com/containerd/imgcrypt/v2 v2.0.3
 ## explicit; go 1.25.0


### PR DESCRIPTION
https://github.com/containerd/go-runc/releases/tag/v1.2.0