### PR TITLE
Use the controller lifetime context for sandbox exit wait

### DIFF
--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -90,6 +90,7 @@ func init() {
 				os:             osinterface.RealOS{},
 				warningService: warningPlugin.(warning.Service),
 				store:          NewStore(),
+				ctx:            ic.Context,
 			}
 
 			// There is no need to subscribe to the exit event for the pause container,
@@ -122,6 +123,8 @@ type Controller struct {
 	eventMonitor *events.EventMonitor
 
 	store *Store
+
+	ctx context.Context
 }
 
 var _ sandbox.Controller = (*Controller)(nil)

--- a/internal/cri/server/podsandbox/controller_test.go
+++ b/internal/cri/server/podsandbox/controller_test.go
@@ -48,6 +48,7 @@ func newControllerService() *Controller {
 		config: testConfig,
 		os:     ostesting.NewFakeOS(),
 		store:  NewStore(),
+		ctx:    context.Background(),
 	}
 }
 

--- a/internal/cri/server/podsandbox/recover.go
+++ b/internal/cri/server/podsandbox/recover.go
@@ -158,7 +158,7 @@ func (c *Controller) RecoverContainer(ctx context.Context, cntr containerd.Conta
 	}
 	if ch != nil {
 		go func() {
-			if err := c.waitSandboxExit(ctrdutil.NamespacedContext(), podSandbox, ch); err != nil {
+			if err := c.waitSandboxExit(ctrdutil.WithNamespace(c.ctx), podSandbox, ch); err != nil {
 				log.G(context.Background()).Warnf("failed to wait pod sandbox exit %v", err)
 			}
 		}()

--- a/internal/cri/server/podsandbox/recover_test.go
+++ b/internal/cri/server/podsandbox/recover_test.go
@@ -217,6 +217,7 @@ func TestRecoverContainer(t *testing.T) {
 	controller := &Controller{
 		config: criconfig.Config{},
 		store:  NewStore(),
+		ctx:    context.Background(),
 	}
 	containers := []struct {
 		container        fakeContainer


### PR DESCRIPTION
Recovery starts the sandbox exit monitor with a context that is never cancelled, so an unreachable shim blocks it indefinitely and CRI recovery never completes. waitSandboxExit already returns on ctx.Done(); wiring the plugin context makes that reachable.

Fixes #14027