### PR TITLE
remotes/docker: defer blob upload PUT until content is written

### DIFF
--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -324,23 +324,32 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 	}
 	req.size = desc.Size
 
-	go func() {
-		resp, err := req.doWithRetries(ctx, true)
-		if err != nil {
-			pushw.setError(err)
-			return
-		}
+	// Defer sending the PUT request until the caller actually starts writing
+	// content (or commits). Issuing the request here would put it on the wire
+	// with an idle body, and a reverse proxy in front of the registry may close
+	// the connection on an inactivity timeout before any content is streamed
+	// (e.g. when many uploads are opened but only a few are fed at a time on a
+	// slow uplink). Starting the request lazily ensures the body streams as soon
+	// as the request is made, so the connection never sits idle.
+	pushw.start = func() {
+		go func() {
+			resp, err := req.doWithRetries(ctx, true)
+			if err != nil {
+				pushw.setError(err)
+				return
+			}
 
-		switch resp.StatusCode {
-		case http.StatusOK, http.StatusCreated, http.StatusNoContent:
-		default:
-			err := unexpectedResponseErr(resp)
-			log.G(ctx).WithError(err).Debug("unexpected response")
-			pushw.setError(err)
-			return
-		}
-		pushw.setResponse(resp)
-	}()
+			switch resp.StatusCode {
+			case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+			default:
+				err := unexpectedResponseErr(resp)
+				log.G(ctx).WithError(err).Debug("unexpected response")
+				pushw.setError(err)
+				return
+			}
+			pushw.setResponse(resp)
+		}()
+	}
 
 	return pushw, nil
 }
@@ -373,6 +382,12 @@ type pushWriter struct {
 	done      chan struct{}
 	closeOnce sync.Once
 
+	// start issues the upload request. It is set by push and invoked lazily,
+	// exactly once, on the first Write or on Commit, so the request body is not
+	// put on the wire until there is content to stream.
+	start     func()
+	startOnce sync.Once
+
 	pipeC chan *io.PipeWriter
 	respC chan *http.Response
 	errC  chan error
@@ -398,10 +413,59 @@ func newPushWriter(db *dockerBase, ref string, expected digest.Digest, tracker S
 	}
 }
 
+// ensureStarted issues the upload request exactly once. It is safe to call
+// from both Write and Commit; only the first call has any effect.
+func (pw *pushWriter) ensureStarted() {
+	pw.startOnce.Do(func() {
+		// Don't start the request if the writer has already been closed. The
+		// caller checks pw.done before calling ensureStarted, but Close can race
+		// in between; checking again here avoids starting a request (and its
+		// goroutine/connection) that would immediately be torn down.
+		select {
+		case <-pw.done:
+			return
+		default:
+		}
+		if pw.start != nil {
+			pw.start()
+		}
+	})
+}
+
 func (pw *pushWriter) setPipe(p *io.PipeWriter) {
+	// If the writer was closed before the request goroutine installed this pipe
+	// (e.g. Close raced with ensureStarted), close the discarded pipe writer so
+	// the request body reader returns an error instead of blocking forever,
+	// which would leak the request goroutine and its connection. Check done with
+	// priority: pipeC is buffered, so a plain select could otherwise enqueue the
+	// pipe into a slot that no one will drain, leaving it unclosed.
 	select {
 	case <-pw.done:
+		p.CloseWithError(io.ErrClosedPipe)
+		return
+	default:
+	}
+	select {
+	case <-pw.done:
+		p.CloseWithError(io.ErrClosedPipe)
+		return
 	case pw.pipeC <- p:
+	}
+
+	// Close may have closed done after the check above but before Write/Commit
+	// adopted the pipe. In that case the receiver can observe done and return
+	// without draining pipeC, leaving the pipe stranded and its request body
+	// reader blocked forever. Reclaim and close it if it is still buffered; if
+	// Write/Commit already adopted it, the receive yields nothing and they own
+	// closing it. Close performs the same reclaim, so the two cover each other.
+	select {
+	case <-pw.done:
+		select {
+		case orphan := <-pw.pipeC:
+			orphan.CloseWithError(io.ErrClosedPipe)
+		default:
+		}
+	default:
 	}
 }
 
