### PR TITLE
fix: bound CRI recovery goroutine with context timeout to prevent goroutine leak

### DIFF
--- a/internal/cri/server/podsandbox/recover.go
+++ b/internal/cri/server/podsandbox/recover.go
@@ -158,7 +158,9 @@ func (c *Controller) RecoverContainer(ctx context.Context, cntr containerd.Conta
 	}
 	if ch != nil {
 		go func() {
-			if err := c.waitSandboxExit(ctrdutil.NamespacedContext(), podSandbox, ch); err != nil {
+			waitCtx, waitCancel := context.WithTimeout(context.Background(), loadContainerTimeout)
+			defer waitCancel()
+			if err := c.waitSandboxExit(waitCtx, podSandbox, ch); err != nil {
 				log.G(context.Background()).Warnf("failed to wait pod sandbox exit %v", err)
 			}
 		}()


### PR DESCRIPTION
**What this PR does / why we need it:**

`podsandbox.(*Controller).RecoverContainer` spawns a goroutine to wait for sandbox exit with an unbounded context (`ctrdutil.NamespacedContext()`). If the shim behind the sandbox does not respond, the goroutine blocks in a ttrpc call forever, leaking one goroutine per unresponsive sandbox. On a node with many sandboxes this can leave hundreds of goroutines parked indefinitely, preventing the CRI plugin from reaching a ready state.

**Fix:** Create a new context with `loadContainerTimeout` (10s) inside the goroutine, so the `waitSandboxExit` call is bounded by the same timeout used for the rest of the recovery logic. The goroutine's context is independent of the parent's cancellation, so `defer cancel()` in the enclosing function does not immediately cancel the goroutine's context.

**Which issue(s) this PR fixes:**

Fixes #14027

**Special notes for your reviewer:**

The goroutine leak was observed with kata-containers `containerd-shim-kata-v2` after a containerd restart on a node with ~50 sandboxes. The daemon accumulated 551 goroutines parked in `[select, 160 minutes]` in the goroutine dump, and the kubelet never reached a ready state.

**Note:** There is a second call to `ctrdutil.NamespacedContext()` on line 124 (`t.Wait(ctrdutil.NamespacedContext())`). That call is bounded by the `loadContainerTimeout` context in the enclosing `RecoverContainer` function because it is called synchronously within the function body, so it does not leak. Only the goroutine-spawned call on line 161 is unbounded.
