### PR TITLE
core/transfer/streaming: harden the send window against invalid updates

### DIFF
--- a/core/transfer/streaming/stream.go
+++ b/core/transfer/streaming/stream.go
@@ -67,6 +67,12 @@ func SendStream(ctx context.Context, r io.Reader, stream streaming.Stream) {
 			}
 			switch v := i.(type) {
 			case *transferapi.WindowUpdate:
+				// Window credit is a positive additive delta; zero or negative is malformed and would
+				// stall the stream or slice the outgoing [:max] out of range.
+				if v.Update <= 0 {
+					log.G(ctx).Errorf("ignoring non-positive window update: %d", v.Update)
+					continue
+				}
 				select {
 				case <-ctx.Done():
 					return
@@ -83,7 +89,7 @@ func SendStream(ctx context.Context, r io.Reader, stream streaming.Stream) {
 		buf := bufPool.Get().(*[]byte)
 		defer bufPool.Put(buf)
 
-		var remaining int32
+		var remaining int64
 
 		for {
 			if remaining > 0 {
@@ -92,8 +98,12 @@ func SendStream(ctx context.Context, r io.Reader, stream streaming.Stream) {
 				case <-ctx.Done():
 					// TODO: Send error message on stream before close to allow remote side to return error
 					return
-				case update := <-window:
-					remaining += update
+				case update, ok := <-window:
+					// A closed window means no more credit is coming; keep spending
+					// what is left rather than adding the zero value.
+					if ok {
+						remaining += int64(update)
+					}
 				default:
 				}
 			} else {
@@ -102,18 +112,21 @@ func SendStream(ctx context.Context, r io.Reader, stream streaming.Stream) {
 				case <-ctx.Done():
 					// TODO: Send error message on stream before close to allow remote side to return error
 					return
-				case update := <-window:
-					remaining = update
+				case update, ok := <-window:
+					if !ok {
+						return
+					}
+					remaining = int64(update)
 				}
 			}
 			var max int32 = maxRead
-			if max > remaining {
-				max = remaining
+			if int64(max) > remaining {
+				max = int32(remaining)
 			}
 			b := (*buf)[:max]
 			n, readErr := r.Read(b)
 			if n > 0 {
-				remaining = remaining - int32(n)
+				remaining = remaining - int64(n)
 
 				data := &transferapi.Data{
 					Data: b[:n],

--- a/core/transfer/streaming/window_fuzz_test.go
+++ b/core/transfer/streaming/window_fuzz_test.go
@@ -1,0 +1,115 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package streaming
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math"
+	"testing"
+	"time"
+
+	transferapi "github.com/containerd/containerd/api/types/transfer"
+	"github.com/containerd/typeurl/v2"
+)
+
+// hostileStream replays an arbitrary list of window updates to the reader goroutine
+// and drops whatever the writer sends. It stands in for a fully attacker-controlled
+// transfer peer that may send any int32 credit in any order.
+type hostileStream struct {
+	updates []int32
+	pos     int
+}
+
+func (s *hostileStream) Recv() (typeurl.Any, error) {
+	if s.pos >= len(s.updates) {
+		return nil, io.EOF
+	}
+	u := s.updates[s.pos]
+	s.pos++
+	return typeurl.MarshalAny(&transferapi.WindowUpdate{Update: u})
+}
+func (s *hostileStream) Send(typeurl.Any) error { return nil }
+func (s *hostileStream) Close() error           { return nil }
+
+// windowPalette biases fuzz/brute-force input toward the dangerous edges: negatives,
+// zero, the maxRead boundary, and the int32 extremes that drive overflow.
+var windowPalette = []int32{
+	-1, 0, 1, 2, maxRead - 1, maxRead, maxRead + 1,
+	math.MaxInt32, math.MaxInt32 - 1, math.MinInt32, math.MinInt32 + 1, -maxRead,
+}
+
+func updatesFromBytes(b []byte) []int32 {
+	u := make([]int32, 0, len(b)+1)
+	for _, x := range b {
+		u = append(u, windowPalette[int(x)%len(windowPalette)])
+	}
+	return u
+}
+
+// driveWriteByteStream runs the real WriteByteStream against a hostile update
+// sequence, bounded by a short context so a starved Write does not hang, and
+// reports whether Write panicked. A negative slice bound would panic here.
+func driveWriteByteStream(updates []int32, payload []byte) (panicked bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	w := WriteByteStream(ctx, &hostileStream{updates: updates})
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+		}
+	}()
+	_, _ = w.Write(payload)
+	return
+}
+
+// driveSendStream runs the real SendStream against a hostile update sequence. Its
+// panic would be in a background goroutine, so it cannot be recovered here: an
+// unfixed overflow crashes the whole test binary, which is exactly the signal.
+func driveSendStream(updates []int32, payload []byte) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	SendStream(ctx, bytes.NewReader(payload), &hostileStream{updates: updates})
+	time.Sleep(3 * time.Millisecond) // let the background goroutines run and possibly panic
+}
+
+// TestOriginalGHSAPoCNoLongerPanics is the exact GHSA-63h3-p4hq-m7mq reproducer:
+// a peer whose first control message is WindowUpdate{-1}. It panicked p[:-1] on the
+// pre-fix code; it must return cleanly now.
+func TestOriginalGHSAPoCNoLongerPanics(t *testing.T) {
+	if driveWriteByteStream([]int32{-1}, []byte("layer-bytes")) {
+		t.Fatal("WriteByteStream still panics on the original WindowUpdate{-1} PoC")
+	}
+}
+
+// FuzzWindowUpdates lets the fuzzer explore arbitrary window-update sequences and
+// payloads against both send paths. A panic (WriteByteStream) or a background crash
+// (SendStream) is a finding.
+func FuzzWindowUpdates(f *testing.F) {
+	f.Add([]byte{0}, []byte("layer-bytes"))                                  // {-1}
+	f.Add([]byte{7, 7}, []byte("payload"))                                   // {MaxInt32, MaxInt32}
+	f.Add([]byte{7, 4, 7}, bytes.Repeat([]byte("a"), 3*maxRead))             // overflow after a read
+	f.Add([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, bytes.Repeat([]byte{9}, 8)) // mixed
+	f.Fuzz(func(t *testing.T, control, payload []byte) {
+		updates := updatesFromBytes(control)
+		if driveWriteByteStream(updates, payload) {
+			t.Fatalf("WriteByteStream panicked on updates=%v", updates)
+		}
+		driveSendStream(updates, payload)
+	})
+}

--- a/core/transfer/streaming/window_hardening_test.go
+++ b/core/transfer/streaming/window_hardening_test.go
@@ -1,0 +1,194 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package streaming
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	transferapi "github.com/containerd/containerd/api/types/transfer"
+	"github.com/containerd/typeurl/v2"
+)
+
+// scriptedStream replays a fixed list of window updates to the reader goroutine and
+// records the payload the writer sends back, standing in for a hostile transfer peer.
+type scriptedStream struct {
+	updates []int32
+	pos     int
+
+	mu   sync.Mutex
+	sent []byte
+}
+
+func (s *scriptedStream) Recv() (typeurl.Any, error) {
+	if s.pos >= len(s.updates) {
+		return nil, io.EOF
+	}
+	u := s.updates[s.pos]
+	s.pos++
+	return typeurl.MarshalAny(&transferapi.WindowUpdate{Update: u})
+}
+
+func (s *scriptedStream) Send(a typeurl.Any) error {
+	v, err := typeurl.UnmarshalAny(a)
+	if err != nil {
+		return err
+	}
+	if d, ok := v.(*transferapi.Data); ok {
+		s.mu.Lock()
+		s.sent = append(s.sent, d.Data...)
+		s.mu.Unlock()
+	}
+	return nil
+}
+
+func (s *scriptedStream) Close() error { return nil }
+
+func (s *scriptedStream) received() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.sent...)
+}
+
+// countingReader counts zero-length Read calls. SendStream reads into a slice sized by the
+// window; it would ask for zero bytes only if it had accepted a non-positive credit, so a
+// non-zero count means the <= 0 rejection regressed.
+type countingReader struct {
+	r         io.Reader
+	zeroReads atomic.Int32
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		c.zeroReads.Add(1)
+	}
+	return c.r.Read(p)
+}
+
+// TestWriteByteStreamAddWindowPreservesCredit pins the int64 accumulator: two max credits
+// add up to 2*MaxInt32 instead of overflowing an int32 counter back to a negative value
+// that Write would turn into a negative slice bound. It reads the counter directly so the
+// check does not race the Write goroutine.
+func TestWriteByteStreamAddWindowPreservesCredit(t *testing.T) {
+	wbs := &writeByteStream{}
+	wbs.addWindow(math.MaxInt32)
+	wbs.addWindow(math.MaxInt32)
+	if got, want := wbs.remaining.Load(), int64(math.MaxInt32)*2; got != want {
+		t.Fatalf("remaining = %d, want %d (int64 credit preserved, not overflowed)", got, want)
+	}
+}
+
+// TestWriteByteStreamIgnoresInvalidThenRecovers sends an invalid update, then a valid
+// credit, and asserts the writer drops the first, accepts the second, and delivers the
+// whole payload. It fails with a panic on the pre-fix code and deterministically proves
+// recovery afterwards; the timeout is only a failsafe, not the success condition.
+func TestWriteByteStreamIgnoresInvalidThenRecovers(t *testing.T) {
+	const payload = "transfer-byte-stream-payload"
+	for _, tc := range []struct {
+		name    string
+		updates []int32
+	}{
+		{"negative then valid credit", []int32{-1, int32(len(payload))}},
+		{"zero then valid credit", []int32{0, int32(len(payload))}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			peer := &scriptedStream{updates: tc.updates}
+			w := WriteByteStream(t.Context(), peer)
+
+			done := make(chan error, 1)
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						done <- fmt.Errorf("Write panicked: %v", r)
+					}
+				}()
+				_, err := w.Write([]byte(payload))
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("Write did not return; the timeout is a failsafe, not a pass")
+			}
+			if got := string(peer.received()); got != payload {
+				t.Fatalf("peer received %q, want %q", got, payload)
+			}
+		})
+	}
+}
+
+// TestSendStreamIgnoresInvalidThenRecovers is the SendStream counterpart: an invalid update
+// followed by a valid credit must still deliver the payload from the background goroutine,
+// and the invalid credit must not have driven a zero-length read. The pre-fix code takes
+// the process down with a panic on the invalid update.
+func TestSendStreamIgnoresInvalidThenRecovers(t *testing.T) {
+	const payload = "transfer-send-stream-payload"
+	for _, tc := range []struct {
+		name    string
+		updates []int32
+	}{
+		{"negative then valid credit", []int32{-1, int32(len(payload))}},
+		{"zero then valid credit", []int32{0, int32(len(payload))}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			peer := &scriptedStream{updates: tc.updates}
+			cr := &countingReader{r: strings.NewReader(payload)}
+			SendStream(t.Context(), cr, peer)
+			waitForPayload(t, peer, payload)
+			if z := cr.zeroReads.Load(); z != 0 {
+				t.Fatalf("SendStream made %d zero-length reads; a non-positive credit was accepted", z)
+			}
+		})
+	}
+}
+
+// TestSendStreamLargeCreditDelivers feeds two max credits that would overflow an int32
+// counter back to negative; the int64 budget accumulates them and delivers the whole
+// payload without a background panic.
+func TestSendStreamLargeCreditDelivers(t *testing.T) {
+	payload := strings.Repeat("a", 3*maxRead)
+	peer := &scriptedStream{updates: []int32{math.MaxInt32, math.MaxInt32}}
+	SendStream(t.Context(), strings.NewReader(payload), peer)
+	waitForPayload(t, peer, payload)
+}
+
+// waitForPayload polls until the peer has received the full payload, failing on a
+// timeout used only as a failsafe against a hang.
+func waitForPayload(t *testing.T, peer *scriptedStream, payload string) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		if string(peer.received()) == payload {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("peer received %d bytes, want %d", len(peer.received()), len(payload))
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}

