### PR TITLE
archive: don't follow symlinks in post-create chmod/chown during extract

### DIFF
--- a/pkg/archive/tar_mostunix.go
+++ b/pkg/archive/tar_mostunix.go
@@ -19,6 +19,7 @@
 package archive
 
 import (
+	"errors"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -39,17 +40,55 @@ func lsetxattrCreate(link string, attr string, data []byte) error {
 	return err
 }
 
-// lchmod checks for symlink and changes the mode if not a symlink
+// lchmod changes the mode of the file at path without following symlinks; a
+// symlink is intentionally left unmodified.
 func lchmod(path string, mode os.FileMode) error {
-	fi, err := os.Lstat(path)
-	if err != nil {
-		return err
+	// Fchmodat with AT_SYMLINK_NOFOLLOW targets the inode at path directly,
+	// removing the TOCTOU window that the previous lstat-then-chmod had: an
+	// attacker racing the extraction could replace a just-created file with a
+	// symlink between the check and the chmod, and the old path-based chmod
+	// would then follow it (cf. ba50a56, which fixed the same race in openFile).
+	//
+	// mode carries os.FileMode's Go-style setuid/setgid/sticky bits, which do
+	// not match the syscall bits, so convert it the way os.Chmod would rather
+	// than casting directly.
+	err := unix.Fchmodat(unix.AT_FDCWD, path, chmodSyscallMode(mode), unix.AT_SYMLINK_NOFOLLOW)
+	if err == nil {
+		return nil
 	}
-
-	if fi.Mode()&os.ModeSymlink == 0 {
-		if err := os.Chmod(path, mode); err != nil {
-			return err
+	if errors.Is(err, unix.EOPNOTSUPP) {
+		// AT_SYMLINK_NOFOLLOW yields EOPNOTSUPP in two situations:
+		//   - path is a symlink: Linux cannot change a symlink's own mode, and
+		//     the historical behaviour is to leave symlinks untouched, so this
+		//     is success; or
+		//   - the running kernel predates fchmodat2 (Linux < 6.6) and cannot
+		//     honour the flag for any path type. Fall back to the previous
+		//     lstat-guarded chmod, preserving behaviour on such kernels.
+		fi, lerr := os.Lstat(path)
+		if lerr != nil {
+			return lerr
 		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		return os.Chmod(path, mode)
 	}
-	return nil
+	return err
+}
+
+// chmodSyscallMode converts an os.FileMode into the raw mode bits accepted by
+// chmod(2)/fchmodat(2). It mirrors the unexported os.syscallMode so that the
+// setuid, setgid and sticky bits survive; a plain uint32(mode) would drop them.
+func chmodSyscallMode(i os.FileMode) uint32 {
+	o := uint32(i.Perm())
+	if i&os.ModeSetuid != 0 {
+		o |= unix.S_ISUID
+	}
+	if i&os.ModeSetgid != 0 {
+		o |= unix.S_ISGID
+	}
+	if i&os.ModeSticky != 0 {
+		o |= unix.S_ISVTX
+	}
+	return o
 }

--- a/pkg/archive/tar_opts_linux.go
+++ b/pkg/archive/tar_opts_linux.go
@@ -18,7 +18,6 @@ package archive
 
 import (
 	"archive/tar"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -44,8 +43,11 @@ func OverlayConvertWhiteout(hdr *tar.Header, path string) (bool, error) {
 		if err := unix.Mknod(originalPath, unix.S_IFCHR, 0); err != nil {
 			return false, err
 		}
-		// don't write the file itself
-		return false, os.Chown(originalPath, hdr.Uid, hdr.Gid)
+		// don't write the file itself. Chown through Fchownat with
+		// AT_SYMLINK_NOFOLLOW so the ownership change cannot be redirected onto
+		// another file via a symlink swapped in for the device after the mknod
+		// (TOCTOU; cf. ba50a56).
+		return false, unix.Fchownat(unix.AT_FDCWD, originalPath, hdr.Uid, hdr.Gid, unix.AT_SYMLINK_NOFOLLOW)
 	}
 
 	return true, nil

--- a/pkg/archive/tar_toctou_test.go
+++ b/pkg/archive/tar_toctou_test.go
@@ -1,0 +1,120 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// modeOf returns the permission bits (including setuid/setgid/sticky) of path,
+// without following symlinks.
+func modeOf(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	fi, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", path, err)
+	}
+	return fi.Mode()
+}
+
+// TestLchmodDoesNotFollowSymlink asserts that lchmod never changes the mode of
+// a symlink's target. This is the metadata-op half of the TOCTOU race: an
+// attacker who swaps a freshly created file for a symlink must not be able to
+// steer the chmod onto the link target.
+func TestLchmodDoesNotFollowSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := lchmod(link, 0o777); err != nil {
+		t.Fatalf("lchmod on symlink returned error: %v", err)
+	}
+
+	if got := modeOf(t, target).Perm(); got != 0o600 {
+		t.Fatalf("symlink target mode changed to %o, want 0600 (chmod followed the symlink)", got)
+	}
+}
+
+// TestLchmodRegularFilePreservesSpecialBits asserts lchmod still applies the
+// mode to a real file and that setuid survives the os.FileMode -> syscall mode
+// conversion (a plain uint32 cast would have dropped it).
+func TestLchmodRegularFilePreservesSpecialBits(t *testing.T) {
+	dir := t.TempDir()
+	reg := filepath.Join(dir, "reg")
+	if err := os.WriteFile(reg, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// tar's FileInfo().Mode() uses os.FileMode's ModeSetuid bit for 04755.
+	want := os.FileMode(0o755) | os.ModeSetuid
+	if err := lchmod(reg, want); err != nil {
+		t.Fatalf("lchmod on regular file: %v", err)
+	}
+
+	got := modeOf(t, reg)
+	if got.Perm() != 0o755 || got&os.ModeSetuid == 0 {
+		t.Fatalf("mode = %v, want 0755 with setuid set", got)
+	}
+}
+
+// TestFchmodDirRefusesSymlink asserts fchmodDir will not chmod through a symlink
+// standing where a directory is expected, and leaves the link target untouched.
+func TestFchmodDirRefusesSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	targetDir := filepath.Join(dir, "targetdir")
+	if err := os.Mkdir(targetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "dlink")
+	if err := os.Symlink(targetDir, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fchmodDir(link, 0o777); err == nil {
+		t.Fatal("fchmodDir followed a symlink; expected an error")
+	}
+	if got := modeOf(t, targetDir).Perm(); got != 0o700 {
+		t.Fatalf("target dir mode changed to %o, want 0700 (chmod followed the symlink)", got)
+	}
+}
+
+// TestFchmodDirChmodsRealDir asserts the happy path still works.
+func TestFchmodDirChmodsRealDir(t *testing.T) {
+	dir := t.TempDir()
+	d := filepath.Join(dir, "d")
+	if err := os.Mkdir(d, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := fchmodDir(d, 0o750); err != nil {
+		t.Fatalf("fchmodDir: %v", err)
+	}
+	if got := modeOf(t, d).Perm(); got != 0o750 {
+		t.Fatalf("dir mode = %o, want 0750", got)
+	}
+}

--- a/pkg/archive/tar_unix.go
+++ b/pkg/archive/tar_unix.go
@@ -92,9 +92,25 @@ func mkdir(path string, perm os.FileMode) error {
 	if err := os.Mkdir(path, perm); err != nil {
 		return err
 	}
-	// Only final created directory gets explicit permission
-	// call to avoid permission mask
-	return os.Chmod(path, perm)
+	// Only final created directory gets explicit permission call to avoid
+	// permission mask. Apply it through an O_NOFOLLOW fd rather than by
+	// re-resolving path, so a symlink swapped in for the directory between the
+	// Mkdir and the chmod cannot redirect the chmod onto another file (TOCTOU;
+	// cf. ba50a56, which fixed the equivalent race in openFile).
+	return fchmodDir(path, perm)
+}
+
+// fchmodDir applies perm to the directory at path via an O_NOFOLLOW|O_DIRECTORY
+// fd, so the mode change targets that exact inode and can never be redirected
+// through a symlink that raced in after the directory was created. The path is
+// always a directory at every call site.
+func fchmodDir(path string, perm os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_RDONLY|unix.O_NOFOLLOW|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Chmod(perm)
 }
 
 func skipFile(hdr *tar.Header) bool {
@@ -170,7 +186,10 @@ func copyDirInfo(fi os.FileInfo, path string) error {
 		}
 	}
 
-	if err := os.Chmod(path, fi.Mode()); err != nil {
+	// path is the directory we just created; chmod it through an O_NOFOLLOW fd
+	// so the mode cannot be redirected through a symlink swapped in after
+	// creation (TOCTOU; cf. ba50a56).
+	if err := fchmodDir(path, fi.Mode()); err != nil {
 		return fmt.Errorf("failed to chmod %s: %w", path, err)
 	}
 


### PR DESCRIPTION
This is a hardening follow-up to ba50a56 ("Fix TOCTOU race bug in tar extraction"), which replaced a path-based `os.Chmod` in `openFile()` with an fd-based `f.Chmod`. The same "create the target, then re-resolve its path to apply metadata" pattern is still present at four other sites in the extraction path, where the path argument derives from an untrusted tar header:

- `mkdir()` — `os.Mkdir` followed by `os.Chmod(path)`
- `copyDirInfo()` — `os.Chmod(path)` after the directory is created
- `lchmod()` — `os.Lstat` guard followed by `os.Chmod(path)` (this file was not touched by ba50a56)
- `OverlayConvertWhiteout()` — `os.Chown(path)` after `mknod`, which follows symlinks

At each site, in the window after creation, the just-created inode can be replaced with a symlink so the following path-based chmod/chown re-resolves onto a different target. This mirrors exactly the race ba50a56 closed in `openFile`.

### Change

Resolve the metadata operation against the created inode instead of re-resolving the path:

- `mkdir()` / `copyDirInfo()` chmod through an `O_NOFOLLOW|O_DIRECTORY` fd (new `fchmodDir` helper). Both sites operate on a directory.
- `lchmod()` uses `Fchmodat(AT_SYMLINK_NOFOLLOW)`. On kernels without `fchmodat2` (< 6.6) the flag returns `EOPNOTSUPP`, so it falls back to the previous lstat-guarded chmod to preserve behaviour there. The mode is converted with the same rules `os.Chmod` uses so setuid/setgid/sticky bits are not dropped (a plain `uint32(mode)` cast would lose them — see the existing FreeBSD `lchmod`).
- `OverlayConvertWhiteout()` uses `Fchownat(AT_SYMLINK_NOFOLLOW)`, honoured on all supported Linux kernels.

The `go-archive` project migrated the same logic to `os.Root` (df55fdf, 51d1dd0, f43ca4d), which removes this class structurally. This PR is the smaller, targeted fix in the style of ba50a56; an `os.Root` migration would be a reasonable larger follow-up.

### Tests

Adds `tar_toctou_test.go` covering the no-follow behaviour of `fchmodDir` and `lchmod`, and that `lchmod` preserves setuid on a regular file. Existing `pkg/archive` tests pass; `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176Pyov5q4Lio4Lkz2PXAvp
