### PR TITLE
add additional tests for toCriSignal contract 

### DIFF
--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -286,6 +286,9 @@ func TestToCRISignal(t *testing.T) {
 		input    string
 		expected runtime.Signal
 	}{
+		{input: "SIGTERM", expected: runtime.Signal_SIGNAL_SIGTERM},
+		{input: "SIGRTMIN+1", expected: runtime.Signal_SIGNAL_SIGRTMINPLUS1},
+		{input: "SIGRTMAX-1", expected: runtime.Signal_SIGNAL_SIGRTMAXMINUS1},
 		{input: "SIGNAL_SIGABRT", expected: runtime.Signal_SIGNAL_SIGABRT},
 		{input: "SIGNAL_SIGALRM", expected: runtime.Signal_SIGNAL_SIGALRM},
 		{input: "SIGNAL_SIGBUS", expected: runtime.Signal_SIGNAL_SIGBUS},


### PR DESCRIPTION
adds tests to cover the new contract allowing older container metadata that was created before the CRI api introduced the breaking change, where signal string values became prefixed with SIGNAL_

closes todo https://github.com/containerd/containerd/pull/14051#discussion_r3873103079