### PR TITLE
all: fix typos in code comments

### DIFF
--- a/core/metadata/db.go
+++ b/core/metadata/db.go
@@ -43,7 +43,7 @@ const (
 	// schemaVersion represents the schema version of
 	// the database. This schema version represents the
 	// structure of the data in the database. The schema
-	// can envolve at any time but any backwards
+	// can evolve at any time but any backwards
 	// incompatible changes or structural changes require
 	// bumping the schema version.
 	schemaVersion = "v1"

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -1039,7 +1039,7 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 
 	nsbkt := v1bkt.Bucket([]byte(node.Namespace))
 	if nsbkt == nil {
-		// Still remove object if refenced outside the db
+		// Still remove object if referenced outside the db
 		if cc, ok := c.contexts[node.Type]; ok {
 			cc.Remove(node)
 		}

--- a/core/mount/manager/manager_test.go
+++ b/core/mount/manager/manager_test.go
@@ -147,7 +147,7 @@ func (h *errOnceHandler) Unmount(_ context.Context, mp string) error {
 	return nil
 }
 
-// TestGC tests the garbage collecion features of the mount manager,
+// TestGC tests the garbage collection features of the mount manager,
 // ensuring that mounts are properly cleaned up when no longer needed.
 func TestGC(t *testing.T) {
 	type gcrun struct {

--- a/internal/cleanup/context.go
+++ b/internal/cleanup/context.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// Package cleanup provides utilies to help cleanup.
+// Package cleanup provides utilities to help cleanup.
 package cleanup
 
 import (

--- a/internal/cri/io/streaming.go
+++ b/internal/cri/io/streaming.go
@@ -37,7 +37,7 @@ import (
 
 // ioStream is a stream created by streaming api for io transfer
 // we add a field c as io.Closer because we do connect the streaming server
-// and create a client everytime we create a stream. so we need to close
+// and create a client every time we create a stream. so we need to close
 // the connection if the stream is closed.
 type ioStream struct {
 	streamingapi.Stream

--- a/internal/cri/server/container_image_mount_linux.go
+++ b/internal/cri/server/container_image_mount_linux.go
@@ -63,7 +63,7 @@ func addVolatileOptionOnImageVolumeMount(mounts []mount.Mount) []mount.Mount {
 
 // ensureImageVolumeMounted ensures target volume is mounted.
 //
-// NOTE: Currently, kubelet creates containers in pod sequencially. It won't
+// NOTE: Currently, kubelet creates containers in pod sequentially. It won't
 // cause multiple mountpoints on same target path.
 func ensureImageVolumeMounted(target string) (bool, error) {
 	_, err := os.Stat(target)

--- a/internal/cri/server/helpers.go
+++ b/internal/cri/server/helpers.go
@@ -40,7 +40,7 @@ import (
 	"github.com/containerd/log"
 )
 
-// TODO: Move common helpers for sbserver and podsandbox to a dedicated package once basic services are functinal.
+// TODO: Move common helpers for sbserver and podsandbox to a dedicated package once basic services are functional.
 
 const (
 	// errorStartReason is the exit reason when fails to start container.
@@ -265,7 +265,7 @@ func unknownContainerStatus() containerstore.Status {
 	}
 }
 
-// copyResourcesToStatus copys container resource contraints from spec to
+// copyResourcesToStatus copies container resource constraints from spec to
 // container status.
 // This will need updates when new fields are added to ContainerResources.
 func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status) containerstore.Status {

--- a/internal/cri/server/sandbox_stats_windows.go
+++ b/internal/cri/server/sandbox_stats_windows.go
@@ -205,7 +205,7 @@ func appendCPUPodStats(podRuntimeStats *runtime.WindowsContainerStats, container
 	}
 
 	// It is possible the pod sandbox might not be populated with values if it doesn't exist
-	// HostProcess pods are an example where there is no actual pod sandbox running and therefor no stats
+	// HostProcess pods are an example where there is no actual pod sandbox running and therefore no stats
 	if podRuntimeStats.Cpu == nil {
 		podRuntimeStats.Cpu = &runtime.WindowsCpuUsage{
 			Timestamp:            timestamp.UnixNano(),
@@ -227,7 +227,7 @@ func appendMemoryPodStats(podRuntimeStats *runtime.WindowsContainerStats, contai
 	}
 
 	// It is possible the pod sandbox might not be populated with values if it doesn't exist
-	// HostProcess pods are an example where there is no actual pod sandbox running and therefor no stats
+	// HostProcess pods are an example where there is no actual pod sandbox running and therefore no stats
 	if podRuntimeStats.Memory == nil {
 		podRuntimeStats.Memory = &runtime.WindowsMemoryUsage{Timestamp: timestamp.UnixNano()}
 	}

--- a/internal/randutil/randutil.go
+++ b/internal/randutil/randutil.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// Package randutil provides utilities for [cyrpto/rand].
+// Package randutil provides utilities for [crypto/rand].
 package randutil
 
 import (

--- a/plugins/cri/runtime/plugin.go
+++ b/plugins/cri/runtime/plugin.go
@@ -173,7 +173,7 @@ func loadOCISpec(filename string) (*oci.Spec, error) {
 }
 
 // Set glog level.
-// TODO: mikebrow remove this klog inititialization func once we are no longer vendoring k8s.io/klog
+// TODO: mikebrow remove this klog initialization func once we are no longer vendoring k8s.io/klog
 func setGLogLevel() error {
 	l := log.GetLevel()
 	fs := flag.NewFlagSet("klog", flag.PanicOnError)

--- a/plugins/services/streaming/service.go
+++ b/plugins/services/streaming/service.go
@@ -36,7 +36,7 @@ import (
 var emptyResponse typeurl.Any
 
 func init() {
-	// save marshalled empty response to avoid marshaling everytime
+	// save marshalled empty response to avoid marshaling every time
 	var err error
 	emptyResponse, err = typeurl.MarshalAny(&ptypes.Empty{})
 	if err != nil {

--- a/plugins/snapshots/windows/common.go
+++ b/plugins/snapshots/windows/common.go
@@ -35,7 +35,7 @@ import (
 )
 
 // windowsBaseSnapshotter is a type that implements common functionality required by both windows & cimfs
-// snapshotters (sort of a base type that windows & cimfs snapshotter types derive from - however, windowsBaseSnapshotter does NOT impelement the full Snapshotter interface).  Some functions
+// snapshotters (sort of a base type that windows & cimfs snapshotter types derive from - however, windowsBaseSnapshotter does NOT implement the full Snapshotter interface).  Some functions
 // (like Stat, Update) that are identical for both snapshotters are directly implemented in this base
 // snapshotter and such functions handle database transaction creation etc. However, the functions that are
 // not common don't create a transaction to allow the caller the flexibility of deciding whether to commit or


### PR DESCRIPTION
Comment-only typo fixes found with codespell. No functional changes.

- `envolve` -> `evolve`, `refenced` -> `referenced` (core/metadata)
- `collecion` -> `collection` (core/mount/manager)
- `utilies` -> `utilities` (internal/cleanup)
- `everytime` -> `every time` (internal/cri/io, plugins/services/streaming)
- `sequencially` -> `sequentially` (internal/cri/server)
- `functinal` -> `functional`, `copys` -> `copies`, `contraints` -> `constraints` (internal/cri/server/helpers.go)
- `therefor` -> `therefore` (internal/cri/server/sandbox_stats_windows.go)
- `[cyrpto/rand]` -> `[crypto/rand]` (internal/randutil, also fixes the broken godoc link)
- `inititialization` -> `initialization` (plugins/cri/runtime)
- `impelement` -> `implement` (plugins/snapshots/windows)

Identifiers and string literals were left untouched.