### PR TITLE
fix(cri): bound waitSandboxExit goroutine context in RecoverContainer

### DIFF
--- a/internal/cri/server/podsandbox/recover.go
+++ b/internal/cri/server/podsandbox/recover.go
@@ -158,8 +158,8 @@ func (c *Controller) RecoverContainer(ctx context.Context, cntr containerd.Conta
 	}
 	if ch != nil {
 		go func() {
-			if err := c.waitSandboxExit(ctrdutil.NamespacedContext(), podSandbox, ch); err != nil {
-				log.G(context.Background()).Warnf("failed to wait pod sandbox exit %v", err)
+			if err := c.waitSandboxExit(ctx, podSandbox, ch); err != nil {
+				log.G(ctx).Warnf("failed to wait pod sandbox exit %v", err)
 			}
 		}()
 	}


### PR DESCRIPTION
fix(cri): bound waitSandboxExit goroutine context in RecoverContainer

The goroutine spawned in `RecoverContainer` previously used `ctrdutil.NamespacedContext()` which is not bound by `loadContainerTimeout`. If the shim behind a sandbox does not answer ttrpc calls, the goroutine blocks indefinitely, leaking one goroutine per sandbox on node restart.

In a reported incident with ~50 sandboxes and an out-of-tree shim (kata-containers), 551 goroutines were parked indefinitely in a `SIGUSR1` dump, preventing the CRI plugin from ever reaching a ready state after a containerd restart.

This PR changes the goroutine to use the timeout-bounded `ctx` instead of `ctrdutil.NamespacedContext()`, so the goroutine is cancelled when `loadContainerTimeout` fires. The logging context is also updated to `ctx` for consistency.

Fixes #14027
```release-notes
[BUGFIX] CRI: bound waitSandboxExit goroutine context in RecoverContainer to prevent goroutine leak when shim is unresponsive.
```