### PR TITLE
erofs: hardlink uncompressed native layers from the content store

### DIFF
--- a/docs/snapshotters/erofs.md
+++ b/docs/snapshotters/erofs.md
@@ -166,6 +166,22 @@ improved performance, as shown below:
     mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
 ```
 
+For images with native (uncompressed) EROFS layers, the differ can hardlink
+the layer blob from the content store into the snapshot instead of copying
+it, which makes applying such a layer a metadata operation:
+
+``` toml
+  [plugins."io.containerd.differ.v1.erofs"]
+    link_blobs = true
+```
+
+Content blobs are immutable and content garbage collection unlinks rather
+than modifies them, so the extra link is safe; whenever linking is not
+possible (for example, the content store lives on a different filesystem),
+the differ falls back to copying. Layers are given back their own inode
+before the snapshotter seals them with `enable_fsverity` or `set_immutable`,
+and layers formatted with the differ's `enable_dmverity` are never linked.
+
 ### Running a container
 
 To run a container using the EROFS snapshotter, it needs to be explicitly

--- a/plugins/content/local/readerat.go
+++ b/plugins/content/local/readerat.go
@@ -70,3 +70,10 @@ func (ra sizeReaderAt) Close() error {
 func (ra sizeReaderAt) Reader() io.Reader {
 	return io.LimitReader(ra.fp, ra.size)
 }
+
+// Name returns the path of the backing file. Blobs are immutable, so
+// consumers may use the path for same-filesystem optimizations such as
+// hardlinking instead of copying.
+func (ra sizeReaderAt) Name() string {
+	return ra.fp.Name()
+}

--- a/plugins/content/local/readerat_test.go
+++ b/plugins/content/local/readerat_test.go
@@ -1,0 +1,65 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+)
+
+// The returned ReaderAt exposes the backing file's path, which consumers use
+// for same-filesystem optimizations such as hardlinking (blobs are
+// immutable). The erofs differ's link_blobs option relies on this.
+func TestReaderAtName(t *testing.T) {
+	ctx := context.Background()
+	cs, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blob := []byte("some blob")
+	dgst := digest.FromBytes(blob)
+	desc := ocispec.Descriptor{Size: int64(len(blob)), Digest: dgst}
+	if err := content.WriteBlob(ctx, cs, dgst.String(), bytes.NewReader(blob), desc); err != nil {
+		t.Fatal(err)
+	}
+
+	ra, err := cs.ReaderAt(ctx, desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ra.Close()
+
+	named, ok := ra.(interface{ Name() string })
+	if !ok {
+		t.Fatal("ReaderAt does not expose the backing file path")
+	}
+	got, err := os.ReadFile(named.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, blob) {
+		t.Fatal("backing file content differs from the blob")
+	}
+}

--- a/plugins/diff/erofs/differ.go
+++ b/plugins/diff/erofs/differ.go
@@ -54,6 +54,15 @@ type erofsDiff struct {
 	enableTarIndex bool
 	// enableDmverity enables formatting layers with dm-verity after creation
 	enableDmverity bool
+	// linkBlobs hardlinks uncompressed native EROFS layers from the content
+	// store into the snapshot instead of copying them, when the content
+	// store exposes the blob's backing file. Content blobs are immutable
+	// and content garbage collection unlinks rather than truncates, so an
+	// extra link is safe; any link failure falls back to the copy path.
+	// This removes the only data-sized operation from the chain-serialized
+	// apply step: even on reflink filesystems, copying a freshly-ingested
+	// blob forces writeback of its dirty extents.
+	linkBlobs bool
 }
 
 // DifferOpt is an option for configuring the erofs differ
@@ -77,6 +86,15 @@ func WithTarIndexMode() DifferOpt {
 func WithDmverity() DifferOpt {
 	return func(d *erofsDiff) {
 		d.enableDmverity = true
+	}
+}
+
+// WithBlobLinks hardlinks uncompressed native EROFS layers from the content
+// store instead of copying them, whenever the content store exposes the
+// blob's backing file on the same filesystem.
+func WithBlobLinks() DifferOpt {
+	return func(d *erofsDiff) {
+		d.linkBlobs = true
 	}
 }
 
@@ -159,6 +177,19 @@ func (s erofsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []
 	layerBlobPath := path.Join(layer, "layer.erofs")
 	// Allow copy file range when there is an uncompressed native EROFS layer
 	if fastcopy {
+		// Never share the inode when this differ formats layers with
+		// dm-verity: verity data is appended to the layer blob, which must
+		// not reach the content store's copy.
+		if s.linkBlobs && !s.enableDmverity {
+			if src, ok := ra.(interface{ Name() string }); ok {
+				if lerr := os.Link(src.Name(), layerBlobPath); lerr == nil {
+					log.G(ctx).WithField("path", layerBlobPath).Debug("Applied layer by hardlinking uncompressed EROFS blob")
+					return desc, nil
+				} else {
+					log.G(ctx).WithError(lerr).WithField("src", src.Name()).Debug("hardlink of EROFS blob failed, falling back to copy")
+				}
+			}
+		}
 		f, err := os.Create(layerBlobPath)
 		if err != nil {
 			return emptyDesc, err

--- a/plugins/diff/erofs/differ_test.go
+++ b/plugins/diff/erofs/differ_test.go
@@ -1,0 +1,128 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofs
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/plugins/content/local"
+)
+
+// applyNativeLayer runs Apply for an uncompressed native EROFS layer blob
+// (the fastcopy path) and returns the store blob path and the applied layer
+// path.
+func applyNativeLayer(t *testing.T, opts ...DifferOpt) (blobPath, layerBlobPath string) {
+	t.Helper()
+	ctx := context.Background()
+
+	store, err := local.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blob := []byte("not a real erofs image, fastcopy does not parse it")
+	dgst := digest.FromBytes(blob)
+	if err := content.WriteBlob(ctx, store, dgst.String(), bytes.NewReader(blob),
+		ocispec.Descriptor{Size: int64(len(blob)), Digest: dgst}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Recover the backing file path the same way Apply does.
+	ra, err := store.ReaderAt(ctx, ocispec.Descriptor{Digest: dgst, Size: int64(len(blob))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ra.Close()
+	named, ok := ra.(interface{ Name() string })
+	if !ok {
+		t.Fatal("local store ReaderAt does not expose the backing file path")
+	}
+	blobPath = named.Name()
+
+	layerDir := t.TempDir()
+	// Mark the directory as an erofs snapshotter layer, as MountsToLayer requires.
+	if err := os.WriteFile(filepath.Join(layerDir, ".erofslayer"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	desc := ocispec.Descriptor{
+		MediaType: images.MediaTypeErofsLayer,
+		Digest:    dgst,
+		Size:      int64(len(blob)),
+	}
+	mounts := []mount.Mount{{Type: "bind", Source: filepath.Join(layerDir, "fs")}}
+
+	d := NewErofsDiffer(store, opts...)
+	if _, err := d.Apply(ctx, desc, mounts); err != nil {
+		t.Fatal(err)
+	}
+
+	layerBlobPath = filepath.Join(layerDir, "layer.erofs")
+	got, err := os.ReadFile(layerBlobPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, blob) {
+		t.Fatal("applied layer content differs from the blob")
+	}
+	return blobPath, layerBlobPath
+}
+
+func sameFile(t *testing.T, a, b string) bool {
+	t.Helper()
+	fa, err := os.Stat(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fb, err := os.Stat(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return os.SameFile(fa, fb)
+}
+
+func TestApplyLinkBlobs(t *testing.T) {
+	blobPath, layerBlobPath := applyNativeLayer(t, WithBlobLinks())
+	if !sameFile(t, blobPath, layerBlobPath) {
+		t.Error("expected the applied layer to be hardlinked from the content store blob")
+	}
+}
+
+func TestApplyLinkBlobsDisabled(t *testing.T) {
+	blobPath, layerBlobPath := applyNativeLayer(t)
+	if sameFile(t, blobPath, layerBlobPath) {
+		t.Error("expected the applied layer to be a copy, not a hardlink")
+	}
+}
+
+// Layers formatted with dm-verity are appended to after apply; the blob's
+// inode must never be shared in that configuration.
+func TestApplyLinkBlobsDmverityNeverLinks(t *testing.T) {
+	blobPath, layerBlobPath := applyNativeLayer(t, WithBlobLinks(), WithDmverity())
+	if sameFile(t, blobPath, layerBlobPath) {
+		t.Error("expected the applied layer to be a copy when dm-verity is enabled")
+	}
+}

--- a/plugins/diff/erofs/plugin/plugin.go
+++ b/plugins/diff/erofs/plugin/plugin.go
@@ -42,6 +42,14 @@ type Config struct {
 	// EnableDmverity enables dm-verity formatting for EROFS layers
 	// Linux only
 	EnableDmverity bool `toml:"enable_dmverity"`
+
+	// LinkBlobs hardlinks uncompressed native EROFS layers from the content
+	// store into snapshots instead of copying them, making the apply step a
+	// metadata operation. Applies are serialized along the snapshot parent
+	// chain, so this directly shortens image unpack. Falls back to copying
+	// whenever linking is not possible (e.g. the content store is on a
+	// different filesystem).
+	LinkBlobs bool `toml:"link_blobs"`
 }
 
 func init() {
@@ -94,6 +102,10 @@ func init() {
 					return nil, fmt.Errorf("dm-verity is not supported on this system (dm_verity module not loaded): %w", plugin.ErrSkipPlugin)
 				}
 				opts = append(opts, erofs.WithDmverity())
+			}
+
+			if config.LinkBlobs {
+				opts = append(opts, erofs.WithBlobLinks())
 			}
 
 			return erofs.NewErofsDiffer(cs, opts...), nil

--- a/plugins/snapshots/erofs/erofs.go
+++ b/plugins/snapshots/erofs/erofs.go
@@ -822,6 +822,16 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 		}
 	}
 
+	// A layer blob hardlinked from the content store (see the differ's
+	// link_blobs option) shares its inode with the blob; sealing it below
+	// would also seal the content store's copy (IMMUTABLE_FL even makes
+	// content garbage collection fail). Give the layer its own inode first.
+	if s.enableFsverity || s.setImmutable {
+		if err := unshareIfLinked(layerBlob); err != nil {
+			return fmt.Errorf("failed to unshare hardlinked layer blob: %w", err)
+		}
+	}
+
 	// Enable fsverity on the EROFS layer if configured
 	if s.enableFsverity {
 		if err := fsverity.Enable(layerBlob); err != nil {

--- a/plugins/snapshots/erofs/erofs_linux.go
+++ b/plugins/snapshots/erofs/erofs_linux.go
@@ -62,6 +62,25 @@ func checkCompatibility(root string) error {
 	return nil
 }
 
+// unshareIfLinked replaces a multiply-linked file with a private copy, so
+// that sealing it (fsverity, IMMUTABLE_FL) cannot affect the other links'
+// owner: the content store, when the differ hardlinks blobs.
+func unshareIfLinked(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); !ok || st.Nlink == 1 {
+		return nil
+	}
+	tmp := path + ".unshare"
+	if err := fs.CopyFile(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
 func setImmutable(path string, enable bool) error {
 	//nolint:revive,staticcheck	// silence "don't use ALL_CAPS in Go names; use CamelCase"
 	const (

--- a/plugins/snapshots/erofs/erofs_other.go
+++ b/plugins/snapshots/erofs/erofs_other.go
@@ -37,6 +37,10 @@ func setImmutable(path string, enable bool) error {
 	return errdefs.ErrNotImplemented
 }
 
+func unshareIfLinked(path string) error {
+	return nil
+}
+
 func cleanupUpper(upper string) error {
 	return nil
 }

--- a/plugins/snapshots/erofs/unshare_linux_test.go
+++ b/plugins/snapshots/erofs/unshare_linux_test.go
@@ -1,0 +1,89 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofs
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func nlink(t *testing.T, path string) uint64 {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return uint64(fi.Sys().(*syscall.Stat_t).Nlink)
+}
+
+func TestUnshareIfLinked(t *testing.T) {
+	dir := t.TempDir()
+	blob := filepath.Join(dir, "blob")
+	layer := filepath.Join(dir, "layer.erofs")
+	data := []byte("layer data")
+	if err := os.WriteFile(blob, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(blob, layer); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := unshareIfLinked(layer); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := nlink(t, blob); n != 1 {
+		t.Errorf("content blob still shares its inode (nlink=%d)", n)
+	}
+	if n := nlink(t, layer); n != 1 {
+		t.Errorf("layer still shares its inode (nlink=%d)", n)
+	}
+	got, err := os.ReadFile(layer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Error("layer content changed by unsharing")
+	}
+}
+
+func TestUnshareIfLinkedSingleLink(t *testing.T) {
+	dir := t.TempDir()
+	layer := filepath.Join(dir, "layer.erofs")
+	if err := os.WriteFile(layer, []byte("layer data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(layer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := unshareIfLinked(layer); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := os.Stat(layer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Error("single-link file was needlessly replaced")
+	}
+}


### PR DESCRIPTION
## Summary

Applying an uncompressed native EROFS layer copies the blob from the content store into the snapshot. That copy is the only data-sized operation left in the apply step, and applies are serialized along the snapshot parent chain, so it directly lengthens image unpack. On a 594MB layer we measured the copy at **5.2s**; hardlinking the same layer applies in **80µs**. Reflink filesystems don't escape this either: copying a freshly-ingested blob forces writeback of its dirty extents.

This adds a `link_blobs` option to the EROFS differ:

``` toml
  [plugins."io.containerd.differ.v1.erofs"]
    link_blobs = true
