### PR TITLE
metadata: bound each content GC pass with a single timeout

### DIFF
--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -37,7 +37,25 @@ import (
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/timeout"
 )
+
+// gcContentTimeoutKey bounds one full content garbage collection pass: the
+// backend Walk/Delete sweep and the ingest Abort sweep, all under the content
+// store write lock. The deadline starts before lock acquisition; the wait
+// itself is not interruptible, but its duration counts against the budget of
+// the pass. An unresponsive content store (e.g. a hung proxy plugin RPC)
+// would otherwise hold the lock and block all content operations forever. On
+// timeout the pass is abandoned; remaining blobs and ingests stay orphaned
+// and are retried on the next GC pass.
+const (
+	gcContentTimeoutKey     = "io.containerd.timeout.gc.content"
+	defaultGCContentTimeout = 30 * time.Minute
+)
+
+func init() {
+	timeout.Set(gcContentTimeoutKey, defaultGCContentTimeout)
+}
 
 type contentStore struct {
 	content.Store
@@ -843,6 +861,9 @@ func writeExpireAt(expire time.Time, bkt *bolt.Bucket) error {
 
 // garbageCollect removes all contents that are no longer used.
 func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, err error) {
+	gcCtx, cancel := timeout.WithContext(ctx, gcContentTimeoutKey)
+	defer cancel()
+
 	cs.l.Lock()
 	t1 := time.Now()
 	defer func() {
@@ -913,9 +934,9 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 		return 0, err
 	}
 
-	err = cs.Store.Walk(ctx, func(info content.Info) error {
+	err = cs.Store.Walk(gcCtx, func(info content.Info) error {
 		if _, ok := contentSeen[info.Digest.String()]; !ok {
-			if err := cs.Store.Delete(ctx, info.Digest); err != nil {
+			if err := cs.Store.Delete(gcCtx, info.Digest); err != nil {
 				return err
 			}
 			log.G(ctx).WithField("digest", info.Digest).Debug("removed content")
@@ -933,9 +954,9 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 		WalkStatusRefs(context.Context, func(string) error) error
 	}
 	if w, ok := cs.Store.(statusWalker); ok {
-		err = w.WalkStatusRefs(ctx, func(ref string) error {
+		err = w.WalkStatusRefs(gcCtx, func(ref string) error {
 			if _, ok := ingestSeen[ref]; !ok {
-				if err := cs.Store.Abort(ctx, ref); err != nil {
+				if err := cs.Store.Abort(gcCtx, ref); err != nil {
 					return err
 				}
 				log.G(ctx).WithField("ref", ref).Debug("cleanup aborting ingest")
@@ -944,13 +965,13 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 		})
 	} else {
 		var statuses []content.Status
-		statuses, err = cs.Store.ListStatuses(ctx)
+		statuses, err = cs.Store.ListStatuses(gcCtx)
 		if err != nil {
 			return 0, err
 		}
 		for _, status := range statuses {
 			if _, ok := ingestSeen[status.Ref]; !ok {
-				if err = cs.Store.Abort(ctx, status.Ref); err != nil {
+				if err = cs.Store.Abort(gcCtx, status.Ref); err != nil {
 					return
 				}
 				log.G(ctx).WithField("ref", status.Ref).Debug("cleanup aborting ingest")

--- a/core/metadata/content_test.go
+++ b/core/metadata/content_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/content/testsuite"
@@ -185,6 +186,204 @@ func createLease(ctx context.Context, db *DB, name string) (context.Context, fun
 			ID: name,
 		})
 	}, nil
+}
+
+type hangingDeleteStore struct {
+	content.Store
+	deletes atomic.Int32
+}
+
+func (s *hangingDeleteStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	s.deletes.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestGarbageCollectHangingDelete(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, bdb := testEnv(t)
+
+		lcs, err := local.NewStore(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		cs := &hangingDeleteStore{Store: lcs}
+		db := NewDB(bdb, cs, nil)
+		if err := db.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		// Orphan blobs: exist in the backend but not in metadata, so GC deletes them.
+		var orphans []digest.Digest
+		for _, data := range []string{"orphan-1", "orphan-2"} {
+			blob := []byte(data)
+			dgst := digest.FromBytes(blob)
+			if err := content.WriteBlob(ctx, lcs, data, bytes.NewReader(blob),
+				ocispec.Descriptor{Size: int64(len(blob)), Digest: dgst}); err != nil {
+				t.Fatal(err)
+			}
+			orphans = append(orphans, dgst)
+		}
+
+		// The fake clock reaches the GC pass deadline as soon as Delete blocks,
+		// so this runs against the real default instead of a shortened one. An
+		// unbounded Delete would deadlock the bubble rather than pass.
+		mcs := db.ContentStore().(*contentStore)
+		_, err = mcs.garbageCollect(ctx)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected the bounded Delete to fail with DeadlineExceeded, got %v", err)
+		}
+
+		if n := cs.deletes.Load(); n != 1 {
+			t.Fatalf("expected 1 delete attempt before abandoning the pass, got %d", n)
+		}
+		for _, dgst := range orphans {
+			if _, err := lcs.Info(ctx, dgst); err != nil {
+				t.Fatalf("orphan %q should survive for the next GC pass: %v", dgst, err)
+			}
+		}
+	})
+}
+
+type hangingAbortStore struct {
+	content.Store
+	aborts atomic.Int32
+}
+
+func (s *hangingAbortStore) Abort(ctx context.Context, ref string) error {
+	s.aborts.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestGarbageCollectHangingAbort(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, bdb := testEnv(t)
+
+		lcs, err := local.NewStore(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		cs := &hangingAbortStore{Store: lcs}
+		db := NewDB(bdb, cs, nil)
+		if err := db.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		// Commit one blob so the backend's blobs directory exists and the
+		// Walk phase can run; it is unreferenced, so GC deletes it (through
+		// the real local Delete) before reaching the ingest phase.
+		blob := []byte("walked")
+		if err := content.WriteBlob(ctx, lcs, "walked", bytes.NewReader(blob),
+			ocispec.Descriptor{Size: int64(len(blob)), Digest: digest.FromBytes(blob)}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Orphan ingests: open in the backend but unknown to metadata, so GC
+		// aborts them. The wrapper does not promote WalkStatusRefs, so this
+		// exercises the ListStatuses fallback.
+		refs := []string{"orphan-ingest-1", "orphan-ingest-2"}
+		for _, ref := range refs {
+			w, err := lcs.Writer(ctx, content.WithRef(ref))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		mcs := db.ContentStore().(*contentStore)
+		_, err = mcs.garbageCollect(ctx)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected the bounded Abort to fail with DeadlineExceeded, got %v", err)
+		}
+
+		if n := cs.aborts.Load(); n != 1 {
+			t.Fatalf("expected 1 abort attempt before abandoning the pass, got %d", n)
+		}
+		statuses, err := lcs.ListStatuses(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(statuses) != len(refs) {
+			t.Fatalf("expected %d ingests to survive for the next GC pass, got %d", len(refs), len(statuses))
+		}
+	})
+}
+
+type hangingWalkStore struct {
+	content.Store
+	walks   atomic.Int32
+	deletes atomic.Int32
+	aborts  atomic.Int32
+}
+
+func (s *hangingWalkStore) Walk(ctx context.Context, fn content.WalkFunc, fs ...string) error {
+	s.walks.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (s *hangingWalkStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	s.deletes.Add(1)
+	return s.Store.Delete(ctx, dgst)
+}
+
+func (s *hangingWalkStore) Abort(ctx context.Context, ref string) error {
+	s.aborts.Add(1)
+	return s.Store.Abort(ctx, ref)
+}
+
+func TestGarbageCollectHangingWalk(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, bdb := testEnv(t)
+
+		lcs, err := local.NewStore(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		cs := &hangingWalkStore{Store: lcs}
+		db := NewDB(bdb, cs, nil)
+		if err := db.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		// Orphan blobs GC would normally delete.
+		var orphans []digest.Digest
+		for _, data := range []string{"orphan-1", "orphan-2"} {
+			blob := []byte(data)
+			dgst := digest.FromBytes(blob)
+			if err := content.WriteBlob(ctx, lcs, data, bytes.NewReader(blob),
+				ocispec.Descriptor{Size: int64(len(blob)), Digest: dgst}); err != nil {
+				t.Fatal(err)
+			}
+			orphans = append(orphans, dgst)
+		}
+
+		// The fake clock reaches the GC pass deadline as soon as Walk blocks;
+		// an unbounded Walk would deadlock the bubble rather than pass.
+		mcs := db.ContentStore().(*contentStore)
+		_, err = mcs.garbageCollect(ctx)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected the bounded Walk to fail with DeadlineExceeded, got %v", err)
+		}
+
+		if n := cs.walks.Load(); n != 1 {
+			t.Fatalf("expected exactly 1 Walk attempt, got %d", n)
+		}
+		if n := cs.deletes.Load(); n != 0 {
+			t.Fatalf("expected no Delete call after a timed-out Walk, got %d", n)
+		}
+		if n := cs.aborts.Load(); n != 0 {
+			t.Fatalf("expected no Abort call after a timed-out Walk, got %d", n)
+		}
+		for _, dgst := range orphans {
+			if _, err := lcs.Info(ctx, dgst); err != nil {
+				t.Fatalf("orphan %q should survive for the next GC pass: %v", dgst, err)
+			}
+		}
+	})
 }
 
 func checkContentLeased(ctx context.Context, db *DB, dgst digest.Digest) error {

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -178,6 +178,7 @@ documentation.
   "io.containerd.timeout.shim.cleanup" = "5s"
   "io.containerd.timeout.shim.load" = "5s"
   "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.gc.content" = "30m"
   "io.containerd.timeout.task.state" = "2s" -->
 
 **imports**


### PR DESCRIPTION
-