### PR TITLE
cmd: refactor in preparation of urfave/cli/v3 migration

### DIFF
--- a/cmd/containerd-stress/density.go
+++ b/cmd/containerd-stress/density.go
@@ -57,7 +57,7 @@ var densityCommand = &cli.Command{
 			return errors.New("count cannot be less than one")
 		}
 
-		config := config{
+		cfg := config{
 			Address:     cliContext.String("address"),
 			Duration:    cliContext.Duration("duration"),
 			Concurrency: cliContext.Int("concurrent"),
@@ -67,7 +67,7 @@ var densityCommand = &cli.Command{
 			Metrics:     cliContext.String("metrics"),
 			Snapshotter: cliContext.String("snapshotter"),
 		}
-		client, err := config.newClient()
+		client, err := cfg.newClient()
 		if err != nil {
 			return err
 		}
@@ -76,8 +76,8 @@ var densityCommand = &cli.Command{
 		if err := cleanup(ctx, client); err != nil {
 			return err
 		}
-		log.L.Infof("pulling %s", config.Image)
-		image, err := client.Pull(ctx, config.Image, containerd.WithPullUnpack, containerd.WithPullSnapshotter(config.Snapshotter))
+		log.L.Infof("pulling %s", cfg.Image)
+		image, err := client.Pull(ctx, cfg.Image, containerd.WithPullUnpack, containerd.WithPullSnapshotter(cfg.Snapshotter))
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ var densityCommand = &cli.Command{
 				id := fmt.Sprintf("density-%d", i)
 
 				c, err := client.NewContainer(ctx, id,
-					containerd.WithSnapshotter(config.Snapshotter),
+					containerd.WithSnapshotter(cfg.Snapshotter),
 					containerd.WithNewSnapshot(id, image),
 					containerd.WithNewSpec(
 						oci.WithImageConfig(image),

--- a/cmd/containerd-stress/density.go
+++ b/cmd/containerd-stress/density.go
@@ -47,10 +47,10 @@ var densityCommand = &cli.Command{
 			Value: 10,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
 			pids  []uint32
-			count = cliContext.Int("count")
+			count = cmd.Int("count")
 		)
 
 		if count < 1 {
@@ -58,14 +58,14 @@ var densityCommand = &cli.Command{
 		}
 
 		cfg := config{
-			Address:     cliContext.String("address"),
-			Duration:    cliContext.Duration("duration"),
-			Concurrency: cliContext.Int("concurrent"),
-			Exec:        cliContext.Bool("exec"),
-			Image:       cliContext.String("image"),
-			JSON:        cliContext.Bool("json"),
-			Metrics:     cliContext.String("metrics"),
-			Snapshotter: cliContext.String("snapshotter"),
+			Address:     cmd.String("address"),
+			Duration:    cmd.Duration("duration"),
+			Concurrency: cmd.Int("concurrent"),
+			Exec:        cmd.Bool("exec"),
+			Image:       cmd.String("image"),
+			JSON:        cmd.Bool("json"),
+			Metrics:     cmd.String("metrics"),
+			Snapshotter: cmd.String("snapshotter"),
 		}
 		client, err := cfg.newClient()
 		if err != nil {

--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -144,106 +144,107 @@ func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	ctx := context.Background()
-	app := cli.NewApp()
-	app.Name = "containerd-stress"
-	app.Description = "stress test a containerd daemon"
-	app.Version = version.Version
-	app.Flags = []cli.Flag{
-		&cli.BoolFlag{
-			Name:  "debug",
-			Usage: "Set debug output in the logs",
+	app := &cli.App{
+		Name:        "containerd-stress",
+		Description: "stress test a containerd daemon",
+		Version:     version.Version,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "debug",
+				Usage: "Set debug output in the logs",
+			},
+			&cli.StringFlag{
+				Name:    "address",
+				Aliases: []string{"a"},
+				Value:   defaults.DefaultAddress,
+				Usage:   "Path to the containerd socket",
+			},
+			&cli.IntFlag{
+				Name:    "concurrent",
+				Aliases: []string{"c"},
+				Value:   1,
+				Usage:   "Set the concurrency of the stress test",
+			},
+			&cli.BoolFlag{
+				Name:  "cri",
+				Usage: "Utilize CRI to create pods for the stress test. This requires a runtime that matches CRI runtime handler. Example: --runtime runc",
+			},
+			&cli.DurationFlag{
+				Name:    "duration",
+				Aliases: []string{"d"},
+				Value:   1 * time.Minute,
+				Usage:   "Set the duration of the stress test",
+			},
+			&cli.BoolFlag{
+				Name:  "exec",
+				Usage: "Add execs to the stress tests (non-CRI only)",
+			},
+			&cli.StringFlag{
+				Name:    "image",
+				Aliases: []string{"i"},
+				Value:   "docker.io/library/alpine:latest",
+				Usage:   "Image to be utilized for testing",
+			},
+			&cli.BoolFlag{
+				Name:    "json",
+				Aliases: []string{"j"},
+				Usage:   "Output results in json format",
+			},
+			&cli.StringFlag{
+				Name:    "metrics",
+				Aliases: []string{"m"},
+				Usage:   "Address to serve the metrics API",
+			},
+			&cli.StringFlag{
+				Name:  "runtime",
+				Usage: "Set the runtime to stress test",
+				Value: plugins.RuntimeRuncV2,
+			},
+			&cli.StringFlag{
+				Name:  "snapshotter",
+				Usage: "Set the snapshotter to use",
+				Value: "overlayfs",
+			},
 		},
-		&cli.StringFlag{
-			Name:    "address",
-			Aliases: []string{"a"},
-			Value:   defaults.DefaultAddress,
-			Usage:   "Path to the containerd socket",
-		},
-		&cli.IntFlag{
-			Name:    "concurrent",
-			Aliases: []string{"c"},
-			Value:   1,
-			Usage:   "Set the concurrency of the stress test",
-		},
-		&cli.BoolFlag{
-			Name:  "cri",
-			Usage: "Utilize CRI to create pods for the stress test. This requires a runtime that matches CRI runtime handler. Example: --runtime runc",
-		},
-		&cli.DurationFlag{
-			Name:    "duration",
-			Aliases: []string{"d"},
-			Value:   1 * time.Minute,
-			Usage:   "Set the duration of the stress test",
-		},
-		&cli.BoolFlag{
-			Name:  "exec",
-			Usage: "Add execs to the stress tests (non-CRI only)",
-		},
-		&cli.StringFlag{
-			Name:    "image",
-			Aliases: []string{"i"},
-			Value:   "docker.io/library/alpine:latest",
-			Usage:   "Image to be utilized for testing",
-		},
-		&cli.BoolFlag{
-			Name:    "json",
-			Aliases: []string{"j"},
-			Usage:   "Output results in json format",
-		},
-		&cli.StringFlag{
-			Name:    "metrics",
-			Aliases: []string{"m"},
-			Usage:   "Address to serve the metrics API",
-		},
-		&cli.StringFlag{
-			Name:  "runtime",
-			Usage: "Set the runtime to stress test",
-			Value: plugins.RuntimeRuncV2,
-		},
-		&cli.StringFlag{
-			Name:  "snapshotter",
-			Usage: "Set the snapshotter to use",
-			Value: "overlayfs",
-		},
-	}
-	app.Before = func(cmd *cli.Context) error {
-		if cmd.Bool("json") {
-			if err := log.SetLevel("warn"); err != nil {
-				return err
+		Before: func(cmd *cli.Context) error {
+			if cmd.Bool("json") {
+				if err := log.SetLevel("warn"); err != nil {
+					return err
+				}
 			}
-		}
-		if cmd.Bool("debug") {
-			if err := log.SetLevel("debug"); err != nil {
-				return err
+			if cmd.Bool("debug") {
+				if err := log.SetLevel("debug"); err != nil {
+					return err
+				}
 			}
-		}
-		return nil
-	}
-	app.Commands = []*cli.Command{
-		densityCommand,
-	}
-	app.Action = func(cmd *cli.Context) error {
-		cfg := config{
-			Address:     cmd.String("address"),
-			Duration:    cmd.Duration("duration"),
-			Concurrency: cmd.Int("concurrent"),
-			CRI:         cmd.Bool("cri"),
-			Exec:        cmd.Bool("exec"),
-			Image:       cmd.String("image"),
-			JSON:        cmd.Bool("json"),
-			Metrics:     cmd.String("metrics"),
-			Runtime:     cmd.String("runtime"),
-			Snapshotter: cmd.String("snapshotter"),
-		}
-		if cfg.Metrics != "" {
-			return serve(cfg)
-		}
+			return nil
+		},
+		Commands: []*cli.Command{
+			densityCommand,
+		},
+		Action: func(cmd *cli.Context) error {
+			cfg := config{
+				Address:     cmd.String("address"),
+				Duration:    cmd.Duration("duration"),
+				Concurrency: cmd.Int("concurrent"),
+				CRI:         cmd.Bool("cri"),
+				Exec:        cmd.Bool("exec"),
+				Image:       cmd.String("image"),
+				JSON:        cmd.Bool("json"),
+				Metrics:     cmd.String("metrics"),
+				Runtime:     cmd.String("runtime"),
+				Snapshotter: cmd.String("snapshotter"),
+			}
+			if cfg.Metrics != "" {
+				return serve(cfg)
+			}
 
-		if cfg.CRI {
-			return criTest(cfg)
-		}
+			if cfg.CRI {
+				return criTest(cfg)
+			}
 
-		return test(cfg)
+			return test(cfg)
+		},
 	}
 	if err := app.RunContext(ctx, os.Args); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "containerd-stress:", err)
@@ -318,7 +319,7 @@ func criTest(c config) error {
 	}()
 
 	// get runtime version:
-	version, err := client.Version("")
+	ver, err := client.Version("")
 	if err != nil {
 		return fmt.Errorf("failed to get runtime version: %w", err)
 	}
@@ -334,7 +335,7 @@ func criTest(c config) error {
 			id:             i,
 			wg:             &wg,
 			client:         client,
-			commit:         fmt.Sprintf("%s-%s", version.RuntimeName, version.RuntimeVersion),
+			commit:         fmt.Sprintf("%s-%s", ver.RuntimeName, ver.RuntimeVersion),
 			runtimeHandler: c.Runtime,
 			snapshotter:    c.Snapshotter,
 		}
@@ -449,7 +450,7 @@ func test(c config) error {
 	r.end()
 
 	results := r.gather(workers)
-	if c.Exec {
+	if c.Exec && exec != nil {
 		results.ExecTotal = exec.count
 		results.ExecFailures = exec.failures
 	}

--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -65,8 +65,8 @@ func init() {
 		panic(err)
 	}
 
-	cli.VersionPrinter = func(cliContext *cli.Context) {
-		fmt.Println(cliContext.App.Name, version.Package, cliContext.App.Version)
+	cli.VersionPrinter = func(cmd *cli.Context) {
+		fmt.Println(cmd.App.Name, version.Package, cmd.App.Version)
 	}
 
 	// Override the default flag descriptions for '--version' and '--help'
@@ -206,13 +206,13 @@ func main() {
 			Value: "overlayfs",
 		},
 	}
-	app.Before = func(cliContext *cli.Context) error {
-		if cliContext.Bool("json") {
+	app.Before = func(cmd *cli.Context) error {
+		if cmd.Bool("json") {
 			if err := log.SetLevel("warn"); err != nil {
 				return err
 			}
 		}
-		if cliContext.Bool("debug") {
+		if cmd.Bool("debug") {
 			if err := log.SetLevel("debug"); err != nil {
 				return err
 			}
@@ -222,18 +222,18 @@ func main() {
 	app.Commands = []*cli.Command{
 		densityCommand,
 	}
-	app.Action = func(cliContext *cli.Context) error {
+	app.Action = func(cmd *cli.Context) error {
 		cfg := config{
-			Address:     cliContext.String("address"),
-			Duration:    cliContext.Duration("duration"),
-			Concurrency: cliContext.Int("concurrent"),
-			CRI:         cliContext.Bool("cri"),
-			Exec:        cliContext.Bool("exec"),
-			Image:       cliContext.String("image"),
-			JSON:        cliContext.Bool("json"),
-			Metrics:     cliContext.String("metrics"),
-			Runtime:     cliContext.String("runtime"),
-			Snapshotter: cliContext.String("snapshotter"),
+			Address:     cmd.String("address"),
+			Duration:    cmd.Duration("duration"),
+			Concurrency: cmd.Int("concurrent"),
+			CRI:         cmd.Bool("cri"),
+			Exec:        cmd.Bool("exec"),
+			Image:       cmd.String("image"),
+			JSON:        cmd.Bool("json"),
+			Metrics:     cmd.String("metrics"),
+			Runtime:     cmd.String("runtime"),
+			Snapshotter: cmd.String("snapshotter"),
 		}
 		if cfg.Metrics != "" {
 			return serve(cfg)

--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -223,7 +223,7 @@ func main() {
 		densityCommand,
 	}
 	app.Action = func(cliContext *cli.Context) error {
-		config := config{
+		cfg := config{
 			Address:     cliContext.String("address"),
 			Duration:    cliContext.Duration("duration"),
 			Concurrency: cliContext.Int("concurrent"),
@@ -235,15 +235,15 @@ func main() {
 			Runtime:     cliContext.String("runtime"),
 			Snapshotter: cliContext.String("snapshotter"),
 		}
-		if config.Metrics != "" {
-			return serve(config)
+		if cfg.Metrics != "" {
+			return serve(cfg)
 		}
 
-		if config.CRI {
-			return criTest(config)
+		if cfg.CRI {
+			return criTest(cfg)
 		}
 
-		return test(config)
+		return test(cfg)
 	}
 	if err := app.RunContext(ctx, os.Args); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "containerd-stress:", err)

--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -143,6 +143,7 @@ func main() {
 	// more power!
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
+	ctx := context.Background()
 	app := cli.NewApp()
 	app.Name = "containerd-stress"
 	app.Description = "stress test a containerd daemon"
@@ -244,8 +245,8 @@ func main() {
 
 		return test(config)
 	}
-	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if err := app.RunContext(ctx, os.Args); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "containerd-stress:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -89,8 +89,8 @@ var configCommand = &cli.Command{
 		{
 			Name:  "default",
 			Usage: "See the output of the default config",
-			Action: func(cliContext *cli.Context) error {
-				ctx := cliContext.Context
+			Action: func(cmd *cli.Context) error {
+				ctx := cmd.Context
 				return outputConfig(ctx, defaultConfig())
 			},
 		},
@@ -108,15 +108,15 @@ var configCommand = &cli.Command{
 	},
 }
 
-func dumpConfig(cliContext *cli.Context) error {
+func dumpConfig(cmd *cli.Context) error {
 	config := defaultConfig()
-	ctx := cliContext.Context
+	ctx := cmd.Context
 
 	g := registry.Graph(func(*plugin.Registration) bool { return false })
 	plugins := func() iter.Seq[plugin.Registration] {
 		return slices.Values(g)
 	}
-	if err := srvconfig.LoadConfigWithPlugins(ctx, cliContext.String("config"), plugins, config); err != nil && !os.IsNotExist(err) {
+	if err := srvconfig.LoadConfigWithPlugins(ctx, cmd.String("config"), plugins, config); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -82,11 +82,11 @@ func init() {
 
 // App returns a *cli.App instance.
 func App() *cli.App {
-	app := cli.NewApp()
-	app.Name = "containerd"
-	app.Version = version.Version
-	app.Usage = usage
-	app.Description = `
+	return &cli.App{
+		Name:    "containerd",
+		Version: version.Version,
+		Usage:   usage,
+		Description: `
 containerd is a high performance container runtime whose daemon can be started
 by using this command. If none of the *config*, *publish*, *oci-hook*, or *help* commands
 are specified, the default action of the **containerd** command is to start the
@@ -96,190 +96,189 @@ containerd daemon in the foreground.
 A default configuration is used if no TOML configuration is specified or located
 at the default file location. The *containerd config* command can be used to
 generate the default configuration for containerd. The output of that command
-can be used and modified as necessary as a custom configuration.`
-	app.Flags = []cli.Flag{
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to the configuration file",
-			Value:   filepath.Join(defaults.DefaultConfigDir, "config.toml"),
+can be used and modified as necessary as a custom configuration.`,
+		Flags: append([]cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "Path to the configuration file",
+				Value:   filepath.Join(defaults.DefaultConfigDir, "config.toml"),
+			},
+			&cli.StringFlag{
+				Name:    "log-level",
+				Aliases: []string{"l"},
+				Usage:   "Set the logging level [trace, debug, info, warn, error, fatal, panic]",
+			},
+			&cli.StringFlag{
+				Name:    "address",
+				Aliases: []string{"a"},
+				Usage:   "Address for containerd's GRPC server",
+			},
+			&cli.StringFlag{
+				Name:  "root",
+				Usage: "containerd root directory",
+			},
+			&cli.StringFlag{
+				Name:  "state",
+				Usage: "containerd state directory",
+			},
+		}, serviceFlags()...),
+		Commands: []*cli.Command{
+			configCommand,
+			publishCommand,
+			ociHook,
 		},
-		&cli.StringFlag{
-			Name:    "log-level",
-			Aliases: []string{"l"},
-			Usage:   "Set the logging level [trace, debug, info, warn, error, fatal, panic]",
-		},
-		&cli.StringFlag{
-			Name:    "address",
-			Aliases: []string{"a"},
-			Usage:   "Address for containerd's GRPC server",
-		},
-		&cli.StringFlag{
-			Name:  "root",
-			Usage: "containerd root directory",
-		},
-		&cli.StringFlag{
-			Name:  "state",
-			Usage: "containerd state directory",
-		},
-	}
-	app.Flags = append(app.Flags, serviceFlags()...)
-	app.Commands = []*cli.Command{
-		configCommand,
-		publishCommand,
-		ociHook,
-	}
-	app.Action = func(cmd *cli.Context) error {
-		if args := cmd.Args(); args.First() != "" {
-			return cli.ShowCommandHelp(cmd, args.First())
-		}
-
-		var (
-			start       = time.Now()
-			signals     = make(chan os.Signal, 2048)
-			serverC     = make(chan *server.Server, 1)
-			ctx, cancel = context.WithCancel(cmd.Context)
-			config      = defaultConfig()
-		)
-
-		defer cancel()
-
-		// Only try to load the config if it either exists, or the user explicitly
-		// told us to load this path.
-		configPath := cmd.String("config")
-		_, err := os.Stat(configPath)
-		if !os.IsNotExist(err) || cmd.IsSet("config") {
-			g := registry.Graph(func(*plugin.Registration) bool { return false })
-			plugins := func() iter.Seq[plugin.Registration] {
-				return slices.Values(g)
+		Action: func(cmd *cli.Context) error {
+			if args := cmd.Args(); args.First() != "" {
+				return cli.ShowCommandHelp(cmd, args.First())
 			}
-			if err := srvconfig.LoadConfigWithPlugins(ctx, configPath, plugins, config); err != nil {
+
+			var (
+				start   = time.Now()
+				signals = make(chan os.Signal, 2048)
+				serverC = make(chan *server.Server, 1)
+				config  = defaultConfig()
+			)
+
+			ctx, cancel := context.WithCancel(cmd.Context)
+			defer cancel()
+
+			// Only try to load the config if it either exists, or the user explicitly
+			// told us to load this path.
+			configPath := cmd.String("config")
+			_, err := os.Stat(configPath)
+			if !os.IsNotExist(err) || cmd.IsSet("config") {
+				g := registry.Graph(func(*plugin.Registration) bool { return false })
+				plugins := func() iter.Seq[plugin.Registration] {
+					return slices.Values(g)
+				}
+				if err := srvconfig.LoadConfigWithPlugins(ctx, configPath, plugins, config); err != nil {
+					return err
+				}
+			}
+
+			// Apply flags to the config
+			if err := applyFlags(cmd, config); err != nil {
 				return err
 			}
-		}
 
-		// Apply flags to the config
-		if err := applyFlags(cmd, config); err != nil {
-			return err
-		}
+			// Register the tracing hook as soon as config is available. Later startup
+			// steps may start goroutines that log, so avoid mutating hooks after hook
+			// reads may have begun.
+			tracingHook := otel.NewLogrusHook(otel.WithTraceIDField(config.Debug.LogTraceID))
+			logrus.StandardLogger().AddHook(tracingHook)
 
-		// Register the tracing hook as soon as config is available. Later startup
-		// steps may start goroutines that log, so avoid mutating hooks after hook
-		// reads may have begun.
-		tracingHook := otel.NewLogrusHook(otel.WithTraceIDField(config.Debug.LogTraceID))
-		logrus.StandardLogger().AddHook(tracingHook)
-
-		// Make sure top-level directories are created early.
-		if err := server.CreateTopLevelDirectories(config); err != nil {
-			return err
-		}
-
-		// Stop if we are registering or unregistering against Windows SCM.
-		stop, err := registerUnregisterService(config.Root)
-		if err != nil {
-			log.L.Fatal(err)
-		}
-		if stop {
-			return nil
-		}
-
-		done := handleSignals(ctx, signals, serverC, cancel)
-		// start the signal handler as soon as we can to make sure that
-		// we don't miss any signals during boot
-		signal.Notify(signals, handledSignals...)
-
-		// cleanup temp mounts
-		if err := mount.SetTempMountLocation(filepath.Join(config.Root, "tmpmounts")); err != nil {
-			return fmt.Errorf("creating temp mount location: %w", err)
-		}
-		// unmount all temp mounts on boot for the server
-		warnings, err := mount.CleanupTempMounts(0)
-		if err != nil {
-			log.G(ctx).WithError(err).Error("unmounting temp mounts")
-		}
-		for _, w := range warnings {
-			log.G(ctx).WithError(w).Warn("cleanup temp mount")
-		}
-
-		log.G(ctx).WithFields(log.Fields{
-			"version":  version.Version,
-			"revision": version.Revision,
-		}).Info("starting containerd")
-
-		type srvResp struct {
-			s   *server.Server
-			err error
-		}
-
-		// run server initialization in a goroutine so we don't end up blocking important things like SIGTERM handling
-		// while the server is initializing.
-		// As an example, opening the bolt database blocks forever if a containerd instance
-		// is already running, which must then be forcibly terminated (SIGKILL) to recover.
-		chsrv := make(chan srvResp)
-		go func() {
-			defer close(chsrv)
-
-			// TODO: When to set grpc address from flag? Migration should be done first
-			srv, err := server.New(ctx, config)
-			if err != nil {
-				select {
-				case chsrv <- srvResp{err: err}:
-				case <-ctx.Done():
-				}
-				return
+			// Make sure top-level directories are created early.
+			if err := server.CreateTopLevelDirectories(config); err != nil {
+				return err
 			}
 
-			// Launch as a Windows Service if necessary
-			if err := launchService(srv, done); err != nil {
+			// Stop if we are registering or unregistering against Windows SCM.
+			stop, err := registerUnregisterService(config.Root)
+			if err != nil {
 				log.L.Fatal(err)
 			}
+			if stop {
+				return nil
+			}
+
+			done := handleSignals(ctx, signals, serverC, cancel)
+			// start the signal handler as soon as we can to make sure that
+			// we don't miss any signals during boot
+			signal.Notify(signals, handledSignals...)
+
+			// cleanup temp mounts
+			if err := mount.SetTempMountLocation(filepath.Join(config.Root, "tmpmounts")); err != nil {
+				return fmt.Errorf("creating temp mount location: %w", err)
+			}
+			// unmount all temp mounts on boot for the server
+			warnings, err := mount.CleanupTempMounts(0)
+			if err != nil {
+				log.G(ctx).WithError(err).Error("unmounting temp mounts")
+			}
+			for _, w := range warnings {
+				log.G(ctx).WithError(w).Warn("cleanup temp mount")
+			}
+
+			log.G(ctx).WithFields(log.Fields{
+				"version":  version.Version,
+				"revision": version.Revision,
+			}).Info("starting containerd")
+
+			type srvResp struct {
+				s   *server.Server
+				err error
+			}
+
+			// run server initialization in a goroutine so we don't end up blocking important things like SIGTERM handling
+			// while the server is initializing.
+			// As an example, opening the bolt database blocks forever if a containerd instance
+			// is already running, which must then be forcibly terminated (SIGKILL) to recover.
+			chsrv := make(chan srvResp)
+			go func() {
+				defer close(chsrv)
+
+				// TODO: When to set grpc address from flag? Migration should be done first
+				srv, err := server.New(ctx, config)
+				if err != nil {
+					select {
+					case chsrv <- srvResp{err: err}:
+					case <-ctx.Done():
+					}
+					return
+				}
+
+				// Launch as a Windows Service if necessary
+				if err := launchService(srv, done); err != nil {
+					log.L.Fatal(err)
+				}
+				select {
+				case <-ctx.Done():
+					srv.Stop()
+				case chsrv <- srvResp{s: srv}:
+				}
+			}()
+
+			var srv *server.Server
 			select {
 			case <-ctx.Done():
-				srv.Stop()
-			case chsrv <- srvResp{s: srv}:
+				return ctx.Err()
+			case r := <-chsrv:
+				if r.err != nil {
+					return r.err
+				}
+				srv = r.s
 			}
-		}()
 
-		var srv *server.Server
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case r := <-chsrv:
-			if r.err != nil {
-				return r.err
+			// We don't send the server down serverC directly in the goroutine above because we need it lower down.
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case serverC <- srv:
 			}
-			srv = r.s
-		}
 
-		// We don't send the server down serverC directly in the goroutine above because we need it lower down.
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case serverC <- srv:
-		}
-
-		if err := srv.Start(ctx); err != nil {
-			return err
-		}
-
-		readyC := make(chan struct{})
-		go func() {
-			srv.Wait()
-			close(readyC)
-		}()
-
-		select {
-		case <-readyC:
-			if err := notifyReady(ctx); err != nil {
-				log.G(ctx).WithError(err).Warn("notify ready failed")
+			if err := srv.Start(ctx); err != nil {
+				return err
 			}
-			log.G(ctx).Infof("containerd successfully booted in %fs", time.Since(start).Seconds())
-			<-done
-		case <-done:
-		}
-		return nil
+
+			readyC := make(chan struct{})
+			go func() {
+				srv.Wait()
+				close(readyC)
+			}()
+
+			select {
+			case <-readyC:
+				if err := notifyReady(ctx); err != nil {
+					log.G(ctx).WithError(err).Warn("notify ready failed")
+				}
+				log.G(ctx).Infof("containerd successfully booted in %fs", time.Since(start).Seconds())
+				<-done
+			case <-done:
+			}
+			return nil
+		},
 	}
-	return app
 }
 
 func applyFlags(cmd *cli.Context, config *srvconfig.Config) error {

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -220,7 +220,7 @@ can be used and modified as necessary as a custom configuration.`
 			defer close(chsrv)
 
 			// TODO: When to set grpc address from flag? Migration should be done first
-			server, err := server.New(ctx, config)
+			srv, err := server.New(ctx, config)
 			if err != nil {
 				select {
 				case chsrv <- srvResp{err: err}:
@@ -230,17 +230,17 @@ can be used and modified as necessary as a custom configuration.`
 			}
 
 			// Launch as a Windows Service if necessary
-			if err := launchService(server, done); err != nil {
+			if err := launchService(srv, done); err != nil {
 				log.L.Fatal(err)
 			}
 			select {
 			case <-ctx.Done():
-				server.Stop()
-			case chsrv <- srvResp{s: server}:
+				srv.Stop()
+			case chsrv <- srvResp{s: srv}:
 			}
 		}()
 
-		var server *server.Server
+		var srv *server.Server
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -248,23 +248,23 @@ can be used and modified as necessary as a custom configuration.`
 			if r.err != nil {
 				return r.err
 			}
-			server = r.s
+			srv = r.s
 		}
 
 		// We don't send the server down serverC directly in the goroutine above because we need it lower down.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case serverC <- server:
+		case serverC <- srv:
 		}
 
-		if err := server.Start(ctx); err != nil {
+		if err := srv.Start(ctx); err != nil {
 			return err
 		}
 
 		readyC := make(chan struct{})
 		go func() {
-			server.Wait()
+			srv.Wait()
 			close(readyC)
 		}()
 

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -58,8 +58,8 @@ func init() {
 	// Discard grpc logs so that they don't mess with our stdio
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 
-	cli.VersionPrinter = func(cliContext *cli.Context) {
-		fmt.Println(cliContext.App.Name, version.Package, cliContext.App.Version, version.Revision)
+	cli.VersionPrinter = func(cmd *cli.Context) {
+		fmt.Println(cmd.App.Name, version.Package, cmd.App.Version, version.Revision)
 	}
 
 	// Override the default flag descriptions for '--version' and '--help'
@@ -129,16 +129,16 @@ can be used and modified as necessary as a custom configuration.`
 		publishCommand,
 		ociHook,
 	}
-	app.Action = func(cliContext *cli.Context) error {
-		if args := cliContext.Args(); args.First() != "" {
-			return cli.ShowCommandHelp(cliContext, args.First())
+	app.Action = func(cmd *cli.Context) error {
+		if args := cmd.Args(); args.First() != "" {
+			return cli.ShowCommandHelp(cmd, args.First())
 		}
 
 		var (
 			start       = time.Now()
 			signals     = make(chan os.Signal, 2048)
 			serverC     = make(chan *server.Server, 1)
-			ctx, cancel = context.WithCancel(cliContext.Context)
+			ctx, cancel = context.WithCancel(cmd.Context)
 			config      = defaultConfig()
 		)
 
@@ -146,9 +146,9 @@ can be used and modified as necessary as a custom configuration.`
 
 		// Only try to load the config if it either exists, or the user explicitly
 		// told us to load this path.
-		configPath := cliContext.String("config")
+		configPath := cmd.String("config")
 		_, err := os.Stat(configPath)
-		if !os.IsNotExist(err) || cliContext.IsSet("config") {
+		if !os.IsNotExist(err) || cmd.IsSet("config") {
 			g := registry.Graph(func(*plugin.Registration) bool { return false })
 			plugins := func() iter.Seq[plugin.Registration] {
 				return slices.Values(g)
@@ -159,7 +159,7 @@ can be used and modified as necessary as a custom configuration.`
 		}
 
 		// Apply flags to the config
-		if err := applyFlags(cliContext, config); err != nil {
+		if err := applyFlags(cmd, config); err != nil {
 			return err
 		}
 
@@ -282,10 +282,10 @@ can be used and modified as necessary as a custom configuration.`
 	return app
 }
 
-func applyFlags(cliContext *cli.Context, config *srvconfig.Config) error {
+func applyFlags(cmd *cli.Context, config *srvconfig.Config) error {
 	// the order for config vs flag values is that flags will always override
 	// the config values if they are set
-	if err := setLogLevel(cliContext, config); err != nil {
+	if err := setLogLevel(cmd, config); err != nil {
 		return err
 	}
 	if err := setLogFormat(config); err != nil {
@@ -305,7 +305,7 @@ func applyFlags(cliContext *cli.Context, config *srvconfig.Config) error {
 			d:    &config.State,
 		},
 	} {
-		if s := cliContext.String(v.name); s != "" {
+		if s := cmd.String(v.name); s != "" {
 			*v.d = s
 			if v.name == "root" || v.name == "state" {
 				absPath, err := filepath.Abs(s)
@@ -317,7 +317,7 @@ func applyFlags(cliContext *cli.Context, config *srvconfig.Config) error {
 		}
 	}
 
-	if s := cliContext.String("address"); s != "" {
+	if s := cmd.String("address"); s != "" {
 		var (
 			grpcConfig  map[string]any
 			ttrpcConfig map[string]any
@@ -346,13 +346,13 @@ func applyFlags(cliContext *cli.Context, config *srvconfig.Config) error {
 		}
 	}
 
-	applyPlatformFlags(cliContext)
+	applyPlatformFlags(cmd)
 
 	return nil
 }
 
-func setLogLevel(cliContext *cli.Context, config *srvconfig.Config) error {
-	l := cliContext.String("log-level")
+func setLogLevel(cmd *cli.Context, config *srvconfig.Config) error {
+	l := cmd.String("log-level")
 	if l == "" {
 		l = config.Debug.Level
 	}

--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -37,11 +37,11 @@ var handledSignals = []os.Signal{
 func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *server.Server, cancel func()) chan struct{} {
 	done := make(chan struct{}, 1)
 	go func() {
-		var server *server.Server
+		var srv *server.Server
 		for {
 			select {
 			case s := <-serverC:
-				server = s
+				srv = s
 			case s := <-signals:
 
 				// Do not print message when dealing with SIGPIPE, which may cause
@@ -60,8 +60,8 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 					}
 
 					cancel()
-					if server != nil {
-						server.Stop()
+					if srv != nil {
+						srv.Stop()
 					}
 					close(done)
 					return

--- a/cmd/containerd/command/main_windows.go
+++ b/cmd/containerd/command/main_windows.go
@@ -38,11 +38,11 @@ var (
 func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *server.Server, cancel func()) chan struct{} {
 	done := make(chan struct{})
 	go func() {
-		var server *server.Server
+		var srv *server.Server
 		for {
 			select {
 			case s := <-serverC:
-				server = s
+				srv = s
 			case s := <-signals:
 				log.G(ctx).WithField("signal", s).Debug("received signal")
 
@@ -51,8 +51,8 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 				}
 
 				cancel()
-				if server != nil {
-					server.Stop()
+				if srv != nil {
+					srv.Stop()
 				}
 				close(done)
 				return

--- a/cmd/containerd/command/oci-hook.go
+++ b/cmd/containerd/command/oci-hook.go
@@ -33,7 +33,7 @@ import (
 var ociHook = &cli.Command{
 	Name:  "oci-hook",
 	Usage: "Provides a base for OCI runtime hooks to allow arguments to be injected.",
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		state, err := loadHookState(os.Stdin)
 		if err != nil {
 			return err
@@ -45,7 +45,7 @@ var ociHook = &cli.Command{
 		}
 		var (
 			tc   = newTemplateContext(state, spec)
-			args = cliContext.Args().Slice()
+			args = cmd.Args().Slice()
 			env  = os.Environ()
 		)
 		if err := newList(&args).render(tc); err != nil {

--- a/cmd/containerd/command/oci-hook.go
+++ b/cmd/containerd/command/oci-hook.go
@@ -44,14 +44,14 @@ var ociHook = &cli.Command{
 			return err
 		}
 		var (
-			ctx  = newTemplateContext(state, spec)
+			tc   = newTemplateContext(state, spec)
 			args = cliContext.Args().Slice()
 			env  = os.Environ()
 		)
-		if err := newList(&args).render(ctx); err != nil {
+		if err := newList(&args).render(tc); err != nil {
 			return err
 		}
-		if err := newList(&env).render(ctx); err != nil {
+		if err := newList(&env).render(tc); err != nil {
 			return err
 		}
 		return syscall.Exec(args[0], args, env)

--- a/cmd/containerd/command/publish.go
+++ b/cmd/containerd/command/publish.go
@@ -51,9 +51,9 @@ var publishCommand = &cli.Command{
 			Usage: "Topic of the event",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		ctx := namespaces.WithNamespace(cliContext.Context, cliContext.String("namespace"))
-		topic := cliContext.String("topic")
+	Action: func(cmd *cli.Context) error {
+		ctx := namespaces.WithNamespace(cmd.Context, cmd.String("namespace"))
+		topic := cmd.String("topic")
 		if topic == "" {
 			return fmt.Errorf("topic required to publish event: %w", errdefs.ErrInvalidArgument)
 		}
@@ -61,7 +61,7 @@ var publishCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		client, err := connectEvents(cliContext.String("address"))
+		client, err := connectEvents(cmd.String("address"))
 		if err != nil {
 			return err
 		}

--- a/cmd/containerd/command/service_unsupported.go
+++ b/cmd/containerd/command/service_unsupported.go
@@ -30,8 +30,7 @@ func serviceFlags() []cli.Flag {
 }
 
 // applyPlatformFlags applies platform-specific flags.
-func applyPlatformFlags(cliContext *cli.Context) {
-}
+func applyPlatformFlags(*cli.Context) {}
 
 // registerUnregisterService is only relevant on Windows.
 func registerUnregisterService(root string) (bool, error) {

--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -79,8 +79,8 @@ func serviceFlags() []cli.Flag {
 }
 
 // applyPlatformFlags applies platform-specific flags.
-func applyPlatformFlags(cliContext *cli.Context) {
-	serviceNameFlag = cliContext.String("service-name")
+func applyPlatformFlags(cmd *cli.Context) {
+	serviceNameFlag = cmd.String("service-name")
 	if serviceNameFlag == "" {
 		serviceNameFlag = defaultServiceName
 	}
@@ -101,9 +101,9 @@ func applyPlatformFlags(cliContext *cli.Context) {
 			d:    &runServiceFlag,
 		},
 	} {
-		*v.d = cliContext.Bool(v.name)
+		*v.d = cmd.Bool(v.name)
 	}
-	logFileFlag = cliContext.String("log-file")
+	logFileFlag = cmd.String("log-file")
 }
 
 type handler struct {

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -26,9 +27,9 @@ import (
 )
 
 func main() {
-	app := command.App()
-	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "containerd: %s\n", err)
+	ctx := context.Background()
+	if err := command.App().RunContext(ctx, os.Args); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "containerd:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -79,15 +79,15 @@ func init() {
 
 // New returns a *cli.App instance.
 func New() *cli.App {
-	app := cli.NewApp()
-	app.Name = "ctr"
-	app.Version = version.Version
-	app.Description = `
+	return &cli.App{
+		Name:    "ctr",
+		Version: version.Version,
+		Description: `
 ctr is an unsupported debug and administrative client for interacting
 with the containerd daemon. Because it is unsupported, the commands,
 options, and operations are not guaranteed to be backward compatible or
-stable from release to release of the containerd project.`
-	app.Usage = `
+stable from release to release of the containerd project.`,
+		Usage: `
         __
   _____/ /______
  / ___/ __/ ___/
@@ -95,61 +95,61 @@ stable from release to release of the containerd project.`
 \___/\__/_/
 
 containerd CLI
-`
-	app.DisableSliceFlagSeparator = true
-	app.EnableBashCompletion = true
-	app.Flags = []cli.Flag{
-		&cli.BoolFlag{
-			Name:  "debug",
-			Usage: "Enable debug output in logs",
+`,
+		DisableSliceFlagSeparator: true,
+		EnableBashCompletion:      true,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "debug",
+				Usage: "Enable debug output in logs",
+			},
+			&cli.StringFlag{
+				Name:    "address",
+				Aliases: []string{"a"},
+				Usage:   "Address for containerd's GRPC server",
+				Value:   defaults.DefaultAddress,
+				EnvVars: []string{"CONTAINERD_ADDRESS"},
+			},
+			&cli.DurationFlag{
+				Name:  "timeout",
+				Usage: "Total timeout for ctr commands",
+			},
+			&cli.DurationFlag{
+				Name:  "connect-timeout",
+				Usage: "Timeout for connecting to containerd",
+			},
+			&cli.StringFlag{
+				Name:    "namespace",
+				Aliases: []string{"n"},
+				Usage:   "Namespace to use with commands",
+				Value:   namespaces.Default,
+				EnvVars: []string{namespaces.NamespaceEnvVar},
+			},
 		},
-		&cli.StringFlag{
-			Name:    "address",
-			Aliases: []string{"a"},
-			Usage:   "Address for containerd's GRPC server",
-			Value:   defaults.DefaultAddress,
-			EnvVars: []string{"CONTAINERD_ADDRESS"},
-		},
-		&cli.DurationFlag{
-			Name:  "timeout",
-			Usage: "Total timeout for ctr commands",
-		},
-		&cli.DurationFlag{
-			Name:  "connect-timeout",
-			Usage: "Timeout for connecting to containerd",
-		},
-		&cli.StringFlag{
-			Name:    "namespace",
-			Aliases: []string{"n"},
-			Usage:   "Namespace to use with commands",
-			Value:   namespaces.Default,
-			EnvVars: []string{namespaces.NamespaceEnvVar},
+		Commands: append([]*cli.Command{
+			plugins.Command,
+			versionCmd.Command,
+			containers.Command,
+			content.Command,
+			events.Command,
+			images.Command,
+			leases.Command,
+			namespacesCmd.Command,
+			pprof.Command,
+			run.Command,
+			snapshots.Command,
+			tasks.Command,
+			install.Command,
+			ociCmd.Command,
+			sandboxes.Command,
+			info.Command,
+			deprecations.Command,
+		}, extraCmds...),
+		Before: func(cmd *cli.Context) error {
+			if cmd.Bool("debug") {
+				return log.SetLevel("debug")
+			}
+			return nil
 		},
 	}
-	app.Commands = append([]*cli.Command{
-		plugins.Command,
-		versionCmd.Command,
-		containers.Command,
-		content.Command,
-		events.Command,
-		images.Command,
-		leases.Command,
-		namespacesCmd.Command,
-		pprof.Command,
-		run.Command,
-		snapshots.Command,
-		tasks.Command,
-		install.Command,
-		ociCmd.Command,
-		sandboxes.Command,
-		info.Command,
-		deprecations.Command,
-	}, extraCmds...)
-	app.Before = func(cmd *cli.Context) error {
-		if cmd.Bool("debug") {
-			return log.SetLevel("debug")
-		}
-		return nil
-	}
-	return app
 }

--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -55,8 +55,8 @@ func init() {
 	// Discard grpc logs so that they don't mess with our stdio
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 
-	cli.VersionPrinter = func(cliContext *cli.Context) {
-		fmt.Println(cliContext.App.Name, version.Package, cliContext.App.Version)
+	cli.VersionPrinter = func(cmd *cli.Context) {
+		fmt.Println(cmd.App.Name, version.Package, cmd.App.Version)
 	}
 
 	// Override the default flag descriptions for '--version' and '--help'
@@ -145,8 +145,8 @@ containerd CLI
 		info.Command,
 		deprecations.Command,
 	}, extraCmds...)
-	app.Before = func(cliContext *cli.Context) error {
-		if cliContext.Bool("debug") {
+	app.Before = func(cmd *cli.Context) error {
+		if cmd.Bool("debug") {
 			return log.SetLevel("debug")
 		}
 		return nil

--- a/cmd/ctr/commands/client.go
+++ b/cmd/ctr/commands/client.go
@@ -34,9 +34,8 @@ import (
 //
 // This will ensure the namespace is picked up and set the timeout, if one is
 // defined.
-func AppContext(cmd *cli.Context) (context.Context, context.CancelFunc) {
+func AppContext(ctx context.Context, cmd *cli.Context) (context.Context, context.CancelFunc) {
 	var (
-		ctx       = cmd.Context
 		timeout   = cmd.Duration("timeout")
 		namespace = cmd.String("namespace")
 		cancel    context.CancelFunc
@@ -58,6 +57,7 @@ func AppContext(cmd *cli.Context) (context.Context, context.CancelFunc) {
 
 // NewClient returns a new containerd client
 func NewClient(cmd *cli.Context, opts ...containerd.Opt) (*containerd.Client, context.Context, context.CancelFunc, error) {
+	ctx := cmd.Context
 	timeoutOpt := containerd.WithTimeout(cmd.Duration("connect-timeout"))
 	opts = append(opts, timeoutOpt)
 	socketPath := cmd.String("address")
@@ -68,7 +68,7 @@ func NewClient(cmd *cli.Context, opts ...containerd.Opt) (*containerd.Client, co
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	ctx, cancel := AppContext(cmd)
+	ctx, cancel := AppContext(ctx, cmd)
 	var suppressDeprecationWarnings bool
 	if s := os.Getenv("CONTAINERD_SUPPRESS_DEPRECATION_WARNINGS"); s != "" {
 		suppressDeprecationWarnings, err = strconv.ParseBool(s)

--- a/cmd/ctr/commands/client.go
+++ b/cmd/ctr/commands/client.go
@@ -34,11 +34,11 @@ import (
 //
 // This will ensure the namespace is picked up and set the timeout, if one is
 // defined.
-func AppContext(cliContext *cli.Context) (context.Context, context.CancelFunc) {
+func AppContext(cmd *cli.Context) (context.Context, context.CancelFunc) {
 	var (
-		ctx       = cliContext.Context
-		timeout   = cliContext.Duration("timeout")
-		namespace = cliContext.String("namespace")
+		ctx       = cmd.Context
+		timeout   = cmd.Duration("timeout")
+		namespace = cmd.String("namespace")
 		cancel    context.CancelFunc
 	)
 	ctx = namespaces.WithNamespace(ctx, namespace)
@@ -57,10 +57,10 @@ func AppContext(cliContext *cli.Context) (context.Context, context.CancelFunc) {
 }
 
 // NewClient returns a new containerd client
-func NewClient(cliContext *cli.Context, opts ...containerd.Opt) (*containerd.Client, context.Context, context.CancelFunc, error) {
-	timeoutOpt := containerd.WithTimeout(cliContext.Duration("connect-timeout"))
+func NewClient(cmd *cli.Context, opts ...containerd.Opt) (*containerd.Client, context.Context, context.CancelFunc, error) {
+	timeoutOpt := containerd.WithTimeout(cmd.Duration("connect-timeout"))
 	opts = append(opts, timeoutOpt)
-	socketPath := cliContext.String("address")
+	socketPath := cmd.String("address")
 	if _, err := os.Stat(socketPath); err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot access socket %s: %w", socketPath, err)
 	}
@@ -68,7 +68,7 @@ func NewClient(cliContext *cli.Context, opts ...containerd.Opt) (*containerd.Cli
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	ctx, cancel := AppContext(cliContext)
+	ctx, cancel := AppContext(cmd)
 	var suppressDeprecationWarnings bool
 	if s := os.Getenv("CONTAINERD_SUPPRESS_DEPRECATION_WARNINGS"); s != "" {
 		suppressDeprecationWarnings, err = strconv.ParseBool(s)

--- a/cmd/ctr/commands/client.go
+++ b/cmd/ctr/commands/client.go
@@ -56,8 +56,7 @@ func AppContext(ctx context.Context, cmd *cli.Context) (context.Context, context
 }
 
 // NewClient returns a new containerd client
-func NewClient(cmd *cli.Context, opts ...containerd.Opt) (*containerd.Client, context.Context, context.CancelFunc, error) {
-	ctx := cmd.Context
+func NewClient(ctx context.Context, cmd *cli.Context, opts ...containerd.Opt) (*containerd.Client, context.Context, context.CancelFunc, error) {
 	timeoutOpt := containerd.WithTimeout(cmd.Duration("connect-timeout"))
 	opts = append(opts, timeoutOpt)
 	socketPath := cmd.String("address")

--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -232,10 +232,10 @@ var (
 )
 
 // ObjectWithLabelArgs returns the first arg and a LabelArgs object
-func ObjectWithLabelArgs(cliContext *cli.Context) (string, map[string]string) {
+func ObjectWithLabelArgs(cmd *cli.Context) (string, map[string]string) {
 	var (
-		first        = cliContext.Args().First()
-		labelStrings = cliContext.Args().Tail()
+		first        = cmd.Args().First()
+		labelStrings = cmd.Args().Tail()
 	)
 
 	return first, LabelArgs(labelStrings)

--- a/cmd/ctr/commands/commands_unix.go
+++ b/cmd/ctr/commands/commands_unix.go
@@ -59,37 +59,37 @@ func init() {
 	})
 }
 
-func getRuncOptions(cliContext *cli.Context) (*options.Options, error) {
+func getRuncOptions(cmd *cli.Context) (*options.Options, error) {
 	runtimeOpts := &options.Options{}
-	if runcBinary := cliContext.String("runc-binary"); runcBinary != "" {
+	if runcBinary := cmd.String("runc-binary"); runcBinary != "" {
 		runtimeOpts.BinaryName = runcBinary
 	}
-	if cliContext.Bool("runc-systemd-cgroup") {
-		if cliContext.String("cgroup") == "" {
+	if cmd.Bool("runc-systemd-cgroup") {
+		if cmd.String("cgroup") == "" {
 			// runc maps "machine.slice:foo:deadbeef" to "/machine.slice/foo-deadbeef.scope"
 			return nil, errors.New("option --runc-systemd-cgroup requires --cgroup to be set, e.g. \"machine.slice:foo:deadbeef\"")
 		}
 		runtimeOpts.SystemdCgroup = true
 	}
-	if root := cliContext.String("runc-root"); root != "" {
+	if root := cmd.String("runc-root"); root != "" {
 		runtimeOpts.Root = root
 	}
 
 	return runtimeOpts, nil
 }
 
-func RuntimeOptions(cliContext *cli.Context) (any, error) {
+func RuntimeOptions(cmd *cli.Context) (any, error) {
 	// validate first
-	if (cliContext.String("runc-binary") != "" || cliContext.Bool("runc-systemd-cgroup")) &&
-		cliContext.String("runtime") != "io.containerd.runc.v2" {
+	if (cmd.String("runc-binary") != "" || cmd.Bool("runc-systemd-cgroup")) &&
+		cmd.String("runtime") != "io.containerd.runc.v2" {
 		return nil, errors.New("specifying runc-binary and runc-systemd-cgroup is only supported for \"io.containerd.runc.v2\" runtime")
 	}
 
-	if cliContext.String("runtime") == "io.containerd.runc.v2" {
-		return getRuncOptions(cliContext)
+	if cmd.String("runtime") == "io.containerd.runc.v2" {
+		return getRuncOptions(cmd)
 	}
 
-	if configPath := cliContext.String("runtime-config-path"); configPath != "" {
+	if configPath := cmd.String("runtime-config-path"); configPath != "" {
 		return &runtimeoptions.Options{
 			ConfigPath: configPath,
 		}, nil

--- a/cmd/ctr/commands/commands_windows.go
+++ b/cmd/ctr/commands/commands_windows.go
@@ -37,6 +37,6 @@ func init() {
 		})
 }
 
-func RuntimeOptions(cliContext *cli.Context) (any, error) {
+func RuntimeOptions(cmd *cli.Context) (any, error) {
 	return nil, nil
 }

--- a/cmd/ctr/commands/containers/checkpoint.go
+++ b/cmd/ctr/commands/containers/checkpoint.go
@@ -44,16 +44,16 @@ var checkpointCommand = &cli.Command{
 			Usage: "Checkpoint container task",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		id := cliContext.Args().First()
+	Action: func(cmd *cli.Context) error {
+		id := cmd.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		ref := cliContext.Args().Get(1)
+		ref := cmd.Args().Get(1)
 		if ref == "" {
 			return errors.New("ref must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -62,13 +62,13 @@ var checkpointCommand = &cli.Command{
 			containerd.WithCheckpointRuntime,
 		}
 
-		if cliContext.Bool("image") {
+		if cmd.Bool("image") {
 			opts = append(opts, containerd.WithCheckpointImage)
 		}
-		if cliContext.Bool("rw") {
+		if cmd.Bool("rw") {
 			opts = append(opts, containerd.WithCheckpointRW)
 		}
-		if cliContext.Bool("task") {
+		if cmd.Bool("task") {
 			opts = append(opts, containerd.WithCheckpointTask)
 		}
 		container, err := client.LoadContainer(ctx, id)

--- a/cmd/ctr/commands/containers/checkpoint.go
+++ b/cmd/ctr/commands/containers/checkpoint.go
@@ -45,6 +45,7 @@ var checkpointCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		id := cmd.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
@@ -53,7 +54,7 @@ var checkpointCommand = &cli.Command{
 		if ref == "" {
 			return errors.New("ref must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -55,21 +55,21 @@ var createCommand = &cli.Command{
 	Usage:     "Create container",
 	ArgsUsage: "[flags] Image|RootFS CONTAINER [COMMAND] [ARG...]",
 	Flags:     append(commands.RuntimeFlags, append(append(commands.SnapshotterFlags, []cli.Flag{commands.SnapshotterLabels}...), commands.ContainerFlags...)...),
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
 			id     string
 			ref    string
-			config = cliContext.IsSet("config")
+			config = cmd.IsSet("config")
 		)
 
 		if config {
-			id = cliContext.Args().First()
-			if cliContext.NArg() > 1 {
+			id = cmd.Args().First()
+			if cmd.NArg() > 1 {
 				return fmt.Errorf("with spec config file, only container id should be provided: %w", errdefs.ErrInvalidArgument)
 			}
 		} else {
-			id = cliContext.Args().Get(1)
-			ref = cliContext.Args().First()
+			id = cmd.Args().Get(1)
+			ref = cmd.Args().First()
 			if ref == "" {
 				return fmt.Errorf("image ref must be provided: %w", errdefs.ErrInvalidArgument)
 			}
@@ -77,12 +77,12 @@ var createCommand = &cli.Command{
 		if id == "" {
 			return fmt.Errorf("container id must be provided: %w", errdefs.ErrInvalidArgument)
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		_, err = run.NewContainer(ctx, client, cliContext)
+		_, err = run.NewContainer(ctx, client, cmd)
 		if err != nil {
 			return err
 		}
@@ -102,12 +102,12 @@ var listCommand = &cli.Command{
 			Usage:   "Print only the container id",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			filters = cliContext.Args().Slice()
-			quiet   = cliContext.Bool("quiet")
+			filters = cmd.Args().Slice()
+			quiet   = cmd.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -156,22 +156,22 @@ var deleteCommand = &cli.Command{
 			Usage: "Do not clean up snapshot with container",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var exitErr error
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		deleteOpts := []containerd.DeleteOpts{}
-		if !cliContext.Bool("keep-snapshot") {
+		if !cmd.Bool("keep-snapshot") {
 			deleteOpts = append(deleteOpts, containerd.WithSnapshotCleanup)
 		}
 
-		if cliContext.NArg() == 0 {
+		if cmd.NArg() == 0 {
 			return fmt.Errorf("must specify at least one container to delete: %w", errdefs.ErrInvalidArgument)
 		}
-		for _, arg := range cliContext.Args().Slice() {
+		for _, arg := range cmd.Args().Slice() {
 			if err := deleteContainer(ctx, client, arg, deleteOpts...); err != nil {
 				if exitErr == nil {
 					exitErr = err
@@ -212,12 +212,12 @@ var setLabelsCommand = &cli.Command{
 	ArgsUsage:   "[flags] CONTAINER [<key>=<value>, ...]",
 	Description: "set and clear labels for a container",
 	Flags:       []cli.Flag{},
-	Action: func(cliContext *cli.Context) error {
-		containerID, labels := commands.ObjectWithLabelArgs(cliContext)
+	Action: func(cmd *cli.Context) error {
+		containerID, labels := commands.ObjectWithLabelArgs(cmd)
 		if containerID == "" {
 			return fmt.Errorf("container id must be provided: %w", errdefs.ErrInvalidArgument)
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -254,12 +254,12 @@ var infoCommand = &cli.Command{
 			Usage: "Only display the spec",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		id := cliContext.Args().First()
+	Action: func(cmd *cli.Context) error {
+		id := cmd.Args().First()
 		if id == "" {
 			return fmt.Errorf("container id must be provided: %w", errdefs.ErrInvalidArgument)
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -272,7 +272,7 @@ var infoCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if cliContext.Bool("spec") {
+		if cmd.Bool("spec") {
 			v, err := typeurl.UnmarshalAny(info.Spec)
 			if err != nil {
 				return err

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -56,6 +56,7 @@ var createCommand = &cli.Command{
 	ArgsUsage: "[flags] Image|RootFS CONTAINER [COMMAND] [ARG...]",
 	Flags:     append(commands.RuntimeFlags, append(append(commands.SnapshotterFlags, []cli.Flag{commands.SnapshotterLabels}...), commands.ContainerFlags...)...),
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			id     string
 			ref    string
@@ -77,7 +78,7 @@ var createCommand = &cli.Command{
 		if id == "" {
 			return fmt.Errorf("container id must be provided: %w", errdefs.ErrInvalidArgument)
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -103,11 +104,12 @@ var listCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			filters = cmd.Args().Slice()
 			quiet   = cmd.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -157,8 +159,9 @@ var deleteCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var exitErr error
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -213,11 +216,12 @@ var setLabelsCommand = &cli.Command{
 	Description: "set and clear labels for a container",
 	Flags:       []cli.Flag{},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		containerID, labels := commands.ObjectWithLabelArgs(cmd)
 		if containerID == "" {
 			return fmt.Errorf("container id must be provided: %w", errdefs.ErrInvalidArgument)
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -255,11 +259,12 @@ var infoCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		id := cmd.Args().First()
 		if id == "" {
 			return fmt.Errorf("container id must be provided: %w", errdefs.ErrInvalidArgument)
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/containers/restore.go
+++ b/cmd/ctr/commands/containers/restore.go
@@ -43,16 +43,16 @@ var restoreCommand = &cli.Command{
 			Usage: "Restore the runtime and memory data from the checkpoint",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		id := cliContext.Args().First()
+	Action: func(cmd *cli.Context) error {
+		id := cmd.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		ref := cliContext.Args().Get(1)
+		ref := cmd.Args().Get(1)
 		if ref == "" {
 			return errors.New("ref must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -76,7 +76,7 @@ var restoreCommand = &cli.Command{
 			containerd.WithRestoreSpec,
 			containerd.WithRestoreRuntime,
 		}
-		if cliContext.Bool("rw") {
+		if cmd.Bool("rw") {
 			opts = append(opts, containerd.WithRestoreRW)
 		}
 
@@ -85,7 +85,7 @@ var restoreCommand = &cli.Command{
 			return err
 		}
 		topts := []containerd.NewTaskOpts{}
-		if cliContext.Bool("live") {
+		if cmd.Bool("live") {
 			topts = append(topts, containerd.WithTaskCheckpoint(checkpoint))
 		}
 		spec, err := ctr.Spec(ctx)

--- a/cmd/ctr/commands/containers/restore.go
+++ b/cmd/ctr/commands/containers/restore.go
@@ -44,6 +44,7 @@ var restoreCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		id := cmd.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
@@ -52,7 +53,7 @@ var restoreCommand = &cli.Command{
 		if ref == "" {
 			return errors.New("ref must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -43,7 +43,7 @@ var (
 	Command = &cli.Command{
 		Name:  "content",
 		Usage: "Manage content",
-		Subcommands: cli.Commands{
+		Subcommands: []*cli.Command{
 			activeIngestCommand,
 			deleteCommand,
 			editCommand,

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -64,12 +64,12 @@ var (
 		Usage:       "Get the data for an object",
 		ArgsUsage:   "[<digest>, ...]",
 		Description: "display the image object",
-		Action: func(cliContext *cli.Context) error {
-			dgst, err := digest.Parse(cliContext.Args().First())
+		Action: func(cmd *cli.Context) error {
+			dgst, err := digest.Parse(cmd.Args().First())
 			if err != nil {
 				return err
 			}
-			client, ctx, cancel, err := commands.NewClient(cliContext)
+			client, ctx, cancel, err := commands.NewClient(cmd)
 			if err != nil {
 				return err
 			}
@@ -103,11 +103,11 @@ var (
 				Usage: "Verify content against expected digest",
 			},
 		},
-		Action: func(cliContext *cli.Context) error {
+		Action: func(cmd *cli.Context) error {
 			var (
-				ref            = cliContext.Args().First()
-				expectedSize   = cliContext.Int64("expected-size")
-				expectedDigest = digest.Digest(cliContext.String("expected-digest"))
+				ref            = cmd.Args().First()
+				expectedSize   = cmd.Int64("expected-size")
+				expectedDigest = digest.Digest(cmd.String("expected-digest"))
 			)
 			if err := expectedDigest.Validate(); expectedDigest != "" && err != nil {
 				return err
@@ -115,7 +115,7 @@ var (
 			if ref == "" {
 				return errors.New("must specify a transaction reference")
 			}
-			client, ctx, cancel, err := commands.NewClient(cliContext)
+			client, ctx, cancel, err := commands.NewClient(cmd)
 			if err != nil {
 				return err
 			}
@@ -148,9 +148,9 @@ var (
 				Value: "/tmp/content", // TODO(stevvooe): for now, just use the PWD/.content
 			},
 		},
-		Action: func(cliContext *cli.Context) error {
-			match := cliContext.Args().First()
-			client, ctx, cancel, err := commands.NewClient(cliContext)
+		Action: func(cmd *cli.Context) error {
+			match := cmd.Args().First()
+			client, ctx, cancel, err := commands.NewClient(cmd)
 			if err != nil {
 				return err
 			}
@@ -186,12 +186,12 @@ var (
 				Usage:   "Print only the blob digest",
 			},
 		},
-		Action: func(cliContext *cli.Context) error {
+		Action: func(cmd *cli.Context) error {
 			var (
-				quiet = cliContext.Bool("quiet")
-				args  = cliContext.Args().Slice()
+				quiet = cmd.Bool("quiet")
+				args  = cmd.Args().Slice()
 			)
-			client, ctx, cancel, err := commands.NewClient(cliContext)
+			client, ctx, cancel, err := commands.NewClient(cmd)
 			if err != nil {
 				return err
 			}
@@ -239,9 +239,9 @@ var (
 		Usage:       "Add labels to content",
 		ArgsUsage:   "<digest> [<label>=<value> ...]",
 		Description: "labels blobs in the content store",
-		Action: func(cliContext *cli.Context) error {
-			object, labels := commands.ObjectWithLabelArgs(cliContext)
-			client, ctx, cancel, err := commands.NewClient(cliContext)
+		Action: func(cmd *cli.Context) error {
+			object, labels := commands.ObjectWithLabelArgs(cmd)
+			client, ctx, cancel, err := commands.NewClient(cmd)
 			if err != nil {
 				return err
 			}
@@ -304,10 +304,10 @@ var (
 				EnvVars: []string{"EDITOR"},
 			},
 		},
-		Action: func(cliContext *cli.Context) error {
+		Action: func(cmd *cli.Context) error {
 			var (
-				validate = cliContext.String("validate")
-				object   = cliContext.Args().First()
+				validate = cmd.String("validate")
+				object   = cmd.Args().First()
 			)
 
 			if validate != "" {
@@ -321,7 +321,7 @@ var (
 			if err != nil {
 				return err
 			}
-			client, ctx, cancel, err := commands.NewClient(cliContext)
+			client, ctx, cancel, err := commands.NewClient(cmd)
 			if err != nil {
 				return err
 			}
@@ -333,7 +333,7 @@ var (
 			}
 			defer ra.Close()
 
-			nrc, err := edit(cliContext.String("editor"), content.NewReader(ra))
+			nrc, err := edit(cmd.String("editor"), content.NewReader(ra))
 			if err != nil {
 				return err
 			}
@@ -364,12 +364,12 @@ var (
 		ArgsUsage: "[<digest>, ...]",
 		Description: `Delete one or more blobs permanently. Successfully deleted
 	blobs are printed to stdout.`,
-		Action: func(cliContext *cli.Context) error {
+		Action: func(cmd *cli.Context) error {
 			var (
-				args      = cliContext.Args().Slice()
+				args      = cmd.Args().Slice()
 				exitError error
 			)
-			client, ctx, cancel, err := commands.NewClient(cliContext)
+			client, ctx, cancel, err := commands.NewClient(cmd)
 			if err != nil {
 				return err
 			}
@@ -412,14 +412,14 @@ var (
 		ArgsUsage:   "[flags] <remote> <object> [<hint>, ...]",
 		Description: `Fetch objects by identifier from a remote.`,
 		Flags:       commands.RegistryFlags,
-		Action: func(cliContext *cli.Context) error {
+		Action: func(cmd *cli.Context) error {
 			var (
-				ref = cliContext.Args().First()
+				ref = cmd.Args().First()
 			)
-			ctx, cancel := commands.AppContext(cliContext)
+			ctx, cancel := commands.AppContext(cmd)
 			defer cancel()
 
-			resolver, err := commands.GetResolver(ctx, cliContext)
+			resolver, err := commands.GetResolver(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -459,18 +459,18 @@ var (
 				Usage: "Specify target mediatype for request header",
 			},
 		}...),
-		Action: func(cliContext *cli.Context) error {
+		Action: func(cmd *cli.Context) error {
 			var (
-				ref     = cliContext.Args().First()
-				digests = cliContext.Args().Tail()
+				ref     = cmd.Args().First()
+				digests = cmd.Args().Tail()
 			)
 			if len(digests) == 0 {
 				return errors.New("must specify digests")
 			}
-			ctx, cancel := commands.AppContext(cliContext)
+			ctx, cancel := commands.AppContext(cmd)
 			defer cancel()
 
-			resolver, err := commands.GetResolver(ctx, cliContext)
+			resolver, err := commands.GetResolver(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -493,7 +493,7 @@ var (
 				if err != nil {
 					return err
 				}
-				rc, desc, err := fetcherByDigest.FetchByDigest(ctx, dgst, remotes.WithMediaType(cliContext.String("media-type")))
+				rc, desc, err := fetcherByDigest.FetchByDigest(ctx, dgst, remotes.WithMediaType(cmd.String("media-type")))
 				if err != nil {
 					return err
 				}
@@ -514,23 +514,23 @@ var (
 		ArgsUsage:   "[flags] <remote> <object> <type>",
 		Description: `Push objects by identifier to a remote.`,
 		Flags:       commands.RegistryFlags,
-		Action: func(cliContext *cli.Context) error {
+		Action: func(cmd *cli.Context) error {
 			var (
-				ref    = cliContext.Args().Get(0)
-				object = cliContext.Args().Get(1)
-				media  = cliContext.Args().Get(2)
+				ref    = cmd.Args().Get(0)
+				object = cmd.Args().Get(1)
+				media  = cmd.Args().Get(2)
 			)
 			dgst, err := digest.Parse(object)
 			if err != nil {
 				return err
 			}
-			client, ctx, cancel, err := commands.NewClient(cliContext)
+			client, ctx, cancel, err := commands.NewClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
-			resolver, err := commands.GetResolver(ctx, cliContext)
+			resolver, err := commands.GetResolver(ctx, cmd)
 			if err != nil {
 				return err
 			}

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -333,7 +333,7 @@ var (
 			}
 			defer ra.Close()
 
-			nrc, err := edit(cliContext, content.NewReader(ra))
+			nrc, err := edit(cliContext.String("editor"), content.NewReader(ra))
 			if err != nil {
 				return err
 			}
@@ -578,8 +578,7 @@ var (
 	}
 )
 
-func edit(cliContext *cli.Context, rd io.Reader) (_ io.ReadCloser, retErr error) {
-	editor := cliContext.String("editor")
+func edit(editor string, rd io.Reader) (_ io.ReadCloser, retErr error) {
 	if editor == "" {
 		return nil, errors.New("editor is required")
 	}

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -413,10 +413,8 @@ var (
 		Description: `Fetch objects by identifier from a remote.`,
 		Flags:       commands.RegistryFlags,
 		Action: func(cmd *cli.Context) error {
-			var (
-				ref = cmd.Args().First()
-			)
-			ctx, cancel := commands.AppContext(cmd)
+			ctx := cmd.Context
+			ctx, cancel := commands.AppContext(ctx, cmd)
 			defer cancel()
 
 			resolver, err := commands.GetResolver(ctx, cmd)
@@ -424,6 +422,7 @@ var (
 				return err
 			}
 
+			ref := cmd.Args().First()
 			ctx = log.WithLogger(ctx, log.G(ctx).WithField("ref", ref))
 
 			log.G(ctx).Tracef("resolving")
@@ -460,14 +459,12 @@ var (
 			},
 		}...),
 		Action: func(cmd *cli.Context) error {
-			var (
-				ref     = cmd.Args().First()
-				digests = cmd.Args().Tail()
-			)
+			digests := cmd.Args().Tail()
 			if len(digests) == 0 {
 				return errors.New("must specify digests")
 			}
-			ctx, cancel := commands.AppContext(cmd)
+			ctx := cmd.Context
+			ctx, cancel := commands.AppContext(ctx, cmd)
 			defer cancel()
 
 			resolver, err := commands.GetResolver(ctx, cmd)
@@ -475,6 +472,7 @@ var (
 				return err
 			}
 
+			ref := cmd.Args().First()
 			ctx = log.WithLogger(ctx, log.G(ctx).WithField("ref", ref))
 
 			log.G(ctx).Tracef("resolving")

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -65,11 +65,12 @@ var (
 		ArgsUsage:   "[<digest>, ...]",
 		Description: "display the image object",
 		Action: func(cmd *cli.Context) error {
+			ctx := cmd.Context
 			dgst, err := digest.Parse(cmd.Args().First())
 			if err != nil {
 				return err
 			}
-			client, ctx, cancel, err := commands.NewClient(cmd)
+			client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -104,6 +105,7 @@ var (
 			},
 		},
 		Action: func(cmd *cli.Context) error {
+			ctx := cmd.Context
 			var (
 				ref            = cmd.Args().First()
 				expectedSize   = cmd.Int64("expected-size")
@@ -115,7 +117,7 @@ var (
 			if ref == "" {
 				return errors.New("must specify a transaction reference")
 			}
-			client, ctx, cancel, err := commands.NewClient(cmd)
+			client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -149,8 +151,9 @@ var (
 			},
 		},
 		Action: func(cmd *cli.Context) error {
+			ctx := cmd.Context
 			match := cmd.Args().First()
-			client, ctx, cancel, err := commands.NewClient(cmd)
+			client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -187,11 +190,12 @@ var (
 			},
 		},
 		Action: func(cmd *cli.Context) error {
+			ctx := cmd.Context
 			var (
 				quiet = cmd.Bool("quiet")
 				args  = cmd.Args().Slice()
 			)
-			client, ctx, cancel, err := commands.NewClient(cmd)
+			client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -240,8 +244,9 @@ var (
 		ArgsUsage:   "<digest> [<label>=<value> ...]",
 		Description: "labels blobs in the content store",
 		Action: func(cmd *cli.Context) error {
+			ctx := cmd.Context
 			object, labels := commands.ObjectWithLabelArgs(cmd)
-			client, ctx, cancel, err := commands.NewClient(cmd)
+			client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -305,6 +310,7 @@ var (
 			},
 		},
 		Action: func(cmd *cli.Context) error {
+			ctx := cmd.Context
 			var (
 				validate = cmd.String("validate")
 				object   = cmd.Args().First()
@@ -321,7 +327,7 @@ var (
 			if err != nil {
 				return err
 			}
-			client, ctx, cancel, err := commands.NewClient(cmd)
+			client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -365,11 +371,12 @@ var (
 		Description: `Delete one or more blobs permanently. Successfully deleted
 	blobs are printed to stdout.`,
 		Action: func(cmd *cli.Context) error {
+			ctx := cmd.Context
 			var (
 				args      = cmd.Args().Slice()
 				exitError error
 			)
-			client, ctx, cancel, err := commands.NewClient(cmd)
+			client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -513,6 +520,7 @@ var (
 		Description: `Push objects by identifier to a remote.`,
 		Flags:       commands.RegistryFlags,
 		Action: func(cmd *cli.Context) error {
+			ctx := cmd.Context
 			var (
 				ref    = cmd.Args().Get(0)
 				object = cmd.Args().Get(1)
@@ -522,7 +530,7 @@ var (
 			if err != nil {
 				return err
 			}
-			client, ctx, cancel, err := commands.NewClient(cmd)
+			client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 			if err != nil {
 				return err
 			}

--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -76,16 +76,16 @@ pull content that will later be used with 'ctr run' or 'ctr images unpack'.`,
 			Usage: "Pull all metadata including manifests and configs",
 		},
 	),
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			ref = cliContext.Args().First()
+			ref = cmd.Args().First()
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		config, err := NewFetchConfig(ctx, cliContext)
+		config, err := NewFetchConfig(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -116,37 +116,37 @@ type FetchConfig struct {
 }
 
 // NewFetchConfig returns the default FetchConfig from cli flags
-func NewFetchConfig(ctx context.Context, cliContext *cli.Context) (*FetchConfig, error) {
-	resolver, err := commands.GetResolver(ctx, cliContext)
+func NewFetchConfig(ctx context.Context, cmd *cli.Context) (*FetchConfig, error) {
+	resolver, err := commands.GetResolver(ctx, cmd)
 	if err != nil {
 		return nil, err
 	}
 	config := &FetchConfig{
 		Resolver:  resolver,
-		Labels:    cliContext.StringSlice("label"),
-		TraceHTTP: cliContext.Bool("http-trace"),
+		Labels:    cmd.StringSlice("label"),
+		TraceHTTP: cmd.Bool("http-trace"),
 	}
-	if !cliContext.Bool("debug") {
+	if !cmd.Bool("debug") {
 		config.ProgressOutput = os.Stdout
 	}
-	if !cliContext.Bool("all-platforms") {
-		p := cliContext.StringSlice("platform")
+	if !cmd.Bool("all-platforms") {
+		p := cmd.StringSlice("platform")
 		if len(p) == 0 {
 			p = append(p, platforms.DefaultString())
 		}
 		config.Platforms = p
 	}
 
-	if cliContext.Bool("metadata-only") {
+	if cmd.Bool("metadata-only") {
 		config.AllMetadata = true
 		// Any with an empty set is None
 		config.PlatformMatcher = platforms.Any()
-	} else if !cliContext.Bool("skip-metadata") {
+	} else if !cmd.Bool("skip-metadata") {
 		config.AllMetadata = true
 	}
 
-	if cliContext.IsSet("max-concurrent-uploaded-layers") {
-		mcu := cliContext.Int("max-concurrent-uploaded-layers")
+	if cmd.IsSet("max-concurrent-uploaded-layers") {
+		mcu := cmd.Int("max-concurrent-uploaded-layers")
 		config.RemoteOpts = append(config.RemoteOpts, containerd.WithMaxConcurrentUploadedLayers(mcu))
 	}
 

--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -77,10 +77,8 @@ pull content that will later be used with 'ctr run' or 'ctr images unpack'.`,
 		},
 	),
 	Action: func(cmd *cli.Context) error {
-		var (
-			ref = cmd.Args().First()
-		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -90,6 +88,7 @@ pull content that will later be used with 'ctr run' or 'ctr images unpack'.`,
 			return err
 		}
 
+		ref := cmd.Args().First()
 		_, err = Fetch(ctx, client, ref, config)
 		return err
 	},

--- a/cmd/ctr/commands/content/prune.go
+++ b/cmd/ctr/commands/content/prune.go
@@ -47,7 +47,7 @@ var pruneFlags = []cli.Flag{
 var pruneCommand = &cli.Command{
 	Name:  "prune",
 	Usage: "Prunes content from the content store",
-	Subcommands: cli.Commands{
+	Subcommands: []*cli.Command{
 		pruneReferencesCommand,
 	},
 }

--- a/cmd/ctr/commands/content/prune.go
+++ b/cmd/ctr/commands/content/prune.go
@@ -57,7 +57,8 @@ var pruneReferencesCommand = &cli.Command{
 	Usage: "Prunes preference labels from the content store (layers only by default)",
 	Flags: pruneFlags,
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/content/prune.go
+++ b/cmd/ctr/commands/content/prune.go
@@ -56,21 +56,21 @@ var pruneReferencesCommand = &cli.Command{
 	Name:  "references",
 	Usage: "Prunes preference labels from the content store (layers only by default)",
 	Flags: pruneFlags,
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		dryRun := cliContext.Bool("dry")
+		dryRun := cmd.Bool("dry")
 		if dryRun {
 			log.G(ctx).Logger.SetLevel(log.DebugLevel)
 			log.G(ctx).Debug("dry run, no changes will be applied")
 		}
 
 		var deleteOpts []leases.DeleteOpt
-		if !cliContext.Bool("async") {
+		if !cmd.Bool("async") {
 			deleteOpts = append(deleteOpts, leases.SynchronousDelete)
 		}
 

--- a/cmd/ctr/commands/deprecations/deprecations.go
+++ b/cmd/ctr/commands/deprecations/deprecations.go
@@ -46,10 +46,11 @@ var listCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		// Suppress automatic warnings, since we print the warnings by ourselves.
-		os.Setenv("CONTAINERD_SUPPRESS_DEPRECATION_WARNINGS", "1")
+		_ = os.Setenv("CONTAINERD_SUPPRESS_DEPRECATION_WARNINGS", "1")
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/deprecations/deprecations.go
+++ b/cmd/ctr/commands/deprecations/deprecations.go
@@ -45,11 +45,11 @@ var listCommand = &cli.Command{
 			Usage: "output format to use (Examples: 'default', 'json')",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		// Suppress automatic warnings, since we print the warnings by ourselves.
 		os.Setenv("CONTAINERD_SUPPRESS_DEPRECATION_WARNINGS", "1")
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -61,7 +61,7 @@ var listCommand = &cli.Command{
 		}
 		wrn := warnings(resp)
 		if len(wrn) > 0 {
-			switch cliContext.String("format") {
+			switch cmd.String("format") {
 			case "json":
 				commands.PrintAsJSON(warnings(resp))
 				return nil

--- a/cmd/ctr/commands/events/events.go
+++ b/cmd/ctr/commands/events/events.go
@@ -35,14 +35,14 @@ var Command = &cli.Command{
 	Name:    "events",
 	Aliases: []string{"event"},
 	Usage:   "Display containerd events",
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		eventsClient := client.EventService()
-		eventsCh, errCh := eventsClient.Subscribe(ctx, cliContext.Args().Slice()...)
+		eventsCh, errCh := eventsClient.Subscribe(ctx, cmd.Args().Slice()...)
 		for {
 			var e *events.Envelope
 			select {

--- a/cmd/ctr/commands/events/events.go
+++ b/cmd/ctr/commands/events/events.go
@@ -36,7 +36,8 @@ var Command = &cli.Command{
 	Aliases: []string{"event"},
 	Usage:   "Display containerd events",
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/build_erofs_cache.go
+++ b/cmd/ctr/commands/images/build_erofs_cache.go
@@ -70,6 +70,7 @@ dmverity_mode=on, which rejects cache hits that lack a sidecar.`,
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		ref := cmd.Args().Get(0)
 		cacheDir := cmd.Args().Get(1)
 		if ref == "" || cacheDir == "" {
@@ -93,7 +94,7 @@ dmverity_mode=on, which rejects cache hits that lack a sidecar.`,
 			opts = append(opts, erofs.WithMkfsOptions(strings.Fields(m)))
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/build_erofs_cache.go
+++ b/cmd/ctr/commands/images/build_erofs_cache.go
@@ -69,15 +69,15 @@ dmverity_mode=on, which rejects cache hits that lack a sidecar.`,
 			Usage: "Generate a dm-verity hash tree and .dmverity sidecar for each blob (Linux only)",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		ref := cliContext.Args().Get(0)
-		cacheDir := cliContext.Args().Get(1)
+	Action: func(cmd *cli.Context) error {
+		ref := cmd.Args().Get(0)
+		cacheDir := cmd.Args().Get(1)
 		if ref == "" || cacheDir == "" {
 			return errors.New("image ref and cache dir must be specified")
 		}
 
 		platform := platforms.DefaultStrict()
-		if p := cliContext.String("platform"); p != "" {
+		if p := cmd.String("platform"); p != "" {
 			parsed, err := platforms.Parse(p)
 			if err != nil {
 				return fmt.Errorf("invalid platform %q: %w", p, err)
@@ -86,14 +86,14 @@ dmverity_mode=on, which rejects cache hits that lack a sidecar.`,
 		}
 
 		var opts []erofs.ConvertOpt
-		if c := cliContext.String("compressors"); c != "" {
+		if c := cmd.String("compressors"); c != "" {
 			opts = append(opts, erofs.WithCompressors(c))
 		}
-		if m := cliContext.String("mkfs-options"); m != "" {
+		if m := cmd.String("mkfs-options"); m != "" {
 			opts = append(opts, erofs.WithMkfsOptions(strings.Fields(m)))
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -104,13 +104,13 @@ dmverity_mode=on, which rejects cache hits that lack a sidecar.`,
 			return err
 		}
 
-		if err := buildCache(ctx, client.ContentStore(), img.Target, platform, cacheDir, cliContext.Bool("dmverity"), opts...); err != nil {
+		if err := buildCache(ctx, client.ContentStore(), img.Target, platform, cacheDir, cmd.Bool("dmverity"), opts...); err != nil {
 			if errdefs.IsNotFound(err) {
 				return fmt.Errorf("fetch the image content first, e.g. `ctr content fetch %s`: %w", ref, err)
 			}
 			return err
 		}
-		fmt.Fprintln(cliContext.App.Writer, cacheDir)
+		fmt.Fprintln(cmd.App.Writer, cacheDir)
 		return nil
 	},
 }

--- a/cmd/ctr/commands/images/convert.go
+++ b/cmd/ctr/commands/images/convert.go
@@ -76,6 +76,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var convertOpts []converter.Opt
 		srcRef := cmd.Args().Get(0)
 		targetRef := cmd.Args().Get(1)
@@ -123,7 +124,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			convertOpts = append(convertOpts, converter.WithDockerToOCI(true))
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/convert.go
+++ b/cmd/ctr/commands/images/convert.go
@@ -75,16 +75,16 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			Usage: "Exports content from all platforms",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var convertOpts []converter.Opt
-		srcRef := cliContext.Args().Get(0)
-		targetRef := cliContext.Args().Get(1)
+		srcRef := cmd.Args().Get(0)
+		targetRef := cmd.Args().Get(1)
 		if srcRef == "" || targetRef == "" {
 			return errors.New("src and target image need to be specified")
 		}
 
-		if !cliContext.Bool("all-platforms") {
-			if pss := cliContext.StringSlice("platform"); len(pss) > 0 {
+		if !cmd.Bool("all-platforms") {
+			if pss := cmd.StringSlice("platform"); len(pss) > 0 {
 				all, err := platforms.ParseAll(pss)
 				if err != nil {
 					return err
@@ -95,23 +95,23 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			}
 		}
 
-		if cliContext.Bool("uncompress") {
+		if cmd.Bool("uncompress") {
 			convertOpts = append(convertOpts, converter.WithLayerConvertFunc(uncompress.LayerConvertFunc))
 		}
 
-		if cliContext.IsSet("erofs") {
+		if cmd.IsSet("erofs") {
 			var erofsOpts []erofs.ConvertOpt
-			switch cliContext.String("erofs") {
+			switch cmd.String("erofs") {
 			case "raw":
 			case "zstd":
 				erofsOpts = append(erofsOpts, erofs.WithBlobCompression("zstd"))
 			default:
-				return fmt.Errorf("unsupported erofs format %q, supported: raw, zstd", cliContext.String("erofs"))
+				return fmt.Errorf("unsupported erofs format %q, supported: raw, zstd", cmd.String("erofs"))
 			}
-			if compressors := cliContext.String("erofs-compressors"); compressors != "" {
+			if compressors := cmd.String("erofs-compressors"); compressors != "" {
 				erofsOpts = append(erofsOpts, erofs.WithCompressors(compressors))
 			}
-			if mkfsOptsStr := cliContext.String("erofs-mkfs-options"); mkfsOptsStr != "" {
+			if mkfsOptsStr := cmd.String("erofs-mkfs-options"); mkfsOptsStr != "" {
 				mkfsOpts := strings.Fields(mkfsOptsStr)
 				erofsOpts = append(erofsOpts, erofs.WithMkfsOptions(mkfsOpts))
 			}
@@ -119,11 +119,11 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			convertOpts = append(convertOpts, converter.WithUpdateManifest(erofs.UpdateManifestPlatform))
 		}
 
-		if cliContext.Bool("oci") {
+		if cmd.Bool("oci") {
 			convertOpts = append(convertOpts, converter.WithDockerToOCI(true))
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(cliContext.App.Writer, newImg.Target.Digest.String())
+		fmt.Fprintln(cmd.App.Writer, newImg.Target.Digest.String())
 		return nil
 	},
 }

--- a/cmd/ctr/commands/images/convert.go
+++ b/cmd/ctr/commands/images/convert.go
@@ -69,7 +69,6 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		&cli.StringSliceFlag{
 			Name:  "platform",
 			Usage: "Pull content from a specific platform",
-			Value: cli.NewStringSlice(),
 		},
 		&cli.BoolFlag{
 			Name:  "all-platforms",

--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -55,7 +55,6 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		&cli.StringSliceFlag{
 			Name:  "platform",
 			Usage: "Pull content from a specific platform",
-			Value: cli.NewStringSlice(),
 		},
 		&cli.BoolFlag{
 			Name:  "all-platforms",

--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -65,17 +65,17 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			Usage: "Run export locally rather than through transfer API",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			out        = cliContext.Args().First()
-			images     = cliContext.Args().Tail()
+			out        = cmd.Args().First()
+			images     = cmd.Args().Tail()
 			exportOpts = []archive.ExportOpt{}
 		)
 		if out == "" || len(images) == 0 {
 			return errors.New("please provide both an output filename and an image reference to export")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -92,12 +92,12 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		}
 		defer w.Close()
 
-		if !cliContext.Bool("local") {
+		if !cmd.Bool("local") {
 			pf, done := ProgressHandler(ctx, os.Stdout)
 			defer done()
 
 			exportOpts := []tarchive.ExportOpt{}
-			if pss := cliContext.StringSlice("platform"); len(pss) > 0 {
+			if pss := cmd.StringSlice("platform"); len(pss) > 0 {
 				for _, ps := range pss {
 					p, err := platforms.Parse(ps)
 					if err != nil {
@@ -106,15 +106,15 @@ When '--all-platforms' is given all images in a manifest list must be available.
 					exportOpts = append(exportOpts, tarchive.WithPlatform(p))
 				}
 			}
-			if cliContext.Bool("all-platforms") {
+			if cmd.Bool("all-platforms") {
 				exportOpts = append(exportOpts, tarchive.WithAllPlatforms)
 			}
 
-			if cliContext.Bool("skip-manifest-json") {
+			if cmd.Bool("skip-manifest-json") {
 				exportOpts = append(exportOpts, tarchive.WithSkipCompatibilityManifest)
 			}
 
-			if cliContext.Bool("skip-non-distributable") {
+			if cmd.Bool("skip-non-distributable") {
 				exportOpts = append(exportOpts, tarchive.WithSkipNonDistributableBlobs)
 			}
 
@@ -130,7 +130,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			)
 		}
 
-		if pss := cliContext.StringSlice("platform"); len(pss) > 0 {
+		if pss := cmd.StringSlice("platform"); len(pss) > 0 {
 			all, err := platforms.ParseAll(pss)
 			if err != nil {
 				return err
@@ -140,15 +140,15 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			exportOpts = append(exportOpts, archive.WithPlatform(platforms.DefaultStrict()))
 		}
 
-		if cliContext.Bool("all-platforms") {
+		if cmd.Bool("all-platforms") {
 			exportOpts = append(exportOpts, archive.WithAllPlatforms())
 		}
 
-		if cliContext.Bool("skip-manifest-json") {
+		if cmd.Bool("skip-manifest-json") {
 			exportOpts = append(exportOpts, archive.WithSkipDockerManifest())
 		}
 
-		if cliContext.Bool("skip-non-distributable") {
+		if cmd.Bool("skip-non-distributable") {
 			exportOpts = append(exportOpts, archive.WithSkipNonDistributableBlobs())
 		}
 

--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -66,6 +66,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			out        = cmd.Args().First()
 			images     = cmd.Args().Tail()
@@ -75,7 +76,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			return errors.New("please provide both an output filename and an image reference to export")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -38,7 +38,7 @@ var Command = &cli.Command{
 	Name:    "images",
 	Aliases: []string{"image", "i"},
 	Usage:   "Manage images",
-	Subcommands: cli.Commands{
+	Subcommands: []*cli.Command{
 		checkCommand,
 		exportCommand,
 		importCommand,

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -71,12 +71,12 @@ var listCommand = &cli.Command{
 			Usage:   "Print only the image refs",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			filters = cliContext.Args().Slice()
-			quiet   = cliContext.Bool("quiet")
+			filters = cmd.Args().Slice()
+			quiet   = cmd.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -155,12 +155,12 @@ var setLabelsCommand = &cli.Command{
 			Usage:   "Replace all labels",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			replaceAll   = cliContext.Bool("replace-all")
-			name, labels = commands.ObjectWithLabelArgs(cliContext)
+			replaceAll   = cmd.Bool("replace-all")
+			name, labels = commands.ObjectWithLabelArgs(cmd)
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -215,12 +215,12 @@ var checkCommand = &cli.Command{
 			Usage:   "Print only the ready image refs (fully downloaded and unpacked)",
 		},
 	}, commands.SnapshotterFlags...),
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
 			exitErr error
-			quiet   = cliContext.Bool("quiet")
+			quiet   = cmd.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -228,7 +228,7 @@ var checkCommand = &cli.Command{
 
 		var contentStore = client.ContentStore()
 
-		args := cliContext.Args().Slice()
+		args := cmd.Args().Slice()
 		imageList, err := client.ListImages(ctx, args...)
 		if err != nil {
 			return fmt.Errorf("failed listing images: %w", err)
@@ -288,7 +288,7 @@ var checkCommand = &cli.Command{
 				size = "-"
 			}
 
-			unpacked, err := image.IsUnpacked(ctx, cliContext.String("snapshotter"))
+			unpacked, err := image.IsUnpacked(ctx, cmd.String("snapshotter"))
 			if err != nil {
 				if exitErr == nil {
 					exitErr = fmt.Errorf("unable to check unpack for %v: %w", image.Name(), err)
@@ -329,8 +329,8 @@ var removeCommand = &cli.Command{
 			Usage: "Synchronously remove image and all associated resources",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -339,9 +339,9 @@ var removeCommand = &cli.Command{
 			exitErr    error
 			imageStore = client.ImageService()
 		)
-		for i, target := range cliContext.Args().Slice() {
+		for i, target := range cmd.Args().Slice() {
 			var opts []images.DeleteOpt
-			if cliContext.Bool("sync") && i == cliContext.NArg()-1 {
+			if cmd.Bool("sync") && i == cmd.NArg()-1 {
 				opts = append(opts, images.SynchronousDelete())
 			}
 			if err := imageStore.Delete(ctx, target, opts...); err != nil {
@@ -374,14 +374,14 @@ var pruneCommand = &cli.Command{
 	},
 	// adapted from `nerdctl`:
 	// https://github.com/containerd/nerdctl/blob/272dc9c29fc1434839d3ec63194d7efa24d7c0ef/cmd/nerdctl/image_prune.go#L86
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		all := cliContext.Bool("all")
+		all := cmd.Bool("all")
 		if !all {
 			log.G(ctx).Warn("No images pruned. `image prune` requires --all to be specified.")
 			// NOP

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -72,11 +72,12 @@ var listCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			filters = cmd.Args().Slice()
 			quiet   = cmd.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -156,11 +157,12 @@ var setLabelsCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			replaceAll   = cmd.Bool("replace-all")
 			name, labels = commands.ObjectWithLabelArgs(cmd)
 		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -216,11 +218,12 @@ var checkCommand = &cli.Command{
 		},
 	}, commands.SnapshotterFlags...),
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			exitErr error
 			quiet   = cmd.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -330,7 +333,8 @@ var removeCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -375,7 +379,8 @@ var pruneCommand = &cli.Command{
 	// adapted from `nerdctl`:
 	// https://github.com/containerd/nerdctl/blob/272dc9c29fc1434839d3ec63194d7efa24d7c0ef/cmd/nerdctl/image_prune.go#L86
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -105,28 +105,28 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 		},
 	}, append(commands.SnapshotterFlags, commands.LabelFlag)...),
 
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			in              = cliContext.Args().First()
+			in              = cmd.Args().First()
 			opts            []containerd.ImportOpt
 			platformMatcher platforms.MatchComparer
 		)
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		if !cliContext.Bool("local") {
+		if !cmd.Bool("local") {
 			unsupportedFlags := []string{"discard-unpacked-layers"}
 			for _, s := range unsupportedFlags {
-				if cliContext.IsSet(s) {
+				if cmd.IsSet(s) {
 					return fmt.Errorf("\"--%s\" requires \"--local\" flag", s)
 				}
 			}
 			var opts []image.StoreOpt
-			prefix := cliContext.String("base-name")
+			prefix := cmd.String("base-name")
 			var overwrite bool
 			if prefix == "" {
 				prefix = fmt.Sprintf("import-%s", time.Now().Format("2006-01-02"))
@@ -134,13 +134,13 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 				overwrite = true
 			}
 
-			labels := cliContext.StringSlice("label")
+			labels := cmd.StringSlice("label")
 			if len(labels) > 0 {
 				opts = append(opts, image.WithImageLabels(commands.LabelArgs(labels)))
 			}
 
-			if cliContext.Bool("digests") {
-				opts = append(opts, image.WithDigestRef(prefix, overwrite, !cliContext.Bool("skip-digest-for-named")))
+			if cmd.Bool("digests") {
+				opts = append(opts, image.WithDigestRef(prefix, overwrite, !cmd.Bool("skip-digest-for-named")))
 			} else {
 				opts = append(opts, image.WithNamedPrefix(prefix, overwrite))
 			}
@@ -151,9 +151,9 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			// This is still not fully compatible with --local, which only unpacks
 			// the strict-default platform layers.
 			platUnpack := platforms.DefaultSpec()
-			if !cliContext.Bool("all-platforms") {
+			if !cmd.Bool("all-platforms") {
 				// If platform specified, use that one, if not use default
-				if platform := cliContext.String("platform"); platform != "" {
+				if platform := cmd.String("platform"); platform != "" {
 					platUnpack, err = platforms.Parse(platform)
 					if err != nil {
 						return err
@@ -162,16 +162,16 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 				opts = append(opts, image.WithPlatforms(platUnpack))
 			}
 
-			if !cliContext.Bool("no-unpack") {
-				snapshotter := cliContext.String("snapshotter")
+			if !cmd.Bool("no-unpack") {
+				snapshotter := cmd.String("snapshotter")
 				opts = append(opts, image.WithUnpack(platUnpack, snapshotter))
 			}
 
-			is := image.NewStore(cliContext.String("index-name"), opts...)
+			is := image.NewStore(cmd.String("index-name"), opts...)
 
 			var iopts []tarchive.ImportOpt
 
-			if cliContext.Bool("compress-blobs") {
+			if cmd.Bool("compress-blobs") {
 				iopts = append(iopts, tarchive.WithForceCompression)
 			}
 
@@ -201,7 +201,7 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 		// Local logic
 
-		prefix := cliContext.String("base-name")
+		prefix := cmd.String("base-name")
 		if prefix == "" {
 			prefix = fmt.Sprintf("import-%s", time.Now().Format("2006-01-02"))
 			opts = append(opts, containerd.WithImageRefTranslator(archive.AddRefPrefix(prefix)))
@@ -210,25 +210,25 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			opts = append(opts, containerd.WithImageRefTranslator(archive.FilterRefPrefix(prefix)))
 		}
 
-		if cliContext.Bool("digests") {
+		if cmd.Bool("digests") {
 			opts = append(opts, containerd.WithDigestRef(archive.DigestTranslator(prefix)))
 		}
-		if cliContext.Bool("skip-digest-for-named") {
-			if !cliContext.Bool("digests") {
+		if cmd.Bool("skip-digest-for-named") {
+			if !cmd.Bool("digests") {
 				return errors.New("--skip-digest-for-named must be specified with --digests option")
 			}
 			opts = append(opts, containerd.WithSkipDigestRef(func(name string) bool { return name != "" }))
 		}
 
-		if idxName := cliContext.String("index-name"); idxName != "" {
+		if idxName := cmd.String("index-name"); idxName != "" {
 			opts = append(opts, containerd.WithIndexName(idxName))
 		}
 
-		if cliContext.Bool("compress-blobs") {
+		if cmd.Bool("compress-blobs") {
 			opts = append(opts, containerd.WithImportCompression())
 		}
 
-		if platform := cliContext.String("platform"); platform != "" {
+		if platform := cmd.String("platform"); platform != "" {
 			platSpec, err := platforms.Parse(platform)
 			if err != nil {
 				return err
@@ -237,16 +237,16 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			opts = append(opts, containerd.WithImportPlatform(platformMatcher))
 		}
 
-		opts = append(opts, containerd.WithAllPlatforms(cliContext.Bool("all-platforms")))
+		opts = append(opts, containerd.WithAllPlatforms(cmd.Bool("all-platforms")))
 
-		if cliContext.Bool("discard-unpacked-layers") {
-			if cliContext.Bool("no-unpack") {
+		if cmd.Bool("discard-unpacked-layers") {
+			if cmd.Bool("no-unpack") {
 				return errors.New("--discard-unpacked-layers and --no-unpack are incompatible options")
 			}
 			opts = append(opts, containerd.WithDiscardUnpackedLayers())
 		}
 
-		labels := cliContext.StringSlice("label")
+		labels := cmd.StringSlice("label")
 		if len(labels) > 0 {
 			opts = append(opts, containerd.WithImageLabels(commands.LabelArgs(labels)))
 		}
@@ -276,7 +276,7 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			return closeErr
 		}
 
-		if !cliContext.Bool("no-unpack") {
+		if !cmd.Bool("no-unpack") {
 			log.G(ctx).Debugf("unpacking %d images", len(imgs))
 
 			for _, img := range imgs {
@@ -287,7 +287,7 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 				// TODO: Show unpack status
 				fmt.Printf("unpacking %s (%s)...", img.Name, img.Target.Digest)
-				err = image.Unpack(ctx, cliContext.String("snapshotter"), containerd.WithUnpackApplyOpts(diff.WithSyncFs(cliContext.Bool("sync-fs"))))
+				err = image.Unpack(ctx, cmd.String("snapshotter"), containerd.WithUnpackApplyOpts(diff.WithSyncFs(cmd.Bool("sync-fs"))))
 				if err != nil {
 					return err
 				}

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -106,13 +106,14 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 	}, append(commands.SnapshotterFlags, commands.LabelFlag)...),
 
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			in              = cmd.Args().First()
 			opts            []containerd.ImportOpt
 			platformMatcher platforms.MatchComparer
 		)
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/inspect.go
+++ b/cmd/ctr/commands/images/inspect.go
@@ -36,14 +36,14 @@ var inspectCommand = &cli.Command{
 			Usage: "Show JSON content",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		var (
-			ref        = cliContext.Args().First()
+			ref        = cmd.Args().First()
 			imageStore = client.ImageService()
 			cs         = client.ContentStore()
 		)
@@ -56,7 +56,7 @@ var inspectCommand = &cli.Command{
 		opts := []display.PrintOpt{
 			display.WithWriter(os.Stdout),
 		}
-		if cliContext.Bool("content") {
+		if cmd.Bool("content") {
 			opts = append(opts, display.Verbose)
 		}
 

--- a/cmd/ctr/commands/images/inspect.go
+++ b/cmd/ctr/commands/images/inspect.go
@@ -37,7 +37,8 @@ var inspectCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/mount.go
+++ b/cmd/ctr/commands/images/mount.go
@@ -66,6 +66,7 @@ When you are done, use the unmount command.
 		},
 	),
 	Action: func(cmd *cli.Context) (retErr error) {
+		ctx := cmd.Context
 		var (
 			ref    = cmd.Args().First()
 			target = cmd.Args().Get(1)
@@ -84,7 +85,7 @@ When you are done, use the unmount command.
 			key = target
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/mount.go
+++ b/cmd/ctr/commands/images/mount.go
@@ -65,10 +65,10 @@ When you are done, use the unmount command.
 			Value:   1 * time.Hour,
 		},
 	),
-	Action: func(cliContext *cli.Context) (retErr error) {
+	Action: func(cmd *cli.Context) (retErr error) {
 		var (
-			ref    = cliContext.Args().First()
-			target = cliContext.Args().Get(1)
+			ref    = cmd.Args().First()
+			target = cmd.Args().Get(1)
 		)
 		if ref == "" {
 			return errors.New("please provide an image reference to mount")
@@ -84,20 +84,20 @@ When you are done, use the unmount command.
 			key = target
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		snapshotter := cliContext.String("snapshotter")
+		snapshotter := cmd.String("snapshotter")
 		if snapshotter == "" {
 			snapshotter = defaults.DefaultSnapshotter
 		}
 
 		ctx, done, err := client.WithLease(ctx,
 			leases.WithID(key),
-			leases.WithExpiration(cliContext.Duration("expiration")),
+			leases.WithExpiration(cmd.Duration("expiration")),
 		)
 		if err != nil && !errdefs.IsAlreadyExists(err) {
 			return err
@@ -109,7 +109,7 @@ When you are done, use the unmount command.
 			}
 		}()
 
-		ps := cliContext.String("platform")
+		ps := cmd.String("platform")
 		p, err := platforms.Parse(ps)
 		if err != nil {
 			return fmt.Errorf("unable to parse platform %s: %w", ps, err)
@@ -121,7 +121,7 @@ When you are done, use the unmount command.
 		}
 
 		i := containerd.NewImageWithPlatform(client, img, platforms.Only(p))
-		if err := i.Unpack(ctx, snapshotter, containerd.WithUnpackApplyOpts(diff.WithSyncFs(cliContext.Bool("sync-fs")))); err != nil {
+		if err := i.Unpack(ctx, snapshotter, containerd.WithUnpackApplyOpts(diff.WithSyncFs(cmd.Bool("sync-fs")))); err != nil {
 			return fmt.Errorf("error unpacking image: %w", err)
 		}
 
@@ -135,7 +135,7 @@ When you are done, use the unmount command.
 		s := client.SnapshotService(snapshotter)
 
 		var mounts []mount.Mount
-		if cliContext.Bool("rw") {
+		if cmd.Bool("rw") {
 			mounts, err = s.Prepare(ctx, key, chainID)
 		} else {
 			mounts, err = s.View(ctx, key, chainID)
@@ -161,7 +161,7 @@ When you are done, use the unmount command.
 		if target != "" {
 			if err := mount.All(mounts, target); err != nil {
 				if err := s.Remove(ctx, key); err != nil && !errdefs.IsNotFound(err) {
-					fmt.Fprintln(cliContext.App.ErrWriter, "Error cleaning up snapshot after mount error:", err)
+					fmt.Fprintln(cmd.App.ErrWriter, "Error cleaning up snapshot after mount error:", err)
 				}
 				return fmt.Errorf("failed to mount %v: %w", mounts, err)
 			}
@@ -171,7 +171,7 @@ When you are done, use the unmount command.
 			return fmt.Errorf("cannot handle returned mounts: %v", mounts)
 		}
 
-		fmt.Fprintln(cliContext.App.Writer, target)
+		fmt.Fprintln(cmd.App.Writer, target)
 		return nil
 	},
 }

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -58,7 +58,6 @@ command. As part of this process, we do the following:
 		&cli.StringSliceFlag{
 			Name:  "platform",
 			Usage: "Pull content from a specific platform",
-			Value: cli.NewStringSlice(),
 		},
 		&cli.BoolFlag{
 			Name:  "all-platforms",

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -90,14 +90,13 @@ command. As part of this process, we do the following:
 		},
 	),
 	Action: func(cmd *cli.Context) error {
-		var (
-			ref = cmd.Args().First()
-		)
+		ctx := cmd.Context
+		ref := cmd.Args().First()
 		if ref == "" {
 			return errors.New("please provide an image reference to pull")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -89,41 +89,41 @@ command. As part of this process, we do the following:
 			Usage: "Synchronize the underlying filesystem containing files when unpack images, false by default",
 		},
 	),
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			ref = cliContext.Args().First()
+			ref = cmd.Args().First()
 		)
 		if ref == "" {
 			return errors.New("please provide an image reference to pull")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		if !cliContext.Bool("local") {
+		if !cmd.Bool("local") {
 			unsupportedFlags := []string{"max-concurrent-downloads", "print-chainid",
 				"skip-verify", "tlscacert", "tlscert", "tlskey", // RegistryFlags
 			}
 			for _, s := range unsupportedFlags {
-				if cliContext.IsSet(s) {
+				if cmd.IsSet(s) {
 					return fmt.Errorf("\"--%s\" requires \"--local\" flag", s)
 				}
 			}
 
-			ch, err := commands.NewStaticCredentials(ctx, cliContext, ref)
+			ch, err := commands.NewStaticCredentials(ctx, cmd, ref)
 			if err != nil {
 				return err
 			}
 
 			var sopts []image.StoreOpt
-			p, err := platforms.ParseAll(cliContext.StringSlice("platform"))
+			p, err := platforms.ParseAll(cmd.StringSlice("platform"))
 			if err != nil {
 				return err
 			}
-			allPlatforms := cliContext.Bool("all-platforms")
+			allPlatforms := cmd.Bool("all-platforms")
 			if len(p) > 0 && allPlatforms {
 				return errors.New("cannot specify both --platform and --all-platforms")
 			}
@@ -140,34 +140,34 @@ command. As part of this process, we do the following:
 			// TODO: Support unpack for all platforms..?
 			// Pass in a *?
 			for _, platform := range p {
-				sopts = append(sopts, image.WithUnpack(platform, cliContext.String("snapshotter")))
+				sopts = append(sopts, image.WithUnpack(platform, cmd.String("snapshotter")))
 			}
 
-			if cliContext.Bool("metadata-only") {
+			if cmd.Bool("metadata-only") {
 				sopts = append(sopts, image.WithAllMetadata)
 				// Any with an empty set is None
 				// TODO: Specify way to specify not default platform
 				// config.PlatformMatcher = platforms.Any()
-			} else if !cliContext.Bool("skip-metadata") {
+			} else if !cmd.Bool("skip-metadata") {
 				sopts = append(sopts, image.WithAllMetadata)
 			}
-			labels := cliContext.StringSlice("label")
+			labels := cmd.StringSlice("label")
 			if len(labels) > 0 {
 				sopts = append(sopts, image.WithImageLabels(commands.LabelArgs(labels)))
 			}
 
 			opts := []registry.Opt{
 				registry.WithCredentials(ch),
-				registry.WithHostDir(cliContext.String("hosts-dir")),
+				registry.WithHostDir(cmd.String("hosts-dir")),
 			}
-			if cliContext.Bool("plain-http") {
+			if cmd.Bool("plain-http") {
 				opts = append(opts, registry.WithDefaultScheme("http"))
 			}
 			logStream := log.G(ctx).Writer()
-			if cliContext.Bool("http-dump") {
+			if cmd.Bool("http-dump") {
 				opts = append(opts, registry.WithHTTPDebug(), registry.WithClientStream(logStream))
 			}
-			if cliContext.Bool("http-trace") {
+			if cmd.Bool("http-trace") {
 				opts = append(opts, registry.WithHTTPTrace(), registry.WithClientStream(logStream))
 			}
 			reg, err := registry.NewOCIRegistry(ctx, ref, opts...)
@@ -189,7 +189,7 @@ command. As part of this process, we do the following:
 		defer done(ctx)
 
 		// TODO: Handle this locally via transfer config
-		config, err := content.NewFetchConfig(ctx, cliContext)
+		config, err := content.NewFetchConfig(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -204,13 +204,13 @@ command. As part of this process, we do the following:
 		// TODO: Show unpack status
 
 		var p []ocispec.Platform
-		if cliContext.Bool("all-platforms") {
+		if cmd.Bool("all-platforms") {
 			p, err = images.Platforms(ctx, client.ContentStore(), img.Target)
 			if err != nil {
 				return fmt.Errorf("unable to resolve image platforms: %w", err)
 			}
 		} else {
-			p, err = platforms.ParseAll(cliContext.StringSlice("platform"))
+			p, err = platforms.ParseAll(cmd.StringSlice("platform"))
 			if err != nil {
 				return err
 			}
@@ -223,11 +223,11 @@ command. As part of this process, we do the following:
 		for _, platform := range p {
 			fmt.Printf("unpacking %s %s...\n", platforms.Format(platform), img.Target.Digest)
 			i := containerd.NewImageWithPlatform(client, img, platforms.Only(platform))
-			err = i.Unpack(ctx, cliContext.String("snapshotter"), containerd.WithUnpackApplyOpts(diff.WithSyncFs(cliContext.Bool("sync-fs"))))
+			err = i.Unpack(ctx, cmd.String("snapshotter"), containerd.WithUnpackApplyOpts(diff.WithSyncFs(cmd.Bool("sync-fs"))))
 			if err != nil {
 				return err
 			}
-			if cliContext.Bool("print-chainid") {
+			if cmd.Bool("print-chainid") {
 				diffIDs, err := i.RootFS(ctx)
 				if err != nil {
 					return err

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -78,6 +78,7 @@ var pushCommand = &cli.Command{
 		Usage: "Allow pushing blobs that are marked as non-distributable",
 	}),
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			ref   = cmd.Args().First()
 			local = cmd.Args().Get(1)
@@ -88,7 +89,7 @@ var pushCommand = &cli.Command{
 			return errors.New("please provide a remote image reference to push")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -67,7 +67,6 @@ var pushCommand = &cli.Command{
 	}, &cli.StringSliceFlag{
 		Name:  "platform",
 		Usage: "Push content from a specific platform",
-		Value: cli.NewStringSlice(),
 	}, &cli.IntFlag{
 		Name:  "max-concurrent-uploaded-layers",
 		Usage: "Set the max concurrent uploaded layers for each push",

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -77,35 +77,35 @@ var pushCommand = &cli.Command{
 		Name:  "allow-non-distributable-blobs",
 		Usage: "Allow pushing blobs that are marked as non-distributable",
 	}),
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			ref   = cliContext.Args().First()
-			local = cliContext.Args().Get(1)
-			debug = cliContext.Bool("debug")
+			ref   = cmd.Args().First()
+			local = cmd.Args().Get(1)
+			debug = cmd.Bool("debug")
 			desc  ocispec.Descriptor
 		)
 		if ref == "" {
 			return errors.New("please provide a remote image reference to push")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		if !cliContext.Bool("local") {
+		if !cmd.Bool("local") {
 			unsupportedFlags := []string{
 				"manifest", "manifest-type", "max-concurrent-uploaded-layers", "allow-non-distributable-blobs",
 				"skip-verify", "tlscacert", "tlscert", "tlskey", "http-dump", "http-trace", // RegistryFlags
 			}
 			for _, s := range unsupportedFlags {
-				if cliContext.IsSet(s) {
+				if cmd.IsSet(s) {
 					return fmt.Errorf("\"--%s\" requires \"--local\" flag", s)
 				}
 			}
 
-			ch, err := commands.NewStaticCredentials(ctx, cliContext, ref)
+			ch, err := commands.NewStaticCredentials(ctx, cmd, ref)
 			if err != nil {
 				return err
 			}
@@ -113,8 +113,8 @@ var pushCommand = &cli.Command{
 			if local == "" {
 				local = ref
 			}
-			opts := []registry.Opt{registry.WithCredentials(ch), registry.WithHostDir(cliContext.String("hosts-dir"))}
-			if cliContext.Bool("plain-http") {
+			opts := []registry.Opt{registry.WithCredentials(ch), registry.WithHostDir(cmd.String("hosts-dir"))}
+			if cmd.Bool("plain-http") {
 				opts = append(opts, registry.WithDefaultScheme("http"))
 			}
 			reg, err := registry.NewOCIRegistry(ctx, ref, opts...)
@@ -122,7 +122,7 @@ var pushCommand = &cli.Command{
 				return err
 			}
 			var p []ocispec.Platform
-			if pss := cliContext.StringSlice("platform"); len(pss) > 0 {
+			if pss := cmd.StringSlice("platform"); len(pss) > 0 {
 				p, err = platforms.ParseAll(pss)
 				if err != nil {
 					return fmt.Errorf("invalid platform %v: %w", pss, err)
@@ -136,12 +136,12 @@ var pushCommand = &cli.Command{
 			return client.Transfer(ctx, is, reg, transfer.WithProgress(pf))
 		}
 
-		if manifest := cliContext.String("manifest"); manifest != "" {
+		if manifest := cmd.String("manifest"); manifest != "" {
 			desc.Digest, err = digest.Parse(manifest)
 			if err != nil {
 				return fmt.Errorf("invalid manifest digest: %w", err)
 			}
-			desc.MediaType = cliContext.String("manifest-type")
+			desc.MediaType = cmd.String("manifest-type")
 		} else {
 			if local == "" {
 				local = ref
@@ -152,7 +152,7 @@ var pushCommand = &cli.Command{
 			}
 			desc = img.Target
 
-			if pss := cliContext.StringSlice("platform"); len(pss) == 1 {
+			if pss := cmd.StringSlice("platform"); len(pss) == 1 {
 				p, err := platforms.Parse(pss[0])
 				if err != nil {
 					return fmt.Errorf("invalid platform %q: %w", pss[0], err)
@@ -174,10 +174,10 @@ var pushCommand = &cli.Command{
 			}
 		}
 
-		if cliContext.Bool("http-trace") {
+		if cmd.Bool("http-trace") {
 			ctx = httpdbg.WithClientTrace(ctx)
 		}
-		resolver, err := commands.GetResolver(ctx, cliContext)
+		resolver, err := commands.GetResolver(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -194,7 +194,7 @@ var pushCommand = &cli.Command{
 			log.G(ctx).WithField("image", ref).WithField("digest", desc.Digest).Debug("pushing")
 
 			jobHandler := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-				if !cliContext.Bool("allow-non-distributable-blobs") && images.IsNonDistributable(desc.MediaType) {
+				if !cmd.Bool("allow-non-distributable-blobs") && images.IsNonDistributable(desc.MediaType) {
 					return nil, nil
 				}
 				ongoing.add(remotes.MakeRefKey(ctx, desc))
@@ -202,7 +202,7 @@ var pushCommand = &cli.Command{
 			})
 
 			handler := jobHandler
-			if !cliContext.Bool("allow-non-distributable-blobs") {
+			if !cmd.Bool("allow-non-distributable-blobs") {
 				handler = remotes.SkipNonDistributableBlobs(handler)
 			}
 
@@ -211,8 +211,8 @@ var pushCommand = &cli.Command{
 				containerd.WithImageHandler(handler),
 			}
 
-			if cliContext.IsSet("max-concurrent-uploaded-layers") {
-				mcu := cliContext.Int("max-concurrent-uploaded-layers")
+			if cmd.IsSet("max-concurrent-uploaded-layers") {
+				mcu := cmd.Int("max-concurrent-uploaded-layers")
 				ropts = append(ropts, containerd.WithMaxConcurrentUploadedLayers(mcu))
 			}
 

--- a/cmd/ctr/commands/images/tag.go
+++ b/cmd/ctr/commands/images/tag.go
@@ -48,9 +48,8 @@ var tagCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		var (
-			ref = cmd.Args().First()
-		)
+		ctx := cmd.Context
+		ref := cmd.Args().First()
 		if ref == "" {
 			return errors.New("please provide an image reference to tag from")
 		}
@@ -58,7 +57,7 @@ var tagCommand = &cli.Command{
 			return errors.New("please provide an image reference to tag to")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/tag.go
+++ b/cmd/ctr/commands/images/tag.go
@@ -47,26 +47,26 @@ var tagCommand = &cli.Command{
 			Usage: "Skip the strict check for reference names",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			ref = cliContext.Args().First()
+			ref = cmd.Args().First()
 		)
 		if ref == "" {
 			return errors.New("please provide an image reference to tag from")
 		}
-		if cliContext.NArg() <= 1 {
+		if cmd.NArg() <= 1 {
 			return errors.New("please provide an image reference to tag to")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		if !cliContext.Bool("local") {
-			for _, targetRef := range cliContext.Args().Slice()[1:] {
-				if !cliContext.Bool("skip-reference-check") {
+		if !cmd.Bool("local") {
+			for _, targetRef := range cmd.Args().Slice()[1:] {
+				if !cmd.Bool("skip-reference-check") {
 					if _, err := reference.ParseAnyReference(targetRef); err != nil {
 						return fmt.Errorf("error parsing reference: %q is not a valid repository/tag %v", targetRef, err)
 					}
@@ -92,8 +92,8 @@ var tagCommand = &cli.Command{
 			return err
 		}
 		// Support multiple references for one command run
-		for _, targetRef := range cliContext.Args().Slice()[1:] {
-			if !cliContext.Bool("skip-reference-check") {
+		for _, targetRef := range cmd.Args().Slice()[1:] {
+			if !cmd.Bool("skip-reference-check") {
 				if _, err := reference.ParseAnyReference(targetRef); err != nil {
 					return fmt.Errorf("error parsing reference: %q is not a valid repository/tag %v", targetRef, err)
 				}
@@ -103,7 +103,7 @@ var tagCommand = &cli.Command{
 			if _, err = imageService.Create(ctx, image); err != nil {
 				// If user has specified force and the image already exists then
 				// delete the original image and attempt to create the new one
-				if errdefs.IsAlreadyExists(err) && cliContext.Bool("force") {
+				if errdefs.IsAlreadyExists(err) && cmd.Bool("force") {
 					if err = imageService.Delete(ctx, targetRef); err != nil {
 						return err
 					}

--- a/cmd/ctr/commands/images/unmount.go
+++ b/cmd/ctr/commands/images/unmount.go
@@ -39,14 +39,13 @@ var unmountCommand = &cli.Command{
 		},
 	),
 	Action: func(cmd *cli.Context) error {
-		var (
-			target = cmd.Args().First()
-		)
+		ctx := cmd.Context
+		target := cmd.Args().First()
 		if target == "" {
 			return errors.New("please provide a target path to unmount from")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/unmount.go
+++ b/cmd/ctr/commands/images/unmount.go
@@ -38,15 +38,15 @@ var unmountCommand = &cli.Command{
 			Usage: "Remove the snapshot after a successful unmount",
 		},
 	),
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			target = cliContext.Args().First()
+			target = cmd.Args().First()
 		)
 		if target == "" {
 			return errors.New("please provide a target path to unmount from")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -56,8 +56,8 @@ var unmountCommand = &cli.Command{
 			return err
 		}
 
-		if cliContext.Bool("rm") {
-			snapshotter := cliContext.String("snapshotter")
+		if cmd.Bool("rm") {
+			snapshotter := cmd.String("snapshotter")
 			s := client.SnapshotService(snapshotter)
 			if err := client.LeasesService().Delete(ctx, leases.Lease{ID: target}); err != nil && !errdefs.IsNotFound(err) {
 				return fmt.Errorf("error deleting lease: %w", err)
@@ -67,7 +67,7 @@ var unmountCommand = &cli.Command{
 			}
 		}
 
-		fmt.Fprintln(cliContext.App.Writer, target)
+		fmt.Fprintln(cmd.App.Writer, target)
 		return nil
 	},
 }

--- a/cmd/ctr/commands/images/usage.go
+++ b/cmd/ctr/commands/images/usage.go
@@ -37,12 +37,13 @@ var usageCommand = &cli.Command{
 	ArgsUsage: "[flags] <ref>",
 	Flags:     commands.SnapshotterFlags,
 	Action: func(cmd *cli.Context) error {
-		var ref = cmd.Args().First()
+		ctx := cmd.Context
+		ref := cmd.Args().First()
 		if ref == "" {
 			return errors.New("please provide an image reference to mount")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/usage.go
+++ b/cmd/ctr/commands/images/usage.go
@@ -36,19 +36,19 @@ var usageCommand = &cli.Command{
 	Usage:     "Display usage of snapshots for a given image ref",
 	ArgsUsage: "[flags] <ref>",
 	Flags:     commands.SnapshotterFlags,
-	Action: func(cliContext *cli.Context) error {
-		var ref = cliContext.Args().First()
+	Action: func(cmd *cli.Context) error {
+		var ref = cmd.Args().First()
 		if ref == "" {
 			return errors.New("please provide an image reference to mount")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		snapshotter := cliContext.String("snapshotter")
+		snapshotter := cmd.String("snapshotter")
 		if snapshotter == "" {
 			snapshotter = defaults.DefaultSnapshotter
 		}

--- a/cmd/ctr/commands/info/info.go
+++ b/cmd/ctr/commands/info/info.go
@@ -30,8 +30,8 @@ type Info struct {
 var Command = &cli.Command{
 	Name:  "info",
 	Usage: "Print the server info",
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/info/info.go
+++ b/cmd/ctr/commands/info/info.go
@@ -31,7 +31,8 @@ var Command = &cli.Command{
 	Name:  "info",
 	Usage: "Print the server info",
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/install/install.go
+++ b/cmd/ctr/commands/install/install.go
@@ -45,7 +45,8 @@ var Command = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/install/install.go
+++ b/cmd/ctr/commands/install/install.go
@@ -44,25 +44,25 @@ var Command = &cli.Command{
 			Usage: "Set an optional install path other than the managed opt directory",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		ref := cliContext.Args().First()
+		ref := cmd.Args().First()
 		image, err := client.GetImage(ctx, ref)
 		if err != nil {
 			return err
 		}
 		var opts []containerd.InstallOpts
-		if cliContext.Bool("libs") {
+		if cmd.Bool("libs") {
 			opts = append(opts, containerd.WithInstallLibs)
 		}
-		if cliContext.Bool("replace") {
+		if cmd.Bool("replace") {
 			opts = append(opts, containerd.WithInstallReplace)
 		}
-		if path := cliContext.String("path"); path != "" {
+		if path := cmd.String("path"); path != "" {
 			opts = append(opts, containerd.WithInstallPath(path))
 		}
 		return client.Install(ctx, image, opts...)

--- a/cmd/ctr/commands/leases/leases.go
+++ b/cmd/ctr/commands/leases/leases.go
@@ -55,11 +55,12 @@ var listCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			filters = cmd.Args().Slice()
 			quiet   = cmd.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -118,8 +119,9 @@ var createCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		var labelstr = cmd.Args().Slice()
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		labelstr := cmd.Args().Slice()
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -167,11 +169,12 @@ var deleteCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		var lids = cmd.Args().Slice()
+		ctx := cmd.Context
+		lids := cmd.Args().Slice()
 		if len(lids) == 0 {
 			return cli.ShowSubcommandHelp(cmd)
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/leases/leases.go
+++ b/cmd/ctr/commands/leases/leases.go
@@ -33,7 +33,7 @@ import (
 var Command = &cli.Command{
 	Name:  "leases",
 	Usage: "Manage leases",
-	Subcommands: cli.Commands{
+	Subcommands: []*cli.Command{
 		listCommand,
 		createCommand,
 		deleteCommand,

--- a/cmd/ctr/commands/leases/leases.go
+++ b/cmd/ctr/commands/leases/leases.go
@@ -54,12 +54,12 @@ var listCommand = &cli.Command{
 			Usage:   "Print only the blob digest",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			filters = cliContext.Args().Slice()
-			quiet   = cliContext.Bool("quiet")
+			filters = cmd.Args().Slice()
+			quiet   = cmd.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -117,9 +117,9 @@ var createCommand = &cli.Command{
 			Value:   24 * time.Hour,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		var labelstr = cliContext.Args().Slice()
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		var labelstr = cmd.Args().Slice()
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -136,10 +136,10 @@ var createCommand = &cli.Command{
 			opts = append(opts, leases.WithLabels(labels))
 		}
 
-		if id := cliContext.String("id"); id != "" {
+		if id := cmd.String("id"); id != "" {
 			opts = append(opts, leases.WithID(id))
 		}
-		if exp := cliContext.Duration("expires"); exp > 0 {
+		if exp := cmd.Duration("expires"); exp > 0 {
 			opts = append(opts, leases.WithExpiration(exp))
 		}
 
@@ -166,19 +166,19 @@ var deleteCommand = &cli.Command{
 			Usage: "Synchronously remove leases and all unreferenced resources",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		var lids = cliContext.Args().Slice()
+	Action: func(cmd *cli.Context) error {
+		var lids = cmd.Args().Slice()
 		if len(lids) == 0 {
-			return cli.ShowSubcommandHelp(cliContext)
+			return cli.ShowSubcommandHelp(cmd)
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
 		ls := client.LeasesService()
-		sync := cliContext.Bool("sync")
+		sync := cmd.Bool("sync")
 		for i, lid := range lids {
 			var opts []leases.DeleteOpt
 			if sync && i == len(lids)-1 {

--- a/cmd/ctr/commands/namespaces/namespaces.go
+++ b/cmd/ctr/commands/namespaces/namespaces.go
@@ -49,12 +49,12 @@ var createCommand = &cli.Command{
 	Usage:       "Create a new namespace",
 	ArgsUsage:   "<name> [<key>=<value>]",
 	Description: "create a new namespace. it must be unique",
-	Action: func(cliContext *cli.Context) error {
-		namespace, labels := commands.ObjectWithLabelArgs(cliContext)
+	Action: func(cmd *cli.Context) error {
+		namespace, labels := commands.ObjectWithLabelArgs(cmd)
 		if namespace == "" {
 			return errors.New("please specify a namespace")
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -69,12 +69,12 @@ var setLabelsCommand = &cli.Command{
 	Usage:       "Set and clear labels for a namespace",
 	ArgsUsage:   "<name> [<key>=<value>, ...]",
 	Description: "set and clear labels for a namespace. empty value clears the label",
-	Action: func(cliContext *cli.Context) error {
-		namespace, labels := commands.ObjectWithLabelArgs(cliContext)
+	Action: func(cmd *cli.Context) error {
+		namespace, labels := commands.ObjectWithLabelArgs(cmd)
 		if namespace == "" {
 			return errors.New("please specify a namespace")
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -102,9 +102,9 @@ var listCommand = &cli.Command{
 			Usage:   "Print only the namespace name",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		quiet := cliContext.Bool("quiet")
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		quiet := cmd.Bool("quiet")
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -155,17 +155,17 @@ var removeCommand = &cli.Command{
 			Usage:   "Delete the namespace's cgroup",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var exitErr error
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		opts := deleteOpts(cliContext)
+		opts := deleteOpts(cmd)
 		namespaces := client.NamespaceService()
-		for _, target := range cliContext.Args().Slice() {
+		for _, target := range cmd.Args().Slice() {
 			if err := namespaces.Delete(ctx, target, opts...); err != nil {
 				if !errdefs.IsNotFound(err) {
 					if exitErr == nil {

--- a/cmd/ctr/commands/namespaces/namespaces.go
+++ b/cmd/ctr/commands/namespaces/namespaces.go
@@ -50,11 +50,12 @@ var createCommand = &cli.Command{
 	ArgsUsage:   "<name> [<key>=<value>]",
 	Description: "create a new namespace. it must be unique",
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		namespace, labels := commands.ObjectWithLabelArgs(cmd)
 		if namespace == "" {
 			return errors.New("please specify a namespace")
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -70,11 +71,12 @@ var setLabelsCommand = &cli.Command{
 	ArgsUsage:   "<name> [<key>=<value>, ...]",
 	Description: "set and clear labels for a namespace. empty value clears the label",
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		namespace, labels := commands.ObjectWithLabelArgs(cmd)
 		if namespace == "" {
 			return errors.New("please specify a namespace")
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -103,8 +105,8 @@ var listCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		quiet := cmd.Bool("quiet")
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -115,6 +117,7 @@ var listCommand = &cli.Command{
 			return err
 		}
 
+		quiet := cmd.Bool("quiet")
 		if quiet {
 			for _, ns := range nss {
 				fmt.Println(ns)
@@ -156,13 +159,14 @@ var removeCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		var exitErr error
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
+		var exitErr error
 		opts := deleteOpts(cmd)
 		namespaces := client.NamespaceService()
 		for _, target := range cmd.Args().Slice() {

--- a/cmd/ctr/commands/namespaces/namespaces.go
+++ b/cmd/ctr/commands/namespaces/namespaces.go
@@ -35,7 +35,7 @@ var Command = &cli.Command{
 	Name:    "namespaces",
 	Aliases: []string{"namespace", "ns"},
 	Usage:   "Manage namespaces",
-	Subcommands: cli.Commands{
+	Subcommands: []*cli.Command{
 		createCommand,
 		listCommand,
 		removeCommand,

--- a/cmd/ctr/commands/namespaces/namespaces_linux.go
+++ b/cmd/ctr/commands/namespaces/namespaces_linux.go
@@ -22,9 +22,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func deleteOpts(cliContext *cli.Context) []namespaces.DeleteOpts {
+func deleteOpts(cmd *cli.Context) []namespaces.DeleteOpts {
 	var delOpts []namespaces.DeleteOpts
-	if cliContext.Bool("cgroup") {
+	if cmd.Bool("cgroup") {
 		delOpts = append(delOpts, opts.WithNamespaceCgroupDeletion)
 	}
 	return delOpts

--- a/cmd/ctr/commands/namespaces/namespaces_other.go
+++ b/cmd/ctr/commands/namespaces/namespaces_other.go
@@ -23,6 +23,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func deleteOpts(cliContext *cli.Context) []namespaces.DeleteOpts {
+func deleteOpts(cmd *cli.Context) []namespaces.DeleteOpts {
 	return nil
 }

--- a/cmd/ctr/commands/oci/oci.go
+++ b/cmd/ctr/commands/oci/oci.go
@@ -45,12 +45,12 @@ var defaultSpecCommand = &cli.Command{
 			Usage: "Platform of the spec to print (Examples: 'linux/arm64', 'windows/amd64')",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		ctx, cancel := commands.AppContext(cliContext)
+	Action: func(cmd *cli.Context) error {
+		ctx, cancel := commands.AppContext(cmd)
 		defer cancel()
 
 		platform := platforms.DefaultString()
-		if plat := cliContext.String("platform"); plat != "" {
+		if plat := cmd.String("platform"); plat != "" {
 			platform = plat
 		}
 

--- a/cmd/ctr/commands/oci/oci.go
+++ b/cmd/ctr/commands/oci/oci.go
@@ -46,7 +46,8 @@ var defaultSpecCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		ctx, cancel := commands.AppContext(cmd)
+		ctx := cmd.Context
+		ctx, cancel := commands.AppContext(ctx, cmd)
 		defer cancel()
 
 		platform := platforms.DefaultString()

--- a/cmd/ctr/commands/plugins/plugins.go
+++ b/cmd/ctr/commands/plugins/plugins.go
@@ -60,18 +60,18 @@ var listCommand = &cli.Command{
 			Usage:   "Print detailed information about each plugin",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			quiet    = cliContext.Bool("quiet")
-			detailed = cliContext.Bool("detailed")
+			quiet    = cmd.Bool("quiet")
+			detailed = cmd.Bool("detailed")
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		ps := client.IntrospectionService()
-		response, err := ps.Plugins(ctx, cliContext.Args().Slice()...)
+		response, err := ps.Plugins(ctx, cmd.Args().Slice()...)
 		if err != nil {
 			return err
 		}
@@ -172,13 +172,13 @@ var inspectRuntimeCommand = &cli.Command{
 	Usage:     "Display runtime info",
 	ArgsUsage: "[flags]",
 	Flags:     commands.RuntimeFlags,
-	Action: func(cliContext *cli.Context) error {
-		rt := cliContext.String("runtime")
-		rtOptions, err := commands.RuntimeOptions(cliContext)
+	Action: func(cmd *cli.Context) error {
+		rt := cmd.String("runtime")
+		rtOptions, err := commands.RuntimeOptions(cmd)
 		if err != nil {
 			return err
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -191,7 +191,7 @@ var inspectRuntimeCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		_, err = fmt.Fprintln(cliContext.App.Writer, string(j))
+		_, err = fmt.Fprintln(cmd.App.Writer, string(j))
 		return err
 	},
 }

--- a/cmd/ctr/commands/plugins/plugins.go
+++ b/cmd/ctr/commands/plugins/plugins.go
@@ -61,11 +61,12 @@ var listCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			quiet    = cmd.Bool("quiet")
 			detailed = cmd.Bool("detailed")
 		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -173,12 +174,13 @@ var inspectRuntimeCommand = &cli.Command{
 	ArgsUsage: "[flags]",
 	Flags:     commands.RuntimeFlags,
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		rt := cmd.String("runtime")
 		rtOptions, err := commands.RuntimeOptions(cmd)
 		if err != nil {
 			return err
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/pprof/pprof.go
+++ b/cmd/ctr/commands/pprof/pprof.go
@@ -64,8 +64,8 @@ var pprofGoroutinesCommand = &cli.Command{
 			Value: 2,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return GoroutineProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return GoroutineProfile(cmd, getPProfClient)
 	},
 }
 
@@ -79,8 +79,8 @@ var pprofHeapCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return HeapProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return HeapProfile(cmd, getPProfClient)
 	},
 }
 
@@ -100,8 +100,8 @@ var pprofProfileCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return CPUProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return CPUProfile(cmd, getPProfClient)
 	},
 }
 
@@ -121,8 +121,8 @@ var pprofTraceCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return TraceProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return TraceProfile(cmd, getPProfClient)
 	},
 }
 
@@ -136,8 +136,8 @@ var pprofBlockCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return BlockProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return BlockProfile(cmd, getPProfClient)
 	},
 }
 
@@ -151,21 +151,21 @@ var pprofThreadcreateCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return ThreadcreateProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return ThreadcreateProfile(cmd, getPProfClient)
 	},
 }
 
 // Client is a func that returns a http client for a pprof server
-type Client func(cliContext *cli.Context) (*http.Client, error)
+type Client func(cmd *cli.Context) (*http.Client, error)
 
 // GoroutineProfile dumps goroutine stack dump
-func GoroutineProfile(cliContext *cli.Context, clientFunc Client) error {
-	client, err := clientFunc(cliContext)
+func GoroutineProfile(cmd *cli.Context, clientFunc Client) error {
+	client, err := clientFunc(cmd)
 	if err != nil {
 		return err
 	}
-	debug := cliContext.Uint("debug")
+	debug := cmd.Uint("debug")
 	output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/goroutine?debug=%d", debug))
 	if err != nil {
 		return err
@@ -176,12 +176,12 @@ func GoroutineProfile(cliContext *cli.Context, clientFunc Client) error {
 }
 
 // HeapProfile dumps the heap profile
-func HeapProfile(cliContext *cli.Context, clientFunc Client) error {
-	client, err := clientFunc(cliContext)
+func HeapProfile(cmd *cli.Context, clientFunc Client) error {
+	client, err := clientFunc(cmd)
 	if err != nil {
 		return err
 	}
-	debug := cliContext.Uint("debug")
+	debug := cmd.Uint("debug")
 	output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/heap?debug=%d", debug))
 	if err != nil {
 		return err
@@ -192,13 +192,13 @@ func HeapProfile(cliContext *cli.Context, clientFunc Client) error {
 }
 
 // CPUProfile dumps CPU profile
-func CPUProfile(cliContext *cli.Context, clientFunc Client) error {
-	client, err := clientFunc(cliContext)
+func CPUProfile(cmd *cli.Context, clientFunc Client) error {
+	client, err := clientFunc(cmd)
 	if err != nil {
 		return err
 	}
-	seconds := cliContext.Duration("seconds").Seconds()
-	debug := cliContext.Uint("debug")
+	seconds := cmd.Duration("seconds").Seconds()
+	debug := cmd.Uint("debug")
 	output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/profile?seconds=%v&debug=%d", seconds, debug))
 	if err != nil {
 		return err
@@ -209,13 +209,13 @@ func CPUProfile(cliContext *cli.Context, clientFunc Client) error {
 }
 
 // TraceProfile collects execution trace
-func TraceProfile(cliContext *cli.Context, clientFunc Client) error {
-	client, err := clientFunc(cliContext)
+func TraceProfile(cmd *cli.Context, clientFunc Client) error {
+	client, err := clientFunc(cmd)
 	if err != nil {
 		return err
 	}
-	seconds := cliContext.Duration("seconds").Seconds()
-	debug := cliContext.Uint("debug")
+	seconds := cmd.Duration("seconds").Seconds()
+	debug := cmd.Uint("debug")
 	uri := fmt.Sprintf("/debug/pprof/trace?seconds=%v&debug=%d", seconds, debug)
 	output, err := httpGetRequest(client, uri)
 	if err != nil {
@@ -227,12 +227,12 @@ func TraceProfile(cliContext *cli.Context, clientFunc Client) error {
 }
 
 // BlockProfile collects goroutine blocking profile
-func BlockProfile(cliContext *cli.Context, clientFunc Client) error {
-	client, err := clientFunc(cliContext)
+func BlockProfile(cmd *cli.Context, clientFunc Client) error {
+	client, err := clientFunc(cmd)
 	if err != nil {
 		return err
 	}
-	debug := cliContext.Uint("debug")
+	debug := cmd.Uint("debug")
 	output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/block?debug=%d", debug))
 	if err != nil {
 		return err
@@ -243,12 +243,12 @@ func BlockProfile(cliContext *cli.Context, clientFunc Client) error {
 }
 
 // ThreadcreateProfile collects goroutine thread creating profile
-func ThreadcreateProfile(cliContext *cli.Context, clientFunc Client) error {
-	client, err := clientFunc(cliContext)
+func ThreadcreateProfile(cmd *cli.Context, clientFunc Client) error {
+	client, err := clientFunc(cmd)
 	if err != nil {
 		return err
 	}
-	debug := cliContext.Uint("debug")
+	debug := cmd.Uint("debug")
 	output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/threadcreate?debug=%d", debug))
 	if err != nil {
 		return err
@@ -258,8 +258,8 @@ func ThreadcreateProfile(cliContext *cli.Context, clientFunc Client) error {
 	return err
 }
 
-func getPProfClient(cliContext *cli.Context) (*http.Client, error) {
-	dialer := getPProfDialer(cliContext.String("debug-socket"))
+func getPProfClient(cmd *cli.Context) (*http.Client, error) {
+	dialer := getPProfDialer(cmd.String("debug-socket"))
 
 	tr := &http.Transport{
 		DialContext: dialer.pprofDial,

--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -55,8 +55,8 @@ func passwordPrompt() (string, error) {
 }
 
 // GetResolver prepares the resolver from the environment and options
-func GetResolver(ctx context.Context, cliContext *cli.Context) (remotes.Resolver, error) {
-	username := cliContext.String("user")
+func GetResolver(ctx context.Context, cmd *cli.Context) (remotes.Resolver, error) {
+	username := cmd.String("user")
 	var secret string
 	if i := strings.IndexByte(username, ':'); i > 0 {
 		secret = username[i+1:]
@@ -77,7 +77,7 @@ func GetResolver(ctx context.Context, cliContext *cli.Context) (remotes.Resolver
 
 			fmt.Print("\n")
 		}
-	} else if rt := cliContext.String("refresh"); rt != "" {
+	} else if rt := cmd.String("refresh"); rt != "" {
 		secret = rt
 	}
 
@@ -87,19 +87,19 @@ func GetResolver(ctx context.Context, cliContext *cli.Context) (remotes.Resolver
 		// Only one host
 		return username, secret, nil
 	}
-	if cliContext.Bool("plain-http") {
+	if cmd.Bool("plain-http") {
 		hostOptions.DefaultScheme = "http"
 	}
-	defaultTLS, err := resolverDefaultTLS(cliContext)
+	defaultTLS, err := resolverDefaultTLS(cmd)
 	if err != nil {
 		return nil, err
 	}
 	hostOptions.DefaultTLS = defaultTLS
-	if hostDir := cliContext.String("hosts-dir"); hostDir != "" {
+	if hostDir := cmd.String("hosts-dir"); hostDir != "" {
 		hostOptions.HostDir = config.HostDirFromRoot(hostDir)
 	}
 
-	if cliContext.Bool("http-dump") {
+	if cmd.Bool("http-dump") {
 		hostOptions.UpdateClient = func(client *http.Client) error {
 			httpdbg.DumpRequests(ctx, client, nil)
 			return nil
@@ -111,14 +111,14 @@ func GetResolver(ctx context.Context, cliContext *cli.Context) (remotes.Resolver
 	return docker.NewResolver(options), nil
 }
 
-func resolverDefaultTLS(cliContext *cli.Context) (*tls.Config, error) {
+func resolverDefaultTLS(cmd *cli.Context) (*tls.Config, error) {
 	tlsConfig := &tls.Config{}
 
-	if cliContext.Bool("skip-verify") {
+	if cmd.Bool("skip-verify") {
 		tlsConfig.InsecureSkipVerify = true
 	}
 
-	if tlsRootPath := cliContext.String("tlscacert"); tlsRootPath != "" {
+	if tlsRootPath := cmd.String("tlscacert"); tlsRootPath != "" {
 		tlsRootData, err := os.ReadFile(tlsRootPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %q: %w", tlsRootPath, err)
@@ -130,8 +130,8 @@ func resolverDefaultTLS(cliContext *cli.Context) (*tls.Config, error) {
 		}
 	}
 
-	tlsCertPath := cliContext.String("tlscert")
-	tlsKeyPath := cliContext.String("tlskey")
+	tlsCertPath := cmd.String("tlscert")
+	tlsKeyPath := cmd.String("tlskey")
 	if tlsCertPath != "" || tlsKeyPath != "" {
 		if tlsCertPath == "" || tlsKeyPath == "" {
 			return nil, errors.New("flags --tlscert and --tlskey must be set together")
@@ -158,8 +158,8 @@ type staticCredentials struct {
 }
 
 // NewStaticCredentials gets credentials from passing in cli context
-func NewStaticCredentials(ctx context.Context, cliContext *cli.Context, ref string) (registry.CredentialHelper, error) {
-	username := cliContext.String("user")
+func NewStaticCredentials(ctx context.Context, cmd *cli.Context, ref string) (registry.CredentialHelper, error) {
+	username := cmd.String("user")
 	var secret string
 	if i := strings.IndexByte(username, ':'); i > 0 {
 		secret = username[i+1:]
@@ -177,7 +177,7 @@ func NewStaticCredentials(ctx context.Context, cliContext *cli.Context, ref stri
 
 			fmt.Print("\n")
 		}
-	} else if rt := cliContext.String("refresh"); rt != "" {
+	} else if rt := cmd.String("refresh"); rt != "" {
 		secret = rt
 	}
 

--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -177,7 +177,7 @@ var Command = &cli.Command{
 			return errors.New("flags --detach and --rm cannot be specified together")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -144,6 +144,7 @@ var Command = &cli.Command{
 			append(append(commands.SnapshotterFlags, []cli.Flag{commands.SnapshotterLabels}...),
 				commands.ContainerFlags...)...)...)...),
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			err error
 			id  string

--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -43,11 +43,11 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
-func withMounts(cliContext *cli.Context) oci.SpecOpts {
+func withMounts(cmd *cli.Context) oci.SpecOpts {
 	return func(ctx context.Context, client oci.Client, container *containers.Container, s *specs.Spec) error {
 		mounts := make([]specs.Mount, 0)
 		dests := make([]string, 0)
-		for _, mount := range cliContext.StringSlice("mount") {
+		for _, mount := range cmd.StringSlice("mount") {
 			m, err := parseMountFlag(mount)
 			if err != nil {
 				return err
@@ -143,27 +143,27 @@ var Command = &cli.Command{
 		append(commands.RuntimeFlags,
 			append(append(commands.SnapshotterFlags, []cli.Flag{commands.SnapshotterLabels}...),
 				commands.ContainerFlags...)...)...)...),
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
 			err error
 			id  string
 			ref string
 
-			rm        = cliContext.Bool("rm")
-			tty       = cliContext.Bool("tty")
-			detach    = cliContext.Bool("detach")
-			config    = cliContext.IsSet("config")
-			enableCNI = cliContext.Bool("cni")
+			rm        = cmd.Bool("rm")
+			tty       = cmd.Bool("tty")
+			detach    = cmd.Bool("detach")
+			config    = cmd.IsSet("config")
+			enableCNI = cmd.Bool("cni")
 		)
 
 		if config {
-			id = cliContext.Args().First()
-			if cliContext.NArg() > 1 {
+			id = cmd.Args().First()
+			if cmd.NArg() > 1 {
 				return errors.New("with spec config file, only container id should be provided")
 			}
 		} else {
-			id = cliContext.Args().Get(1)
-			ref = cliContext.Args().First()
+			id = cmd.Args().Get(1)
+			ref = cmd.Args().First()
 
 			if ref == "" {
 				return errors.New("image ref must be provided")
@@ -176,13 +176,13 @@ var Command = &cli.Command{
 			return errors.New("flags --detach and --rm cannot be specified together")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		container, err := NewContainer(ctx, client, cliContext)
+		container, err := NewContainer(ctx, client, cmd)
 		if err != nil {
 			return err
 		}
@@ -193,8 +193,8 @@ var Command = &cli.Command{
 				}
 			}()
 		}
-		if cliContext.IsSet("dump-config") {
-			filename := cliContext.String("dump-config")
+		if cmd.IsSet("dump-config") {
+			filename := cmd.String("dump-config")
 			if filename == "" {
 				return errors.New("file name is required with --dump-config")
 			}
@@ -225,9 +225,9 @@ var Command = &cli.Command{
 			}
 		}
 
-		opts := tasks.GetNewTaskOpts(cliContext)
-		ioOpts := []cio.Opt{cio.WithFIFODir(cliContext.String("fifo-dir"))}
-		task, err := tasks.NewTask(ctx, client, container, cliContext.String("checkpoint"), con, cliContext.Bool("null-io"), cliContext.String("log-uri"), ioOpts, opts...)
+		opts := tasks.GetNewTaskOpts(cmd)
+		ioOpts := []cio.Opt{cio.WithFIFODir(cmd.String("fifo-dir"))}
+		task, err := tasks.NewTask(ctx, client, container, cmd.String("checkpoint"), con, cmd.Bool("null-io"), cmd.String("log-uri"), ioOpts, opts...)
 		if err != nil {
 			return err
 		}
@@ -250,8 +250,8 @@ var Command = &cli.Command{
 				return err
 			}
 		}
-		if cliContext.IsSet("pid-file") {
-			if err := commands.WritePidFile(cliContext.String("pid-file"), int(task.Pid())); err != nil {
+		if cmd.IsSet("pid-file") {
+			if err := commands.WritePidFile(cmd.String("pid-file"), int(task.Pid())); err != nil {
 				return err
 			}
 		}

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -90,18 +90,18 @@ var platformRunFlags = []cli.Flag{
 }
 
 // NewContainer creates a new container
-func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cli.Context) (containerd.Container, error) {
+func NewContainer(ctx context.Context, client *containerd.Client, cmd *cli.Context) (containerd.Container, error) {
 	var (
 		id     string
-		config = cliContext.IsSet("config")
+		config = cmd.IsSet("config")
 	)
 	if config {
-		id = cliContext.Args().First()
+		id = cmd.Args().First()
 	} else {
-		id = cliContext.Args().Get(1)
+		id = cmd.Args().Get(1)
 	}
 
-	platform := cliContext.String("platform")
+	platform := cmd.String("platform")
 	if platform == "" {
 		plat := platforms.DefaultSpec()
 		switch plat.OS {
@@ -125,41 +125,41 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 		spec  containerd.NewContainerOpts
 	)
 
-	if sandbox := cliContext.String("sandbox"); sandbox != "" {
+	if sandbox := cmd.String("sandbox"); sandbox != "" {
 		cOpts = append(cOpts, containerd.WithSandbox(sandbox))
 	}
 
 	if config {
-		cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(cliContext.StringSlice("label"))))
-		opts = append(opts, oci.WithSpecFromFile(cliContext.String("config")))
+		cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(cmd.StringSlice("label"))))
+		opts = append(opts, oci.WithSpecFromFile(cmd.String("config")))
 	} else {
 		var (
-			ref = cliContext.Args().First()
+			ref = cmd.Args().First()
 			// for container's id is Args[1]
-			args = cliContext.Args().Slice()[2:]
+			args = cmd.Args().Slice()[2:]
 		)
 		opts = append(opts, oci.WithDefaultSpecForPlatform(platform), oci.WithDefaultUnixDevices)
-		if ef := cliContext.String("env-file"); ef != "" {
+		if ef := cmd.String("env-file"); ef != "" {
 			opts = append(opts, oci.WithEnvFile(ef))
 		}
-		opts = append(opts, oci.WithEnv(cliContext.StringSlice("env")))
-		opts = append(opts, withMounts(cliContext))
+		opts = append(opts, oci.WithEnv(cmd.StringSlice("env")))
+		opts = append(opts, withMounts(cmd))
 
-		if cliContext.Bool("rootfs") {
+		if cmd.Bool("rootfs") {
 			rootfs, err := filepath.Abs(ref)
 			if err != nil {
 				return nil, err
 			}
 			opts = append(opts, oci.WithRootFSPath(rootfs))
-			cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(cliContext.StringSlice("label"))))
+			cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(cmd.StringSlice("label"))))
 		} else {
-			snapshotter := cliContext.String("snapshotter")
+			snapshotter := cmd.String("snapshotter")
 			var image containerd.Image
 			i, err := client.ImageService().Get(ctx, ref)
 			if err != nil {
 				return nil, err
 			}
-			if ps := cliContext.String("platform"); ps != "" {
+			if ps := cmd.String("platform"); ps != "" {
 				platform, err := platforms.Parse(ps)
 				if err != nil {
 					return nil, err
@@ -174,11 +174,11 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 				return nil, err
 			}
 			if !unpacked {
-				if err := image.Unpack(ctx, snapshotter, containerd.WithUnpackApplyOpts(diff.WithSyncFs(cliContext.Bool("sync-fs")))); err != nil {
+				if err := image.Unpack(ctx, snapshotter, containerd.WithUnpackApplyOpts(diff.WithSyncFs(cmd.Bool("sync-fs")))); err != nil {
 					return nil, err
 				}
 			}
-			labels := buildLabels(commands.LabelArgs(cliContext.StringSlice("label")), image.Labels())
+			labels := buildLabels(commands.LabelArgs(cmd.StringSlice("label")), image.Labels())
 			opts = append(opts, oci.WithImageConfig(image))
 			cOpts = append(cOpts,
 				containerd.WithImage(image),
@@ -186,7 +186,7 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 				containerd.WithAdditionalContainerLabels(labels),
 				containerd.WithSnapshotter(snapshotter))
 
-			if uidmaps, gidmaps := cliContext.StringSlice("uidmap"), cliContext.StringSlice("gidmap"); len(uidmaps) > 0 && len(gidmaps) > 0 {
+			if uidmaps, gidmaps := cmd.StringSlice("uidmap"), cmd.StringSlice("gidmap"); len(uidmaps) > 0 && len(gidmaps) > 0 {
 				var uidSpec, gidSpec []specs.LinuxIDMapping
 				if uidSpec, err = parseIDMappingOption(uidmaps); err != nil {
 					return nil, err
@@ -199,7 +199,7 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 				// currently the snapshotters known to support the labels are:
 				// fuse-overlayfs - https://github.com/containerd/fuse-overlayfs-snapshotter
 				// overlay - in case of idmapped mount points are supported by host kernel (Linux kernel 5.19)
-				if cliContext.Bool("remap-labels") {
+				if cmd.Bool("remap-labels") {
 					cOpts = append(cOpts, containerd.WithNewSnapshot(id, image, containerd.WithUserNSRemapperLabels(uidSpec, gidSpec)))
 				} else {
 					cOpts = append(cOpts, containerd.WithUserNSRemappedSnapshot(id, image, uidSpec, gidSpec))
@@ -211,28 +211,28 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 				// For some snapshotter, such as overlaybd, it can provide 2 kind of writable snapshot(overlayfs dir or block-device)
 				// by command label values.
 				cOpts = append(cOpts, containerd.WithNewSnapshot(id, image,
-					snapshots.WithLabels(commands.LabelArgs(cliContext.StringSlice("snapshotter-label")))))
+					snapshots.WithLabels(commands.LabelArgs(cmd.StringSlice("snapshotter-label")))))
 			}
 			cOpts = append(cOpts, containerd.WithImageStopSignal(image, "SIGTERM"))
 		}
-		if cliContext.Bool("read-only") {
+		if cmd.Bool("read-only") {
 			opts = append(opts, oci.WithRootFSReadonly())
 		}
 		if len(args) > 0 {
 			opts = append(opts, oci.WithProcessArgs(args...))
 		}
-		if cwd := cliContext.String("cwd"); cwd != "" {
+		if cwd := cmd.String("cwd"); cwd != "" {
 			opts = append(opts, oci.WithProcessCwd(cwd))
 		}
-		if user := cliContext.String("user"); user != "" {
+		if user := cmd.String("user"); user != "" {
 			opts = append(opts, oci.WithUser(user), oci.WithAdditionalGIDs(user))
 		}
-		if cliContext.Bool("tty") {
+		if cmd.Bool("tty") {
 			opts = append(opts, oci.WithTTY)
 		}
 
-		privileged := cliContext.Bool("privileged")
-		privilegedWithoutHostDevices := cliContext.Bool("privileged-without-host-devices")
+		privileged := cmd.Bool("privileged")
+		privilegedWithoutHostDevices := cmd.Bool("privileged-without-host-devices")
 		if privilegedWithoutHostDevices && !privileged {
 			return nil, errors.New("can't use 'privileged-without-host-devices' without 'privileged' specified")
 		}
@@ -244,7 +244,7 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			}
 		}
 
-		if cliContext.Bool("net-host") {
+		if cmd.Bool("net-host") {
 			hostname, err := os.Hostname()
 			if err != nil {
 				return nil, fmt.Errorf("get hostname: %w", err)
@@ -256,7 +256,7 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 				oci.WithEnv([]string{fmt.Sprintf("HOSTNAME=%s", hostname)}),
 			)
 		}
-		if annoStrings := cliContext.StringSlice("annotation"); len(annoStrings) > 0 {
+		if annoStrings := cmd.StringSlice("annotation"); len(annoStrings) > 0 {
 			annos, err := commands.AnnotationArgs(annoStrings)
 			if err != nil {
 				return nil, err
@@ -264,7 +264,7 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			opts = append(opts, oci.WithAnnotations(annos))
 		}
 
-		if caps := cliContext.StringSlice("cap-add"); len(caps) > 0 {
+		if caps := cmd.StringSlice("cap-add"); len(caps) > 0 {
 			for _, c := range caps {
 				if !strings.HasPrefix(c, "CAP_") {
 					return nil, errors.New("capabilities must be specified with 'CAP_' prefix")
@@ -273,7 +273,7 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			opts = append(opts, oci.WithAddedCapabilities(caps))
 		}
 
-		if caps := cliContext.StringSlice("cap-drop"); len(caps) > 0 {
+		if caps := cmd.StringSlice("cap-drop"); len(caps) > 0 {
 			for _, c := range caps {
 				if !strings.HasPrefix(c, "CAP_") {
 					return nil, errors.New("capabilities must be specified with 'CAP_' prefix")
@@ -282,13 +282,13 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			opts = append(opts, oci.WithDroppedCapabilities(caps))
 		}
 
-		seccompProfile := cliContext.String("seccomp-profile")
+		seccompProfile := cmd.String("seccomp-profile")
 
-		if !cliContext.Bool("seccomp") && seccompProfile != "" {
+		if !cmd.Bool("seccomp") && seccompProfile != "" {
 			return nil, errors.New("seccomp must be set to true, if using a custom seccomp-profile")
 		}
 
-		if cliContext.Bool("seccomp") {
+		if cmd.Bool("seccomp") {
 			if seccompProfile != "" {
 				opts = append(opts, seccomp.WithProfile(seccompProfile))
 			} else {
@@ -296,18 +296,18 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			}
 		}
 
-		if s := cliContext.String("apparmor-default-profile"); len(s) > 0 {
+		if s := cmd.String("apparmor-default-profile"); len(s) > 0 {
 			opts = append(opts, apparmor.WithDefaultProfile(s))
 		}
 
-		if s := cliContext.String("apparmor-profile"); len(s) > 0 {
-			if len(cliContext.String("apparmor-default-profile")) > 0 {
+		if s := cmd.String("apparmor-profile"); len(s) > 0 {
+			if len(cmd.String("apparmor-default-profile")) > 0 {
 				return nil, errors.New("apparmor-profile conflicts with apparmor-default-profile")
 			}
 			opts = append(opts, apparmor.WithProfile(s))
 		}
 
-		if cpus := cliContext.Float64("cpus"); cpus > 0.0 {
+		if cpus := cmd.Float64("cpus"); cpus > 0.0 {
 			var (
 				period = uint64(100000)
 				quota  = int64(cpus * 100000.0)
@@ -315,32 +315,32 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			opts = append(opts, oci.WithCPUCFS(quota, period))
 		}
 
-		if cpusetCpus := cliContext.String("cpuset-cpus"); len(cpusetCpus) > 0 {
+		if cpusetCpus := cmd.String("cpuset-cpus"); len(cpusetCpus) > 0 {
 			opts = append(opts, oci.WithCPUs(cpusetCpus))
 		}
 
-		if cpusetMems := cliContext.String("cpuset-mems"); len(cpusetMems) > 0 {
+		if cpusetMems := cmd.String("cpuset-mems"); len(cpusetMems) > 0 {
 			opts = append(opts, oci.WithCPUsMems(cpusetMems))
 		}
 
-		if shares := cliContext.Int("cpu-shares"); shares > 0 {
+		if shares := cmd.Int("cpu-shares"); shares > 0 {
 			opts = append(opts, oci.WithCPUShares(uint64(shares)))
 		}
 
-		quota := cliContext.Int64("cpu-quota")
-		period := cliContext.Uint64("cpu-period")
+		quota := cmd.Int64("cpu-quota")
+		period := cmd.Uint64("cpu-period")
 		if quota != -1 || period != 0 {
-			if cpus := cliContext.Float64("cpus"); cpus > 0.0 {
+			if cpus := cmd.Float64("cpus"); cpus > 0.0 {
 				return nil, errors.New("cpus and quota/period should be used separately")
 			}
 			opts = append(opts, oci.WithCPUCFS(quota, period))
 		}
 
-		if burst := cliContext.Uint64("cpu-burst"); burst != 0 {
+		if burst := cmd.Uint64("cpu-burst"); burst != 0 {
 			opts = append(opts, oci.WithCPUBurst(burst))
 		}
 
-		joinNs := cliContext.StringSlice("with-ns")
+		joinNs := cmd.StringSlice("with-ns")
 		for _, ns := range joinNs {
 			nsType, nsPath, ok := strings.Cut(ns, ":")
 			if !ok {
@@ -354,20 +354,20 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 				Path: nsPath,
 			}))
 		}
-		if cliContext.IsSet("allow-new-privs") {
+		if cmd.IsSet("allow-new-privs") {
 			opts = append(opts, oci.WithNewPrivileges)
 		}
-		if cliContext.IsSet("cgroup") {
+		if cmd.IsSet("cgroup") {
 			// NOTE: can be set to "" explicitly for disabling cgroup.
-			opts = append(opts, oci.WithCgroup(cliContext.String("cgroup")))
+			opts = append(opts, oci.WithCgroup(cmd.String("cgroup")))
 		}
-		limit := cliContext.Uint64("memory-limit")
+		limit := cmd.Uint64("memory-limit")
 		if limit != 0 {
 			opts = append(opts, oci.WithMemoryLimit(limit))
 		}
 
 		var cdiDeviceIDs []string
-		for _, dev := range cliContext.StringSlice("device") {
+		for _, dev := range cmd.StringSlice("device") {
 			if parser.IsQualifiedName(dev) {
 				cdiDeviceIDs = append(cdiDeviceIDs, dev)
 				continue
@@ -375,11 +375,11 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			opts = append(opts, oci.WithDevices(dev, "", "rwm"))
 		}
 
-		if gpuIDs := cliContext.IntSlice("gpus"); len(cdiDeviceIDs) > 0 || len(gpuIDs) > 0 {
+		if gpuIDs := cmd.IntSlice("gpus"); len(cdiDeviceIDs) > 0 || len(gpuIDs) > 0 {
 			opts = append(opts, withCDIDeviceRequests(cdiDeviceIDs, gpuIDs)...)
 		}
 
-		rootfsPropagation := cliContext.String("rootfs-propagation")
+		rootfsPropagation := cmd.String("rootfs-propagation")
 		if rootfsPropagation != "" {
 			opts = append(opts, func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
 				if s.Linux != nil {
@@ -394,26 +394,26 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			})
 		}
 
-		if c := cliContext.String("blockio-config-file"); c != "" {
+		if c := cmd.String("blockio-config-file"); c != "" {
 			if err := blockio.SetConfigFromFile(c, false); err != nil {
 				return nil, fmt.Errorf("blockio-config-file error: %w", err)
 			}
 		}
 
-		if c := cliContext.String("blockio-class"); c != "" {
+		if c := cmd.String("blockio-class"); c != "" {
 			if linuxBlockIO, err := blockio.OciLinuxBlockIO(c); err == nil {
 				opts = append(opts, oci.WithBlockIO(linuxBlockIO))
 			} else {
 				return nil, fmt.Errorf("blockio-class error: %w", err)
 			}
 		}
-		if c := cliContext.String("rdt-class"); c != "" {
+		if c := cmd.String("rdt-class"); c != "" {
 			opts = append(opts, oci.WithRdt(c, "", ""))
 		}
-		if hostname := cliContext.String("hostname"); hostname != "" {
+		if hostname := cmd.String("hostname"); hostname != "" {
 			opts = append(opts, oci.WithHostname(hostname))
 		}
-		if c := cliContext.String("rlimit-nofile"); c != "" {
+		if c := cmd.String("rlimit-nofile"); c != "" {
 			softS, hardS, found := strings.Cut(c, ":")
 			if !found {
 				hardS = softS
@@ -435,18 +435,18 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 		}
 	}
 
-	if cliContext.Bool("cni") {
+	if cmd.Bool("cni") {
 		cniMeta := &commands.NetworkMetaData{EnableCni: true}
 		cOpts = append(cOpts, containerd.WithContainerExtension(commands.CtrCniMetadataExtension, cniMeta))
 	}
 
-	runtimeOpts, err := commands.RuntimeOptions(cliContext)
+	runtimeOpts, err := commands.RuntimeOptions(cmd)
 	if err != nil {
 		return nil, err
 	}
-	cOpts = append(cOpts, containerd.WithRuntime(cliContext.String("runtime"), runtimeOpts))
+	cOpts = append(cOpts, containerd.WithRuntime(cmd.String("runtime"), runtimeOpts))
 
-	opts = append(opts, oci.WithAnnotations(commands.LabelArgs(cliContext.StringSlice("label"))))
+	opts = append(opts, oci.WithAnnotations(commands.LabelArgs(cmd.StringSlice("label"))))
 	var s specs.Spec
 	spec = containerd.WithSpec(&s, opts...)
 

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -46,32 +46,32 @@ var platformRunFlags = []cli.Flag{
 }
 
 // NewContainer creates a new container
-func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cli.Context) (containerd.Container, error) {
+func NewContainer(ctx context.Context, client *containerd.Client, cmd *cli.Context) (containerd.Container, error) {
 	var (
 		id    string
 		opts  []oci.SpecOpts
 		cOpts []containerd.NewContainerOpts
 		spec  containerd.NewContainerOpts
 
-		config = cliContext.IsSet("config")
+		config = cmd.IsSet("config")
 	)
 
-	if sandbox := cliContext.String("sandbox"); sandbox != "" {
+	if sandbox := cmd.String("sandbox"); sandbox != "" {
 		cOpts = append(cOpts, containerd.WithSandbox(sandbox))
 	}
 
 	if config {
-		id = cliContext.Args().First()
-		opts = append(opts, oci.WithSpecFromFile(cliContext.String("config")))
-		cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(cliContext.StringSlice("label"))))
+		id = cmd.Args().First()
+		opts = append(opts, oci.WithSpecFromFile(cmd.String("config")))
+		cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(cmd.StringSlice("label"))))
 	} else {
 		var (
-			ref  = cliContext.Args().First()
-			args = cliContext.Args().Slice()[2:]
+			ref  = cmd.Args().First()
+			args = cmd.Args().Slice()[2:]
 		)
 
-		id = cliContext.Args().Get(1)
-		snapshotter := cliContext.String("snapshotter")
+		id = cmd.Args().Get(1)
+		snapshotter := cmd.String("snapshotter")
 		if snapshotter == "windows-lcow" {
 			opts = append(opts, oci.WithDefaultSpecForPlatform("linux/amd64"))
 			// Clear the rootfs section.
@@ -81,11 +81,11 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			opts = append(opts, oci.WithWindowNetworksAllowUnqualifiedDNSQuery())
 			opts = append(opts, oci.WithWindowsIgnoreFlushesDuringBoot())
 		}
-		if ef := cliContext.String("env-file"); ef != "" {
+		if ef := cmd.String("env-file"); ef != "" {
 			opts = append(opts, oci.WithEnvFile(ef))
 		}
-		opts = append(opts, oci.WithEnv(cliContext.StringSlice("env")))
-		opts = append(opts, withMounts(cliContext))
+		opts = append(opts, oci.WithEnv(cmd.StringSlice("env")))
+		opts = append(opts, withMounts(cmd))
 
 		image, err := client.GetImage(ctx, ref)
 		if err != nil {
@@ -96,12 +96,12 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			return nil, err
 		}
 		if !unpacked {
-			if err := image.Unpack(ctx, snapshotter, containerd.WithUnpackApplyOpts(diff.WithSyncFs(cliContext.Bool("sync-fs")))); err != nil {
+			if err := image.Unpack(ctx, snapshotter, containerd.WithUnpackApplyOpts(diff.WithSyncFs(cmd.Bool("sync-fs")))); err != nil {
 				return nil, err
 			}
 		}
 		opts = append(opts, oci.WithImageConfig(image))
-		labels := buildLabels(commands.LabelArgs(cliContext.StringSlice("label")), image.Labels())
+		labels := buildLabels(commands.LabelArgs(cmd.StringSlice("label")), image.Labels())
 		cOpts = append(cOpts,
 			containerd.WithImage(image),
 			containerd.WithImageConfigLabels(image),
@@ -109,19 +109,19 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			containerd.WithNewSnapshot(
 				id,
 				image,
-				snapshots.WithLabels(commands.LabelArgs(cliContext.StringSlice("snapshotter-label")))),
+				snapshots.WithLabels(commands.LabelArgs(cmd.StringSlice("snapshotter-label")))),
 			containerd.WithAdditionalContainerLabels(labels))
 
 		if len(args) > 0 {
 			opts = append(opts, oci.WithProcessArgs(args...))
 		}
-		if cwd := cliContext.String("cwd"); cwd != "" {
+		if cwd := cmd.String("cwd"); cwd != "" {
 			opts = append(opts, oci.WithProcessCwd(cwd))
 		}
-		if user := cliContext.String("user"); user != "" {
+		if user := cmd.String("user"); user != "" {
 			opts = append(opts, oci.WithUser(user))
 		}
-		if cliContext.Bool("tty") {
+		if cmd.Bool("tty") {
 			opts = append(opts, oci.WithTTY)
 
 			con := console.Current()
@@ -131,36 +131,36 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 			}
 			opts = append(opts, oci.WithTTYSize(int(size.Width), int(size.Height)))
 		}
-		if cliContext.Bool("net-host") {
+		if cmd.Bool("net-host") {
 			return nil, errors.New("cannot use host mode networking with Windows containers")
 		}
-		if cliContext.Bool("cni") {
+		if cmd.Bool("cni") {
 			ns, err := netns.NewNetNS("")
 			if err != nil {
 				return nil, err
 			}
 			opts = append(opts, oci.WithWindowsNetworkNamespace(ns.GetPath()))
 		}
-		if cliContext.Bool("isolated") {
+		if cmd.Bool("isolated") {
 			opts = append(opts, oci.WithWindowsHyperV)
 		}
-		limit := cliContext.Uint64("memory-limit")
+		limit := cmd.Uint64("memory-limit")
 		if limit != 0 {
 			opts = append(opts, oci.WithMemoryLimit(limit))
 		}
-		ccount := cliContext.Uint64("cpu-count")
+		ccount := cmd.Uint64("cpu-count")
 		if ccount != 0 {
 			opts = append(opts, oci.WithWindowsCPUCount(ccount))
 		}
-		cshares := cliContext.Uint64("cpu-shares")
+		cshares := cmd.Uint64("cpu-shares")
 		if cshares != 0 {
 			opts = append(opts, oci.WithWindowsCPUShares(uint16(cshares)))
 		}
-		cmax := cliContext.Uint64("cpu-max")
+		cmax := cmd.Uint64("cpu-max")
 		if cmax != 0 {
 			opts = append(opts, oci.WithWindowsCPUMaximum(uint16(cmax)))
 		}
-		for _, dev := range cliContext.StringSlice("device") {
+		for _, dev := range cmd.StringSlice("device") {
 			idType, devID, ok := strings.Cut(dev, "://")
 			if !ok {
 				return nil, errors.New("devices must be in the format IDType://ID")
@@ -172,19 +172,19 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 		}
 	}
 
-	if cliContext.Bool("cni") {
+	if cmd.Bool("cni") {
 		cniMeta := &commands.NetworkMetaData{EnableCni: true}
 		cOpts = append(cOpts, containerd.WithContainerExtension(commands.CtrCniMetadataExtension, cniMeta))
 	}
 
-	runtime := cliContext.String("runtime")
+	runtime := cmd.String("runtime")
 	var runtimeOpts any
 	if runtime == "io.containerd.runhcs.v1" {
 		opts := &options.Options{
-			Debug: cliContext.Bool("debug"),
+			Debug: cmd.Bool("debug"),
 		}
-		if cliContext.IsSet("scrub-logs") {
-			scrubLogs := cliContext.Bool("scrub-logs")
+		if cmd.IsSet("scrub-logs") {
+			scrubLogs := cmd.Bool("scrub-logs")
 			opts.ScrubLogs = &scrubLogs
 		}
 		runtimeOpts = opts

--- a/cmd/ctr/commands/sandboxes/sandboxes.go
+++ b/cmd/ctr/commands/sandboxes/sandboxes.go
@@ -57,6 +57,7 @@ var runCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		if cmd.NArg() != 2 {
 			return cli.ShowSubcommandHelp(cmd)
 		}
@@ -75,7 +76,7 @@ var runCommand = &cli.Command{
 			return fmt.Errorf("failed to parse sandbox config: %w", err)
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -110,7 +111,8 @@ var listCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -158,7 +160,8 @@ var removeCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -200,7 +203,8 @@ var infoCommand = &cli.Command{
 	Usage:     "Get info about a sandbox",
 	ArgsUsage: "<sandbox id>",
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/sandboxes/sandboxes.go
+++ b/cmd/ctr/commands/sandboxes/sandboxes.go
@@ -56,16 +56,16 @@ var runCommand = &cli.Command{
 			Value: defaults.DefaultRuntime,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		if cliContext.NArg() != 2 {
-			return cli.ShowSubcommandHelp(cliContext)
+	Action: func(cmd *cli.Context) error {
+		if cmd.NArg() != 2 {
+			return cli.ShowSubcommandHelp(cmd)
 		}
 		var (
-			id      = cliContext.Args().Get(1)
-			runtime = cliContext.String("runtime")
+			id      = cmd.Args().Get(1)
+			runtime = cmd.String("runtime")
 		)
 
-		spec, err := os.ReadFile(cliContext.Args().First())
+		spec, err := os.ReadFile(cmd.Args().First())
 		if err != nil {
 			return fmt.Errorf("failed to read sandbox config: %w", err)
 		}
@@ -75,7 +75,7 @@ var runCommand = &cli.Command{
 			return fmt.Errorf("failed to parse sandbox config: %w", err)
 		}
 
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -109,8 +109,8 @@ var listCommand = &cli.Command{
 			Usage: "The list of filters to apply when querying sandboxes from the store",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -118,7 +118,7 @@ var listCommand = &cli.Command{
 
 		var (
 			writer  = tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
-			filters = cliContext.StringSlice("filters")
+			filters = cmd.StringSlice("filters")
 		)
 
 		defer func() {
@@ -157,16 +157,16 @@ var removeCommand = &cli.Command{
 			Usage:   "Ignore shutdown errors when removing sandbox",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		force := cliContext.Bool("force")
+		force := cmd.Bool("force")
 
-		for _, id := range cliContext.Args().Slice() {
+		for _, id := range cmd.Args().Slice() {
 			sandbox, err := client.LoadSandbox(ctx, id)
 			if err != nil {
 				log.G(ctx).WithError(err).Errorf("failed to load sandbox %s", id)
@@ -199,14 +199,14 @@ var infoCommand = &cli.Command{
 	Aliases:   []string{"i"},
 	Usage:     "Get info about a sandbox",
 	ArgsUsage: "<sandbox id>",
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		id := cliContext.Args().First()
+		id := cmd.Args().First()
 		if id == "" {
 			return fmt.Errorf("sandbox id must be provided: %w", errdefs.ErrInvalidArgument)
 		}

--- a/cmd/ctr/commands/sandboxes/sandboxes.go
+++ b/cmd/ctr/commands/sandboxes/sandboxes.go
@@ -36,7 +36,7 @@ var Command = &cli.Command{
 	Name:    "sandboxes",
 	Aliases: []string{"sandbox", "sb", "s"},
 	Usage:   "Manage sandboxes",
-	Subcommands: cli.Commands{
+	Subcommands: []*cli.Command{
 		runCommand,
 		listCommand,
 		removeCommand,

--- a/cmd/ctr/commands/shim/pprof.go
+++ b/cmd/ctr/commands/shim/pprof.go
@@ -55,8 +55,8 @@ var pprofGoroutinesCommand = &cli.Command{
 			Value: 2,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return pprof.GoroutineProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return pprof.GoroutineProfile(cmd, getPProfClient)
 	},
 }
 
@@ -70,8 +70,8 @@ var pprofHeapCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return pprof.HeapProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return pprof.HeapProfile(cmd, getPProfClient)
 	},
 }
 
@@ -91,8 +91,8 @@ var pprofProfileCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return pprof.CPUProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return pprof.CPUProfile(cmd, getPProfClient)
 	},
 }
 
@@ -112,8 +112,8 @@ var pprofTraceCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return pprof.TraceProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return pprof.TraceProfile(cmd, getPProfClient)
 	},
 }
 
@@ -127,8 +127,8 @@ var pprofBlockCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return pprof.BlockProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return pprof.BlockProfile(cmd, getPProfClient)
 	},
 }
 
@@ -142,21 +142,21 @@ var pprofThreadcreateCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		return pprof.ThreadcreateProfile(cliContext, getPProfClient)
+	Action: func(cmd *cli.Context) error {
+		return pprof.ThreadcreateProfile(cmd, getPProfClient)
 	},
 }
 
-func getPProfClient(cliContext *cli.Context) (*http.Client, error) {
-	id := cliContext.String("id")
+func getPProfClient(cmd *cli.Context) (*http.Client, error) {
+	id := cmd.String("id")
 	if id == "" {
 		return nil, errors.New("container id must be provided")
 	}
 	tr := &http.Transport{
 		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			ns := cliContext.String("namespace")
+			ns := cmd.String("namespace")
 			ctx = namespaces.WithNamespace(ctx, ns)
-			s, _ := shim.SocketAddress(ctx, cliContext.String("address"), id, true)
+			s, _ := shim.SocketAddress(ctx, cmd.String("address"), id, true)
 			s = strings.TrimPrefix(s, "unix://")
 			var dialer net.Dialer
 			return dialer.DialContext(ctx, "unix", s)

--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -231,7 +231,6 @@ var execCommand = &cli.Command{
 			Name:    "env",
 			Aliases: []string{"e"},
 			Usage:   "Add environment vars",
-			Value:   cli.NewStringSlice(),
 		},
 		&cli.StringFlag{
 			Name:  "cwd",

--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -89,13 +89,13 @@ var Command = &cli.Command{
 var startCommand = &cli.Command{
 	Name:  "start",
 	Usage: "Start a container with a task",
-	Action: func(cliContext *cli.Context) error {
-		service, err := getTaskService(cliContext)
+	Action: func(cmd *cli.Context) error {
+		service, err := getTaskService(cmd)
 		if err != nil {
 			return err
 		}
 		_, err = service.Start(context.Background(), &task.StartRequest{
-			ID: cliContext.Args().First(),
+			ID: cmd.Args().First(),
 		})
 		return err
 	},
@@ -104,13 +104,13 @@ var startCommand = &cli.Command{
 var deleteCommand = &cli.Command{
 	Name:  "delete",
 	Usage: "Delete a container with a task",
-	Action: func(cliContext *cli.Context) error {
-		service, err := getTaskService(cliContext)
+	Action: func(cmd *cli.Context) error {
+		service, err := getTaskService(cmd)
 		if err != nil {
 			return err
 		}
 		r, err := service.Delete(context.Background(), &task.DeleteRequest{
-			ID: cliContext.Args().First(),
+			ID: cmd.Args().First(),
 		})
 		if err != nil {
 			return err
@@ -128,7 +128,7 @@ var shutdownCommand = &cli.Command{
 			Name:  "api-version",
 			Usage: "shim API version {2,3}",
 			Value: 3,
-			Action: func(c *cli.Context, v int) error {
+			Action: func(cmd *cli.Context, v int) error {
 				if v != 2 && v != 3 {
 					return fmt.Errorf("api-version must be 2 or 3")
 				}
@@ -136,10 +136,10 @@ var shutdownCommand = &cli.Command{
 			},
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		switch cliContext.Int("api-version") {
+	Action: func(cmd *cli.Context) error {
+		switch cmd.Int("api-version") {
 		case 2:
-			service, err := getTaskServiceV2(cliContext)
+			service, err := getTaskServiceV2(cmd)
 			if err != nil {
 				return err
 			}
@@ -148,7 +148,7 @@ var shutdownCommand = &cli.Command{
 				return err
 			}
 		default:
-			service, err := getTaskService(cliContext)
+			service, err := getTaskService(cmd)
 			if err != nil {
 				return err
 			}
@@ -174,7 +174,7 @@ var stateCommand = &cli.Command{
 			Name:  "api-version",
 			Usage: "shim API version {2,3}",
 			Value: 3,
-			Action: func(c *cli.Context, v int) error {
+			Action: func(cmd *cli.Context, v int) error {
 				if v != 2 && v != 3 {
 					return fmt.Errorf("api-version must be 2 or 3")
 				}
@@ -182,16 +182,16 @@ var stateCommand = &cli.Command{
 			},
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		id := cliContext.String("task-id")
+	Action: func(cmd *cli.Context) error {
+		id := cmd.String("task-id")
 		if id == "" {
-			id = cliContext.String("id")
+			id = cmd.String("id")
 		}
 
 		var r any
-		switch cliContext.Int("api-version") {
+		switch cmd.Int("api-version") {
 		case 2:
-			service, err := getTaskServiceV2(cliContext)
+			service, err := getTaskServiceV2(cmd)
 			if err != nil {
 				return err
 			}
@@ -202,7 +202,7 @@ var stateCommand = &cli.Command{
 				return err
 			}
 		default:
-			service, err := getTaskService(cliContext)
+			service, err := getTaskService(cmd)
 			if err != nil {
 				return err
 			}
@@ -241,13 +241,13 @@ var execCommand = &cli.Command{
 			Usage: "Runtime spec",
 		},
 	),
-	Action: func(cliContext *cli.Context) error {
-		service, err := getTaskService(cliContext)
+	Action: func(cmd *cli.Context) error {
+		service, err := getTaskService(cmd)
 		if err != nil {
 			return err
 		}
 		var (
-			id  = cliContext.Args().First()
+			id  = cmd.Args().First()
 			ctx = context.Background()
 		)
 
@@ -255,14 +255,14 @@ var execCommand = &cli.Command{
 			return errors.New("exec id must be provided")
 		}
 
-		tty := cliContext.Bool("tty")
-		wg, err := prepareStdio(cliContext.String("stdin"), cliContext.String("stdout"), cliContext.String("stderr"), tty)
+		tty := cmd.Bool("tty")
+		wg, err := prepareStdio(cmd.String("stdin"), cmd.String("stdout"), cmd.String("stderr"), tty)
 		if err != nil {
 			return err
 		}
 
 		// read spec file and extract Any object
-		spec, err := os.ReadFile(cliContext.String("spec"))
+		spec, err := os.ReadFile(cmd.String("spec"))
 		if err != nil {
 			return err
 		}
@@ -277,9 +277,9 @@ var execCommand = &cli.Command{
 				TypeUrl: url,
 				Value:   spec,
 			},
-			Stdin:    cliContext.String("stdin"),
-			Stdout:   cliContext.String("stdout"),
-			Stderr:   cliContext.String("stderr"),
+			Stdin:    cmd.String("stdin"),
+			Stdout:   cmd.String("stdout"),
+			Stderr:   cmd.String("stderr"),
 			Terminal: tty,
 		}
 		if _, err := service.Exec(ctx, rq); err != nil {
@@ -292,7 +292,7 @@ var execCommand = &cli.Command{
 			return err
 		}
 		fmt.Printf("exec running with pid %d\n", r.Pid)
-		if cliContext.Bool("attach") {
+		if cmd.Bool("attach") {
 			log.L.Info("attaching")
 			if tty {
 				current := console.Current()
@@ -318,28 +318,28 @@ var execCommand = &cli.Command{
 	},
 }
 
-func getTaskService(cliContext *cli.Context) (task.TTRPCTaskService, error) {
-	client, err := getTTRPCClient(cliContext)
+func getTaskService(cmd *cli.Context) (task.TTRPCTaskService, error) {
+	client, err := getTTRPCClient(cmd)
 	if err != nil {
 		return nil, err
 	}
 	return task.NewTTRPCTaskClient(client), nil
 }
-func getTaskServiceV2(cliContext *cli.Context) (taskv2.TTRPCTaskService, error) {
-	client, err := getTTRPCClient(cliContext)
+func getTaskServiceV2(cmd *cli.Context) (taskv2.TTRPCTaskService, error) {
+	client, err := getTTRPCClient(cmd)
 	if err != nil {
 		return nil, err
 	}
 	return taskv2.NewTTRPCTaskClient(client), nil
 }
 
-func getTTRPCClient(cliContext *cli.Context) (*ttrpc.Client, error) {
-	id := cliContext.String("id")
-	shimAddress := cliContext.String("shim-address")
+func getTTRPCClient(cmd *cli.Context) (*ttrpc.Client, error) {
+	id := cmd.String("id")
+	shimAddress := cmd.String("shim-address")
 	if id == "" && shimAddress == "" {
 		return nil, fmt.Errorf("shim ID (--id) or address (--shim-address) must be specified")
 	}
-	ns := cliContext.String("namespace")
+	ns := cmd.String("namespace")
 
 	sockets := make([]string, 0)
 	if shimAddress != "" {
@@ -352,7 +352,7 @@ func getTTRPCClient(cliContext *cli.Context) (*ttrpc.Client, error) {
 		s1 := filepath.Join(string(filepath.Separator), "containerd-shim", ns, id, "shim.sock")
 		// this should not error, ctr always get a default ns
 		ctx := namespaces.WithNamespace(context.Background(), ns)
-		s2, _ := shim.SocketAddress(ctx, cliContext.String("address"), id, false)
+		s2, _ := shim.SocketAddress(ctx, cmd.String("address"), id, false)
 		s2 = strings.TrimPrefix(s2, "unix://")
 		sockets = append(sockets, s2, "\x00"+s1)
 	}

--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -71,7 +71,8 @@ var listCommand = &cli.Command{
 	Aliases: []string{"ls"},
 	Usage:   "List snapshots",
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -115,6 +116,7 @@ var diffCommand = &cli.Command{
 		},
 	}, commands.LabelFlag),
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			idA = cmd.Args().First()
 			idB = cmd.Args().Get(1)
@@ -122,7 +124,7 @@ var diffCommand = &cli.Command{
 		if idA == "" {
 			return errors.New("snapshot id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -208,6 +210,7 @@ var usageCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var displaySize func(int64) string
 		if cmd.Bool("b") {
 			displaySize = func(s int64) string {
@@ -218,7 +221,7 @@ var usageCommand = &cli.Command{
 				return progress.Bytes(s).String()
 			}
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -259,7 +262,8 @@ var removeCommand = &cli.Command{
 	ArgsUsage: "<key> [<key>, ...]",
 	Usage:     "Remove snapshots",
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -292,6 +296,7 @@ var prepareCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		if narg := cmd.NArg(); narg < 1 || narg > 2 {
 			return cli.ShowSubcommandHelp(cmd)
 		}
@@ -300,7 +305,7 @@ var prepareCommand = &cli.Command{
 			key    = cmd.Args().Get(0)
 			parent = cmd.Args().Get(1)
 		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -344,6 +349,7 @@ var viewCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		if narg := cmd.NArg(); narg < 1 || narg > 2 {
 			return cli.ShowSubcommandHelp(cmd)
 		}
@@ -352,7 +358,7 @@ var viewCommand = &cli.Command{
 			key    = cmd.Args().Get(0)
 			parent = cmd.Args().Get(1)
 		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -388,6 +394,7 @@ var mountCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		if cmd.NArg() != 2 {
 			return cli.ShowSubcommandHelp(cmd)
 		}
@@ -395,7 +402,7 @@ var mountCommand = &cli.Command{
 			target = cmd.Args().Get(0)
 			key    = cmd.Args().Get(1)
 		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -430,6 +437,7 @@ var commitCommand = &cli.Command{
 	Usage:     "Commit an active snapshot into the provided name",
 	ArgsUsage: "<key> <active>",
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		if cmd.NArg() != 2 {
 			return cli.ShowSubcommandHelp(cmd)
 		}
@@ -437,7 +445,7 @@ var commitCommand = &cli.Command{
 			key    = cmd.Args().Get(0)
 			active = cmd.Args().Get(1)
 		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -454,7 +462,8 @@ var treeCommand = &cli.Command{
 	Name:  "tree",
 	Usage: "Display tree view of snapshot branches",
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -483,12 +492,13 @@ var infoCommand = &cli.Command{
 	Usage:     "Get info about a snapshot",
 	ArgsUsage: "<key>",
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		if cmd.NArg() != 1 {
 			return cli.ShowSubcommandHelp(cmd)
 		}
 
 		key := cmd.Args().Get(0)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -511,8 +521,8 @@ var setLabelCommand = &cli.Command{
 	ArgsUsage:   "<name> [<label>=<value> ...]",
 	Description: "labels snapshots in the snapshotter",
 	Action: func(cmd *cli.Context) error {
-		key, labels := commands.ObjectWithLabelArgs(cmd)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -520,6 +530,7 @@ var setLabelCommand = &cli.Command{
 
 		snapshotter := client.SnapshotService(cmd.String("snapshotter"))
 
+		key, labels := commands.ObjectWithLabelArgs(cmd)
 		info := snapshots.Info{
 			Name:   key,
 			Labels: map[string]string{},
@@ -565,11 +576,12 @@ var unpackCommand = &cli.Command{
 		},
 	}, commands.SnapshotterFlags...),
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		dgst, err := digest.Parse(cmd.Args().First())
 		if err != nil {
 			return err
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -70,14 +70,14 @@ var listCommand = &cli.Command{
 	Name:    "list",
 	Aliases: []string{"ls"},
 	Usage:   "List snapshots",
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		var (
-			snapshotter = client.SnapshotService(cliContext.String("snapshotter"))
+			snapshotter = client.SnapshotService(cmd.String("snapshotter"))
 			tw          = tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
 		)
 		fmt.Fprintln(tw, "KEY\tPARENT\tKIND\t")
@@ -114,15 +114,15 @@ var diffCommand = &cli.Command{
 			Usage: "Keep diff content. up to creator to delete it.",
 		},
 	}, commands.LabelFlag),
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			idA = cliContext.Args().First()
-			idB = cliContext.Args().Get(1)
+			idA = cmd.Args().First()
+			idB = cmd.Args().Get(1)
 		)
 		if idA == "" {
 			return errors.New("snapshot id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -135,15 +135,15 @@ var diffCommand = &cli.Command{
 		defer done(ctx)
 
 		var desc ocispec.Descriptor
-		labels := commands.LabelArgs(cliContext.StringSlice("label"))
-		snapshotter := client.SnapshotService(cliContext.String("snapshotter"))
+		labels := commands.LabelArgs(cmd.StringSlice("label"))
+		snapshotter := client.SnapshotService(cmd.String("snapshotter"))
 
-		if cliContext.Bool("keep") {
+		if cmd.Bool("keep") {
 			labels["containerd.io/gc.root"] = time.Now().UTC().Format(time.RFC3339)
 		}
 		opts := []diff.Opt{
-			diff.WithMediaType(cliContext.String("media-type")),
-			diff.WithReference(cliContext.String("ref")),
+			diff.WithMediaType(cmd.String("media-type")),
+			diff.WithReference(cmd.String("ref")),
 			diff.WithLabels(labels),
 		}
 		// SOURCE_DATE_EPOCH is propagated via the ctx, so no need to specify diff.WithSourceDateEpoch here
@@ -207,9 +207,9 @@ var usageCommand = &cli.Command{
 			Usage: "Display size in bytes",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var displaySize func(int64) string
-		if cliContext.Bool("b") {
+		if cmd.Bool("b") {
 			displaySize = func(s int64) string {
 				return strconv.FormatInt(s, 10)
 			}
@@ -218,17 +218,17 @@ var usageCommand = &cli.Command{
 				return progress.Bytes(s).String()
 			}
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		var (
-			snapshotter = client.SnapshotService(cliContext.String("snapshotter"))
+			snapshotter = client.SnapshotService(cmd.String("snapshotter"))
 			tw          = tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
 		)
 		fmt.Fprintln(tw, "KEY\tSIZE\tINODES\t")
-		if cliContext.NArg() == 0 {
+		if cmd.NArg() == 0 {
 			if err := snapshotter.Walk(ctx, func(ctx context.Context, info snapshots.Info) error {
 				usage, err := snapshotter.Usage(ctx, info.Name)
 				if err != nil {
@@ -240,7 +240,7 @@ var usageCommand = &cli.Command{
 				return err
 			}
 		} else {
-			for _, id := range cliContext.Args().Slice() {
+			for _, id := range cmd.Args().Slice() {
 				usage, err := snapshotter.Usage(ctx, id)
 				if err != nil {
 					return err
@@ -258,14 +258,14 @@ var removeCommand = &cli.Command{
 	Aliases:   []string{"del", "remove", "rm"},
 	ArgsUsage: "<key> [<key>, ...]",
 	Usage:     "Remove snapshots",
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		snapshotter := client.SnapshotService(cliContext.String("snapshotter"))
-		for _, key := range cliContext.Args().Slice() {
+		snapshotter := client.SnapshotService(cmd.String("snapshotter"))
+		for _, key := range cmd.Args().Slice() {
 			err = snapshotter.Remove(ctx, key)
 			if err != nil {
 				return fmt.Errorf("failed to remove %q: %w", key, err)
@@ -291,22 +291,22 @@ var prepareCommand = &cli.Command{
 			Usage: "Print out snapshot mounts as JSON",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		if narg := cliContext.NArg(); narg < 1 || narg > 2 {
-			return cli.ShowSubcommandHelp(cliContext)
+	Action: func(cmd *cli.Context) error {
+		if narg := cmd.NArg(); narg < 1 || narg > 2 {
+			return cli.ShowSubcommandHelp(cmd)
 		}
 		var (
-			target = cliContext.String("target")
-			key    = cliContext.Args().Get(0)
-			parent = cliContext.Args().Get(1)
+			target = cmd.String("target")
+			key    = cmd.Args().Get(0)
+			parent = cmd.Args().Get(1)
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		snapshotter := client.SnapshotService(cliContext.String("snapshotter"))
+		snapshotter := client.SnapshotService(cmd.String("snapshotter"))
 		labels := map[string]string{
 			"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
 		}
@@ -320,7 +320,7 @@ var prepareCommand = &cli.Command{
 			printMounts(target, mounts)
 		}
 
-		if cliContext.Bool("mounts") {
+		if cmd.Bool("mounts") {
 			commands.PrintAsJSON(mounts)
 		}
 
@@ -343,22 +343,22 @@ var viewCommand = &cli.Command{
 			Usage: "Print out snapshot mounts as JSON",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		if narg := cliContext.NArg(); narg < 1 || narg > 2 {
-			return cli.ShowSubcommandHelp(cliContext)
+	Action: func(cmd *cli.Context) error {
+		if narg := cmd.NArg(); narg < 1 || narg > 2 {
+			return cli.ShowSubcommandHelp(cmd)
 		}
 		var (
-			target = cliContext.String("target")
-			key    = cliContext.Args().Get(0)
-			parent = cliContext.Args().Get(1)
+			target = cmd.String("target")
+			key    = cmd.Args().Get(0)
+			parent = cmd.Args().Get(1)
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		snapshotter := client.SnapshotService(cliContext.String("snapshotter"))
+		snapshotter := client.SnapshotService(cmd.String("snapshotter"))
 		mounts, err := snapshotter.View(ctx, key, parent)
 		if err != nil {
 			return err
@@ -368,7 +368,7 @@ var viewCommand = &cli.Command{
 			printMounts(target, mounts)
 		}
 
-		if cliContext.Bool("mounts") {
+		if cmd.Bool("mounts") {
 			commands.PrintAsJSON(mounts)
 		}
 
@@ -387,20 +387,20 @@ var mountCommand = &cli.Command{
 			Usage: "Mounts the snapshot mounts as a temp mount and returns a bind mount",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		if cliContext.NArg() != 2 {
-			return cli.ShowSubcommandHelp(cliContext)
+	Action: func(cmd *cli.Context) error {
+		if cmd.NArg() != 2 {
+			return cli.ShowSubcommandHelp(cmd)
 		}
 		var (
-			target = cliContext.Args().Get(0)
-			key    = cliContext.Args().Get(1)
+			target = cmd.Args().Get(0)
+			key    = cmd.Args().Get(1)
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		snapshotter := client.SnapshotService(cliContext.String("snapshotter"))
+		snapshotter := client.SnapshotService(cmd.String("snapshotter"))
 		mounts, err := snapshotter.Mounts(ctx, key)
 		if err != nil {
 			return err
@@ -409,7 +409,7 @@ var mountCommand = &cli.Command{
 		mm := client.MountManager()
 
 		var opts []mount.ActivateOpt
-		if cliContext.Bool("temp") {
+		if cmd.Bool("temp") {
 			opts = append(opts, mount.WithTemporary)
 		}
 		info, err := mm.Activate(ctx, "ctr"+key, mounts, opts...)
@@ -429,20 +429,20 @@ var commitCommand = &cli.Command{
 	Name:      "commit",
 	Usage:     "Commit an active snapshot into the provided name",
 	ArgsUsage: "<key> <active>",
-	Action: func(cliContext *cli.Context) error {
-		if cliContext.NArg() != 2 {
-			return cli.ShowSubcommandHelp(cliContext)
+	Action: func(cmd *cli.Context) error {
+		if cmd.NArg() != 2 {
+			return cli.ShowSubcommandHelp(cmd)
 		}
 		var (
-			key    = cliContext.Args().Get(0)
-			active = cliContext.Args().Get(1)
+			key    = cmd.Args().Get(0)
+			active = cmd.Args().Get(1)
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		snapshotter := client.SnapshotService(cliContext.String("snapshotter"))
+		snapshotter := client.SnapshotService(cmd.String("snapshotter"))
 		labels := map[string]string{
 			"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
 		}
@@ -453,14 +453,14 @@ var commitCommand = &cli.Command{
 var treeCommand = &cli.Command{
 	Name:  "tree",
 	Usage: "Display tree view of snapshot branches",
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		var (
-			snapshotter = client.SnapshotService(cliContext.String("snapshotter"))
+			snapshotter = client.SnapshotService(cmd.String("snapshotter"))
 			tree        = newSnapshotTree()
 		)
 
@@ -482,18 +482,18 @@ var infoCommand = &cli.Command{
 	Name:      "info",
 	Usage:     "Get info about a snapshot",
 	ArgsUsage: "<key>",
-	Action: func(cliContext *cli.Context) error {
-		if cliContext.NArg() != 1 {
-			return cli.ShowSubcommandHelp(cliContext)
+	Action: func(cmd *cli.Context) error {
+		if cmd.NArg() != 1 {
+			return cli.ShowSubcommandHelp(cmd)
 		}
 
-		key := cliContext.Args().Get(0)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		key := cmd.Args().Get(0)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		snapshotter := client.SnapshotService(cliContext.String("snapshotter"))
+		snapshotter := client.SnapshotService(cmd.String("snapshotter"))
 		info, err := snapshotter.Stat(ctx, key)
 		if err != nil {
 			return err
@@ -510,15 +510,15 @@ var setLabelCommand = &cli.Command{
 	Usage:       "Add labels to content",
 	ArgsUsage:   "<name> [<label>=<value> ...]",
 	Description: "labels snapshots in the snapshotter",
-	Action: func(cliContext *cli.Context) error {
-		key, labels := commands.ObjectWithLabelArgs(cliContext)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		key, labels := commands.ObjectWithLabelArgs(cmd)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		snapshotter := client.SnapshotService(cliContext.String("snapshotter"))
+		snapshotter := client.SnapshotService(cmd.String("snapshotter"))
 
 		info := snapshots.Info{
 			Name:   key,
@@ -564,12 +564,12 @@ var unpackCommand = &cli.Command{
 			Usage: "Synchronize the underlying filesystem containing files when unpack images, false by default",
 		},
 	}, commands.SnapshotterFlags...),
-	Action: func(cliContext *cli.Context) error {
-		dgst, err := digest.Parse(cliContext.Args().First())
+	Action: func(cmd *cli.Context) error {
+		dgst, err := digest.Parse(cmd.Args().First())
 		if err != nil {
 			return err
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -584,7 +584,7 @@ var unpackCommand = &cli.Command{
 		for _, image := range images {
 			if image.Target().Digest == dgst {
 				fmt.Printf("unpacking %s (%s)...", dgst, image.Target().MediaType)
-				if err := image.Unpack(ctx, cliContext.String("snapshotter"), containerd.WithUnpackApplyOpts(diff.WithSyncFs(cliContext.Bool("sync-fs")))); err != nil {
+				if err := image.Unpack(ctx, cmd.String("snapshotter"), containerd.WithUnpackApplyOpts(diff.WithSyncFs(cmd.Bool("sync-fs")))); err != nil {
 					fmt.Println()
 					return err
 				}

--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -50,7 +50,7 @@ var Command = &cli.Command{
 	Aliases: []string{"snapshot"},
 	Usage:   "Manage snapshots",
 	Flags:   commands.SnapshotterFlags,
-	Subcommands: cli.Commands{
+	Subcommands: []*cli.Command{
 		commitCommand,
 		diffCommand,
 		infoCommand,

--- a/cmd/ctr/commands/tasks/attach.go
+++ b/cmd/ctr/commands/tasks/attach.go
@@ -29,7 +29,8 @@ var attachCommand = &cli.Command{
 	Usage:     "Attach to the IO of a running container",
 	ArgsUsage: "CONTAINER",
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/attach.go
+++ b/cmd/ctr/commands/tasks/attach.go
@@ -28,13 +28,13 @@ var attachCommand = &cli.Command{
 	Name:      "attach",
 	Usage:     "Attach to the IO of a running container",
 	ArgsUsage: "CONTAINER",
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		container, err := client.LoadContainer(ctx, cliContext.Args().First())
+		container, err := client.LoadContainer(ctx, cmd.Args().First())
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/checkpoint.go
+++ b/cmd/ctr/commands/tasks/checkpoint.go
@@ -45,11 +45,12 @@ var checkpointCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		id := cmd.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd, containerd.WithDefaultRuntime(cmd.String("runtime")))
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd, containerd.WithDefaultRuntime(cmd.String("runtime")))
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/checkpoint.go
+++ b/cmd/ctr/commands/tasks/checkpoint.go
@@ -44,12 +44,12 @@ var checkpointCommand = &cli.Command{
 			Usage: "Path to criu work files and logs",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		id := cliContext.Args().First()
+	Action: func(cmd *cli.Context) error {
+		id := cmd.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext, containerd.WithDefaultRuntime(cliContext.String("runtime")))
+		client, ctx, cancel, err := commands.NewClient(cmd, containerd.WithDefaultRuntime(cmd.String("runtime")))
 		if err != nil {
 			return err
 		}
@@ -66,12 +66,12 @@ var checkpointCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		opts := []containerd.CheckpointTaskOpts{withCheckpointOpts(info.Runtime.Name, cliContext)}
+		opts := []containerd.CheckpointTaskOpts{withCheckpointOpts(info.Runtime.Name, cmd)}
 		checkpoint, err := task.Checkpoint(ctx, opts...)
 		if err != nil {
 			return err
 		}
-		if cliContext.String("image-path") == "" {
+		if cmd.String("image-path") == "" {
 			fmt.Println(checkpoint.Name())
 		}
 		return nil
@@ -79,17 +79,17 @@ var checkpointCommand = &cli.Command{
 }
 
 // withCheckpointOpts only suitable for runc runtime now
-func withCheckpointOpts(rt string, cliContext *cli.Context) containerd.CheckpointTaskOpts {
+func withCheckpointOpts(rt string, cmd *cli.Context) containerd.CheckpointTaskOpts {
 	return func(r *containerd.CheckpointTaskInfo) error {
-		imagePath := cliContext.String("image-path")
-		workPath := cliContext.String("work-path")
+		imagePath := cmd.String("image-path")
+		workPath := cmd.String("work-path")
 
 		if r.Options == nil {
 			r.Options = &options.CheckpointOptions{}
 		}
 		opts, _ := r.Options.(*options.CheckpointOptions)
 
-		if cliContext.Bool("exit") {
+		if cmd.Bool("exit") {
 			opts.Exit = true
 		}
 		if imagePath != "" {

--- a/cmd/ctr/commands/tasks/delete.go
+++ b/cmd/ctr/commands/tasks/delete.go
@@ -43,20 +43,19 @@ var deleteCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		var (
-			execID = cmd.String("exec-id")
-			force  = cmd.Bool("force")
-		)
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		var opts []containerd.ProcessDeleteOpts
+		force := cmd.Bool("force")
 		if force {
 			opts = append(opts, containerd.WithProcessKill)
 		}
 		var exitErr error
+		execID := cmd.String("exec-id")
 		if execID != "" {
 			task, err := loadTask(ctx, client, cmd.Args().First())
 			if err != nil {

--- a/cmd/ctr/commands/tasks/delete.go
+++ b/cmd/ctr/commands/tasks/delete.go
@@ -42,12 +42,12 @@ var deleteCommand = &cli.Command{
 			Usage: "Process ID to kill",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			execID = cliContext.String("exec-id")
-			force  = cliContext.Bool("force")
+			execID = cmd.String("exec-id")
+			force  = cmd.Bool("force")
 		)
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ var deleteCommand = &cli.Command{
 		}
 		var exitErr error
 		if execID != "" {
-			task, err := loadTask(ctx, client, cliContext.Args().First())
+			task, err := loadTask(ctx, client, cmd.Args().First())
 			if err != nil {
 				return err
 			}
@@ -74,7 +74,7 @@ var deleteCommand = &cli.Command{
 				return cli.Exit("", int(ec))
 			}
 		} else {
-			for _, target := range cliContext.Args().Slice() {
+			for _, target := range cmd.Args().Slice() {
 				task, err := loadTask(ctx, client, target)
 				if err != nil {
 					if exitErr == nil {

--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -69,6 +69,7 @@ var execCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
 			id     = cmd.Args().First()
 			args   = cmd.Args().Tail()
@@ -78,7 +79,7 @@ var execCommand = &cli.Command{
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -68,17 +68,17 @@ var execCommand = &cli.Command{
 			Usage: "User id or name",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
-			id     = cliContext.Args().First()
-			args   = cliContext.Args().Tail()
-			tty    = cliContext.Bool("tty")
-			detach = cliContext.Bool("detach")
+			id     = cmd.Args().First()
+			args   = cmd.Args().Tail()
+			tty    = cmd.Bool("tty")
+			detach = cmd.Bool("detach")
 		)
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -91,7 +91,7 @@ var execCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if user := cliContext.String("user"); user != "" {
+		if user := cmd.String("user"); user != "" {
 			c, err := container.Info(ctx)
 			if err != nil {
 				return err
@@ -105,7 +105,7 @@ var execCommand = &cli.Command{
 		pspec.Terminal = tty
 		pspec.Args = args
 
-		if cwd := cliContext.String("cwd"); cwd != "" {
+		if cwd := cmd.String("cwd"); cwd != "" {
 			pspec.Cwd = cwd
 		}
 
@@ -122,8 +122,8 @@ var execCommand = &cli.Command{
 			con console.Console
 		)
 
-		fifoDir := cliContext.String("fifo-dir")
-		logURI := cliContext.String("log-uri")
+		fifoDir := cmd.String("fifo-dir")
+		logURI := cmd.String("log-uri")
 		ioOpts := []cio.Opt{cio.WithFIFODir(fifoDir)}
 		switch {
 		case tty && logURI != "":
@@ -150,7 +150,7 @@ var execCommand = &cli.Command{
 			ioCreator = cio.NewCreator(append([]cio.Opt{cio.WithStreams(stdinC, os.Stdout, os.Stderr)}, ioOpts...)...)
 		}
 
-		process, err := task.Exec(ctx, cliContext.String("exec-id"), pspec, ioCreator)
+		process, err := task.Exec(ctx, cmd.String("exec-id"), pspec, ioCreator)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/kill.go
+++ b/cmd/ctr/commands/tasks/kill.go
@@ -83,6 +83,7 @@ var killCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		id := cmd.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
@@ -99,7 +100,7 @@ var killCommand = &cli.Command{
 		if all && execID != "" {
 			return errors.New("specify an exec-id or all; not both")
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/kill.go
+++ b/cmd/ctr/commands/tasks/kill.go
@@ -82,8 +82,8 @@ var killCommand = &cli.Command{
 			Usage:   "Send signal to all processes inside the container",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		id := cliContext.Args().First()
+	Action: func(cmd *cli.Context) error {
+		id := cmd.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
@@ -92,14 +92,14 @@ var killCommand = &cli.Command{
 			return err
 		}
 		var (
-			all    = cliContext.Bool("all")
-			execID = cliContext.String("exec-id")
+			all    = cmd.Bool("all")
+			execID = cmd.String("exec-id")
 			opts   []containerd.KillOpts
 		)
 		if all && execID != "" {
 			return errors.New("specify an exec-id or all; not both")
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -114,8 +114,8 @@ var killCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if cliContext.String("signal") != "" {
-			sig, err = signal.ParseSignal(cliContext.String("signal"))
+		if cmd.String("signal") != "" {
+			sig, err = signal.ParseSignal(cmd.String("signal"))
 			if err != nil {
 				return err
 			}

--- a/cmd/ctr/commands/tasks/list.go
+++ b/cmd/ctr/commands/tasks/list.go
@@ -39,8 +39,8 @@ var listCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		quiet := cmd.Bool("quiet")
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}
@@ -50,6 +50,7 @@ var listCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		quiet := cmd.Bool("quiet")
 		if quiet {
 			for _, task := range response.Tasks {
 				fmt.Println(task.ID)

--- a/cmd/ctr/commands/tasks/list.go
+++ b/cmd/ctr/commands/tasks/list.go
@@ -38,9 +38,9 @@ var listCommand = &cli.Command{
 			Usage:   "Print only the task id",
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		quiet := cliContext.Bool("quiet")
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		quiet := cmd.Bool("quiet")
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -49,13 +49,13 @@ var metricsCommand = &cli.Command{
 			Value: formatTable,
 		},
 	},
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		container, err := client.LoadContainer(ctx, cliContext.Args().First())
+		container, err := client.LoadContainer(ctx, cmd.Args().First())
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var metricsCommand = &cli.Command{
 			return err
 		}
 
-		switch cliContext.String(formatFlag) {
+		switch cmd.String(formatFlag) {
 		case formatTable:
 			w := tabwriter.NewWriter(os.Stdout, 1, 8, 4, ' ', 0)
 			fmt.Fprintf(w, "ID\tTIMESTAMP\t\n")

--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -50,7 +50,8 @@ var metricsCommand = &cli.Command{
 		},
 	},
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/pause.go
+++ b/cmd/ctr/commands/tasks/pause.go
@@ -26,7 +26,8 @@ var pauseCommand = &cli.Command{
 	Usage:     "Pause an existing container",
 	ArgsUsage: "CONTAINER",
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/pause.go
+++ b/cmd/ctr/commands/tasks/pause.go
@@ -25,13 +25,13 @@ var pauseCommand = &cli.Command{
 	Name:      "pause",
 	Usage:     "Pause an existing container",
 	ArgsUsage: "CONTAINER",
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		container, err := client.LoadContainer(ctx, cliContext.Args().First())
+		container, err := client.LoadContainer(ctx, cmd.Args().First())
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/ps.go
+++ b/cmd/ctr/commands/tasks/ps.go
@@ -32,11 +32,12 @@ var psCommand = &cli.Command{
 	Usage:     "List processes for container",
 	ArgsUsage: "CONTAINER",
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		id := cmd.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/ps.go
+++ b/cmd/ctr/commands/tasks/ps.go
@@ -31,12 +31,12 @@ var psCommand = &cli.Command{
 	Name:      "ps",
 	Usage:     "List processes for container",
 	ArgsUsage: "CONTAINER",
-	Action: func(cliContext *cli.Context) error {
-		id := cliContext.Args().First()
+	Action: func(cmd *cli.Context) error {
+		id := cmd.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/resume.go
+++ b/cmd/ctr/commands/tasks/resume.go
@@ -25,13 +25,13 @@ var resumeCommand = &cli.Command{
 	Name:      "resume",
 	Usage:     "Resume a paused container",
 	ArgsUsage: "CONTAINER",
-	Action: func(cliContext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+	Action: func(cmd *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		container, err := client.LoadContainer(ctx, cliContext.Args().First())
+		container, err := client.LoadContainer(ctx, cmd.Args().First())
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/resume.go
+++ b/cmd/ctr/commands/tasks/resume.go
@@ -26,7 +26,8 @@ var resumeCommand = &cli.Command{
 	Usage:     "Resume a paused container",
 	ArgsUsage: "CONTAINER",
 	Action: func(cmd *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		ctx := cmd.Context
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/start.go
+++ b/cmd/ctr/commands/tasks/start.go
@@ -56,15 +56,15 @@ var startCommand = &cli.Command{
 		},
 	}...),
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		var (
-			err    error
 			id     = cmd.Args().Get(0)
 			detach = cmd.Bool("detach")
 		)
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/start.go
+++ b/cmd/ctr/commands/tasks/start.go
@@ -55,16 +55,16 @@ var startCommand = &cli.Command{
 			Usage:   "Detach from the task after it has started execution",
 		},
 	}...),
-	Action: func(cliContext *cli.Context) error {
+	Action: func(cmd *cli.Context) error {
 		var (
 			err    error
-			id     = cliContext.Args().Get(0)
-			detach = cliContext.Bool("detach")
+			id     = cmd.Args().Get(0)
+			detach = cmd.Bool("detach")
 		)
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}
@@ -80,8 +80,8 @@ var startCommand = &cli.Command{
 		}
 		var (
 			tty    = spec.Process.Terminal
-			opts   = GetNewTaskOpts(cliContext)
-			ioOpts = []cio.Opt{cio.WithFIFODir(cliContext.String("fifo-dir"))}
+			opts   = GetNewTaskOpts(cmd)
+			ioOpts = []cio.Opt{cio.WithFIFODir(cmd.String("fifo-dir"))}
 		)
 		var con console.Console
 		if tty {
@@ -92,7 +92,7 @@ var startCommand = &cli.Command{
 			}
 		}
 
-		task, err := NewTask(ctx, client, container, "", con, cliContext.Bool("null-io"), cliContext.String("log-uri"), ioOpts, opts...)
+		task, err := NewTask(ctx, client, container, "", con, cmd.Bool("null-io"), cmd.String("log-uri"), ioOpts, opts...)
 		if err != nil {
 			return err
 		}
@@ -108,8 +108,8 @@ var startCommand = &cli.Command{
 				return err
 			}
 		}
-		if cliContext.IsSet("pid-file") {
-			if err := commands.WritePidFile(cliContext.String("pid-file"), int(task.Pid())); err != nil {
+		if cmd.IsSet("pid-file") {
+			if err := commands.WritePidFile(cmd.String("pid-file"), int(task.Pid())); err != nil {
 				return err
 			}
 		}

--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -121,8 +121,8 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 }
 
 // GetNewTaskOpts resolves containerd.NewTaskOpts from cli.Context
-func GetNewTaskOpts(cliContext *cli.Context) []containerd.NewTaskOpts {
-	if cliContext.Bool("no-pivot") {
+func GetNewTaskOpts(cmd *cli.Context) []containerd.NewTaskOpts {
+	if cmd.Bool("no-pivot") {
 		return []containerd.NewTaskOpts{containerd.WithNoPivotRoot}
 	}
 	return nil

--- a/cmd/ctr/commands/version/version.go
+++ b/cmd/ctr/commands/version/version.go
@@ -29,9 +29,9 @@ import (
 var Command = &cli.Command{
 	Name:  "version",
 	Usage: "Print the client and server versions",
-	Action: func(cliContext *cli.Context) error {
-		if cliContext.NArg() != 0 {
-			return fmt.Errorf("extra arguments: %v", cliContext.Args())
+	Action: func(cmd *cli.Context) error {
+		if cmd.NArg() != 0 {
+			return fmt.Errorf("extra arguments: %v", cmd.Args())
 		}
 
 		fmt.Println("Client:")
@@ -39,7 +39,7 @@ var Command = &cli.Command{
 		fmt.Println("  Revision:", version.Revision)
 		fmt.Println("  Go version:", version.GoVersion)
 		fmt.Println("")
-		client, ctx, cancel, err := commands.NewClient(cliContext)
+		client, ctx, cancel, err := commands.NewClient(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/version/version.go
+++ b/cmd/ctr/commands/version/version.go
@@ -30,6 +30,7 @@ var Command = &cli.Command{
 	Name:  "version",
 	Usage: "Print the client and server versions",
 	Action: func(cmd *cli.Context) error {
+		ctx := cmd.Context
 		if cmd.NArg() != 0 {
 			return fmt.Errorf("extra arguments: %v", cmd.Args())
 		}
@@ -39,7 +40,7 @@ var Command = &cli.Command{
 		fmt.Println("  Revision:", version.Revision)
 		fmt.Println("  Go version:", version.GoVersion)
 		fmt.Println("")
-		client, ctx, cancel, err := commands.NewClient(cmd)
+		client, ctx, cancel, err := commands.NewClient(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -24,7 +25,8 @@ import (
 )
 
 func main() {
-	if err := app.New().Run(os.Args); err != nil {
+	ctx := context.Background()
+	if err := app.New().RunContext(ctx, os.Args); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "ctr:", err)
 		os.Exit(1)
 	}

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -21,16 +21,11 @@ import (
 	"os"
 
 	"github.com/containerd/containerd/v2/cmd/ctr/app"
-	"github.com/urfave/cli/v2"
 )
 
-var pluginCmds = []*cli.Command{}
-
 func main() {
-	app := app.New()
-	app.Commands = append(app.Commands, pluginCmds...)
-	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "ctr: %s\n", err)
+	if err := app.New().Run(os.Args); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "ctr:", err)
 		os.Exit(1)
 	}
 }

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -81,7 +81,7 @@ func clientWithTrace() error {
         grpc.WithTransportCredentials(insecure.NewCredentials()),
         grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
     }
-    client, ctx, cancel, err := commands.NewClient(context, containerd.WithDialOpts(dialOpts))
+    client, ctx, cancel, err := commands.NewClient(ctx, cmd, containerd.WithDialOpts(dialOpts))
     if err != nil {
         return err
     }


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/14095

### cmd/ctr: remove unused pluginCmds

### cmd: remove uses of urfave/cli.Commands

The `Commands` type is removed in v3 and already identical to `[]*Command`
in v2; remove its uses to ease the transition to v3.

### cmd: remove redundant empty slice flag values

Leave the Value field unset for slice flags without default values. The CLI
initializes these flags with an empty value when they are applied, making
the explicit initializations unnecessary.

### cmd: use urfave/cli RunContext

This allows explicitly setting up the context inside main, and makes the
transition to urfave/cli/v3 more transparent.

### cmd: rename some vars that shadowed

### cmd: edit: pass editor name instead of cli.Context

### cmd: rename cliContext -> cmd in preparation of v3 migration

In urfave/cli/v3, cli.Context is replaced with cli.Command, making cmd
a more logical name. Rename the vars ahead of time to make the v3
migration a more mechanical change.

### cmd: initialize CLI apps with struct literals

Although urfave/cli v2 recommends constructing apps with cli.NewApp,
App.Run initializes unset fields through App.Setup, making the zero
value usable. Use struct literals to define the application fields
directly without changing behavior.

This prepares for urfave/cli v3, which removes cli.NewApp and replaces
cli.App with cli.Command.

### cmd: commands.AppContext: explicitly pass context

urfave/cli/v3 no longer passes the context through the Command; pass
it explicitly to prepare for the v3 migration.

### cmd: commands.NewClient: explicitly pass context

urfave/cli/v3 no longer passes the context through the Command; pass
it explicitly to prepare for the v3 migration.

