### PR TITLE
core/remotes/docker: url-encode cross-repo mount query values

### DIFF
--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -635,7 +635,7 @@ func requestWithMountFrom(req *request, mount, from string) *request {
 		sep = "&"
 	}
 
-	creq.path = creq.path + sep + "mount=" + mount + "&from=" + from
+	creq.path = creq.path + sep + "mount=" + url.QueryEscape(mount) + "&from=" + url.QueryEscape(from)
 
 	return &creq
 }

--- a/core/remotes/docker/pusher_test.go
+++ b/core/remotes/docker/pusher_test.go
@@ -74,6 +74,27 @@ func TestGetManifestPath(t *testing.T) {
 	}
 }
 
+func TestRequestWithMountFrom(t *testing.T) {
+	// from comes from the distribution-source annotation, which is propagated
+	// out of registry-supplied manifest content, so it must be escaped before
+	// it lands in the upload query string.
+	mount := "sha256:" + strings.Repeat("a", 64)
+	from := "library/redis&ns=attacker.example.com"
+
+	creq := requestWithMountFrom(&request{path: "/v2/target/blobs/uploads/"}, mount, from)
+
+	_, rawQuery, ok := strings.Cut(creq.path, "?")
+	require.True(t, ok, "expected a query string in %q", creq.path)
+
+	q, err := url.ParseQuery(rawQuery)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{mount}, q["mount"])
+	assert.Equal(t, []string{from}, q["from"])
+	// The '&'/'=' in from must not be interpreted as extra query parameters.
+	assert.NotContains(t, q, "ns")
+}
+
 // TestPusherErrClosedRetry tests if retrying work when error occurred on close.
 func TestPusherErrClosedRetry(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
requestWithMountFrom assembles the cross-repo blob mount request by pasting the mount digest and the from repository straight into the query string with no URL encoding. The from value is picked from a blob's containerd.io/distribution.source.<host> annotation, and annotateDistributionSourceHandler propagates those annotations from the manifest/index content the registry returns, with only a length check applied to the value. A crafted image can set from to something like `library/redis&ns=attacker.example.com`, so on a later push the `&` and `=` are parsed as extra query parameters on the authenticated `POST /v2/<repo>/blobs/uploads/` request. `ns` is containerd's own mirror/namespace routing parameter, so this is parameter smuggling into a request that carries the Authorization header, not just a cosmetic quirk.

Escape both values with url.QueryEscape before they enter the path, the same way the neighboring addQuery helper already handles every other query it writes. Keeping the encoding inside requestWithMountFrom means callers don't have to pre-sanitize annotation-derived repository names.

Disclosure: AI tooling was used to find and prepare this change, including the test and this description. I am responsible for what is submitted here.
