### PR TITLE
metadata: bound content store calls during garbage collection

### DIFF
--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -37,7 +37,22 @@ import (
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/timeout"
 )
+
+// gcContentCleanupTimeoutKey bounds the whole content cleanup pass during
+// garbage collection, which holds the content store write lock: an
+// unresponsive backing store (e.g. a hung proxy plugin RPC) would otherwise
+// block all content operations forever. On timeout the rest of the pass is
+// abandoned; remaining blobs stay orphaned and are retried on the next GC pass.
+const (
+	gcContentCleanupTimeoutKey     = "io.containerd.timeout.gc.content.cleanup"
+	defaultGCContentCleanupTimeout = 30 * time.Minute
+)
+
+func init() {
+	timeout.Set(gcContentCleanupTimeoutKey, defaultGCContentCleanupTimeout)
+}
 
 type contentStore struct {
 	content.Store
@@ -912,6 +927,9 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 	}); err != nil {
 		return 0, err
 	}
+
+	ctx, cancel := timeout.WithContext(ctx, gcContentCleanupTimeoutKey)
+	defer cancel()
 
 	err = cs.Store.Walk(ctx, func(info content.Info) error {
 		if _, ok := contentSeen[info.Digest.String()]; !ok {

--- a/core/metadata/content_test.go
+++ b/core/metadata/content_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/content/testsuite"
@@ -34,6 +35,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -232,5 +234,37 @@ func checkIngestLeased(ctx context.Context, db *DB, ref string) error {
 		}
 
 		return nil
+	})
+}
+
+type hangingDeleteStore struct {
+	content.Store
+	deletes atomic.Int32
+}
+
+func (s *hangingDeleteStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	s.deletes.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestContentGarbageCollectHangingDelete(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, bdb := testEnv(t)
+
+		backend, err := local.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		cs := &hangingDeleteStore{Store: backend}
+		db := NewDB(bdb, cs, nil)
+		require.NoError(t, db.Init(ctx))
+
+		blob := []byte("unreferenced")
+		desc := ocispec.Descriptor{Digest: digest.FromBytes(blob), Size: int64(len(blob))}
+		require.NoError(t, content.WriteBlob(ctx, backend, "unreferenced", bytes.NewReader(blob), desc))
+
+		_, err = db.cs.garbageCollect(ctx)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Equal(t, int32(1), cs.deletes.Load())
 	})
 }

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -178,6 +178,7 @@ documentation.
   "io.containerd.timeout.shim.cleanup" = "5s"
   "io.containerd.timeout.shim.load" = "5s"
   "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.gc.content.cleanup" = "30m"
   "io.containerd.timeout.gc.snapshotter.remove" = "30m"
   "io.containerd.timeout.task.state" = "2s" -->
 


### PR DESCRIPTION
`contentStore.garbageCollect` holds `cs.l` while calling the backing content
store. Since `DB.cleanupContent` strips cancellation, a stalled proxy can hold
the lock forever and block every content operation.

Apply a 30-minute timeout to the backing store calls. The timeout covers the
whole pass rather than each deletion, so the lock hold has one upper bound. The
next GC pass retries any unfinished cleanup.

Fixes: #14010
