### PR TITLE
vendor: github.com/containerd/go-runc v1.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/go-cni v1.1.13
 	github.com/containerd/go-dmverity v0.1.0
-	github.com/containerd/go-runc v1.2.0
+	github.com/containerd/go-runc v1.2.1
 	github.com/containerd/imgcrypt/v2 v2.0.3
 	github.com/containerd/log v0.1.0
 	github.com/containerd/nri v0.12.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/containerd/go-cni v1.1.13 h1:eFSGOKlhoYNxpJ51KRIMHZNlg5UgocXEIEBGkY7H
 github.com/containerd/go-cni v1.1.13/go.mod h1:nTieub0XDRmvCZ9VI/SBG6PyqT95N4FIhxsauF1vSBI=
 github.com/containerd/go-dmverity v0.1.0 h1:aqnpBRI6mmscya/XqvknZ4wQNJnXzx6lKxPa7Q71hDo=
 github.com/containerd/go-dmverity v0.1.0/go.mod h1:vYevYgfeVF244IpQCKshXLvyKoRHwoVrFG0HV6GrUrs=
-github.com/containerd/go-runc v1.2.0 h1:2bR2WFllv1e6NkGqdxv4vq6yjn20rn0A3Ya1Szo5zJg=
-github.com/containerd/go-runc v1.2.0/go.mod h1:fnxllTlO2iROsGzcfY1P2IfFW4bGpt7CIMKhgj1s1Xk=
+github.com/containerd/go-runc v1.2.1 h1:TAnah92bVA7dYDZ7Mm9FrOoFQvnLZdL3z3xT7BS19kA=
+github.com/containerd/go-runc v1.2.1/go.mod h1:Azy6SkBcIFMSMYiYUuSQhZ25zD3zJEYYbbIVplhYD7M=
 github.com/containerd/imgcrypt/v2 v2.0.3 h1:yM6//IOTtca9TpxPP8prJqLDuidbF/VhUQujLw7UQ3w=
 github.com/containerd/imgcrypt/v2 v2.0.3/go.mod h1:Sjfd3uOiBWtb1dUo1yS5Z/ZxdfMU7MpBr2pzs9HoRDs=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/vendor/github.com/containerd/go-runc/.golangci.yml
+++ b/vendor/github.com/containerd/go-runc/.golangci.yml
@@ -1,20 +1,27 @@
+version: "2"
+
 linters:
   enable:
-    - gofmt
-    - goimports
+    - gosec
+    - govet
     - ineffassign
     - misspell
     - revive
     - staticcheck
     - unconvert
     - unused
-    - vet
   disable:
     - errcheck
+  exclusions:
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
 
-issues:
-  include:
-    - EXC0002
+formatters:
+  enable:
+    - gofmt
+    - goimports
 
 run:
-  timeout: 2m
+  timeout: 5m

