### PR TITLE
remotes/docker: delay retries on HTTP 429

### DIFF
--- a/core/remotes/docker/fetcher_test.go
+++ b/core/remotes/docker/fetcher_test.go
@@ -873,6 +873,7 @@ func TestDockerFetcherOpen(t *testing.T) {
 
 			f := dockerFetcher{&dockerBase{
 				repository: "ns",
+				sleeper:    func(context.Context, time.Duration) error { return nil },
 			}}
 
 			host := RegistryHost{

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -22,11 +22,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -152,6 +156,7 @@ type dockerResolver struct {
 	tracker        StatusTracker
 	config         transfer.ImageResolverOptions
 	warningHandler WarningHandler
+	sleeper        func(context.Context, time.Duration) error
 }
 
 // NewResolver returns a new resolver to a Docker registry
@@ -540,6 +545,7 @@ type dockerBase struct {
 	performances   transfer.ImageResolverPerformanceSettings
 	limiter        *semaphore.Weighted
 	warningHandler WarningHandler
+	sleeper        func(context.Context, time.Duration) error
 }
 
 func (r *dockerBase) Acquire(ctx context.Context, weight int64) error {
@@ -569,6 +575,7 @@ func (r *dockerResolver) base(refspec reference.Spec) (*dockerBase, error) {
 		performances:   r.config.Performances,
 		limiter:        r.config.DownloadLimiter,
 		warningHandler: r.warningHandler,
+		sleeper:        r.sleeper,
 	}, nil
 }
 
@@ -608,6 +615,7 @@ func (r *dockerBase) request(host RegistryHost, method string, ps ...string) *re
 		host:           host,
 		refspec:        r.refspec,
 		warningHandler: r.warningHandler,
+		sleeper:        r.sleeper,
 	}
 }
 
@@ -660,6 +668,7 @@ type request struct {
 	size           int64
 	refspec        reference.Spec
 	warningHandler WarningHandler
+	sleeper        func(context.Context, time.Duration) error
 }
 
 func (r *request) clone() *request {
@@ -808,6 +817,11 @@ func (r *request) doWithRetriesInner(ctx context.Context, responses []*http.Resp
 	}
 	if retry && *attempts > 0 {
 		resp.Body.Close()
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if err := r.delay429(ctx, responses); err != nil {
+				return nil, err
+			}
+		}
 		return r.doWithRetriesInner(ctx, responses, attempts, lastHost)
 	}
 	return resp, err
@@ -881,7 +895,26 @@ func (r *request) retryRequest(ctx context.Context, responses []*http.Response, 
 			r.method = http.MethodGet
 			return true, nil
 		}
-	case http.StatusRequestTimeout, http.StatusTooManyRequests:
+	case http.StatusRequestTimeout:
+		return true, nil
+	case http.StatusTooManyRequests:
+		// Only retry if this is the last host that will be attempted, allowing
+		// earlier rate-limited mirrors to immediately fall back to another mirror.
+		if !lastHost {
+			return false, nil
+		}
+		if retryAfterStr := last.Header.Get("Retry-After"); retryAfterStr != "" {
+			if d, ok := parseRetryAfter(retryAfterStr); ok && d > default429MaxRetryAfter {
+				log.G(ctx).WithFields(log.Fields{
+					"url":         r.sanitizedURL(),
+					"host":        r.host.Host,
+					"retry-after": retryAfterStr,
+					"delay":       d,
+					"threshold":   default429MaxRetryAfter,
+				}).Debug("rate limited (429), Retry-After exceeds threshold, not retrying")
+				return false, nil
+			}
+		}
 		return true, nil
 	case http.StatusServiceUnavailable, http.StatusGatewayTimeout, http.StatusInternalServerError:
 		// Do not retry if the same error was seen in the last request
