### PR TITLE
cri: Fix image pull progress timeout during unpack

### DIFF
--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -987,7 +987,7 @@ func (reporter *transferProgressReporter) handleProgress(p transfer.Progress) {
 			delete(reporter.statuses, p.Name)
 		}
 
-	case "complete":
+	case "complete", "extracting", "extracted", "already exists":
 		if node, exists := reporter.statuses[p.Name]; exists {
 			if curProgress := p.Progress - node.Progress; curProgress > 0 {
 				reporter.IncBytesRead(curProgress)


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fixes false timeout cancellations during CRI image pull when extraction starts before the transfer service sends a 'complete' event.

When pulling an image through the transfer service (`use_local_image_pull = false`), the CRI progress reporter's active-request counter can leak, causing the watchdog to incorrectly cancel pulls with "no progress" even though extraction is actively progressing.

## The Problem:

The transfer service `ProgressTracker` polls statuses every 300ms and only sends `complete` events while the job is in `jobAdded` or `jobInProgress` state. However, extraction starts immediately after download completes, moving the job to `jobExtracting` within milliseconds—before the next polling tick. This causes the job to skip the `complete` event and instead send `extracting` and `extracted` events.

The CRI `transferProgressReporter` only handles `waiting`, `downloading`, and `complete` events, ignoring `extracting`, `extracted`, and `already exists`. This leaves `activeReqs` incremented, and when `bytesRead` stops increasing during unpack, the watchdog times out and cancels the pull.

## The Solution:

This PR changes `handleProgress()` to also handle `extracting`, `extracted`, and `already exists` events as download completion, properly decrementing the active request counter and preventing false timeouts.

## Which issue(s) this PR fixes:

Fixes #13909

## Special notes for your reviewer:

- This is a minimal 1-line change following the patch suggested in #13909
- The fix only affects the CRI image pull progress reporter
- All download completion events now properly update the request counter
- No functional changes to the actual image pull/unpack logic
