### PR TITLE
cri: Fix image volume cleanup with nested mounts

### DIFF
--- a/internal/cri/server/container_image_mount.go
+++ b/internal/cri/server/container_image_mount.go
@@ -215,7 +215,7 @@ func (c *criService) cleanupImageMounts(
 	for _, entry := range entries {
 		target := filepath.Join(targetBase, entry.Name())
 
-		err = mount.UnmountAll(target, 0)
+		err = mount.UnmountRecursive(target, 0)
 		if err != nil {
 			return fmt.Errorf("failed to unmount image volume component %q: %w", target, err)
 		}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fixes Pod deletion failure when using CRI image volumes with nested mounts (e.g., nix-snapshotter).

When deleting a Pod with CRI image volumes backed by snapshotter implementations that create nested bind mounts (like nix-snapshotter with /nix/store paths), the cleanup would fail with 'device or resource busy' because containerd tried to unmount the parent overlay before its nested children.

This PR changes cleanupImageMounts() to use mount.UnmountRecursive() instead of mount.UnmountAll(). UnmountRecursive() handles nested mounts by discovering all mounts under the target and unmounting them depth-first.

## Which issue(s) this PR fixes:

Fixes #14032

## Special notes for your reviewer:

- This is a minimal 1-line change using an existing, well-tested containerd function
- UnmountRecursive() is already used elsewhere in containerd for similar cases (see bundle cleanup, rootfs unmount)
- The fix only affects CRI image volume cleanup path, no other code paths are touched