### PR TITLE
cri: register NRI before starting background services

### DIFF
--- a/integration/nri_register_ordering_linux_test.go
+++ b/integration/nri_register_ordering_linux_test.go
@@ -1,0 +1,105 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNRIRegisterBeforeCRIBackgroundServices verifies that the CRI service
+// registers the CRI domain with NRI before it starts any background service.
+//
+// If NRI registration fails, criService.Run returns an error and containerd
+// exits. When Register ran after the background services (the stats collector,
+// event monitor, CNI conf syncers, and streaming server), those services -
+// including the streaming server accepting connections on its port - were
+// started during a startup that was already doomed to fail.
+//
+// This test forces NRI registration to fail deterministically by pointing the
+// NRI socket at a path whose parent is a regular file, so creating the socket
+// directory fails with ENOTDIR for any user. It then asserts that none of the
+// "Start ..." background-service log lines were emitted before containerd
+// exited. On the buggy ordering those lines appear; with registration moved
+// ahead of the services they do not.
+func TestNRIRegisterBeforeCRIBackgroundServices(t *testing.T) {
+	workDir := t.TempDir()
+
+	// A regular file cannot be a socket's parent directory: os.MkdirAll on it
+	// returns ENOTDIR, so nri.Start (and therefore nri.Register) fails.
+	notADir := filepath.Join(workDir, "nri-not-a-dir")
+	require.NoError(t, os.WriteFile(notADir, nil, 0600))
+	nriSocket := filepath.Join(notADir, "nri.sock")
+
+	config := fmt.Sprintf(`
+version = 3
+
+[plugins.'io.containerd.nri.v1.nri']
+  disable = false
+  socket_path = '%s'
+  plugin_registration_timeout = '5s'
+  plugin_request_timeout = '2s'
+`, nriSocket)
+
+	configPath := filepath.Join(workDir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0600))
+
+	// Launch containerd directly rather than through newCtrdProc: this process
+	// is expected to exit non-zero because the failed NRI registration is fatal
+	// for the CRI service, and newCtrdProc asserts a clean exit.
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, *containerdBin,
+		"--root", filepath.Join(workDir, "root"),
+		"--state", filepath.Join(workDir, "state"),
+		"--address", filepath.Join(workDir, "containerd.sock"),
+		"--config", configPath,
+		"--log-level", "info",
+	)
+	out, runErr := cmd.CombinedOutput()
+	logs := string(out)
+
+	// A timeout means containerd stayed up; the NRI failure must be fatal.
+	require.NoError(t, ctx.Err(), "containerd did not exit; NRI registration failure should be fatal\n%s", logs)
+	// The failed NRI registration must make containerd exit non-zero. Checked
+	// after ctx.Err() so a timeout kill is not mistaken for the fatal exit.
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, runErr, &exitErr, "containerd should exit non-zero on the fatal NRI failure\n%s", logs)
+
+	require.Contains(t, logs, "failed to set up NRI for CRI service",
+		"expected containerd to fail CRI startup on NRI registration\n%s", logs)
+
+	// Regression assertion: none of the background services may start once NRI
+	// registration has failed, because Register runs before all of them.
+	for _, unexpected := range []string{
+		"Start stats collector",
+		"Start event monitor",
+		"Start streaming server",
+	} {
+		assert.NotContains(t, logs, unexpected,
+			"%q must not be logged when NRI registration fails before the services start\n%s", unexpected, logs)
+	}
+}

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -301,6 +301,18 @@ func (c *criService) Run(ready func()) error {
 	// then you have to manually filter namespace foo
 	c.eventMonitor.Subscribe(c.client, []string{`topic=="/tasks/oom"`, `topic~="/images/"`})
 
+	log.L.Infof("Start recovering state")
+	if err := c.recover(ctrdutil.NamespacedContext()); err != nil {
+		return fmt.Errorf("failed to recover state: %w", err)
+	}
+
+	// Register the CRI domain with NRI before starting any background service.
+	// If registration fails, Run returns here rather than leaving the stats
+	// collector, event monitor, CNI syncers, or streaming server running.
+	if err := c.nri.Register(); err != nil {
+		return fmt.Errorf("failed to set up NRI for CRI service: %w", err)
+	}
+
 	// Start the background stats collector for UsageNanoCores calculation
 	log.L.Info("Start stats collector")
 	if c.statsCollector != nil {
@@ -312,11 +324,6 @@ func (c *criService) Run(ready func()) error {
 			c.sandboxService.SandboxController,
 		)
 		c.statsCollector.Start()
-	}
-
-	log.L.Infof("Start recovering state")
-	if err := c.recover(ctrdutil.NamespacedContext()); err != nil {
-		return fmt.Errorf("failed to recover state: %w", err)
 	}
 
 	// Start event handler.
@@ -356,11 +363,6 @@ func (c *criService) Run(ready func()) error {
 			streamServerErrCh <- err
 		}
 	}()