@@ -933,6 +966,137 @@ func (r *request) sanitizedURL() string {
 
 	parsed.RawQuery = query.Encode()
 	return parsed.Redacted()
+}
+
+// For a consistent sequence of 429 responses without Retry-After, maxAttempts (5)
+// allows 1 initial request and 4 retries with exponential backoff (0.5s, 1s, 2s, 4s),
+// resulting in a total base sleep delay of ~7.5 seconds (6.0s–7.5s with up to 20%
+// jitter subtracted).
+const (
+	default429BaseDelay     = 500 * time.Millisecond
+	default429MaxDelay      = 5 * time.Second
+	default429MaxRetryAfter = 1 * time.Minute
+	maxJitterFraction       = 5 // up to 20% (1/5) jitter
+)
+
+func (r *request) delay429(ctx context.Context, responses []*http.Response) error {
+	last := responses[len(responses)-1]
+	retryAfterStr := last.Header.Get("Retry-After")
+	var delay time.Duration
+	if d, ok := parseRetryAfter(retryAfterStr); ok {
+		delay = d
+	} else {
+		consecutive := countConsecutive429(responses)
+		delay = calculateBackoff(consecutive, default429BaseDelay, default429MaxDelay)
+	}
+
+	fields := log.Fields{
+		"url":     r.sanitizedURL(),
+		"host":    r.host.Host,
+		"attempt": len(responses),
+		"delay":   delay,
+	}
+	// r.refspec is propagated from dockerBase, initialized from the image
+	// reference provided to Resolver.Resolve or Resolver.Fetcher.
+	if r.refspec.Locator != "" {
+		fields["image"] = r.refspec.Locator
+	}
+	if d := r.refspec.Digest(); d != "" {
+		fields["digest"] = d.String()
+	} else if r.refspec.Object != "" {
+		fields["object"] = r.refspec.Object
+	}
+	if retryAfterStr != "" {
+		fields["retry-after"] = retryAfterStr
+	}
+	log.G(ctx).WithFields(fields).Debug("rate limited (429), delaying retry")
+
+	return r.sleep(ctx, delay)
+}
+
+// countConsecutive429 counts consecutive 429 responses at the end of the response chain
+// so that exponential backoff doubles only across consecutive rate-limiting responses
+// and resets if an intervening non-429 error was encountered.
+func countConsecutive429(responses []*http.Response) int {
+	count := 0
+	for _, resp := range slices.Backward(responses) {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			count++
+		} else {
+			break
+		}
+	}
+	return count
+}
+
+// calculateBackoff computes the exponential backoff duration for the given 429 retry
+// attempt (1-indexed). The delay doubles with each attempt starting from baseDelay
+// up to maxDelay, with up to 20% jitter subtracted.
+func calculateBackoff(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
+	if attempt <= 0 {
+		attempt = 1
+	}
+	// Cap shift at 30 to prevent 1<<shift from overflowing time.Duration before
+	// the maxDelay check clamps it.
+	shift := min(attempt-1, 30)
+	delay := baseDelay * time.Duration(1<<shift)
+	if delay > maxDelay || delay <= 0 {
+		delay = maxDelay
+	}
+
+	if delay > 0 {
+		// Subtract full jitter up to 20% (1/maxJitterFraction) of the calculated delay.
+		jitter := time.Duration(rand.Int64N(int64(delay/maxJitterFraction) + 1))
+		delay -= jitter
+	}
+	return delay
+}
+
+const maxRetryAfterSeconds = math.MaxInt64 / int64(time.Second)
+
+func parseRetryAfter(header string) (time.Duration, bool) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.ParseInt(header, 10, 64); err == nil {
+		if seconds < 0 || seconds > maxRetryAfterSeconds {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	if t, err := http.ParseTime(header); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0, true
+		}
+		return d, true
+	}
+	return 0, false
+}
+
+func (r *request) sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	if r.sleeper != nil {
+		return r.sleeper(ctx, d)
+	}
+	return defaultSleep(ctx, d)
+}
+
+func defaultSleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
 }
 
 func (r *request) setMediaType(mediatype string) {

--- a/core/remotes/docker/resolver_429_test.go
+++ b/core/remotes/docker/resolver_429_test.go
@@ -1,0 +1,532 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package docker
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/errors"
+	"github.com/containerd/containerd/v2/pkg/reference"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func assertRange(t *testing.T, actual, min, max time.Duration) {
+	t.Helper()
+	assert.GreaterOrEqual(t, actual, min)
+	assert.LessOrEqual(t, actual, max)
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name         string
+		header       string
+		wantOk       bool
+		wantMin      time.Duration
+		wantMax      time.Duration
+		wantDuration time.Duration
+	}{
+		{
+			name:   "empty header",
+			header: "",
+			wantOk: false,
+		},
+		{
+			name:   "whitespace only",
+			header: "   ",
+			wantOk: false,
+		},
+		{
+			name:         "valid delta seconds",
+			header:       "120",
+			wantOk:       true,
+			wantDuration: 120 * time.Second,
+		},
+		{
+			name:         "valid delta seconds with spaces",
+			header:       "  5  ",
+			wantOk:       true,
+			wantDuration: 5 * time.Second,
+		},
+		{
+			name:         "zero delta seconds",
+			header:       "0",
+			wantOk:       true,
+			wantDuration: 0,
+		},
+		{
+			name:   "negative delta seconds invalid",
+			header: "-10",
+			wantOk: false,
+		},
+		{
+			name:   "delta seconds overflow time.Duration",
+			header: "9223372037",
+			wantOk: false,
+		},
+		{
+			name:   "delta seconds overflow int64",
+			header: "99999999999999999999999999999",
+			wantOk: false,
+		},
+		{
+			name:         "HTTP date in the past",
+			header:       "Wed, 21 Oct 2015 07:28:00 GMT",
+			wantOk:       true,
+			wantDuration: 0,
+		},
+		{
+			name:    "HTTP date in the future",
+			header:  time.Now().Add(60 * time.Second).UTC().Format(http.TimeFormat),
+			wantOk:  true,
+			wantMin: 55 * time.Second,
+			wantMax: 65 * time.Second,
+		},
+		{
+			name:   "invalid header string",
+			header: "not-a-number-or-date",
+			wantOk: false,
+		},
+		{
+			name:   "invalid suffix like 120s",
+			header: "120s",
+			wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, ok := parseRetryAfter(tt.header)
+			assert.Equal(t, tt.wantOk, ok)
+			if !tt.wantOk {
+				return
+			}
+			if tt.wantMin > 0 || tt.wantMax > 0 {
+				assertRange(t, d, tt.wantMin, tt.wantMax)
+			} else {
+				assert.Equal(t, tt.wantDuration, d)
+			}
+		})
+	}
+}
+
+func TestCalculateBackoff(t *testing.T) {
+	base := 500 * time.Millisecond
+	max := 5 * time.Second
+
+	// Attempt 1: 500ms base - up to 20% jitter (100ms) -> [400ms, 500ms]
+	for range 10 {
+		d := calculateBackoff(1, base, max)
+		assertRange(t, d, 400*time.Millisecond, 500*time.Millisecond)
+	}
+
+	// Attempt 2: 1000ms base - up to 20% jitter (200ms) -> [800ms, 1000ms]
+	for range 10 {
+		d := calculateBackoff(2, base, max)
+		assertRange(t, d, 800*time.Millisecond, 1000*time.Millisecond)
+	}
+
+	// Attempt 3: 2000ms base - up to 20% jitter (400ms) -> [1600ms, 2000ms]
+	for range 10 {
+		d := calculateBackoff(3, base, max)
+		assertRange(t, d, 1600*time.Millisecond, 2000*time.Millisecond)
+	}
+
+	// Attempt 4: 4000ms base - up to 20% jitter (800ms) -> [3200ms, 4000ms]
+	for range 10 {
+		d := calculateBackoff(4, base, max)
+		assertRange(t, d, 3200*time.Millisecond, 4000*time.Millisecond)
+	}
+
+	// Attempt 5+: capped at max (5s) - up to 20% jitter (1000ms) -> [4000ms, 5000ms]
+	for range 10 {
+		d := calculateBackoff(5, base, max)
+		assertRange(t, d, 4000*time.Millisecond, 5000*time.Millisecond)
+	}
+
+	// Attempt 100: no integer overflow, still capped at max with jitter
+	d := calculateBackoff(100, base, max)
+	assertRange(t, d, 4000*time.Millisecond, 5000*time.Millisecond)
+
+	// Attempt 0 or negative: treated as attempt 1
+	d0 := calculateBackoff(0, base, max)
+	assertRange(t, d0, 400*time.Millisecond, 500*time.Millisecond)
+}
+
+func TestRetry429WithRetryAfterHeader(t *testing.T) {
+	t.Run("eventual success", func(t *testing.T) {
+		var (
+			sleepMu        sync.Mutex
+			sleptDurations []time.Duration
+			attempts       atomic.Int32
+		)
+		sleeper := func(ctx context.Context, d time.Duration) error {
+			sleepMu.Lock()
+			sleptDurations = append(sleptDurations, d)
+			sleepMu.Unlock()
+			return nil
+		}
+
+		s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			current := attempts.Add(1)
+			if current <= 2 {
+				rw.Header().Set("Retry-After", strconv.Itoa(int(current)))
+				rw.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+
+			rw.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(s.Close)
+
+		u, err := url.Parse(s.URL)
+		require.NoError(t, err)
+
+		refspec, err := reference.Parse(u.Host + "/test/image:latest")
+		require.NoError(t, err)
+
+		req := &request{
+			method:  http.MethodGet,
+			path:    "/v2/test/image/manifests/latest",
+			host:    RegistryHost{Client: s.Client(), Host: u.Host, Scheme: u.Scheme},
+			refspec: refspec,
+			sleeper: sleeper,
+		}
+
+		resp, err := req.doWithRetries(context.Background(), true, withErrorCheck)
+		require.NoError(t, err)
+		t.Cleanup(func() { resp.Body.Close() })
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, int32(3), attempts.Load())
+		sleepMu.Lock()
+		defer sleepMu.Unlock()
+		require.Len(t, sleptDurations, 2)
+		assert.Equal(t, 1*time.Second, sleptDurations[0])
+		assert.Equal(t, 2*time.Second, sleptDurations[1])
+	})
+
+	t.Run("retries exhausted", func(t *testing.T) {
+		var (
+			sleepMu        sync.Mutex
+			sleptDurations []time.Duration
+			attempts       atomic.Int32
+		)
+		sleeper := func(ctx context.Context, d time.Duration) error {
+			sleepMu.Lock()
+			sleptDurations = append(sleptDurations, d)
+			sleepMu.Unlock()
+			return nil
+		}
+
+		s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			rw.Header().Set("Retry-After", "30")
+			rw.WriteHeader(http.StatusTooManyRequests)
+			rw.Write([]byte(`{"errors":[{"code":"TOOMANYREQUESTS","message":"pull rate limit reached"}]}`))
+		}))
+		t.Cleanup(s.Close)
+
+		u, err := url.Parse(s.URL)
+		require.NoError(t, err)
+
+		refspec, err := reference.Parse(u.Host + "/test/jsonerr:latest")
+		require.NoError(t, err)
+
+		req := &request{
+			method:  http.MethodGet,
+			path:    "/v2/test/jsonerr/manifests/latest",
+			host:    RegistryHost{Client: s.Client(), Host: u.Host, Scheme: u.Scheme},
+			refspec: refspec,
+			sleeper: sleeper,
+		}
+
+		_, err = req.doWithRetries(context.Background(), true, withErrorCheck)
+		require.Error(t, err)
+
+		assert.Equal(t, int32(5), attempts.Load())
+		sleepMu.Lock()
+		defer sleepMu.Unlock()
+		require.Len(t, sleptDurations, 4)
+
+		var statusErr remoteerrors.ErrUnexpectedStatus
+		require.True(t, errors.As(err, &statusErr))
+		assert.Equal(t, http.StatusTooManyRequests, statusErr.StatusCode)
+		assert.Equal(t, "30", statusErr.RetryAfter)
+
+		errStr := err.Error()
+		assert.Contains(t, errStr, "(Retry-After: 30)")
+		assert.Contains(t, errStr, "toomanyrequests")
+		assert.Contains(t, errStr, "pull rate limit reached")
+	})
+}
+
+func TestRetry429ExponentialBackoff(t *testing.T) {
+	var (
+		sleepMu        sync.Mutex
+		sleptDurations []time.Duration
+		attempts       atomic.Int32
+	)
+	sleeper := func(ctx context.Context, d time.Duration) error {
+		sleepMu.Lock()
+		sleptDurations = append(sleptDurations, d)
+		sleepMu.Unlock()
+		return nil
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		current := attempts.Add(1)
+		if current <= 2 {
+			rw.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+
+		rw.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(s.Close)
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err)
+
+	refspec, err := reference.Parse(u.Host + "/test/backoff:latest")
+	require.NoError(t, err)
+
+	req := &request{
+		method:  http.MethodGet,
+		path:    "/v2/test/backoff/manifests/latest",
+		host:    RegistryHost{Client: s.Client(), Host: u.Host, Scheme: u.Scheme},
+		refspec: refspec,
+		sleeper: sleeper,
+	}
+
+	resp, err := req.doWithRetries(context.Background(), true, withErrorCheck)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(3), attempts.Load())
+	sleepMu.Lock()
+	defer sleepMu.Unlock()
+	require.Len(t, sleptDurations, 2)
+
+	// Attempt 1 backoff: [400ms, 500ms]
+	assertRange(t, sleptDurations[0], 400*time.Millisecond, 500*time.Millisecond)
+
+	// Attempt 2 backoff: [800ms, 1000ms]
+	assertRange(t, sleptDurations[1], 800*time.Millisecond, 1000*time.Millisecond)
+}
+
+func TestRetry429NotLastHostFailsImmediately(t *testing.T) {
+	var attempts atomic.Int32
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		rw.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(s.Close)
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err)
+
+	refspec, err := reference.Parse(u.Host + "/test/not-lasthost:latest")
+	require.NoError(t, err)
+
+	req := &request{
+		method:  http.MethodGet,
+		path:    "/v2/test/not-lasthost/manifests/latest",
+		host:    RegistryHost{Client: s.Client(), Host: u.Host, Scheme: u.Scheme},
+		refspec: refspec,
+	}
+
+	// With lastHost=false, 429 should not retry, allowing fallback to next host
+	_, err = req.doWithRetries(context.Background(), false, withErrorCheck)
+	require.Error(t, err)
+	assert.Equal(t, int32(1), attempts.Load())
+
+	var statusErr remoteerrors.ErrUnexpectedStatus
+	require.True(t, errors.As(err, &statusErr))
+	assert.Equal(t, http.StatusTooManyRequests, statusErr.StatusCode)
+}
+
+func TestRetry429RespectsRetryAfterWithoutMaxDelayCap(t *testing.T) {
+	var (
+		sleepMu        sync.Mutex
+		sleptDurations []time.Duration
+		attempts       atomic.Int32
+	)
+	sleeper := func(ctx context.Context, d time.Duration) error {
+		sleepMu.Lock()
+		sleptDurations = append(sleptDurations, d)
+		sleepMu.Unlock()
+		return nil
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		current := attempts.Add(1)
+		if current <= 1 {
+			rw.Header().Set("Retry-After", "60")
+			rw.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+
+		rw.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(s.Close)
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err)
+
+	refspec, err := reference.Parse(u.Host + "/test/no-cap:latest")
+	require.NoError(t, err)
+
+	req := &request{
+		method:  http.MethodGet,
+		path:    "/v2/test/no-cap/manifests/latest",
+		host:    RegistryHost{Client: s.Client(), Host: u.Host, Scheme: u.Scheme},
+		refspec: refspec,
+		sleeper: sleeper,
+	}
+
+	resp, err := req.doWithRetries(context.Background(), true, withErrorCheck)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	// Retry-After (60s) is respected
+	assert.Equal(t, int32(2), attempts.Load())
+	sleepMu.Lock()
+	defer sleepMu.Unlock()
+	require.Len(t, sleptDurations, 1)
+	assert.Equal(t, 60*time.Second, sleptDurations[0])
+}
+
+func TestRetry429ExceedsMaxRetryAfterFailsImmediately(t *testing.T) {
+	var (
+		sleepMu        sync.Mutex
+		sleptDurations []time.Duration
+		attempts       atomic.Int32
+	)
+	sleeper := func(ctx context.Context, d time.Duration) error {
+		sleepMu.Lock()
+		sleptDurations = append(sleptDurations, d)
+		sleepMu.Unlock()
+		return nil
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		rw.Header().Set("Retry-After", "61")
+		rw.WriteHeader(http.StatusTooManyRequests)
+		rw.Write([]byte(`{"errors":[{"code":"TOOMANYREQUESTS","message":"rate limit exceeded, try later"}]}`))
+	}))
+	t.Cleanup(s.Close)
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err)
+
+	refspec, err := reference.Parse(u.Host + "/test/excessive:latest")
+	require.NoError(t, err)
+
+	req := &request{
+		method:  http.MethodGet,
+		path:    "/v2/test/excessive/manifests/latest",
+		host:    RegistryHost{Client: s.Client(), Host: u.Host, Scheme: u.Scheme},
+		refspec: refspec,
+		sleeper: sleeper,
+	}
+
+	_, err = req.doWithRetries(context.Background(), true, withErrorCheck)
+	require.Error(t, err)
+
+	// Fails immediately on first attempt without retrying or sleeping
+	assert.Equal(t, int32(1), attempts.Load())
+	sleepMu.Lock()
+	defer sleepMu.Unlock()
+	assert.Empty(t, sleptDurations)
+
+	var statusErr remoteerrors.ErrUnexpectedStatus
+	require.True(t, errors.As(err, &statusErr))
+	assert.Equal(t, http.StatusTooManyRequests, statusErr.StatusCode)
+	assert.Equal(t, "61", statusErr.RetryAfter)
+	assert.Contains(t, err.Error(), "(Retry-After: 61)")
+	assert.Contains(t, err.Error(), "rate limit exceeded, try later")
+}
+
+func TestRetry429ContextCancellation(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Retry-After", "10")
+		rw.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(s.Close)
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err)
+
+	refspec, err := reference.Parse(u.Host + "/test/cancel:latest")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	start := time.Now()
+	req := &request{
+		method:  http.MethodGet,
+		path:    "/v2/test/cancel/manifests/latest",
+		host:    RegistryHost{Client: s.Client(), Host: u.Host, Scheme: u.Scheme},
+		refspec: refspec,
+		sleeper: func(ctx context.Context, d time.Duration) error {
+			// Trigger context cancel while sleeping
+			cancel()
+			return defaultSleep(ctx, d)
+		},
+	}
+
+	_, err = req.doWithRetries(ctx, true, withErrorCheck)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+func TestRetry429Synctest(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		// Verify defaultSleep advances virtual time durably and immediately
+		start := time.Now()
+		err := defaultSleep(ctx, 3*time.Second)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, time.Since(start), 3*time.Second)
+
+		// Verify context timeout terminates defaultSleep with DeadlineExceeded in virtual time
+		timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+
+		start = time.Now()
+		err = defaultSleep(timeoutCtx, 5*time.Second)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		elapsed := time.Since(start)
+		assert.GreaterOrEqual(t, elapsed, 1*time.Second)
+		assert.Less(t, elapsed, 5*time.Second)
+	})
+}

