### PR TITLE
Add content delete event when GC deleted

### DIFF
--- a/core/metadata/db.go
+++ b/core/metadata/db.go
@@ -352,6 +352,8 @@ func (m *DB) publishEvents(events []namespacedEvent) {
 			ctx := namespaces.WithNamespace(ctx, ne.namespace)
 			var topic string
 			switch ne.event.(type) {
+			case *eventstypes.ContentDelete:
+				topic = "/content/delete"
 			case *eventstypes.ImageDelete:
 				topic = "/images/delete"
 			case *eventstypes.SnapshotRemove:

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -1054,7 +1054,9 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 		}
 		if cbkt != nil {
 			log.G(ctx).WithField("key", node.Key).Debug("remove content")
-			return nil, cbkt.DeleteBucket([]byte(node.Key))
+			return &eventstypes.ContentDelete{
+				Digest: node.Key,
+			}, cbkt.DeleteBucket([]byte(node.Key))
 		}
 	case ResourceSnapshot:
 		sbkt := nsbkt.Bucket(bucketKeyObjectSnapshots)


### PR DESCRIPTION
This adds a content delete event when content is removed due to GC. This brings the event feature in line to how for example image delete already works.

Fixes #14018