### PR TITLE
fix(cri): request cgroup delegation for writable cgroups

### DIFF
--- a/internal/cri/server/cgroup_delegate.go
+++ b/internal/cri/server/cgroup_delegate.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package server
 
 // cgroupDelegateAnnotations returns systemd Delegate annotations for writable cgroup

--- a/internal/cri/server/cgroup_delegate.go
+++ b/internal/cri/server/cgroup_delegate.go
@@ -1,0 +1,12 @@
+package server
+
+// cgroupDelegateAnnotations returns systemd Delegate annotations for writable cgroup
+// containers on cgroup v2 when the workload is not privileged.
+func cgroupDelegateAnnotations(cgroupWritable, unifiedCgroups, privileged bool) map[string]string {
+	if !cgroupWritable || !unifiedCgroups || privileged {
+		return nil
+	}
+	return map[string]string{
+		"org.systemd.property.Delegate": "true",
+	}
+}

--- a/internal/cri/server/cgroup_delegate_test.go
+++ b/internal/cri/server/cgroup_delegate_test.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package server
 
 import (

--- a/internal/cri/server/cgroup_delegate_test.go
+++ b/internal/cri/server/cgroup_delegate_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCgroupDelegateAnnotations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		cgroupWritable  bool
+		unifiedCgroups  bool
+		privileged      bool
+		wantAnnotations map[string]string
+	}{
+		{
+			name:            "writable cgroup v2 unprivileged",
+			cgroupWritable:  true,
+			unifiedCgroups:  true,
+			privileged:      false,
+			wantAnnotations: map[string]string{"org.systemd.property.Delegate": "true"},
+		},
+		{
+			name:           "writable cgroup v2 privileged",
+			cgroupWritable: true,
+			unifiedCgroups: true,
+			privileged:     true,
+		},
+		{
+			name:           "writable cgroup v1",
+			cgroupWritable: true,
+			unifiedCgroups: false,
+			privileged:     false,
+		},
+		{
+			name:           "read-only cgroup v2",
+			cgroupWritable: false,
+			unifiedCgroups: true,
+			privileged:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.wantAnnotations, cgroupDelegateAnnotations(tc.cgroupWritable, tc.unifiedCgroups, tc.privileged))
+		})
+	}
+}

--- a/internal/cri/server/cgroup_delegate_test.go
+++ b/internal/cri/server/cgroup_delegate_test.go
@@ -60,6 +60,7 @@ func TestCgroupDelegateAnnotations(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.wantAnnotations, cgroupDelegateAnnotations(tc.cgroupWritable, tc.unifiedCgroups, tc.privileged))

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -814,6 +814,11 @@ func (c *criService) buildLinuxSpec(
 	var ociSpecOpts oci.SpecOpts
 	if ociRuntime.CgroupWritable {
 		ociSpecOpts = customopts.WithMountsCgroupWritable(c.os, config, extraMounts, mountLabel, runtimeHandler)
+		if isUnifiedCgroupsMode() && !securityContext.GetPrivileged() {
+			specOpts = append(specOpts, oci.WithAnnotations(map[string]string{
+				"org.systemd.property.Delegate": "true",
+			}))
+		}
 	} else {
 		ociSpecOpts = customopts.WithMounts(c.os, config, extraMounts, mountLabel, runtimeHandler)
 	}

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -814,10 +814,8 @@ func (c *criService) buildLinuxSpec(
 	var ociSpecOpts oci.SpecOpts
 	if ociRuntime.CgroupWritable {
 		ociSpecOpts = customopts.WithMountsCgroupWritable(c.os, config, extraMounts, mountLabel, runtimeHandler)
-		if isUnifiedCgroupsMode() && !securityContext.GetPrivileged() {
-			specOpts = append(specOpts, oci.WithAnnotations(map[string]string{
-				"org.systemd.property.Delegate": "true",
-			}))
+		if annotations := cgroupDelegateAnnotations(ociRuntime.CgroupWritable, isUnifiedCgroupsMode(), securityContext.GetPrivileged()); annotations != nil {
+			specOpts = append(specOpts, oci.WithAnnotations(annotations))
 		}
 	} else {
 		ociSpecOpts = customopts.WithMounts(c.os, config, extraMounts, mountLabel, runtimeHandler)


### PR DESCRIPTION
## Summary
- Request systemd cgroup delegation when cgroup_writable is enabled for unprivileged containers on cgroup v2
- Allows workloads to enable controllers in child cgroups under nsdelegate

Fixes #14040

## Test plan
- [x] Verified spec option adds org.systemd.property.Delegate=true when cgroup_writable is set