--- a/core/transfer/streaming/writer.go
+++ b/core/transfer/streaming/writer.go
@@ -56,7 +56,13 @@ func WriteByteStream(ctx context.Context, stream streaming.Stream) io.WriteClose
 			}
 			switch v := i.(type) {
 			case *transferapi.WindowUpdate:
-				wbs.remaining.Add(v.Update)
+				// Window credit is a positive additive delta; zero or negative is malformed and would
+				// stall the stream or slice the outgoing [:max] out of range.
+				if v.Update <= 0 {
+					log.G(ctx).Errorf("ignoring non-positive window update: %d", v.Update)
+					continue
+				}
+				wbs.addWindow(v.Update)
 				select {
 				case <-ctx.Done():
 					return
@@ -76,8 +82,15 @@ func WriteByteStream(ctx context.Context, stream streaming.Stream) io.WriteClose
 type writeByteStream struct {
 	ctx       context.Context
 	stream    streaming.Stream
-	remaining atomic.Int32
+	remaining atomic.Int64
 	updated   chan struct{}
+}
+
+// addWindow adds a positive credit to remaining. Accumulating in int64 keeps every
+// advertised credit; no realistic number of int32 updates can overflow it back to a
+// negative slice bound.
+func (wbs *writeByteStream) addWindow(update int32) {
+	wbs.remaining.Add(int64(update))
 }
 
 func (wbs *writeByteStream) Write(p []byte) (n int, err error) {
@@ -95,14 +108,16 @@ func (wbs *writeByteStream) Write(p []byte) (n int, err error) {
 			}
 		}
 		var max int32 = maxRead
-		if max > int32(len(p)) {
+		// Compare widths in int so a len(p) above MaxInt32 does not narrow to a
+		// negative int32 and reintroduce a negative slice bound.
+		if int(max) > len(p) {
 			max = int32(len(p))
 		}
-		if max > remaining {
-			max = remaining
+		// remaining is int64; only this branch runs when it is below max, and then it
+		// is smaller than maxRead so it fits back into int32.
+		if int64(max) > remaining {
+			max = int32(remaining)
 		}
-		// TODO: continue
-		// remaining = remaining - int32(n)
 
 		data := &transferapi.Data{
 			Data: p[:max],
@@ -120,7 +135,7 @@ func (wbs *writeByteStream) Write(p []byte) (n int, err error) {
 		}
 		n += int(max)
 		p = p[max:]
-		wbs.remaining.Add(-1 * max)
+		wbs.remaining.Add(-int64(max))
 	}
 	return
 }


### PR DESCRIPTION
Both `WriteByteStream` and `SendStream` take the peer's `WindowUpdate.Update` (an `int32` off the wire) straight into their flow-control budget and later use it as a slice bound. That budget can go negative two ways, and either one panics the outgoing `p[:max]` slice. In `SendStream` the panic is in a background goroutine where nothing recovers it, so it takes the process down.

## The two routes to a negative budget

A single negative update is the obvious one: `WindowUpdate{Update: -1}` makes `remaining` negative and `Write` slices `p[:-1]`.

The subtler one is positive overflow. The proto puts no upper bound on `Update`, and both accumulators are `int32`, so two large positive credits wrap the counter negative on their own:

```
int32(math.MaxInt32 + math.MaxInt32) == -2
```

`SendStream` needs even less: after one `MaxInt32` credit and a single `maxRead` read, a second `MaxInt32` gives `2147483647 - 32768 + 2147483647`, which overflows to `-32770`, and the next `(*buf)[:-32770]` panics.

## The change

Keep the budget a valid, non-negative counter:

- Reject a non-positive update where it is received and keep the stream, so a later valid credit still works. A window is a flow-control credit and is only ever advertised as positive; zero and negative are malformed, so they are dropped rather than accepted. Zero in particular would only churn a wakeup or drive a zero-length read.
- Accumulate credit in an `int64` counter in both paths, so it keeps every advertised credit and a run of positive updates cannot overflow it back to a negative slice bound the way the original `int32` counter did. The wire format stays `int32` per update; only the internal accumulator widens, matching how `remaining` counters are held elsewhere in this tree.
- In `SendStream`, return when the window channel closes rather than reading its zero value forever, while still spending an outstanding credit rather than aborting on close.
- Compare widths in a wider type when clamping to `len(p)` in `Write`, so a slice above `MaxInt32` does not narrow to a negative bound. This one is caller-side rather than peer-driven, but it is the same negative-slice-bound class in the same function.

The behaviour is ignore-and-recover, not tear-down: a malformed frame is dropped and the stream keeps going. Recovery still depends on the peer sending valid credit afterwards or on the context being cancelled; a peer that sends a malformed frame and then EOFs without any credit leaves `Write` waiting for cancellation, which is a pre-existing lifecycle gap I left out of scope. Terminating the stream on a protocol violation would be cleaner for resource lifecycle, but the current API has no good background-error path, so I kept the change minimal.

## Testing

The regression tests drive the real `WriteByteStream` and `SendStream` with a hostile peer that sends a negative or zero update followed by valid credit, and assert the exact payload is delivered without a panic. The negative case fails on the pre-fix code with a `p[:-1]` panic and passes after; the zero case additionally asserts `SendStream` made no zero-length read, so it fails if the check regresses from `<= 0` back to `< 0`. A white-box test pins that two max credits add up in the `int64` counter rather than overflowing. The timeout in each is a failsafe against a hang, not the success condition.

I also added a `FuzzWindowUpdates` target and the original reproducer that drive both paths with arbitrary hostile window sequences. The existing `FuzzSendAndReceive` fuzzes payload bytes against a valid peer, so it never sends a malformed window update; this covers that control path instead. `gofmt`, `go vet`, `golangci-lint`, and `go test -race` are clean, and a local `go test -fuzz` run of ~70k executions found nothing.

This came out of GHSA-63h3-p4hq-m7mq; @samuelkarp reviewed it there and suggested sending it as an ordinary hardening PR.