--- a/core/remotes/errors/errors.go
+++ b/core/remotes/errors/errors.go
@@ -37,10 +37,15 @@ type ErrUnexpectedStatus struct {
 	Body          []byte `json:"body,omitempty"`
 	RequestURL    string `json:"requestURL,omitempty"`
 	RequestMethod string `json:"requestMethod,omitempty"`
+	RetryAfter    string `json:"retryAfter,omitempty"`
 }
 
 func (e ErrUnexpectedStatus) Error() string {
-	return fmt.Sprintf("unexpected status from %s request to %s: %s", e.RequestMethod, e.RequestURL, e.Status)
+	msg := fmt.Sprintf("unexpected status from %s request to %s: %s", e.RequestMethod, e.RequestURL, e.Status)
+	if e.RetryAfter != "" {
+		msg += fmt.Sprintf(" (Retry-After: %s)", e.RetryAfter)
+	}
+	return msg
 }
 
 // NewUnexpectedStatusErr creates an ErrUnexpectedStatus from HTTP response
@@ -54,6 +59,7 @@ func NewUnexpectedStatusErr(resp *http.Response) error {
 		Status:        resp.Status,
 		StatusCode:    resp.StatusCode,
 		RequestMethod: resp.Request.Method,
+		RetryAfter:    resp.Header.Get("Retry-After"),
 	}
 	if resp.Request.URL != nil {
 		err.RequestURL = resp.Request.URL.String()

--- a/core/remotes/errors/errors_test.go
+++ b/core/remotes/errors/errors_test.go
@@ -1,0 +1,101 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package errors
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/containerd/typeurl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrUnexpectedStatus(t *testing.T) {
+	reqURL, err := url.Parse("https://example.com/v2/image/manifests/latest")
+	require.NoError(t, err)
+
+	t.Run("with Retry-After header", func(t *testing.T) {
+		resp := &http.Response{
+			Status:     "429 Too Many Requests",
+			StatusCode: http.StatusTooManyRequests,
+			Header: http.Header{
+				"Retry-After": []string{"120"},
+			},
+			Body: io.NopCloser(strings.NewReader("rate limit reached")),
+			Request: &http.Request{
+				Method: http.MethodGet,
+				URL:    reqURL,
+			},
+		}
+
+		err := NewUnexpectedStatusErr(resp)
+		require.Error(t, err)
+
+		statusErr, ok := err.(ErrUnexpectedStatus)
+		require.True(t, ok)
+		assert.Equal(t, "429 Too Many Requests", statusErr.Status)
+		assert.Equal(t, http.StatusTooManyRequests, statusErr.StatusCode)
+		assert.Equal(t, "120", statusErr.RetryAfter)
+		assert.Equal(t, "unexpected status from GET request to https://example.com/v2/image/manifests/latest: 429 Too Many Requests (Retry-After: 120)", statusErr.Error())
+	})
+
+	t.Run("without Retry-After header", func(t *testing.T) {
+		resp := &http.Response{
+			Status:     "500 Internal Server Error",
+			StatusCode: http.StatusInternalServerError,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("error")),
+			Request: &http.Request{
+				Method: http.MethodHead,
+				URL:    reqURL,
+			},
+		}
+
+		err := NewUnexpectedStatusErr(resp)
+		require.Error(t, err)
+
+		statusErr, ok := err.(ErrUnexpectedStatus)
+		require.True(t, ok)
+		assert.Equal(t, "", statusErr.RetryAfter)
+		assert.Equal(t, "unexpected status from HEAD request to https://example.com/v2/image/manifests/latest: 500 Internal Server Error", statusErr.Error())
+	})
+
+	t.Run("typeurl registration", func(t *testing.T) {
+		err := ErrUnexpectedStatus{
+			Status:        "429 Too Many Requests",
+			StatusCode:    429,
+			RetryAfter:    "60",
+			RequestURL:    "https://example.com",
+			RequestMethod: "GET",
+		}
+
+		any, errMarshal := typeurl.MarshalAny(&err)
+		require.NoError(t, errMarshal)
+
+		unmarshaled, errUnmarshal := typeurl.UnmarshalAny(any)
+		require.NoError(t, errUnmarshal)
+
+		statusErr, ok := unmarshaled.(*ErrUnexpectedStatus)
+		require.True(t, ok)
+		assert.Equal(t, "60", statusErr.RetryAfter)
+		assert.Equal(t, 429, statusErr.StatusCode)
+	})
+}

