### PR TITLE
erofs: enable fsview fallback for unsupported features

### DIFF
--- a/plugins/mount/fsview/erofs/erofs.go
+++ b/plugins/mount/fsview/erofs/erofs.go
@@ -79,6 +79,9 @@ func handleMount(m mount.Mount) (fsview.View, error) {
 		for _, c := range closers {
 			c.Close()
 		}
+		if errors.Is(err, erofs.ErrNotImplemented) {
+			err = fmt.Errorf("%w: %w", errdefs.ErrNotImplemented, err)
+		}
 		return nil, err
 	}
 

--- a/plugins/mount/fsview/erofs/erofs_test.go
+++ b/plugins/mount/fsview/erofs/erofs_test.go
@@ -1,0 +1,60 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofs
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/errdefs"
+	goerofs "github.com/erofs/go-erofs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleMountUnsupportedCompression(t *testing.T) {
+	const (
+		superBlockOffset       = 1024
+		superBlockSize         = 128
+		blockSizeBitsOffset    = 12
+		featureIncompatOffset  = 80
+		unsupportedCompression = 0x2
+		erofsMagic             = 0xe0f5e1e2
+	)
+
+	image := make([]byte, superBlockOffset+superBlockSize)
+	superBlock := image[superBlockOffset:]
+	binary.LittleEndian.PutUint32(superBlock, erofsMagic)
+	superBlock[blockSizeBitsOffset] = 12
+	binary.LittleEndian.PutUint32(superBlock[featureIncompatOffset:], unsupportedCompression)
+
+	imagePath := filepath.Join(t.TempDir(), "compressed.erofs")
+	require.NoError(t, os.WriteFile(imagePath, image, 0o600))
+
+	view, err := handleMount(mount.Mount{
+		Type:   "erofs",
+		Source: imagePath,
+	})
+	require.Nil(t, view)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unsupported incompatible feature 0x2")
+	require.ErrorIs(t, err, goerofs.ErrNotImplemented)
+	assert.ErrorIs(t, err, errdefs.ErrNotImplemented)
+}


### PR DESCRIPTION
Fixes #14076

`go-erofs` returns its own `ErrNotImplemented` sentinel when its userspace reader cannot open a compressed EROFS filesystem. The EROFS fsview adapter previously returned that error unchanged, so `withReadonlyFS` did not recognize the operation as unsupported and returned before reaching the existing read-only kernel-mount fallback.

Translate only errors matching `go-erofs.ErrNotImplemented` at the adapter boundary while preserving the original error and diagnostic in the chain. Other parser, superblock, path, device, and I/O errors remain unchanged.

Add a focused regression test that constructs a minimal parser-valid EROFS image with incompatible compression feature `0x2` and verifies that the returned error matches both the go-erofs and containerd `ErrNotImplemented` sentinels.

## Testing

- `go test ./plugins/mount/fsview/erofs -run '^TestHandleMountUnsupportedCompression$' -count=1`
- `go test ./plugins/mount/fsview/erofs ./internal/fsview ./pkg/oci -count=1`
- `git diff --check HEAD^ HEAD`

The original runtime failure is reproduced in #14076. I did not rerun the privileged Kubernetes reproduction against this patched build because the local host does not have `mkfs.erofs` or kernel EROFS support; the regression test verifies the error classification that enables the existing fallback.

```release-note
Fix fsview fallback to kernel mount for compressed EROFS filesystems
```
