### PR TITLE
[release/2.1] Set SystemTemp env var to config temp on Windows

### DIFF
--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -110,20 +110,32 @@ func CreateTopLevelDirectories(config *srvconfig.Config) error {
 		if err := os.Chmod(config.Root, 0o700); err != nil {
 			return err
 		}
-		if runtime.GOOS == "windows" {
-			// On Windows, the Host Compute Service (vmcompute) will read the
-			// TEMP/TMP setting from the calling process when creating the
-			// tempdir to extract an image layer to. This allows the
-			// administrator to align the tempdir location with the same volume
-			// as the snapshot dir to avoid a copy operation when moving the
-			// extracted layer to the snapshot dir location.
-			os.Setenv("TEMP", config.TempDir)
-			os.Setenv("TMP", config.TempDir)
-		} else {
-			os.Setenv("TMPDIR", config.TempDir)
-		}
+		setTempDirEnv(config.TempDir)
 	}
 	return nil
+}
+
+// setTempDirEnv points the process' temp-directory environment variables at
+// tempDir so that components (and the OS) honor the configured temp location.
+func setTempDirEnv(tempDir string) {
+	if runtime.GOOS == "windows" {
+		// On Windows, the Host Compute Service (vmcompute) will read the
+		// TEMP/TMP setting from the calling process when creating the
+		// tempdir to extract an image layer to. This allows the
+		// administrator to align the tempdir location with the same volume
+		// as the snapshot dir to avoid a copy operation when moving the
+		// extracted layer to the snapshot dir location.
+		os.Setenv("TEMP", tempDir)
+		os.Setenv("TMP", tempDir)
+		// Since Go 1.21, os.MkdirTemp/os.TempDir resolve the temp dir via
+		// Windows' GetTempPath2W. For processes running as SYSTEM (as
+		// containerd does under the SCM), that API reads SystemTemp rather
+		// than TEMP/TMP, so set it too to keep the override effective.
+		// https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/os/file_windows.go
+		os.Setenv("SystemTemp", tempDir)
+	} else {
+		os.Setenv("TMPDIR", tempDir)
+	}
 }
 
 // New creates and initializes a new containerd server

--- a/cmd/containerd/server/server_test.go
+++ b/cmd/containerd/server/server_test.go
@@ -18,6 +18,8 @@ package server
 
 import (
 	"context"
+	"os"
+	"runtime"
 	"testing"
 
 	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
@@ -146,5 +148,27 @@ func TestMigration(t *testing.T) {
 	_, err := New(ctx, config)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSetTempDirEnv(t *testing.T) {
+	const tempDir = "/tmp/path/for/testing/temp"
+
+	var keys []string
+	if runtime.GOOS == "windows" {
+		keys = []string{"TEMP", "TMP", "SystemTemp"}
+	} else {
+		keys = []string{"TMPDIR"}
+	}
+	for _, k := range keys {
+		t.Setenv(k, "")
+	}
+
+	setTempDirEnv(tempDir)
+
+	for _, k := range keys {
+		if got := os.Getenv(k); got != tempDir {
+			t.Errorf("expected %s=%q, got %q", k, tempDir, got)
+		}
 	}
 }


### PR DESCRIPTION
Since Go 1.21, os.MkdirTemp/os.TempDir resolve the temp directory via Windows' GetTempPath2W. For processes running as SYSTEM (as containerd does when running under the SCM), that API reads the temp location from the SystemTemp environment variable rather than TMP/TEMP. As a result, the existing TMP/TEMP overrides no longer steer the layer-extraction tempdir for the containerd service, so it falls back to the default C:\\Windows\\SystemTemp and unpacks on the SystemDrive, reintroducing the cross-volume copy the 'temp' config option was meant to avoid.

Set SystemTemp to config.TempDir alongside TEMP/TMP so the override keeps working on Go 1.21+.

Factor the env-var setting out of CreateTopLevelDirectories into a small setTempDirEnv helper and add a focused unit test (TestSetTempDirEnv) that verifies the expected variables are set: TEMP/TMP/SystemTemp on Windows, TMPDIR on other platforms.

Ref: https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/os/file_windows.go

(cherry picked from commit faff4d66ba60734cf309d442266cb9a1d061e8a8)