### PR TITLE
metadata: unlink a garbage-collected snapshot from its parent

### DIFF
--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -1066,6 +1066,16 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 			ssbkt := sbkt.Bucket([]byte(ss))
 			if ssbkt != nil {
 				log.G(ctx).WithField("key", key).WithField("snapshotter", ss).Debug("remove snapshot")
+				// Unlink from the parent before deleting, the same way an
+				// explicit Remove does. Without this the parent keeps a child
+				// entry naming a snapshot that no longer exists, and because
+				// Remove refuses any snapshot whose children bucket is
+				// non-empty, that parent can never be deleted again -- while
+				// Walk, which enumerates snapshot buckets, cannot see the
+				// dangling child that is blocking it. See containerd#11908.
+				if err := unlinkSnapshotFromParent(ssbkt, key); err != nil {
+					return nil, err
+				}
 				return &eventstypes.SnapshotRemove{
 					Key:         key,
 					Snapshotter: ss,
@@ -1155,4 +1165,32 @@ func gcnode(t gc.ResourceType, ns, key string) gc.Node {
 		Namespace: ns,
 		Key:       key,
 	}
+}
+
+// unlinkSnapshotFromParent removes key's entry from its parent's children
+// bucket. Mirrors the unlink an explicit snapshot Remove performs; the garbage
+// collector previously deleted the snapshot bucket without it, stranding the
+// child link. A missing parent or missing children bucket is not an error --
+// there is simply nothing to unlink.
+func unlinkSnapshotFromParent(ssbkt *bolt.Bucket, key string) error {
+	sbkt := ssbkt.Bucket([]byte(key))
+	if sbkt == nil {
+		return nil
+	}
+	parent := sbkt.Get(bucketKeyParent)
+	if len(parent) == 0 {
+		return nil
+	}
+	pbkt := ssbkt.Bucket(parent)
+	if pbkt == nil {
+		return nil
+	}
+	cbkt := pbkt.Bucket(bucketKeyChildren)
+	if cbkt == nil {
+		return nil
+	}
+	if err := cbkt.Delete([]byte(key)); err != nil {
+		return fmt.Errorf("failed to remove child link: %w", err)
+	}
+	return nil
 }

--- a/core/metadata/snapshot_test.go
+++ b/core/metadata/snapshot_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
+	bolt "go.etcd.io/bbolt"
 )
 
 func snapshotLease(ctx context.Context, t *testing.T, db *DB, sn string) (context.Context, func(string) bool) {
@@ -549,5 +550,229 @@ func TestGarbageCollectFailedPreconditionRemove(t *testing.T) {
 	msn := db.Snapshotter("tmp").(*snapshotter)
 	if _, err := msn.garbageCollect(ctx); err != nil {
 		t.Fatalf("FailedPrecondition on Remove must not fail garbage collection: %v", err)
+	}
+}
+
+// childrenOf reads a snapshot's children bucket directly. The bug this file
+// guards is invisible through the public API -- Walk cannot see a stranded
+// child, and Remove only reports that one exists -- so the assertions have to
+// look at the stored link itself.
+func childrenOf(t *testing.T, db *DB, ns, snapshotter, key string) []string {
+	t.Helper()
+	var out []string
+	if err := db.View(func(tx *bolt.Tx) error {
+		bkt := getSnapshotterBucket(tx, ns, snapshotter)
+		if bkt == nil {
+			return nil
+		}
+		sbkt := bkt.Bucket([]byte(key))
+		if sbkt == nil {
+			return nil
+		}
+		cbkt := sbkt.Bucket(bucketKeyChildren)
+		if cbkt == nil {
+			return nil
+		}
+		return cbkt.ForEach(func(k, _ []byte) error {
+			out = append(out, string(k))
+			return nil
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func commitSnapshot(ctx context.Context, t *testing.T, sn snapshots.Snapshotter, key, parent string) {
+	t.Helper()
+	if _, err := sn.Prepare(ctx, key+"-active", parent); err != nil {
+		t.Fatalf("prepare %s: %v", key, err)
+	}
+	if err := sn.Commit(ctx, key, key+"-active"); err != nil {
+		t.Fatalf("commit %s: %v", key, err)
+	}
+}
+
+func walkKeys(ctx context.Context, t *testing.T, sn snapshots.Snapshotter) map[string]bool {
+	t.Helper()
+	seen := map[string]bool{}
+	if err := sn.Walk(ctx, func(_ context.Context, info snapshots.Info) error {
+		seen[info.Name] = true
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return seen
+}
+
+// A snapshot removed by the garbage collector must be unlinked from its parent,
+// or the parent becomes permanently unremovable: Remove refuses any snapshot
+// whose children bucket is non-empty, and Walk -- which enumerates snapshot
+// buckets -- cannot see a child whose bucket is already gone. The parent is then
+// stuck behind a blocker nothing can observe. See containerd#11908.
+func TestGarbageCollectedSnapshotUnlinksFromParent(t *testing.T) {
+	ctx, db := testDB(t, withSnapshotter("tmp", func(string) (snapshots.Snapshotter, error) {
+		return NewTmpSnapshotter(), nil
+	}))
+	sn := db.Snapshotter("tmp")
+
+	// base is leased so it survives collection; child is not, so the GC takes
+	// it. Both must hold, or the Remove below proves nothing.
+	leasedCtx, _ := snapshotLease(ctx, t, db, "tmp")
+	commitSnapshot(leasedCtx, t, sn, "base", "")
+	commitSnapshot(ctx, t, sn, "child", "base")
+
+	if got := childrenOf(t, db, "testing", "tmp", "base"); len(got) != 1 {
+		t.Fatalf("expected base to have one child before collection, got %v", got)
+	}
+
+	if _, err := db.GarbageCollect(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := walkKeys(ctx, t, sn)
+	if seen["child"] {
+		t.Fatal("child survived collection; this test cannot exercise the bug")
+	}
+	if !seen["base"] {
+		t.Fatal("base was collected too; this test cannot exercise the bug")
+	}
+
+	// The stored link, not just the symptom: a stranded entry here is what
+	// makes base unremovable forever.
+	if got := childrenOf(t, db, "testing", "tmp", "base"); len(got) != 0 {
+		t.Errorf("base still links to collected children: %v", got)
+	}
+	if err := sn.Remove(ctx, "base"); err != nil {
+		t.Fatalf("base unremovable after its child was garbage collected: %v", err)
+	}
+}
+
+// The real shape: an image's layer chain, where only the tip is collected.
+func TestGarbageCollectedSnapshotUnlinksThroughAChain(t *testing.T) {
+	ctx, db := testDB(t, withSnapshotter("tmp", func(string) (snapshots.Snapshotter, error) {
+		return NewTmpSnapshotter(), nil
+	}))
+	sn := db.Snapshotter("tmp")
+
+	leasedCtx, _ := snapshotLease(ctx, t, db, "tmp")
+	commitSnapshot(leasedCtx, t, sn, "base", "")
+	commitSnapshot(leasedCtx, t, sn, "mid", "base")
+	commitSnapshot(ctx, t, sn, "leaf", "mid")
+
+	if _, err := db.GarbageCollect(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := walkKeys(ctx, t, sn)
+	if seen["leaf"] || !seen["mid"] || !seen["base"] {
+		t.Fatalf("unexpected survivors after collection: %v", seen)
+	}
+	if got := childrenOf(t, db, "testing", "tmp", "mid"); len(got) != 0 {
+		t.Errorf("mid still links to the collected leaf: %v", got)
+	}
+	// Leaf-first, exactly as a caller emptying a snapshotter must do.
+	if err := sn.Remove(ctx, "mid"); err != nil {
+		t.Fatalf("mid unremovable: %v", err)
+	}
+	if err := sn.Remove(ctx, "base"); err != nil {
+		t.Fatalf("base unremovable: %v", err)
+	}
+}
+
+// A parent with one collected and one surviving child must still refuse
+// removal -- for the surviving child, which is a real blocker, not a stale
+// link. Unlinking must be precise, not a wipe of the children bucket.
+func TestGarbageCollectedSnapshotLeavesSurvivingSiblingsLinked(t *testing.T) {
+	ctx, db := testDB(t, withSnapshotter("tmp", func(string) (snapshots.Snapshotter, error) {
+		return NewTmpSnapshotter(), nil
+	}))
+	sn := db.Snapshotter("tmp")
+
+	leasedCtx, _ := snapshotLease(ctx, t, db, "tmp")
+	commitSnapshot(leasedCtx, t, sn, "base", "")
+	commitSnapshot(leasedCtx, t, sn, "keeper", "base")
+	commitSnapshot(ctx, t, sn, "doomed", "base")
+
+	if _, err := db.GarbageCollect(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := walkKeys(ctx, t, sn)
+	if seen["doomed"] || !seen["keeper"] {
+		t.Fatalf("unexpected survivors: %v", seen)
+	}
+	children := childrenOf(t, db, "testing", "tmp", "base")
+	if len(children) != 1 || children[0] != "keeper" {
+		t.Fatalf("base children = %v, want exactly [keeper]", children)
+	}
+	if err := sn.Remove(ctx, "base"); err == nil {
+		t.Fatal("base removed while a live child still exists")
+	}
+	// ...and once the survivor goes, the parent is free.
+	if err := sn.Remove(ctx, "keeper"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sn.Remove(ctx, "base"); err != nil {
+		t.Fatalf("base unremovable after all children are gone: %v", err)
+	}
+}
+
+// Parent and child collected together: the unlink must not care which bucket
+// bolt deletes first.
+func TestGarbageCollectingParentAndChildTogetherIsClean(t *testing.T) {
+	ctx, db := testDB(t, withSnapshotter("tmp", func(string) (snapshots.Snapshotter, error) {
+		return NewTmpSnapshotter(), nil
+	}))
+	sn := db.Snapshotter("tmp")
+
+	commitSnapshot(ctx, t, sn, "base", "")
+	commitSnapshot(ctx, t, sn, "child", "base")
+
+	if _, err := db.GarbageCollect(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if seen := walkKeys(ctx, t, sn); len(seen) != 0 {
+		t.Fatalf("expected an empty snapshotter, got %v", seen)
+	}
+}
+
+// A root snapshot has no parent to unlink from; collecting it must not error.
+func TestGarbageCollectedRootSnapshotNeedsNoUnlink(t *testing.T) {
+	ctx, db := testDB(t, withSnapshotter("tmp", func(string) (snapshots.Snapshotter, error) {
+		return NewTmpSnapshotter(), nil
+	}))
+	sn := db.Snapshotter("tmp")
+
+	commitSnapshot(ctx, t, sn, "solo", "")
+
+	if _, err := db.GarbageCollect(ctx); err != nil {
+		t.Fatalf("collecting a parentless snapshot failed: %v", err)
+	}
+	if seen := walkKeys(ctx, t, sn); seen["solo"] {
+		t.Fatal("solo survived collection")
+	}
+}
+
+// Regression guard: the explicit Remove path already unlinked, and must keep
+// doing so. This fix is about the collector matching it, not replacing it.
+func TestExplicitRemoveStillUnlinksFromParent(t *testing.T) {
+	ctx, db := testDB(t, withSnapshotter("tmp", func(string) (snapshots.Snapshotter, error) {
+		return NewTmpSnapshotter(), nil
+	}))
+	sn := db.Snapshotter("tmp")
+
+	leasedCtx, _ := snapshotLease(ctx, t, db, "tmp")
+	commitSnapshot(leasedCtx, t, sn, "base", "")
+	commitSnapshot(leasedCtx, t, sn, "child", "base")
+
+	if err := sn.Remove(ctx, "child"); err != nil {
+		t.Fatal(err)
+	}
+	if got := childrenOf(t, db, "testing", "tmp", "base"); len(got) != 0 {
+		t.Errorf("explicit Remove left a stale child link: %v", got)
+	}
+	if err := sn.Remove(ctx, "base"); err != nil {
+		t.Fatalf("base unremovable after its child was explicitly removed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

`(*snapshotter).Remove` deletes a snapshot's entry from its parent's `children` bucket before deleting the snapshot itself (`core/metadata/snapshot.go`). The garbage collector deletes only the snapshot's own bucket (`core/metadata/gc.go`):

```go
return &eventstypes.SnapshotRemove{
    Key:         key,
    Snapshotter: ss,
}, ssbkt.DeleteBucket([]byte(key))
```

The parent is left holding a child entry naming a snapshot that no longer exists. That parent can then never be removed:

- `Remove` refuses any snapshot whose `children` bucket is non-empty — `cannot remove snapshot with child: failed precondition`
- `Walk` enumerates snapshot buckets, so the collected child is invisible to it

The snapshot is permanently undeletable, blocked by a child nothing can observe. A client emptying a snapshotter sees a leaf it cannot remove and has no way to diagnose or recover from it — the blocking entry is reachable only by reading bolt directly.

This is #11908, where the mechanism was identified in [this comment](https://github.com/containerd/containerd/issues/11908#issuecomment-2916531411). The issue was later closed by stalebot without a fix.

## Why only the parent side

`references()` emits an edge from each snapshot to its parent:

```go
if pv := bkt.Get(bucketKeyParent); len(pv) > 0 {
    fn(gcnode(node.Type, node.Namespace, fmt.Sprintf("%s/%s", ss, pv)))
}
```

so a reachable child always keeps its parent alive. A collected snapshot therefore cannot have a surviving child; only the reverse occurs — a parent held by a lease or an image reference, whose children are collected. That is the case this fixes, and it is order-independent: when a parent and child are collected in the same pass, whichever bucket is deleted second finds no parent and does nothing.

## Reproduction

Any workload where a parent outlives a collected child hits this. It is easy to reach with an image whose layers are shared: pull a derived image, delete it, and the base image's snapshot becomes permanently unremovable — the report in #11908.

We hit it converting a devcontainer image set to native EROFS. Finalization has to empty the OverlayFS snapshotter after conversion, and the build had collected child snapshots throughout (`docker system prune`, `builder prune`, container removal, retagging). Every one of 120 snapshots was refused, including the 7 the walk reported as leaves:

```
120 remaining, walk returned 120, kinds=map[Committed:120], leaves=7
leaf sha256:84bf76a4… (kind=Committed parent="sha256:e24bb987…")
  remove -> cannot remove snapshot with child: failed precondition
```

Every leaf had a child that the walk could not see. With this patch the same build removes all 120 and finalization completes.

## Commits

Split so the fix is a self-contained backport candidate:

1. **`metadata: unlink a garbage-collected snapshot from its parent`** — the fix. Performs the same unlink the explicit path performs, before deleting the bucket. A missing parent or missing children bucket is not an error; there is nothing to unlink.

2. **`metadata: test that garbage collection unlinks a snapshot from its parent`** — six tests.

Three fail without commit 1: a leased parent whose only child is collected, the same through a multi-level layer chain, and a parent with one collected and one surviving child. The last also guards the opposite error — it asserts the surviving sibling stays linked and the parent still refuses removal for it, so a fix that cleared the whole children bucket would not pass.

Three pass either way, as regression guards: parent and child collected in the same pass (deletion order), a parentless snapshot (nothing to unlink), and the explicit `Remove` path, which already unlinked and must keep doing so.

Assertions read the stored child link directly. The defect is invisible through the public API, so a test written against the API alone cannot tell a repaired link from a broken one.

## Verification

```console
# without commit 1, on main:
--- FAIL: TestGarbageCollectedSnapshotUnlinksFromParent
--- FAIL: TestGarbageCollectedSnapshotUnlinksThroughAChain
--- FAIL: TestGarbageCollectedSnapshotLeavesSurvivingSiblingsLinked

# with:
ok  github.com/containerd/containerd/v2/core/metadata
```

No regressions in `core/metadata`, `core/snapshots/storage`, `pkg/gc` or `plugins/snapshots`.

---

These patches were developed with AI assistance (Claude); they have been reviewed, tested, and are submitted under the DCO by the human author.