### PR TITLE
snapshots/erofs: advertise the erofs OS feature from the snapshotter plugin

### DIFF
--- a/plugins/snapshots/erofs/plugin/plugin.go
+++ b/plugins/snapshots/erofs/plugin/plugin.go
@@ -75,7 +75,15 @@ func init() {
 		ID:     "erofs",
 		Config: &Config{},
 		InitFn: func(ic *plugin.InitContext) (any, error) {
-			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
+			p := platforms.DefaultSpec()
+			ic.Meta.Platforms = append(ic.Meta.Platforms, p)
+			// Also advertise the "erofs" OS feature platform (see the EROFS
+			// image layer format specification,
+			// https://github.com/erofs/erofs-image-spec) so that clients
+			// pulling with --snapshotter erofs prefer the native EROFS image
+			// variant when one is available in a multi-platform index.
+			p.OSFeatures = []string{"erofs"}
+			ic.Meta.Platforms = append(ic.Meta.Platforms, p)
 
 			config, ok := ic.Config.(*Config)
 			if !ok {

--- a/plugins/snapshots/erofs/plugin/plugin.go
+++ b/plugins/snapshots/erofs/plugin/plugin.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/snapshots/erofs"
 	"github.com/docker/go-units"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (
@@ -69,21 +70,25 @@ type Config struct {
 	LayerContentCaches []string `toml:"layer_content_caches"`
 }
 
+// snapshotterPlatforms returns the platforms this snapshotter advertises: the
+// default platform, plus the "erofs" OS feature platform (see the EROFS image
+// layer format specification, https://github.com/erofs/erofs-image-spec) so
+// that clients pulling with --snapshotter erofs prefer the native EROFS image
+// variant when one is available in a multi-platform index.
+func snapshotterPlatforms() []ocispec.Platform {
+	erofsPlatform := platforms.DefaultSpec()
+	result := []ocispec.Platform{erofsPlatform}
+	erofsPlatform.OSFeatures = []string{"erofs"}
+	return append(result, erofsPlatform)
+}
+
 func init() {
 	registry.Register(&plugin.Registration{
 		Type:   plugins.SnapshotPlugin,
 		ID:     "erofs",
 		Config: &Config{},
 		InitFn: func(ic *plugin.InitContext) (any, error) {
-			p := platforms.DefaultSpec()
-			ic.Meta.Platforms = append(ic.Meta.Platforms, p)
-			// Also advertise the "erofs" OS feature platform (see the EROFS
-			// image layer format specification,
-			// https://github.com/erofs/erofs-image-spec) so that clients
-			// pulling with --snapshotter erofs prefer the native EROFS image
-			// variant when one is available in a multi-platform index.
-			p.OSFeatures = []string{"erofs"}
-			ic.Meta.Platforms = append(ic.Meta.Platforms, p)
+			ic.Meta.Platforms = append(ic.Meta.Platforms, snapshotterPlatforms()...)
 
 			config, ok := ic.Config.(*Config)
 			if !ok {

--- a/plugins/snapshots/erofs/plugin/plugin_test.go
+++ b/plugins/snapshots/erofs/plugin/plugin_test.go
@@ -1,0 +1,46 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/containerd/platforms"
+)
+
+// The erofs converter stamps os.features=["erofs"] into the image configs it
+// produces, and the client-side snapshotter support check matches that
+// platform against the platforms the snapshotter plugin advertises
+// (platforms.Any over the introspected plugin platforms, see
+// Client.GetSnapshotterSupportedPlatforms). The advertised platforms must
+// therefore match both plain default-platform images and converter-stamped
+// native erofs images.
+func TestSnapshotterPlatforms(t *testing.T) {
+	matcher := platforms.Any(snapshotterPlatforms()...)
+
+	if p := platforms.DefaultSpec(); !matcher.Match(p) {
+		t.Errorf("advertised platforms do not match the default platform %s", platforms.FormatAll(p))
+	}
+
+	// EROFS identifies the image layer package format, independently of the
+	// operating system represented by the image.
+	stamped := platforms.DefaultSpec()
+	stamped.OSFeatures = []string{"erofs"}
+	if !matcher.Match(stamped) {
+		t.Errorf("advertised platforms do not match the erofs converter's stamped platform %s", platforms.FormatAll(stamped))
+	}
+}


### PR DESCRIPTION
## Summary

The erofs converter stamps `os.features=["erofs"]` into the image configs it produces, but the erofs snapshotter plugin never advertises a platform carrying that feature. The client-side snapshotter support check (`checkSnapshotterSupport` in `client/image.go`, reached from `image.Unpack`) matches the config platform against the platforms the snapshotter plugin declares, so unpacking through the Go client is refused for exactly the images the converter produces:

```
snapshotter erofs does not support platform {arm64 linux  [erofs] } for image sha256:...
```

Note the check runs unconditionally whenever the config carries `os.features`, regardless of `CheckPlatformSupported`. The current workaround is to strip `os.features` from the config before publishing native erofs images, which discards the marker that lets the transfer service select the erofs unpack configuration in the first place.

The fix is to advertise a second platform with `OSFeatures: ["erofs"]` from the snapshotter plugin — the same advertisement the erofs differ plugin (`plugins/diff/erofs/plugin/plugin.go`) and the transfer service's default unpack configuration (`plugins/transfer/plugin_defaults_linux.go`) already make.

## Commits

Per @hsiangkao's [review](https://github.com/containerd/containerd/pull/14012#issuecomment-5386632201), this carries @dmcgowan's existing fix rather than a parallel implementation of it, split so the fix itself is a self-contained backport candidate for `release/2.3`:

1. **`erofs: advertise the erofs OS feature platform from the snapshotter`** — @dmcgowan's [`954bd7d`](https://github.com/dmcgowan/containerd/commit/954bd7dde0465dae2915dd107776a934392dd5e9), carried verbatim. This is the whole fix and stands alone.

2. **`snapshots/erofs: pin the erofs OS feature platform to Linux, with a test`** — a follow-up, and a no-op on Linux. The advertisement in (1) builds the feature-bearing platform from `platforms.DefaultSpec()`, so on a non-Linux host the snapshotter advertises `<host>(+erofs)` — a platform it cannot serve, since the non-Linux snapshotter returns `ErrNotImplemented` for conversion (`plugins/snapshots/erofs/erofs_other.go`) and the differ scopes both of its advertised platforms to `linux`. Advertising it only lets `checkSnapshotterSupport` accept a config that then fails during unpack. This pins the feature-bearing platform to Linux the way the differ does, leaves the plain default platform untouched, and moves the advertised set into `snapshotterPlatforms()` so a test can assert that a matcher built the way the client builds it (`platforms.Any` over the introspected plugin platforms) matches both the default platform and the converter-stamped platform.

Drop (2) if you would rather keep the fix byte-identical to Derek's; it changes nothing on Linux.

## Reproduction

Verified stock vs. patched daemon (repro run at `fd399bd7`, since rebased), with the diff service configured with `default = ["erofs", "walking"]`:

```console
$ ctr image pull docker.io/library/busybox:latest
$ ctr image convert --erofs raw docker.io/library/busybox:latest docker.io/library/busybox:erofs

# stock daemon:
$ ctr image mount --snapshotter erofs --platform 'linux(+erofs)/arm64' docker.io/library/busybox:erofs /tmp/m
ctr: error unpacking image: snapshotter erofs does not support platform {arm64 linux  [erofs] } for image sha256:e4794331...

# patched daemon: unpack succeeds and the image mounts
$ ctr image mount --snapshotter erofs --platform 'linux(+erofs)/arm64' docker.io/library/busybox:erofs /tmp/m
sha256:3fa90a69...
$ ls /tmp/m
bin  dev  etc  home  lib  lib64  root  tmp  usr  var
```

(The explicit `--platform 'linux(+erofs)/arm64'` is needed because the default platform matcher only matches a manifest whose `os.features` are a subset of the matcher's — a stamped manifest is otherwise not selected at all.)

Also carried in production on top of v2.3.4: native erofs images produced by the converter unpack through the erofs snapshotter without stripping `os.features`.

---

Commit (2) and the test were developed with AI assistance (Claude); they have been reviewed, tested, and are submitted under the DCO by the human author. Commit (1) is @dmcgowan's work, carried unmodified.
