### PR TITLE
metadata: bound each snapshot GC pass with a single timeout

### DIFF
--- a/core/metadata/snapshot.go
+++ b/core/metadata/snapshot.go
@@ -42,18 +42,21 @@ const (
 	inheritedLabelsPrefix = "containerd.io/snapshot/"
 )
 
-// gcSnapshotterRemoveTimeoutKey bounds each Snapshotter.Remove during garbage
-// collection, which holds the snapshotter write lock: an unresponsive
-// snapshotter (e.g. a hung proxy plugin RPC) would otherwise block all
-// snapshot operations forever. On timeout the rest of the pass is abandoned;
-// remaining snapshots stay orphaned and are retried on the next GC pass.
+// gcSnapshotterTimeoutKey bounds one full snapshot garbage collection pass:
+// Walk and each Remove under the snapshotter write lock, and the final
+// Cleanup after it is released. The deadline starts before lock acquisition;
+// the wait itself is not interruptible, but its duration counts against the
+// budget of the pass. An unresponsive snapshotter (e.g. a hung proxy plugin
+// RPC) would otherwise hold the lock and block all snapshot operations
+// forever. On timeout the pass is abandoned; remaining snapshots stay
+// orphaned and are retried on the next GC pass.
 const (
-	gcSnapshotterRemoveTimeoutKey     = "io.containerd.timeout.gc.snapshotter.remove"
-	defaultGCSnapshotterRemoveTimeout = 30 * time.Minute
+	gcSnapshotterTimeoutKey     = "io.containerd.timeout.gc.snapshotter"
+	defaultGCSnapshotterTimeout = 30 * time.Minute
 )
 
 func init() {
-	timeout.Set(gcSnapshotterRemoveTimeoutKey, defaultGCSnapshotterRemoveTimeout)
+	timeout.Set(gcSnapshotterTimeoutKey, defaultGCSnapshotterTimeout)
 }
 
 type snapshotter struct {
@@ -875,13 +878,16 @@ func validateSnapshot(info *snapshots.Info) error {
 
 // garbageCollect removes all snapshots that are no longer used.
 func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, err error) {
+	gcCtx, cancel := timeout.WithContext(ctx, gcSnapshotterTimeoutKey)
+	defer cancel()
+
 	s.l.Lock()
 	t1 := time.Now()
 	defer func() {
 		s.l.Unlock()
 		if err == nil {
 			if c, ok := s.Snapshotter.(snapshots.Cleaner); ok {
-				err = c.Cleanup(ctx)
+				err = c.Cleanup(gcCtx)
 				if errdefs.IsNotImplemented(err) {
 					err = nil
 				}
@@ -936,7 +942,7 @@ func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, err 
 		return 0, err
 	}
 
-	roots, err := s.walkTree(ctx, seen)
+	roots, err := s.walkTree(gcCtx, seen)
 	if err != nil {
 		return 0, err
 	}
@@ -947,7 +953,7 @@ func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, err 
 	// deletions on the snapshotters which support it.
 
 	for _, node := range roots {
-		if err := s.pruneBranch(ctx, node); err != nil {
+		if err := s.pruneBranch(gcCtx, node); err != nil {
 			return 0, err
 		}
 	}
@@ -1004,10 +1010,7 @@ func (s *snapshotter) pruneBranch(ctx context.Context, node *treeNode) error {
 
 	if node.remove {
 		logger := log.G(ctx).WithField("snapshotter", s.name)
-		removeCtx, cancel := timeout.WithContext(ctx, gcSnapshotterRemoveTimeoutKey)
-		err := s.Snapshotter.Remove(removeCtx, node.info.Name)
-		cancel()
-		if err != nil {
+		if err := s.Snapshotter.Remove(ctx, node.info.Name); err != nil {
 			if !errdefs.IsFailedPrecondition(err) {
 				return err
 			}

--- a/core/metadata/snapshot_test.go
+++ b/core/metadata/snapshot_test.go
@@ -498,7 +498,7 @@ func TestGarbageCollectHangingRemove(t *testing.T) {
 			}
 		}
 
-		// The fake clock reaches the removal deadline as soon as Remove blocks,
+		// The fake clock reaches the GC pass deadline as soon as Remove blocks,
 		// so this runs against the real default instead of a shortened one. An
 		// unbounded Remove would deadlock the bubble rather than pass.
 		msn := db.Snapshotter("tmp").(*snapshotter)
@@ -512,11 +512,77 @@ func TestGarbageCollectHangingRemove(t *testing.T) {
 			t.Fatalf("expected 1 remove attempt before abandoning the pass, got %d", n)
 		}
 		// Cleanup must be skipped after an abandoned pass: the snapshotter just
-		// failed to answer a bounded Remove, and Cleanup has no bound.
+		// failed to answer a Remove, and the pass's shared deadline has expired.
 		if n := sn.cleanups.Load(); n != 0 {
 			t.Fatalf("expected no Cleanup call after abandoned pass, got %d", n)
 		}
 		// Skipped snapshots stay orphaned for the next GC pass.
+		for _, key := range []string{"orphan-1", "orphan-2"} {
+			if _, err := sn.Snapshotter.Stat(ctx, key); err != nil {
+				t.Fatalf("orphan %q should survive for the next GC pass: %v", key, err)
+			}
+		}
+	})
+}
+
+type hangingWalkSnapshotter struct {
+	snapshots.Snapshotter
+	walks    atomic.Int32
+	removes  atomic.Int32
+	cleanups atomic.Int32
+}
+
+func (s *hangingWalkSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...string) error {
+	s.walks.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (s *hangingWalkSnapshotter) Remove(ctx context.Context, key string) error {
+	s.removes.Add(1)
+	return s.Snapshotter.Remove(ctx, key)
+}
+
+// Cleanup makes the wrapper a snapshots.Cleaner so its skip can be asserted.
+func (s *hangingWalkSnapshotter) Cleanup(ctx context.Context) error {
+	s.cleanups.Add(1)
+	return nil
+}
+
+func TestGarbageCollectHangingWalk(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, bdb := testEnv(t)
+
+		sn := &hangingWalkSnapshotter{Snapshotter: NewTmpSnapshotter()}
+		db := NewDB(bdb, nil, map[string]snapshots.Snapshotter{"tmp": sn})
+		if err := db.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		// Orphan snapshots GC would normally remove.
+		for _, key := range []string{"orphan-1", "orphan-2"} {
+			if _, err := sn.Snapshotter.Prepare(ctx, key, ""); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// The fake clock reaches the GC pass deadline as soon as Walk blocks;
+		// an unbounded Walk would deadlock the bubble rather than pass.
+		msn := db.Snapshotter("tmp").(*snapshotter)
+		_, err := msn.garbageCollect(ctx)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected the bounded Walk to fail with DeadlineExceeded, got %v", err)
+		}
+
+		if n := sn.walks.Load(); n != 1 {
+			t.Fatalf("expected exactly 1 Walk attempt, got %d", n)
+		}
+		if n := sn.removes.Load(); n != 0 {
+			t.Fatalf("expected no Remove call after a timed-out Walk, got %d", n)
+		}
+		if n := sn.cleanups.Load(); n != 0 {
+			t.Fatalf("expected no Cleanup call after a failed pass, got %d", n)
+		}
 		for _, key := range []string{"orphan-1", "orphan-2"} {
 			if _, err := sn.Snapshotter.Stat(ctx, key); err != nil {
 				t.Fatalf("orphan %q should survive for the next GC pass: %v", key, err)

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -178,7 +178,7 @@ documentation.
   "io.containerd.timeout.shim.cleanup" = "5s"
   "io.containerd.timeout.shim.load" = "5s"
   "io.containerd.timeout.shim.shutdown" = "3s"
-  "io.containerd.timeout.gc.snapshotter.remove" = "30m"
+  "io.containerd.timeout.gc.snapshotter" = "30m"
   "io.containerd.timeout.task.state" = "2s" -->
 
 **imports**


### PR DESCRIPTION
**Problem**

Snapshot GC holds the snapshotter write lock across every snapshotter call it makes: `Walk` to build the tree, each `Remove` while pruning, and the final `Cleanup`. Only `Remove` was bounded (#13799); a proxy snapshotter that wedges in `Walk` or `Cleanup` still holds the lock forever and no new container can start. `Walk` runs first in the pass, so the bounded `Remove` path is never even reached. Called out as a known gap in #13799.

**Fix**

One timeout for the whole GC pass, per review feedback from @mikebrow (move the context up to `garbageCollect`) and @fuweid (a single timeout instead of per-call keys): `io.containerd.timeout.gc.snapshotter` (default 30m) created in `garbageCollect`, covering `Walk`, every `Remove`, and `Cleanup` under one deadline. The per-call `io.containerd.timeout.gc.snapshotter.remove` key from #13799 is removed; it never shipped in a release, so no deprecation is needed.

On timeout the pass fails before any further pruning, so a partial walk result is never used to remove snapshots; the next pass retries.

The synctest regression tests assert a timed-out `Walk` triggers zero `Remove` and zero `Cleanup` calls, and that a timed-out `Remove` abandons the pass, deadlocking in under a second if the bound is removed.

Refs #13798.