```

Design:

- The local content store's `ReaderAt` now exposes the backing file's path via an optional `Name()` method (mirroring the existing optional `Reader()` interface used by `content.NewReader`). Blobs are immutable, so handing out the path for same-filesystem optimizations is safe.
- The differ sniffs that interface and hardlinks the blob into the snapshot, falling back to the copy whenever linking fails or the reader exposes no path (content store on another filesystem, non-local store). No path derivation or layout coupling anywhere.

Sharing the inode is safe because content blobs are immutable and content GC unlinks rather than modifies them. Two guards keep it that way:

- Layers formatted with the differ's dm-verity support are **never linked** — verity data is appended to the layer blob and must not reach the content store's copy.
- The snapshotter **unshares** a multiply-linked layer blob (copy + rename) before sealing it with fsverity or `IMMUTABLE_FL`, so the seal cannot reach the content store's inode (`IMMUTABLE_FL` on a shared inode would even make content GC's deletion fail). This lives in the snapshotter because the two options belong to different plugins and cannot be cross-validated at init time.

Related to (and compatible with) `layer_content_caches`: the cache serves pre-converted layers on `Prepare` from operator-provided directories via symlinks; `link_blobs` removes the copy from the differ's `Apply` of a blob already in the content store.

## Testing

- Unit tests: differ links/copies/never-links-under-dmverity (rootless, no kernel EROFS needed), snapshotter unshare helper, content store path exposure.
- End-to-end on this tree (privileged container, arm64): `ctr image convert --erofs raw` + unpack through the erofs snapshotter:
  - `link_blobs = true`: the applied `layer.erofs` has nlink=2 and shares its inode with the content store blob; the image mounts and the rootfs is intact.
  - `link_blobs = true` + `set_immutable = true`: the applied layer has nlink=1 (unshared at commit), the immutable flag is on the layer's private inode only, every content blob remains nlink=1 and unsealed.
  - Content deletion: `ctr image rm` + `ctr content rm` of the linked blob — the blob file is unlinked by GC, the layer's nlink drops to 1, and the layer remains fully readable and mountable. (The local store also keeps blobs at mode 0444, which the linked layer inherits — nothing on the snapshot side can open it for writing.)
- Carried in production on top of v2.3.4 (an earlier shape of the same differ optimization, hardlinking from the content store's blob directory).

---

This patch was developed with AI assistance (Claude); it has been reviewed, tested, and is submitted under the DCO by the human author.
