### PR TITLE
cri: fix sandbox name lock leak on context cancellation

### DIFF
--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -163,7 +163,9 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	}
 	defer func() {
 		if retErr != nil && cleanupErr == nil {
-			cleanupErr = c.client.SandboxStore().Delete(ctx, id)
+			deferCtx, deferCancel := util.DeferContext()
+			defer deferCancel()
+			cleanupErr = c.client.SandboxStore().Delete(deferCtx, id)
 		}
 	}()
 


### PR DESCRIPTION
Fixes #141599

When \RunPodSandbox\ is interrupted (e.g. by kubelet timeout or context cancellation), the \ctx\ becomes canceled. If the CNI plugin fails (e.g. \signal: killed\ due to timeout) and the network teardown executes, the subsequent \defer\ that deletes the sandbox metadata from the BoltDB \SandboxStore()\ fails with \context canceled\, because it reuses the original canceled \ctx\.

This failure sets \cleanupErr\ to \context.Canceled\, which causes the subsequent \defer\ to skip releasing the sandbox name reservation from the in-memory \sandboxNameIndex\.

This PR fixes the lock leak by using a detached \deferCtx\ for \c.client.SandboxStore().Delete(deferCtx, id)\, matching the exact pattern used in all other cleanup defers in \RunPodSandbox\.