@@ -413,9 +477,31 @@ func (pw *pushWriter) setError(err error) {
 }
 
 func (pw *pushWriter) setResponse(resp *http.Response) {
+	// If the writer was closed before the response was consumed, close the
+	// response body so the underlying connection is not leaked. Mirror setPipe:
+	// check done with priority (respC is buffered) and reclaim after the send in
+	// case Close races in between.
 	select {
 	case <-pw.done:
+		resp.Body.Close()
+		return
+	default:
+	}
+	select {
+	case <-pw.done:
+		resp.Body.Close()
+		return
 	case pw.respC <- resp:
+	}
+
+	select {
+	case <-pw.done:
+		select {
+		case orphan := <-pw.respC:
+			orphan.Body.Close()
+		default:
+		}
+	default:
 	}
 }
 
@@ -441,10 +527,30 @@ func (pw *pushWriter) replacePipe(p *io.PipeWriter) error {
 }
 
 func (pw *pushWriter) Write(p []byte) (n int, err error) {
+	// A zero-length write is a valid no-op. Don't start the request for it;
+	// doing so would reintroduce the idle-body window this change removes.
+	if len(p) == 0 {
+		return 0, nil
+	}
+
 	status, err := pw.tracker.GetStatus(pw.ref)
 	if err != nil {
 		return n, err
 	}
+
+	// Don't start the request if the writer has already been closed. Starting it
+	// here would leave the request goroutine blocked reading from a pipe that is
+	// never written or closed, leaking the goroutine and its connection.
+	select {
+	case <-pw.done:
+		return 0, io.ErrClosedPipe
+	default:
+	}
+
+	// Issue the upload request now that there is content to stream. The pipe is
+	// delivered by the request goroutine, so this must happen before waiting on
+	// pipeC below.
+	pw.ensureStarted()
 
 	if pw.pipe == nil {
 		select {
@@ -488,14 +594,34 @@ func (pw *pushWriter) Close() error {
 	// called multiple times without panicking
 	pw.closeOnce.Do(func() {
 		close(pw.done)
-	})
-	if pw.pipe != nil {
-		status, err := pw.tracker.GetStatus(pw.ref)
-		if err == nil && !status.Committed {
-			// Closing an incomplete writer. Record this as an error so that following write can retry it.
-			status.ErrClosed = errors.New("closed incomplete writer")
-			pw.tracker.SetStatus(pw.ref, status)
+		// Reclaim any pipe setPipe left buffered that Write/Commit will not
+		// adopt (they return once done is closed), so the request body reader
+		// unblocks instead of leaking the request goroutine and its connection.
+		select {
+		case p := <-pw.pipeC:
+			p.CloseWithError(io.ErrClosedPipe)
+		default:
 		}
+		// Likewise reclaim a buffered response that will never be committed and
+		// close its body, otherwise the underlying connection is leaked.
+		select {
+		case resp := <-pw.respC:
+			resp.Body.Close()
+		default:
+		}
+	})
+	// Closing an incomplete writer. Record this as an error so that a following
+	// push of the same ref can retry it. This also covers a writer that was
+	// opened but never fed (pw.pipe == nil): with the request started lazily
+	// that is a normal path, and without this the tracker entry would keep
+	// looking like an in-progress upload and block later pushes with
+	// ErrUnavailable.
+	status, err := pw.tracker.GetStatus(pw.ref)
+	if err == nil && !status.Committed {
+		status.ErrClosed = errors.New("closed incomplete writer")
+		pw.tracker.SetStatus(pw.ref, status)
+	}
+	if pw.pipe != nil {
 		return pw.pipe.Close()
 	}
 	return nil
@@ -516,6 +642,38 @@ func (pw *pushWriter) Digest() digest.Digest {
 }
 
 func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	// Don't start the request if the writer has already been closed; starting it
+	// would leak the request goroutine and its connection (see Write).
+	select {
+	case <-pw.done:
+		return io.ErrClosedPipe
+	default:
+	}
+
+	// Ensure the upload request has been issued. For zero-length content Write
+	// is never called, so the request must be started here.
+	pw.ensureStarted()
+
+	// If Write was never called (e.g. a zero-length blob) the request goroutine
+	// still creates a pipe for the request body but it was never adopted. The
+	// goroutine enqueues that pipe on pipeC before it produces a response, so
+	// always adopt the pipe when it is available, even if a response or error is
+	// already queued. Otherwise the response wait below could take its pipeC
+	// branch and return early, skipping validation and leaving the pipe
+	// unclosed. It is then closed below to signal an empty body.
+	if pw.pipe == nil {
+		select {
+		case p := <-pw.pipeC:
+			pw.pipe = p
+		case <-pw.done:
+			return io.ErrClosedPipe
+		case err := <-pw.errC:
+			// Reached only if the request failed before the body pipe was created.
+			pw.Close()
+			return err
+		}
+	}
+
 	// Check whether read has already thrown an error
 	if pw.pipe != nil {
 		if _, err := pw.pipe.Write([]byte{}); err != nil && !errors.Is(err, io.ErrClosedPipe) {

--- a/core/remotes/docker/pusher_test.go
+++ b/core/remotes/docker/pusher_test.go
@@ -33,6 +33,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/remotes"
@@ -813,4 +814,261 @@ func TestPusherForbiddenGETFallbackProxy(t *testing.T) {
 	assert.Contains(t, err.Error(), errorMessage)
 	assert.Equal(t, samplePusherHostname, gotNsParam,
 		"GET fallback on proxy must include ?ns= query parameter")
+}
+
+// TestPusherPutDeferredUntilWrite verifies that the blob upload PUT request is
+// not put on the wire until the caller writes content. Issuing it eagerly with
+// an idle body lets a reverse proxy close the connection on an inactivity
+// timeout before any content is streamed.
+func TestPusherPutDeferredUntilWrite(t *testing.T) {
+	p, reg, _, done := samplePusher(t)
+	defer done()
+
+	reg.uploadable = true
+
+	postedC := make(chan struct{}, 1)
+	putC := make(chan struct{}, 1)
+
+	// Observe when the upload session POST is received.
+	reg.defaultHandlerFunc = func(w http.ResponseWriter, r *http.Request) bool {
+		if r.Method == http.MethodPost {
+			select {
+			case postedC <- struct{}{}:
+			default:
+			}
+		}
+		return false
+	}
+	// Observe when the blob PUT is received, then fall through to the default
+	// handler so the upload completes normally.
+	reg.putHandlerFunc = func(w http.ResponseWriter, r *http.Request) bool {
+		select {
+		case putC <- struct{}{}:
+		default:
+		}
+		return false
+	}
+
+	layerContent := []byte("layer-content")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(layerContent),
+		Size:      int64(len(layerContent)),
+	}
+
+	cw, err := p.push(context.Background(), desc, "layer-"+desc.Digest.String(), false)
+	require.NoError(t, err)
+	defer cw.Close()
+
+	// The POST that reserves the upload location is issued eagerly by push.
+	select {
+	case <-postedC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected upload session POST to be sent by push")
+	}
+
+	// The PUT must not be sent until content is written.
+	select {
+	case <-putC:
+		t.Fatal("PUT request was sent before any content was written")
+	case <-time.After(time.Second):
+	}
+
+	// Writing content triggers the deferred PUT.
+	_, err = cw.Write(layerContent)
+	require.NoError(t, err)
+
+	select {
+	case <-putC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected PUT to be sent after writing content")
+	}
+}
+
+// TestPusherZeroLengthCommit verifies that a zero-length blob, for which Write
+// is never called, is uploaded and its response validated by Commit rather
+// than returning early without sending or checking the PUT.
+func TestPusherZeroLengthCommit(t *testing.T) {
+	p, reg, _, done := samplePusher(t)
+	defer done()
+
+	reg.uploadable = true
+
+	var empty []byte
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(empty),
+		Size:      0,
+	}
+
+	cw, err := p.push(context.Background(), desc, "empty-"+desc.Digest.String(), false)
+	require.NoError(t, err)
+	defer cw.Close()
+
+	// No Write call; Commit must start the request, close the body and validate.
+	err = cw.Commit(context.Background(), 0, desc.Digest)
+	require.NoError(t, err)
+
+	assert.Contains(t, reg.availableContents, desc.Digest.String(),
+		"zero-length blob should have been uploaded")
+}
+
+// TestPushWriterSetPipeClosesDiscardedPipe verifies that when the writer is
+// already closed, setPipe closes the pipe it discards. Otherwise the request
+// goroutine using the reader end as its body would block forever, leaking the
+// goroutine and its connection.
+func TestPushWriterSetPipeClosesDiscardedPipe(t *testing.T) {
+	pw := &pushWriter{
+		done:  make(chan struct{}),
+		pipeC: make(chan *io.PipeWriter, 1),
+	}
+	close(pw.done) // simulate Close() having already happened
+
+	r, w := io.Pipe()
+	pw.setPipe(w)
+
+	readErr := make(chan error, 1)
+	go func() {
+		_, err := r.Read(make([]byte, 1))
+		readErr <- err
+	}()
+
+	select {
+	case err := <-readErr:
+		assert.Error(t, err, "read on discarded pipe should return an error")
+	case <-time.After(2 * time.Second):
+		t.Fatal("read on discarded pipe blocked; pipe writer was not closed")
+	}
+}
+
+// TestPushWriterCloseReclaimsBufferedPipe verifies that Close closes a pipe
+// that setPipe left buffered but that Write/Commit never adopted, so the
+// request body reader unblocks instead of leaking.
+func TestPushWriterCloseReclaimsBufferedPipe(t *testing.T) {
+	tracker := NewInMemoryTracker()
+	tracker.SetStatus("r", Status{})
+	pw := &pushWriter{
+		ref:     "r",
+		tracker: tracker,
+		done:    make(chan struct{}),
+		pipeC:   make(chan *io.PipeWriter, 1),
+	}
+
+	r, w := io.Pipe()
+	pw.pipeC <- w // simulate setPipe having enqueued the pipe
+
+	require.NoError(t, pw.Close())
+
+	readErr := make(chan error, 1)
+	go func() {
+		_, err := r.Read(make([]byte, 1))
+		readErr <- err
+	}()
+
+	select {
+	case err := <-readErr:
+		assert.Error(t, err, "buffered pipe should be closed by Close")
+	case <-time.After(2 * time.Second):
+		t.Fatal("read on buffered pipe blocked; Close did not reclaim it")
+	}
+}
+
+// TestPushWriterEmptyWriteDoesNotStart verifies that a zero-length Write is a
+// no-op and does not start the upload request.
+func TestPushWriterEmptyWriteDoesNotStart(t *testing.T) {
+	started := false
+	pw := &pushWriter{
+		done:  make(chan struct{}),
+		pipeC: make(chan *io.PipeWriter, 1),
+	}
+	pw.start = func() { started = true }
+
+	n, err := pw.Write(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+	assert.False(t, started, "empty write must not start the request")
+}
+
+// TestPusherCloseWithoutWriteAllowsRetry verifies that closing a writer that
+// was opened but never fed marks the tracker entry as closed, so a later push
+// of the same ref is not blocked with ErrUnavailable.
+func TestPusherCloseWithoutWriteAllowsRetry(t *testing.T) {
+	p, reg, _, done := samplePusher(t)
+	defer done()
+
+	reg.uploadable = true
+
+	layerContent := []byte("layer-content")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(layerContent),
+		Size:      int64(len(layerContent)),
+	}
+	ref := "layer-" + desc.Digest.String()
+
+	// Open a writer and close it without writing (opened but never fed). Writer
+	// uses unavailableOnFail=true, which is the path that would otherwise stay
+	// blocked.
+	cw, err := p.Writer(context.Background(), content.WithRef(ref), content.WithDescriptor(desc))
+	require.NoError(t, err)
+	require.NoError(t, cw.Close())
+
+	// A subsequent Writer for the same ref must succeed rather than return
+	// ErrUnavailable.
+	cw2, err := p.Writer(context.Background(), content.WithRef(ref), content.WithDescriptor(desc))
+	require.NoError(t, err)
+	require.NoError(t, cw2.Close())
+}
+
+type bodyCloseTracker struct{ closed bool }
+
+func (b *bodyCloseTracker) Read([]byte) (int, error) { return 0, io.EOF }
+func (b *bodyCloseTracker) Close() error             { b.closed = true; return nil }
+
+// TestPushWriterSetResponseClosesBodyWhenClosed verifies that a response
+// arriving after the writer is closed has its body closed, rather than being
+// dropped and leaking the connection.
+func TestPushWriterSetResponseClosesBodyWhenClosed(t *testing.T) {
+	pw := &pushWriter{
+		done:  make(chan struct{}),
+		respC: make(chan *http.Response, 1),
+	}
+	close(pw.done)
+
+	body := &bodyCloseTracker{}
+	pw.setResponse(&http.Response{Body: body})
+
+	assert.True(t, body.closed, "response body should be closed when the writer is already closed")
+}
+
+// TestPushWriterCloseDrainsResponse verifies that Close closes the body of a
+// response left buffered by a completed request that the caller never
+// committed.
+func TestPushWriterCloseDrainsResponse(t *testing.T) {
+	pw := &pushWriter{
+		done:    make(chan struct{}),
+		pipeC:   make(chan *io.PipeWriter, 1),
+		respC:   make(chan *http.Response, 1),
+		tracker: NewInMemoryTracker(),
+		ref:     "test-ref",
+	}
+
+	body := &bodyCloseTracker{}
+	pw.respC <- &http.Response{Body: body}
+
+	require.NoError(t, pw.Close())
+	assert.True(t, body.closed, "buffered response body should be closed by Close")
+}
+
+// TestEnsureStartedSkipsWhenClosed verifies that the request is not started if
+// the writer was already closed, even though the start func is set.
+func TestEnsureStartedSkipsWhenClosed(t *testing.T) {
+	started := false
+	pw := &pushWriter{done: make(chan struct{})}
+	pw.start = func() { started = true }
+
+	close(pw.done)
+	pw.ensureStarted()
+
+	assert.False(t, started, "request must not start after the writer is closed")
 }


### PR DESCRIPTION
### Summary

The docker pusher currently puts the blob upload PUT on the wire the moment the writer is created, before any content exists. `push()` sends the upload POST, then launches the request goroutine with an `io.Pipe` body; content only flows later when the caller copies into `pushWriter.Write`. Until then the PUT sits open with an idle body.

This lets a reverse proxy in front of a registry close the connection on its client-inactivity timeout before any content is streamed, which surfaces to the caller as a fatal, non-retryable error. See docker/buildx#4057 for a downstream report and packet capture: on a slow, high-latency uplink BuildKit opens ~8 concurrent PUTs (roughly 4 for the image export and 4 for the cache export), a few saturate the link, and the rest send only a few KB then go idle. They stay TCP-alive via keep-alives but carry no HTTP body, so the proxy (HAProxy, `timeout client 90s`) resets them at ~90s and the registry logs a client disconnect. The client sees a `400` and the whole build fails.

### Change

Start the upload request lazily. `push()` stores the request goroutine in `pushWriter.start`; `ensureStarted()` (guarded by `sync.Once`) runs it on the first `Write`, or on `Commit` for zero-length blobs. The POST that reserves the upload location stays eager; only the PUT body is deferred.

Effect:

- The PUT goes on the wire when there is content to stream, so the body flows immediately and the connection does not sit idle.
- A writer that is opened but never fed, or closed without writing, sends no PUT.
- No API or wire-protocol change; behavior for a normally-fed upload is unchanged.

### Scope / non-goals

This removes the "PUT opened before the copy is scheduled" idle window. It does not address a connection that stalls mid-body because concurrent uploads starve it of bandwidth; mitigating that needs an upload-concurrency limit on the client and a more tolerant inactivity timeout on the registry/proxy side. It is also distinct from, and complementary to, chunked/PATCH upload (#3533).

### Test

Adds `TestPusherPutDeferredUntilWrite`: asserts the POST is sent by `push()`, no PUT is sent before `Write`, and the PUT is sent after `Write`. Existing pusher tests pass unchanged.

```
go test ./core/remotes/docker/
ok  github.com/containerd/containerd/v2/core/remotes/docker
```

Fixes: docker/buildx#4057
Refs: #3533