--- a/integration/client/image_429_test.go
+++ b/integration/client/image_429_test.go
@@ -1,0 +1,271 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/testutil"
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func emptyOCITestImage() (map[digest.Digest][]byte, ocispec.Descriptor) {
+	blobs := make(map[digest.Digest][]byte)
+
+	layerBytes := make([]byte, 1024)
+	layerDigest := digest.FromBytes(layerBytes)
+	blobs[layerDigest] = layerBytes
+
+	configJSON := []byte(`{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["` + layerDigest.String() + `"]}}`)
+	configDigest := digest.FromBytes(configJSON)
+	blobs[configDigest] = configJSON
+
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config: ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageConfig,
+			Digest:    configDigest,
+			Size:      int64(len(configJSON)),
+		},
+		Layers: []ocispec.Descriptor{
+			{
+				MediaType: ocispec.MediaTypeImageLayer,
+				Digest:    layerDigest,
+				Size:      int64(len(layerBytes)),
+			},
+		},
+	}
+	manifestJSON, _ := json.Marshal(manifest)
+	manifestDigest := digest.FromBytes(manifestJSON)
+	blobs[manifestDigest] = manifestJSON
+
+	target := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    manifestDigest,
+		Size:      int64(len(manifestJSON)),
+	}
+
+	return blobs, target
+}
+
+func TestImagePullWith429RetryAfter(t *testing.T) {
+	client, err := newClient(t, address)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	blobs, target := emptyOCITestImage()
+
+	var attempts atomic.Int32
+	interceptor := func(w http.ResponseWriter, r *http.Request) bool {
+		if strings.Contains(r.URL.Path, "/manifests/") {
+			if attempts.Add(1) <= 2 {
+				w.Header().Set("Retry-After", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				w.Write([]byte(`{"errors":[{"code":"TOOMANYREQUESTS","message":"rate limit exceeded"}]}`))
+				return true
+			}
+		}
+		return false
+	}
+
+	ref := testutil.ServeImageWithInterceptor(t, "retryafter-429", "latest", target, blobs, interceptor)
+	t.Cleanup(func() {
+		client.ImageService().Delete(ctx, ref)
+	})
+
+	start := time.Now()
+	image, err := client.Pull(ctx, ref, WithPlatformMatcher(platforms.Default()))
+	require.NoError(t, err)
+	require.NotNil(t, image)
+
+	// Since two 429s each requested 1s Retry-After, pull must have taken >= 2 seconds
+	assert.GreaterOrEqual(t, time.Since(start), 2*time.Second)
+	assert.GreaterOrEqual(t, attempts.Load(), int32(3))
+}
+
+func TestImagePullWith429ExponentialBackoff(t *testing.T) {
+	client, err := newClient(t, address)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	blobs, target := emptyOCITestImage()
+
+	var attempts atomic.Int32
+	interceptor := func(w http.ResponseWriter, r *http.Request) bool {
+		if strings.Contains(r.URL.Path, "/manifests/") {
+			// Return 429 without Retry-After twice to test exponential backoff
+			// Attempt 1 backoff: ~500ms
+			// Attempt 2 backoff: ~1000ms
+			// Total backoff delay: ~1500ms
+			if attempts.Add(1) <= 2 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				w.Write([]byte(`rate limit reached`))
+				return true
+			}
+		}
+		return false
+	}
+
+	ref := testutil.ServeImageWithInterceptor(t, "backoff-429", "latest", target, blobs, interceptor)
+	t.Cleanup(func() {
+		client.ImageService().Delete(ctx, ref)
+	})
+
+	start := time.Now()
+	image, err := client.Pull(ctx, ref, WithPlatformMatcher(platforms.Default()))
+	require.NoError(t, err)
+	require.NotNil(t, image)
+
+	// Exponential backoff with 500ms base (down to 400ms with jitter) doubling to 1000ms (down to 800ms with jitter) means >= 1200ms elapsed
+	assert.GreaterOrEqual(t, time.Since(start), 1200*time.Millisecond)
+	assert.GreaterOrEqual(t, attempts.Load(), int32(3))
+}
+
+func TestImagePullWith429ContextTimeout(t *testing.T) {
+	client, err := newClient(t, address)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+	ctx, timeoutCancel := context.WithTimeout(ctx, 1*time.Second)
+	t.Cleanup(timeoutCancel)
+
+	blobs, target := emptyOCITestImage()
+
+	var attempts atomic.Int32
+	interceptor := func(w http.ResponseWriter, r *http.Request) bool {
+		if strings.Contains(r.URL.Path, "/manifests/") {
+			attempts.Add(1)
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return true
+		}
+		return false
+	}
+
+	ref := testutil.ServeImageWithInterceptor(t, "timeout-429", "latest", target, blobs, interceptor)
+	t.Cleanup(func() {
+		ctxClean, cancelClean := testContext(t)
+		defer cancelClean()
+		client.ImageService().Delete(ctxClean, ref)
+	})
+
+	start := time.Now()
+	_, err = client.Pull(ctx, ref, WithPlatformMatcher(platforms.Default()))
+	require.Error(t, err)
+
+	// Since Retry-After is 60s but ctx timeout is 1s, pull should abort after ~1s
+	elapsed := time.Since(start)
+	assert.GreaterOrEqual(t, elapsed, 1*time.Second)
+	assert.Less(t, elapsed, 10*time.Second)
+	assert.Equal(t, int32(1), attempts.Load())
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestImagePullWith429ExhaustedRetries(t *testing.T) {
+	client, err := newClient(t, address)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	blobs, target := emptyOCITestImage()
+
+	var attempts atomic.Int32
+	interceptor := func(w http.ResponseWriter, r *http.Request) bool {
+		if strings.Contains(r.URL.Path, "/manifests/") {
+			attempts.Add(1)
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return true
+		}
+		return false
+	}
+
+	ref := testutil.ServeImageWithInterceptor(t, "exhausted-429", "latest", target, blobs, interceptor)
+	t.Cleanup(func() {
+		client.ImageService().Delete(ctx, ref)
+	})
+
+	_, err = client.Pull(ctx, ref, WithPlatformMatcher(platforms.Default()))
+	require.Error(t, err)
+
+	// All 5 attempts exhausted
+	assert.Equal(t, int32(5), attempts.Load())
+	assert.Contains(t, err.Error(), "429 Too Many Requests")
+	assert.Contains(t, err.Error(), "(Retry-After: 0)")
+}
+
+func TestImagePullWith429ExcessiveRetryAfter(t *testing.T) {
+	client, err := newClient(t, address)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	blobs, target := emptyOCITestImage()
+
+	var attempts atomic.Int32
+	interceptor := func(w http.ResponseWriter, r *http.Request) bool {
+		if strings.Contains(r.URL.Path, "/manifests/") {
+			attempts.Add(1)
+			w.Header().Set("Retry-After", "300")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return true
+		}
+		return false
+	}
+
+	ref := testutil.ServeImageWithInterceptor(t, "excessive-429", "latest", target, blobs, interceptor)
+	t.Cleanup(func() {
+		client.ImageService().Delete(ctx, ref)
+	})
+
+	start := time.Now()
+	_, err = client.Pull(ctx, ref, WithPlatformMatcher(platforms.Default()))
+	require.Error(t, err)
+
+	// Fails immediately on first attempt without retrying or sleeping
+	assert.Less(t, time.Since(start), 5*time.Second)
+	assert.Equal(t, int32(1), attempts.Load())
+	assert.Contains(t, err.Error(), "429 Too Many Requests")
+	assert.Contains(t, err.Error(), "(Retry-After: 300)")
+}

--- a/pkg/testutil/registry.go
+++ b/pkg/testutil/registry.go
@@ -35,9 +35,19 @@ import (
 // present in the puller's content store. The registry is shut down when the
 // test completes.
 func ServeImage(t *testing.T, name, tag string, target ocispec.Descriptor, blobs map[digest.Digest][]byte) string {
+	return ServeImageWithInterceptor(t, name, tag, target, blobs, nil)
+}
+
+// ServeImageWithInterceptor is like ServeImage, but allows injecting an HTTP interceptor
+// (for instance, to simulate HTTP 429 Too Many Requests rate limiting and retry behavior).
+// If the interceptor returns true, the request has been handled and normal processing is skipped.
+func ServeImageWithInterceptor(t *testing.T, name, tag string, target ocispec.Descriptor, blobs map[digest.Digest][]byte, interceptor func(w http.ResponseWriter, r *http.Request) bool) string {
 	manifestPath := "/v2/" + name + "/manifests/"
 	blobPath := "/v2/" + name + "/blobs/"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if interceptor != nil && interceptor(w, r) {
+			return
+		}
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return


### PR DESCRIPTION
    remotes/docker: delay retries on HTTP 429
    
    HTTP 429 Too Many Requests indicates rate limiting by the registry,
    where immediate retries fail and exacerbate server load.
    
    Implement a delay policy for 429 responses:
    - When Retry-After is specified (in seconds or HTTP-date format), wait
      the requested duration up to 1 minute, bounded by the context timeout.
      If Retry-After exceeds 1 minute, fail immediately with
      ErrUnexpectedStatus rather than waiting or retrying.
    - When Retry-After is omitted or unparseable, apply exponential backoff
      starting at 500ms and doubling per attempt up to a 5s cap, with up to
      20% jitter subtracted from the calculated delay.
    - Only retry on 429 when on the last host, allowing earlier rate-limited
      mirrors to immediately fall back to another mirror.
    - Close the response body prior to sleeping to avoid holding HTTP
      connections open during delay intervals.
    - Emit debug logs with the delay duration, retry attempt, image ref,
      object digest, and Retry-After header.
    - Preserve 429 status codes and parsed Retry-After timestamps in
      returned ErrUnexpectedStatus errors when retries fail.