-
-	// register CRI domain with NRI
-	if err := c.nri.Register(); err != nil {
-		return fmt.Errorf("failed to set up NRI for CRI service: %w", err)
-	}
 
 	// Set the server as initialized. GRPC services could start serving traffic.
 	c.initialized.Store(true)


### PR DESCRIPTION
## Problem

`criService.Run` starts a bunch of services before it registers the CRI domain with NRI:

```go
// ... stats collector, event monitor, cni syncers, streaming server all started

// register CRI domain with NRI
if err := c.nri.Register(); err != nil {
    return fmt.Errorf("failed to set up NRI for CRI service: %w", err)
}
```

If NRI registration fails, `Run` returns an error and the CRI service exits. But by then the streaming server has already opened its port and is serving requests for the registration window. There's a window where the streaming endpoint is live behind a service that never finished initializing.

## Fix

Move state recovery and `nri.Register()` ahead of the background services, so a registration failure returns before any of them start and the streaming port is never opened.

## Testing

Added `integration/nri_register_ordering_linux_test.go`: it boots containerd with an NRI `socket_path` whose parent is a regular file (so registration fails deterministically), then checks containerd exits with `failed to set up NRI for CRI service` and that none of `Start stats collector`, `Start event monitor`, or `Start streaming server` were ever logged. I also confirmed by building `main` and watching the streaming port: on `main` it listens for the full timeout window before the exit; with this change it never listens.

## Repro

Boot an isolated containerd (as root) with NRI registration forced to fail — a `socket_path` whose parent is a regular file (`ENOTDIR`), plus a plugin that only sleeps to hold `plugin_registration_timeout` open — and watch the CRI streaming port:

```console
mkdir -p /tmp/nri-plugins
printf '#!/bin/sh\nsleep 30\n' > /tmp/nri-plugins/99-hang && chmod +x /tmp/nri-plugins/99-hang
: > /tmp/nri-not-a-dir   # a regular file, so its child path can't be a socket dir

cat > /tmp/nri-repro.toml <<'EOF'
version = 3
[plugins.'io.containerd.grpc.v1.cri']
  stream_server_address = '127.0.0.1'
  stream_server_port = '18080'
[plugins.'io.containerd.nri.v1.nri']
  disable = false
  socket_path = '/tmp/nri-not-a-dir/nri.sock'
  plugin_path = '/tmp/nri-plugins'
  plugin_registration_timeout = '5s'
EOF

containerd -c /tmp/nri-repro.toml &
while :; do ss -ltn | grep -q 127.0.0.1:18080 && echo LISTENING; sleep 0.5; done
```

**Before:** `127.0.0.1:18080` enters `LISTEN` for the full ~5s window (`Start streaming server` is logged before the NRI failure), then containerd exits fatally. **After:** the port never listens and none of the `Start …` service lines appear. The failed `Run` is fatal either way, so this is a transient partially-initialized CRI service during registration, not a permanent leak.


## AI assistance disclosure

I am building a static analyzer library called [gohawk](https://gohawk.dev) that was used to find this bug. gohawk itself is being built with LLMs; the rule that flagged this bug was through static analysis, and an LLM wrote the test + made sure it wasn't a false positive. I have reviewed & understand the code.
