### PR TITLE
resolver: retry on connection reset and broken pipe

### DIFF
--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -29,6 +29,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/containerd/errdefs"
@@ -855,6 +856,9 @@ func isTransientTransportErr(err error) bool {
 		return true
 	}
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
 		return true
 	}
 	return false

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -28,8 +28,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -781,6 +783,10 @@ func TestIsTransientTransportErr(t *testing.T) {
 		{name: "io.EOF", err: io.EOF, want: true},
 		{name: "io.ErrUnexpectedEOF", err: io.ErrUnexpectedEOF, want: true},
 		{name: "wrapped io.EOF", err: fmt.Errorf("wrapped: %w", io.EOF), want: true},
+		{name: "connection reset by peer", err: &net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}, want: true},
+		{name: "wrapped connection reset by peer", err: fmt.Errorf("wrapped: %w", syscall.ECONNRESET), want: true},
+		{name: "broken pipe", err: &net.OpError{Op: "write", Net: "tcp", Err: os.NewSyscallError("write", syscall.EPIPE)}, want: true},
+		{name: "connection refused not transient", err: &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}, want: false},
 		{name: "generic error not transient", err: errors.New("nope"), want: false},
 		{name: "context canceled not transient", err: context.Canceled, want: false},
 		{name: "context deadline exceeded not transient", err: context.DeadlineExceeded, want: false},
@@ -857,6 +863,24 @@ func TestDoWithTransportRetries(t *testing.T) {
 		var calls int
 		attempts := 3
 		results := []error{fakeTimeoutErr{}, nil}
+		r := newTransportRetryRequest(newSequenceRT(t, results, &calls))
+		resp, err := r.doWithTransportRetries(context.Background(), &attempts, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		resp.Body.Close()
+		if calls != 2 {
+			t.Errorf("expected 2 calls, got %d", calls)
+		}
+		if attempts != 1 {
+			t.Errorf("expected 2 attempts consumed (1 remaining), got %d", attempts)
+		}
+	})
+
+	t.Run("retries connection reset then succeeds", func(t *testing.T) {
+		var calls int
+		attempts := 3
+		results := []error{&net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}, nil}
 		r := newTransportRetryRequest(newSequenceRT(t, results, &calls))
 		resp, err := r.doWithTransportRetries(context.Background(), &attempts, true)
 		if err != nil {


### PR DESCRIPTION
`isTransientTransportErr` treats a timeout or an EOF as transient, but not a connection reset. A registry that resets the connection therefore fails the request on its first attempt with no retry, even though a reset is the same kind of transport-level failure #13323 set out to absorb.

This surfaced as a hard build failure in BuildKit's registry cache exporter — a manifest `PUT` reset by the registry after ~124s, while the twelve identical `PUT`s to the same registry in the preceding six minutes each completed in 0.2–0.4s:

```
error writing manifest blob: failed commit on ref "sha256:4761b3f6…":
failed to do request: Put "https://<registry>/v2/<repo>/manifests/<tag>":
read tcp <local>-><registry>:443: read: connection reset by peer
```

**Why retrying these is safe.** `pusher.push` sets `req.body` to a function returning a fresh `io.Pipe` per call, so a retried attempt re-derives its body; once bytes have already flowed, `replacePipe` returns `content.ErrReset` and `content.Copy` rewinds the source before writing again. That is the same mechanism the existing timeout and EOF cases already depend on.

The layer above disagrees with us today: BuildKit's `retryhandler`, which wraps some of these same registry operations, lists both errors as retryable — [`util/resolver/retryhandler/retry.go`](https://github.com/moby/buildkit/blob/master/util/resolver/retryhandler/retry.go). So a cache *layer* write survives a reset while the *manifest* write beside it does not, purely because of which retry it lands on.

`ECONNREFUSED` is deliberately left non-transient, with a test case pinning it, so this does not widen the classifier to every `syscall.Errno`.

**Tests.** Extended the existing `TestIsTransientTransportErr` table with the real error shape (`net.OpError` wrapping `os.SyscallError`), plus a `doWithTransportRetries` subtest asserting the request is retried and then succeeds. Verified by reverting only `resolver.go`: the four new cases fail, and the `ECONNREFUSED` case still passes. `gofmt -s`, `go vet`, and `go test -race` on the package are clean, and the package builds for linux, windows and darwin.

For context, I first proposed this a layer up in BuildKit (moby/buildkit#7001) and the guidance there was that the retry belongs at the HTTP request level — which is what this does.