--- a/vendor/github.com/containerd/go-runc/README.md
+++ b/vendor/github.com/containerd/go-runc/README.md
@@ -1,21 +1,15 @@
 # go-runc
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/containerd/go-runc.svg)](https://pkg.go.dev/github.com/containerd/go-runc)
 [![Build Status](https://github.com/containerd/go-runc/workflows/CI/badge.svg)](https://github.com/containerd/go-runc/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/containerd/go-runc/branch/main/graph/badge.svg)](https://codecov.io/gh/containerd/go-runc)
+[![codecov](https://codecov.io/gh/containerd/go-runc/tree/main/graph/badge.svg)](https://app.codecov.io/gh/containerd/go-runc/tree/main)
 
-This is a package for consuming the [runc](https://github.com/opencontainers/runc) binary in your Go applications.
-It tries to expose all the settings and features of the runc CLI.  If there is something missing then add it, its opensource!
-
-This needs runc @ [a9610f2c0](https://github.com/opencontainers/runc/commit/a9610f2c0237d2636d05a031ec8659a70e75ffeb)
-or greater.
-
-## Docs
-
-Docs can be found at [godoc.org](https://godoc.org/github.com/containerd/go-runc).
+This is a module for consuming the [runc](https://github.com/opencontainers/runc) binary in your Go applications.
+It tries to expose all the settings and features of the runc CLI.
 
 ## Project details
 
-The go-runc is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+**go-runc** is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
 As a containerd sub-project, you will find the:
 
  * [Project governance](https://github.com/containerd/project/blob/main/GOVERNANCE.md),

--- a/vendor/github.com/containerd/go-runc/command_linux.go
+++ b/vendor/github.com/containerd/go-runc/command_linux.go
@@ -33,7 +33,7 @@ func (r *Runc) commandWithCustomLogFile(context context.Context, logFile string,
 	if command == "" {
 		command = DefaultCommand
 	}
-	cmd := exec.CommandContext(context, command, append(r.args(logFile), args...)...)
+	cmd := exec.CommandContext(context, command, append(r.args(logFile), args...)...) // #nosec G702 -- executing the caller-configured runtime is the purpose of this package.
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: r.Setpgid,
 	}

--- a/vendor/github.com/containerd/go-runc/command_other.go
+++ b/vendor/github.com/containerd/go-runc/command_other.go
@@ -33,7 +33,7 @@ func (r *Runc) commandWithCustomLogFile(context context.Context, logFile string,
 	if command == "" {
 		command = DefaultCommand
 	}
-	cmd := exec.CommandContext(context, command, append(r.args(logFile), args...)...)
+	cmd := exec.CommandContext(context, command, append(r.args(logFile), args...)...) // #nosec G702 -- executing the caller-configured runtime is the purpose of this package.
 	cmd.Env = append(os.Environ(), extraEnv(context)...)
 	cmd.Dir = r.WorkDir
 	return cmd

--- a/vendor/github.com/containerd/go-runc/io_linux.go
+++ b/vendor/github.com/containerd/go-runc/io_linux.go
@@ -1,0 +1,23 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+import "golang.org/x/sys/unix"
+
+func chownPipe(fd, uid, gid int) error {
+	return unix.Fchown(fd, uid, gid)
+}

--- a/vendor/github.com/containerd/go-runc/io_nolinux.go
+++ b/vendor/github.com/containerd/go-runc/io_nolinux.go
@@ -1,0 +1,25 @@
+//go:build !linux && !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+// chownPipe is a no-op because BSD variants, including macOS, FreeBSD,
+// and OpenBSD, do not support changing ownership of anonymous pipes.
+func chownPipe(fd, uid, gid int) error {
+	return nil
+}

--- a/vendor/github.com/containerd/go-runc/io_unix.go
+++ b/vendor/github.com/containerd/go-runc/io_unix.go
@@ -20,14 +20,10 @@ package runc
 
 import (
 	"fmt"
-	"runtime"
-
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 // newPipeIO creates pipe pairs to be used with runc
-func newPipeIO(uid, gid int, opts ...IOOpt) (i IO, err error) {
+func newPipeIO(uid, gid int, opts ...IOOpt) (_ IO, retErr error) {
 	option := defaultIOOption()
 	for _, o := range opts {
 		o(option)
@@ -38,55 +34,40 @@ func newPipeIO(uid, gid int, opts ...IOOpt) (i IO, err error) {
 	)
 	// cleanup in case of an error
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			for _, p := range pipes {
-				p.Close()
+				_ = p.Close()
 			}
 		}
 	}()
 	if option.OpenStdin {
+		var err error
 		if stdin, err = newPipe(); err != nil {
 			return nil, err
 		}
 		pipes = append(pipes, stdin)
-		if err = unix.Fchown(int(stdin.r.Fd()), uid, gid); err != nil {
-			// TODO: revert with proper darwin solution, skipping for now
-			// as darwin chown is returning EINVAL on anonymous pipe
-			if runtime.GOOS == "darwin" {
-				logrus.WithError(err).Debug("failed to chown stdin, ignored")
-			} else {
-				return nil, fmt.Errorf("failed to chown stdin: %w", err)
-			}
+		if err := chownPipe(int(stdin.r.Fd()), uid, gid); err != nil {
+			return nil, fmt.Errorf("failed to chown stdin: %w", err)
 		}
 	}
 	if option.OpenStdout {
+		var err error
 		if stdout, err = newPipe(); err != nil {
 			return nil, err
 		}
 		pipes = append(pipes, stdout)
-		if err = unix.Fchown(int(stdout.w.Fd()), uid, gid); err != nil {
-			// TODO: revert with proper darwin solution, skipping for now
-			// as darwin chown is returning EINVAL on anonymous pipe
-			if runtime.GOOS == "darwin" {
-				logrus.WithError(err).Debug("failed to chown stdout, ignored")
-			} else {
-				return nil, fmt.Errorf("failed to chown stdout: %w", err)
-			}
+		if err := chownPipe(int(stdout.w.Fd()), uid, gid); err != nil {
+			return nil, fmt.Errorf("failed to chown stdout: %w", err)
 		}
 	}
 	if option.OpenStderr {
+		var err error
 		if stderr, err = newPipe(); err != nil {
 			return nil, err
 		}
 		pipes = append(pipes, stderr)
-		if err = unix.Fchown(int(stderr.w.Fd()), uid, gid); err != nil {
-			// TODO: revert with proper darwin solution, skipping for now
-			// as darwin chown is returning EINVAL on anonymous pipe
-			if runtime.GOOS == "darwin" {
-				logrus.WithError(err).Debug("failed to chown stderr, ignored")
-			} else {
-				return nil, fmt.Errorf("failed to chown stderr: %w", err)
-			}
+		if err := chownPipe(int(stderr.w.Fd()), uid, gid); err != nil {
+			return nil, fmt.Errorf("failed to chown stderr: %w", err)
 		}
 	}
 	return &pipeIO{

--- a/vendor/github.com/containerd/go-runc/monitor.go
+++ b/vendor/github.com/containerd/go-runc/monitor.go
@@ -112,7 +112,7 @@ func (m *defaultMonitor) StartLocked(c *exec.Cmd) (chan Exit, error) {
 	return ec, nil
 }
 
-func (m *defaultMonitor) Wait(c *exec.Cmd, ec chan Exit) (int, error) {
+func (m *defaultMonitor) Wait(_ *exec.Cmd, ec chan Exit) (int, error) {
 	e := <-ec
 	return e.Status, nil
 }

--- a/vendor/github.com/containerd/go-runc/runc.go
+++ b/vendor/github.com/containerd/go-runc/runc.go
@@ -14,6 +14,10 @@
    limitations under the License.
 */
 
+// Package runc provides Go bindings for invoking and interacting with the
+// [runc] command-line interface.
+//
+// [runc]: https://github.com/opencontainers/runc
 package runc
 
 import (
@@ -730,7 +734,9 @@ func (r *Runc) Update(context context.Context, id string, resources *specs.Linux
 	return r.runOrError(cmd)
 }
 
-// ErrParseRuncVersion is used when the runc version can't be parsed
+// ErrParseRuncVersion is kept for backward compatibility with older versions.
+//
+// Deprecated: ErrParseRuncVersion is never emitted, and should not be used.
 var ErrParseRuncVersion = errors.New("unable to parse runc version")
 
 // Version represents the runc version information
@@ -747,16 +753,16 @@ func (r *Runc) Version(context context.Context) (Version, error) {
 	if err != nil {
 		return Version{}, err
 	}
-	return parseVersion(data.Bytes())
+	return parseVersion(data.Bytes()), nil
 }
 
-func parseVersion(data []byte) (Version, error) {
+func parseVersion(data []byte) Version {
 	var v Version
 	parts := strings.Split(strings.TrimSpace(string(data)), "\n")
 
 	if len(parts) > 0 {
 		if !strings.HasPrefix(parts[0], "runc version ") {
-			return v, nil
+			return v
 		}
 		v.Runc = parts[0][13:]
 
@@ -769,7 +775,7 @@ func parseVersion(data []byte) (Version, error) {
 		}
 	}
 
-	return v, nil
+	return v
 }
 
 // Features shows the features implemented by the runtime.

--- a/vendor/github.com/containerd/go-runc/socket.go
+++ b/vendor/github.com/containerd/go-runc/socket.go
@@ -64,13 +64,13 @@ func newTempSocket(prefix, name string) (*Socket, error) {
 	}
 	s, err := newSocket(filepath.Join(dir, name))
 	if err != nil {
-		os.RemoveAll(dir)
+		_ = os.RemoveAll(dir) // #nosec G703 -- dir was created by os.MkdirTemp above.
 		return nil, err
 	}
 	s.rmdir = true
 	if runtimeDir != "" {
-		if err := os.Chmod(s.Path(), 0o755|os.ModeSticky); err != nil {
-			s.Close()
+		if err := os.Chmod(s.Path(), 0o755|os.ModeSticky); err != nil { // #nosec G703 -- the path identifies the socket created in the temporary directory.
+			_ = s.Close()
 			return nil, err
 		}
 	}
@@ -86,8 +86,8 @@ func (c *Socket) Path() string {
 func (c *Socket) Close() error {
 	err := c.l.Close()
 	if c.rmdir {
-		if rerr := os.RemoveAll(filepath.Dir(c.Path())); err == nil {
-			err = rerr
+		if rErr := os.RemoveAll(filepath.Dir(c.Path())); err == nil { // #nosec G703 -- rmdir is set only for sockets created in a private temporary directory.
+			err = rErr
 		}
 	}
 	return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -217,7 +217,7 @@ github.com/containerd/go-dmverity/pkg/dm
 github.com/containerd/go-dmverity/pkg/keyring
 github.com/containerd/go-dmverity/pkg/utils
 github.com/containerd/go-dmverity/pkg/verity
-# github.com/containerd/go-runc v1.2.0
+# github.com/containerd/go-runc v1.2.1
 ## explicit; go 1.21
 github.com/containerd/go-runc
 # github.com/containerd/imgcrypt/v2 v2.0.3


### PR DESCRIPTION
full diff: https://github.com/containerd/go-runc/compare/v1.2.0...v1.2.1