### PR TITLE
metadata: bound content Store.Walk/Delete during garbage collection with timeout

### DIFF
--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -37,7 +37,23 @@ import (
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/timeout"
 )
+
+// gcContentTimeoutKey bounds each content Store.Walk and Store.Delete during
+// garbage collection, which holds the content store exclusive lock. An
+// unresponsive content store (e.g. a hung proxy plugin RPC) would otherwise
+// block all content operations (pull, ingest, etc.) forever. On timeout the
+// rest of the pass is abandoned; remaining orphaned blobs are retried on the
+// next GC pass.
+const (
+	gcContentWalkTimeoutKey   = "io.containerd.timeout.gc.content.walk"
+	defaultGCContentWalkTimeout = 30 * time.Minute
+)
+
+func init() {
+	timeout.Set(gcContentWalkTimeoutKey, defaultGCContentWalkTimeout)
+}
 
 type contentStore struct {
 	content.Store
@@ -913,9 +929,11 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 		return 0, err
 	}
 
-	err = cs.Store.Walk(ctx, func(info content.Info) error {
+	walkCtx, cancel := timeout.WithContext(ctx, gcContentWalkTimeoutKey)
+	defer cancel()
+	err = cs.Store.Walk(walkCtx, func(info content.Info) error {
 		if _, ok := contentSeen[info.Digest.String()]; !ok {
-			if err := cs.Store.Delete(ctx, info.Digest); err != nil {
+			if err := cs.Store.Delete(walkCtx, info.Digest); err != nil {
 				return err
 			}
 			log.G(ctx).WithField("digest", info.Digest).Debug("removed content")
@@ -944,13 +962,13 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 		})
 	} else {
 		var statuses []content.Status
-		statuses, err = cs.Store.ListStatuses(ctx)
+		statuses, err = cs.Store.ListStatuses(walkCtx)
 		if err != nil {
 			return 0, err
 		}
 		for _, status := range statuses {
 			if _, ok := ingestSeen[status.Ref]; !ok {
-				if err = cs.Store.Abort(ctx, status.Ref); err != nil {
+				if err = cs.Store.Abort(walkCtx, status.Ref); err != nil {
 					return
 				}
 				log.G(ctx).WithField("ref", status.Ref).Debug("cleanup aborting ingest")

--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -951,9 +951,9 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 		WalkStatusRefs(context.Context, func(string) error) error
 	}
 	if w, ok := cs.Store.(statusWalker); ok {
-		err = w.WalkStatusRefs(ctx, func(ref string) error {
+		err = w.WalkStatusRefs(walkCtx, func(ref string) error {
 			if _, ok := ingestSeen[ref]; !ok {
-				if err := cs.Store.Abort(ctx, ref); err != nil {
+				if err := cs.Store.Abort(walkCtx, ref); err != nil {
 					return err
 				}
 				log.G(ctx).WithField("ref", ref).Debug("cleanup aborting ingest")

--- a/core/metadata/content_test.go
+++ b/core/metadata/content_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/content/testsuite"
@@ -276,7 +277,7 @@ func TestGarbageCollectHangingDelete(t *testing.T) {
 	if _, err := ww.Write(blob); err != nil {
 		t.Fatal(err)
 	}
-	if err := ww.Commit(ctx, 0, dgst, ""); err != nil {
+	if err := ww.Commit(ctx, 0, dgst); err != nil {
 		t.Fatal(err)
 	}
 

--- a/core/metadata/content_test.go
+++ b/core/metadata/content_test.go
@@ -296,7 +296,8 @@ func TestGarbageCollectHangingDelete(t *testing.T) {
 		}
 	}()
 
-	_, err = db.GarbageCollect(ctx)
+	cs := db.ContentStore().(*contentStore)
+	_, err = cs.garbageCollect(ctx)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected the bounded Delete to fail with DeadlineExceeded, got %v", err)
 	}

--- a/core/metadata/content_test.go
+++ b/core/metadata/content_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/containerd/containerd/v2/pkg/timeout"
 )
 
 func createContentStore(ctx context.Context, root string, opts ...DBOpt) (context.Context, content.Store, func() error, error) {
@@ -233,4 +235,71 @@ func checkIngestLeased(ctx context.Context, db *DB, ref string) error {
 
 		return nil
 	})
+}
+
+type hangingDeleteContentStore struct {
+	content.Store
+	deletes atomic.Int32
+}
+
+func (s *hangingDeleteContentStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	s.deletes.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// TestGarbageCollectHangingDelete verifies that a content store whose Delete
+// never returns cannot hold the content store lock forever: the GC pass is
+// bounded by io.containerd.timeout.gc.content.walk and returns
+// DeadlineExceeded instead of blocking all content operations.
+func TestGarbageCollectHangingDelete(t *testing.T) {
+	timeout.Set(gcContentWalkTimeoutKey, 100*time.Millisecond)
+	defer timeout.Set(gcContentWalkTimeoutKey, defaultGCContentWalkTimeout)
+
+	ctx := t.Context()
+
+	dirname := t.TempDir()
+	base, err := local.NewStore(filepath.Join(dirname, "content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write an orphan blob that exists in the backing store but has no metadata
+	// reference, so GC tries to delete it.
+	blob := []byte("orphaned-and-unreferenced")
+	dgst := digest.FromBytes(blob)
+	ww, err := base.Writer(ctx, content.WithRef("orphan"),
+		content.WithDescriptor(ocispec.Descriptor{Size: int64(len(blob)), Digest: dgst}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ww.Write(blob); err != nil {
+		t.Fatal(err)
+	}
+	if err := ww.Commit(ctx, 0, dgst, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	st := &hangingDeleteContentStore{Store: base}
+	bdb, err := bolt.Open(filepath.Join(dirname, "metadata.db"), 0644, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := NewDB(bdb, st, nil)
+	if err := db.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	_, err = db.GarbageCollect(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected the bounded Delete to fail with DeadlineExceeded, got %v", err)
+	}
+	if n := st.deletes.Load(); n != 1 {
+		t.Fatalf("expected 1 delete attempt before abandoning the pass, got %d", n)
+	}
 }


### PR DESCRIPTION
Fixes #14010

**Problem**

During content GC, `cleanupContent` calls `cs.Store.Walk` and `cs.Store.Delete` while holding the content store exclusive lock (`cs.l.Lock`), with no deadline (it strips the caller's cancellation via `context.WithoutCancel`). If the content store proxy plugin never answers, the lock is held forever. Every content operation on the node (pull, ingest, etc.) queues behind it, including the kubelet's image pull path.

**Fix**

Bound each GC-path call with a timeout key (`io.containerd.timeout.gc.content.walk`, default 30m), following the same pattern as #13799 for snapshotter Remove.

On timeout the rest of the pass is abandoned; orphaned blobs are retried on the next GC pass.

**Changes**

- `core/metadata/content.go`: add `gcContentWalkTimeoutKey`, register in `init()`, wrap the Walk/Delete/Abort/ListStatuses calls with `timeout.WithContext()`
- `core/metadata/content_test.go`: add `TestGarbageCollectHangingDelete` verifying that a hanging Delete times out instead of blocking forever

**Not in this PR**

Snapshot GC `Walk` (`snapshot.go:953`) runs under the same lock and is also unbounded. Left out because #13799 (which fixes snapshot GC `Remove`) is still in flight and overlapping changes would conflict.