### PR TITLE
Add Spinifex to adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -58,6 +58,8 @@ including the Balena project listed below.
 
 **_[Syself Autopilot](https://syself.com)** - Syself Autopilot is a simplified Kubernetes platform based on Cluster API that can run on various providers. Syself Autopilot uses containerd as the default CRI runtime.
 
+**_[Spinifex](https://github.com/mulgadc/spinifex)_** - Spinifex is an AWS-compatible infrastructure control plane for bare-metal, edge, and on-premise deployments. Spinifex uses containerd as the container runtime for all compute instances provisioned via its EC2-compatible API.
+
 **_Other Projects_** - While the above list provides a cross-section of well known uses of containerd, the simplicity and clear API layer for containerd has inspired many smaller projects around providing simple container management platforms. Several examples of building higher layer functionality on top of the containerd base have come from various containerd community participants:
  - Michael Crosby's [boss](https://github.com/crosbymichael/boss) project,
  - Evan Hazlett's [stellar](https://github.com/ehazlett/stellar) project,


### PR DESCRIPTION
[Spinifex](https://github.com/mulgadc/spinifex) is an AWS-compatible infrastructure control plane for bare-metal and edge deployments. Its ECS agent uses containerd to pull and run container images for ECS task execution on Spinifex-managed compute nodes.