### PR TITLE
shim-runc-v2: record exit status in bundle

### DIFF
--- a/cmd/containerd-shim-runc-v2/manager/manager_linux.go
+++ b/cmd/containerd-shim-runc-v2/manager/manager_linux.go
@@ -327,15 +327,38 @@ func (manager) Stop(ctx context.Context, id string) (shim.StopStatus, error) {
 	}); err != nil {
 		log.G(ctx).WithError(err).Warn("failed to remove runc container")
 	}
+
+	// Use the time immediately after the forced runc deletion attempt as the
+	// fallback when no recorded exit time is available.
+	fallbackExitedAt := time.Now()
+
 	if err := mount.UnmountRecursive(filepath.Join(path, "rootfs"), 0); err != nil {
 		log.G(ctx).WithError(err).Warn("failed to cleanup rootfs mount")
 	}
-	pid, err := runcC.ReadPidFile(filepath.Join(path, process.InitPidFile))
-	if err != nil {
-		log.G(ctx).WithError(err).Warn("failed to read init pid file")
+
+	// Prefer the exit status recorded by the shim. The record may be unavailable
+	// for bundles created by older shims or if the shim terminated before writing it.
+	exitEvent, exitErr := runc.ReadExitStatus(path)
+	if exitErr == nil {
+		return shim.StopStatus{
+			ExitedAt:   exitEvent.Timestamp,
+			ExitStatus: exitEvent.Status,
+			Pid:        exitEvent.Pid,
+		}, nil
 	}
+
+	if !errors.Is(exitErr, os.ErrNotExist) {
+		log.G(ctx).WithError(exitErr).Warn("failed to read recorded exit status")
+	}
+
+	pid, pidErr := runcC.ReadPidFile(filepath.Join(path, process.InitPidFile))
+	if pidErr != nil {
+		log.G(ctx).WithError(pidErr).Warn("failed to read init pid file")
+		pid = 0
+	}
+
 	return shim.StopStatus{
-		ExitedAt:   time.Now(),
+		ExitedAt:   fallbackExitedAt,
 		ExitStatus: 128 + int(unix.SIGKILL),
 		Pid:        pid,
 	}, nil

--- a/cmd/containerd-shim-runc-v2/runc/util.go
+++ b/cmd/containerd-shim-runc-v2/runc/util.go
@@ -21,11 +21,15 @@ package runc
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
+	pkgrunc "github.com/containerd/go-runc"
 	"github.com/containerd/log"
 	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/containerd/containerd/v2/pkg/atomicfile"
 )
 
 // ShouldKillAllOnExit reads the bundle's OCI spec and returns true if
@@ -59,4 +63,46 @@ func readSpec(p string) (*specs.Spec, error) {
 		return nil, err
 	}
 	return &s, nil
+}
+
+const exitStatusFileName = "exit.json"
+
+// WriteExitStatus stores exit status for exited container process.
+func WriteExitStatus(bundlePath string, e pkgrunc.Exit) error {
+	exitValue, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("failed to marshal runc.Exit value: %w", err)
+	}
+
+	f, err := atomicfile.New(filepath.Join(bundlePath, exitStatusFileName), 0600)
+	if err != nil {
+		return fmt.Errorf("failed to create exit status file: %w", err)
+	}
+	if _, err := f.Write(exitValue); err != nil {
+		_ = f.Cancel()
+		return fmt.Errorf("failed to write exit status: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to commit exit status: %w", err)
+	}
+	return nil
+}
+
+// ReadExitStatus reads exit status of exited container process.
+func ReadExitStatus(bundlePath string) (pkgrunc.Exit, error) {
+	exitFile := filepath.Join(bundlePath, exitStatusFileName)
+	f, err := os.Open(exitFile)
+	if err != nil {
+		return pkgrunc.Exit{}, fmt.Errorf("failed to open %s: %w", exitFile, err)
+	}
+	defer f.Close()
+
+	var e pkgrunc.Exit
+	if err := json.NewDecoder(f).Decode(&e); err != nil {
+		return pkgrunc.Exit{}, fmt.Errorf("failed to unmarshal runc.Exit: %w", err)
+	}
+	if e.Pid <= 0 || e.Timestamp.IsZero() || e.Status < 0 {
+		return pkgrunc.Exit{}, fmt.Errorf("invalid runc.Exit value: %v", e)
+	}
+	return e, nil
 }

--- a/cmd/containerd-shim-runc-v2/runc/util_linux_test.go
+++ b/cmd/containerd-shim-runc-v2/runc/util_linux_test.go
@@ -1,0 +1,94 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	runcC "github.com/containerd/go-runc"
+)
+
+func TestExitStatusFile(t *testing.T) {
+	now := time.Now().Round(0).UTC()
+
+	for _, tc := range []struct {
+		name     string
+		input    runcC.Exit
+		corrupt  func(*testing.T, string)
+		expected runcC.Exit
+		hasErr   bool
+	}{
+		{
+			name:   "invalid pid",
+			input:  runcC.Exit{Pid: -1, Timestamp: time.Now(), Status: 1},
+			hasErr: true,
+		},
+		{
+			name:   "invalid status",
+			input:  runcC.Exit{Pid: 10, Timestamp: time.Now(), Status: -1},
+			hasErr: true,
+		},
+		{
+			name:   "empty timestamp",
+			input:  runcC.Exit{Pid: 10, Status: 0},
+			hasErr: true,
+		},
+		{
+			name:     "no error",
+			input:    runcC.Exit{Pid: 10, Timestamp: now, Status: 0},
+			expected: runcC.Exit{Pid: 10, Timestamp: now, Status: 0},
+		},
+		{
+			name:  "file corrupted",
+			input: runcC.Exit{Pid: 10, Timestamp: now, Status: 0},
+			corrupt: func(t *testing.T, bundlePath string) {
+				target := filepath.Join(bundlePath, exitStatusFileName)
+				err := os.WriteFile(target, []byte("{oops:...}"), 0600)
+				if err != nil {
+					t.Fatalf("failed to corrupt file: %v", err)
+				}
+			},
+			hasErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			if err := WriteExitStatus(tmpDir, tc.input); err != nil {
+				t.Fatalf("failed to write exit status: %v", err)
+			}
+
+			if tc.corrupt != nil {
+				tc.corrupt(t, tmpDir)
+			}
+
+			got, err := ReadExitStatus(tmpDir)
+			if tc.hasErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if !reflect.DeepEqual(tc.expected, got) {
+				t.Fatalf("expected %v, but got %v", tc.expected, got)
+			}
+		})
+	}
+}

--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -768,6 +768,14 @@ func (s *service) handleProcessExit(e runcC.Exit, c *runc.Container, p process.P
 	p.SetExited(e.Status)
 	_, isInit := p.(*process.Init)
 	if isInit {
+		e.Timestamp = p.ExitedAt()
+		if err := runc.WriteExitStatus(c.Bundle, e); err != nil {
+			log.G(s.context).
+				WithField("container_id", c.ID).
+				WithError(err).
+				Error("failed to store exit status in bundle")
+		}
+
 		if err := s.cg2oom.Stop(c.ID); err != nil {
 			log.G(context.Background()).
 				WithField("container_id", c.ID).

--- a/integration/issue7496_shutdown_linux_test.go
+++ b/integration/issue7496_shutdown_linux_test.go
@@ -17,22 +17,31 @@
 package integration
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	eventtypes "github.com/containerd/containerd/api/events"
 	apitask "github.com/containerd/containerd/api/runtime/task/v3"
+	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/events"
 	ctrdruntime "github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
+	"github.com/containerd/containerd/v2/plugins"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -105,6 +114,13 @@ func TestKillShimPublishesTaskExitAndDeleteEvents(t *testing.T) {
 		require.NoError(t, runtimeService.RemovePodSandbox(sbID))
 	})
 
+	container, err := containerdClient.LoadContainer(ctx, sbID)
+	require.NoError(t, err)
+	task, err := container.Task(ctx, nil)
+	require.NoError(t, err)
+	sandboxPID := task.Pid()
+	require.NotZero(t, sandboxPID)
+
 	shimCli := connectToShim(ctx, t, containerdEndpoint, 3, sbID)
 	shimPID := shimPid(ctx, t, shimCli)
 
@@ -114,7 +130,27 @@ func TestKillShimPublishesTaskExitAndDeleteEvents(t *testing.T) {
 	)
 
 	require.NoError(t, syscall.Kill(int(shimPID), syscall.SIGKILL))
-	waitForTaskExitDeleteEvents(t, sbID, eventCh, eventErrCh, 10*time.Second)
+	gotEvents := waitForTaskExitDeleteEvents(t, sbID, eventCh, eventErrCh, 2, 10*time.Second)
+	wantEvents := []taskEvent{
+		{Exit: &eventtypes.TaskExit{
+			ContainerID: sbID,
+			ID:          sbID,
+			Pid:         sandboxPID,
+			ExitStatus:  uint32(128 + syscall.SIGKILL),
+		}},
+		{Delete: &eventtypes.TaskDelete{
+			ContainerID: sbID,
+			Pid:         sandboxPID,
+			ExitStatus:  uint32(128 + syscall.SIGKILL),
+		}},
+	}
+	if diff := cmp.Diff(wantEvents, gotEvents,
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&eventtypes.TaskExit{}, "exited_at"),
+		protocmp.IgnoreFields(&eventtypes.TaskDelete{}, "exited_at"),
+	); diff != "" {
+		t.Fatalf("unexpected task events (-want +got):\n%s", diff)
+	}
 }
 
 // Regression test for https://github.com/containerd/containerd/issues/13293 (orphaned shim state after shim SIGKILL).
@@ -145,6 +181,13 @@ func TestKillShimPublishesTaskExitAndDeleteEventsForContainer(t *testing.T) {
 	t.Log("Start the container")
 	require.NoError(t, runtimeService.StartContainer(cnID))
 
+	container, err := containerdClient.LoadContainer(ctx, cnID)
+	require.NoError(t, err)
+	task, err := container.Task(ctx, nil)
+	require.NoError(t, err)
+	workloadPID := task.Pid()
+	require.NotZero(t, workloadPID)
+
 	shimCli := connectToShim(ctx, t, containerdEndpoint, 3, sbID)
 	shimPID := shimPid(ctx, t, shimCli)
 
@@ -154,7 +197,28 @@ func TestKillShimPublishesTaskExitAndDeleteEventsForContainer(t *testing.T) {
 	)
 
 	require.NoError(t, syscall.Kill(int(shimPID), syscall.SIGKILL))
-	waitForTaskExitDeleteEvents(t, cnID, eventCh, eventErrCh, 10*time.Second)
+	gotEvents := waitForTaskExitDeleteEvents(t, cnID, eventCh, eventErrCh, 2, 10*time.Second)
+
+	wantEvents := []taskEvent{
+		{Exit: &eventtypes.TaskExit{
+			ContainerID: cnID,
+			ID:          cnID,
+			Pid:         workloadPID,
+			ExitStatus:  uint32(128 + syscall.SIGKILL),
+		}},
+		{Delete: &eventtypes.TaskDelete{
+			ContainerID: cnID,
+			Pid:         workloadPID,
+			ExitStatus:  uint32(128 + syscall.SIGKILL),
+		}},
+	}
+	if diff := cmp.Diff(wantEvents, gotEvents,
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&eventtypes.TaskExit{}, "exited_at"),
+		protocmp.IgnoreFields(&eventtypes.TaskDelete{}, "exited_at"),
+	); diff != "" {
+		t.Fatalf("unexpected task events (-want +got):\n%s", diff)
+	}
 
 	// Wait for the container to exit and ensure it is fully cleaned up.
 	require.NoError(t, Eventually(func() (bool, error) {
@@ -169,22 +233,125 @@ func TestKillShimPublishesTaskExitAndDeleteEventsForContainer(t *testing.T) {
 	}, 1000*time.Millisecond, 30*time.Second))
 }
 
+func TestKillShimPreservesExitStatusForMultipleContainers(t *testing.T) {
+	const groupAnnotation = "io.containerd.runc.v2.group"
+
+	ctx := namespaces.WithNamespace(t.Context(), namespaces.Default)
+	cleanupCtx := namespaces.WithNamespace(context.Background(), namespaces.Default)
+	shimPath := filepath.Join(*buildDir, "containerd-shim-runc-v2")
+	require.FileExists(t, shimPath)
+
+	image, err := containerdClient.Pull(ctx, images.Get(images.BusyBox), containerd.WithPullUnpack)
+	require.NoError(t, err)
+
+	type testTask struct {
+		id         string
+		exitStatus uint32
+		task       containerd.Task
+		eventCh    <-chan *events.Envelope
+		eventErrCh <-chan error
+	}
+	groupID := t.Name()
+	newTask := func(id string, exitStatus uint32) testTask {
+		container, err := containerdClient.NewContainer(ctx, id,
+			containerd.WithNewSnapshot(id, image),
+			containerd.WithNewSpec(
+				oci.WithImageConfig(image),
+				oci.WithProcessArgs("sh", "-c", fmt.Sprintf("exit %d", exitStatus)),
+				oci.WithAnnotations(map[string]string{groupAnnotation: groupID}),
+			),
+			containerd.WithRuntime(plugins.RuntimeRuncV2, nil),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = container.Delete(cleanupCtx, containerd.WithSnapshotCleanup)
+		})
+
+		t.Logf("Use the shim built from the current source: %s", shimPath)
+		task, err := container.NewTask(ctx, cio.NullIO, containerd.WithRuntimePath(shimPath))
+		require.NoError(t, err)
+		require.NotZero(t, task.Pid())
+		t.Cleanup(func() {
+			_, _ = task.Delete(cleanupCtx, containerd.WithProcessKill)
+		})
+
+		eventCh, eventErrCh := containerdClient.EventService().Subscribe(ctx,
+			fmt.Sprintf(`topic=="%s",event.container_id=="%s"`, ctrdruntime.TaskExitEventTopic, id),
+			fmt.Sprintf(`topic=="%s",event.container_id=="%s"`, ctrdruntime.TaskDeleteEventTopic, id),
+		)
+		return testTask{id, exitStatus, task, eventCh, eventErrCh}
+	}
+	tasks := []testTask{
+		newTask("multi-container-exit-42", 42),
+		newTask("multi-container-exit-43", 43),
+	}
+
+	t.Log("Start two containers in the same shim with different exit statuses")
+	shimClient := connectToShim(ctx, t, containerdEndpoint, 3, groupID)
+	for _, tc := range tasks {
+		require.NoError(t, tc.task.Start(ctx))
+	}
+
+	checkEvents := func(tc testTask, afterShimExit bool) {
+		wantEvents := []taskEvent{{Exit: &eventtypes.TaskExit{
+			ContainerID: tc.id,
+			ID:          tc.id,
+			Pid:         tc.task.Pid(),
+			ExitStatus:  tc.exitStatus,
+		}}}
+		if afterShimExit {
+			wantEvents = append(wantEvents, taskEvent{Delete: &eventtypes.TaskDelete{
+				ContainerID: tc.id,
+				Pid:         tc.task.Pid(),
+				ExitStatus:  tc.exitStatus,
+			}})
+		}
+
+		gotEvents := waitForTaskExitDeleteEvents(t, tc.id, tc.eventCh, tc.eventErrCh, len(wantEvents), 10*time.Second)
+
+		if diff := cmp.Diff(wantEvents, gotEvents,
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&eventtypes.TaskExit{}, "exited_at"),
+			protocmp.IgnoreFields(&eventtypes.TaskDelete{}, "exited_at"),
+		); diff != "" {
+			t.Fatalf("unexpected task events for %q (-want +got):\n%s", tc.id, diff)
+		}
+	}
+	for _, tc := range tasks {
+		checkEvents(tc, false)
+	}
+
+	t.Log("Kill the shared shim after both containers have exited")
+	shimProcess, err := os.FindProcess(int(shimPid(ctx, t, shimClient)))
+	require.NoError(t, err)
+	defer shimProcess.Release()
+
+	t.Log("Verify dead-shim cleanup preserves each container's exit status")
+	require.NoError(t, shimProcess.Signal(syscall.SIGKILL))
+	for _, tc := range tasks {
+		checkEvents(tc, true)
+	}
+}
+
+// taskEvent is either a task exit or delete event.
+type taskEvent struct {
+	Exit   *eventtypes.TaskExit
+	Delete *eventtypes.TaskDelete
+}
+
 func waitForTaskExitDeleteEvents(t *testing.T, id string,
-	ch <-chan *events.Envelope, errCh <-chan error, timeout time.Duration,
-) {
+	ch <-chan *events.Envelope, errCh <-chan error, eventCount int, timeout time.Duration,
+) []taskEvent {
 	t.Helper()
 
-	pending := map[string]struct{}{
-		ctrdruntime.TaskExitEventTopic:   {},
-		ctrdruntime.TaskDeleteEventTopic: {},
-	}
+	received := make([]taskEvent, 0, eventCount)
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
-	for len(pending) != 0 {
+	for len(received) < eventCount {
 		select {
 		case <-timer.C:
-			t.Fatalf("timed out waiting for task exit/delete events for %q", id)
+			t.Fatalf("timed out waiting for %d task exit/delete events for %q", eventCount, id)
 		case err, ok := <-errCh:
 			if !ok {
 				t.Fatalf("event subscription closed while waiting for %q", id)
@@ -193,9 +360,26 @@ func waitForTaskExitDeleteEvents(t *testing.T, id string,
 		case env, ok := <-ch:
 			require.True(t, ok, "event subscription closed while waiting for %q", id)
 			t.Logf("received event %q for %q", env.Topic, id)
-			delete(pending, env.Topic)
+
+			event, err := typeurl.UnmarshalAny(env.Event)
+			require.NoError(t, err, "failed to unmarshal event")
+
+			switch event := event.(type) {
+			case *eventtypes.TaskExit:
+				require.Equal(t, id, event.ContainerID)
+				require.NoError(t, event.GetExitedAt().CheckValid())
+				received = append(received, taskEvent{Exit: event})
+			case *eventtypes.TaskDelete:
+				require.Equal(t, id, event.ContainerID)
+				require.NoError(t, event.GetExitedAt().CheckValid())
+				received = append(received, taskEvent{Delete: event})
+			default:
+				t.Fatalf("unexpected task event type %T", event)
+			}
 		}
 	}
+
+	return received
 }
 
 // countTaskExitDeleteEventsUntilBarrier counts task exit and delete events for

--- a/integration/release_upgrade_exit_status_linux_test.go
+++ b/integration/release_upgrade_exit_status_linux_test.go
@@ -1,0 +1,172 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/continuity/fs"
+	"github.com/containerd/errdefs"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	eventtypes "github.com/containerd/containerd/api/events"
+	containerd "github.com/containerd/containerd/v2/client"
+	ctrdruntime "github.com/containerd/containerd/v2/core/runtime"
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/containerd/containerd/v2/integration/remote"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/containerd/v2/plugins"
+)
+
+func shouldHandleShimExitStatusAfterUpgrade(previousReleaseBinDir string) setupUpgradeVerifyCase {
+	const (
+		shimExitStatus          uint32 = 42
+		shimExitStatusNamespace        = "kill-shim-before-delete-task"
+	)
+
+	return func(t *testing.T, _ int, rSvc *remote.RuntimeService, _ *remote.ImageService) ([]upgradeVerifyCaseFunc, beforeUpgradeHookFunc) {
+		client := newUpgradeContainerdClient(t, rSvc, shimExitStatusNamespace)
+		ctx := t.Context()
+
+		image, err := client.Pull(ctx, images.Get(images.BusyBox), containerd.WithPullUnpack)
+		require.NoError(t, err)
+
+		const id = "old-shim-exit-status"
+		// previousReleaseBinDir is shared by all upgrade cases, so use a private
+		// copy that can be replaced without affecting later tests.
+		oldShim := filepath.Join(t.TempDir(), "containerd-shim-runc-v2")
+
+		require.NoError(t, fs.CopyFile(oldShim,
+			filepath.Join(previousReleaseBinDir, "bin", "containerd-shim-runc-v2")))
+		require.NoError(t, os.Chmod(oldShim, 0755))
+
+		container, err := client.NewContainer(ctx, id,
+			containerd.WithNewSnapshot(id, image),
+			containerd.WithNewSpec(oci.WithImageConfig(image),
+				oci.WithProcessArgs("sh", "-c", fmt.Sprintf("exit %d", shimExitStatus))),
+			containerd.WithRuntime(plugins.RuntimeRuncV2, nil),
+		)
+		require.NoError(t, err)
+
+		_, err = container.NewTask(ctx, cio.NullIO, containerd.WithRuntimePath(oldShim))
+		require.NoError(t, err)
+
+		beforeUpgrade := func(t *testing.T) {
+			// Replace the shim binary to verify that the current shim can delete an old bundle.
+			require.NoError(t, os.Remove(oldShim))
+			require.NoError(t, fs.CopyFile(oldShim,
+				filepath.Join(*buildDir, "containerd-shim-runc-v2")))
+			require.NoError(t, os.Chmod(oldShim, 0755))
+		}
+
+		verify := func(t *testing.T, rSvc *remote.RuntimeService, _ *remote.ImageService) {
+			client := newUpgradeContainerdClient(t, rSvc, shimExitStatusNamespace)
+			ctx := t.Context()
+
+			container, err := client.LoadContainer(ctx, id)
+			require.NoError(t, err)
+			task, err := container.Task(ctx, nil)
+			require.NoError(t, err)
+			taskPID := task.Pid()
+			require.NotZero(t, taskPID)
+
+			eventCh, eventErrCh := client.EventService().Subscribe(ctx,
+				fmt.Sprintf(`topic=="%s",event.container_id=="%s"`, ctrdruntime.TaskExitEventTopic, id),
+				fmt.Sprintf(`topic=="%s",event.container_id=="%s"`, ctrdruntime.TaskDeleteEventTopic, id),
+			)
+
+			shim := buildShimClientFromNamespacedBundle(t, rSvc, shimExitStatusNamespace, id)
+			shimProcess, err := os.FindProcess(int(shimPid(ctx, t, shim.cli)))
+			require.NoError(t, err)
+			defer shimProcess.Release()
+			defer shimProcess.Signal(syscall.SIGKILL)
+
+			require.NoError(t, task.Start(ctx))
+
+			gotEvents := waitForTaskExitDeleteEvents(t, id, eventCh, eventErrCh, 1, 30*time.Second)
+			wantEvents := []taskEvent{{Exit: &eventtypes.TaskExit{
+				ContainerID: id,
+				ID:          id,
+				Pid:         taskPID,
+				ExitStatus:  shimExitStatus,
+			}}}
+			cmpOpts := []cmp.Option{
+				protocmp.Transform(),
+				protocmp.IgnoreFields(&eventtypes.TaskExit{}, "exited_at"),
+				protocmp.IgnoreFields(&eventtypes.TaskDelete{}, "exited_at"),
+			}
+			if diff := cmp.Diff(wantEvents, gotEvents, cmpOpts...); diff != "" {
+				t.Fatalf("unexpected task exit event (-want +got):\n%s", diff)
+			}
+
+			// We should have two events after killed shim
+			require.NoError(t, shimProcess.Signal(syscall.SIGKILL))
+			gotEvents = waitForTaskExitDeleteEvents(t, id, eventCh, eventErrCh, 2, 30*time.Second)
+			wantEvents = []taskEvent{
+				{Exit: &eventtypes.TaskExit{
+					ContainerID: id,
+					ID:          id,
+					Pid:         taskPID,
+					ExitStatus:  uint32(128 + syscall.SIGKILL),
+				}},
+				{Delete: &eventtypes.TaskDelete{
+					ContainerID: id,
+					Pid:         taskPID,
+					ExitStatus:  uint32(128 + syscall.SIGKILL),
+				}},
+			}
+			if diff := cmp.Diff(wantEvents, gotEvents, cmpOpts...); diff != "" {
+				t.Fatalf("unexpected task cleanup events (-want +got):\n%s", diff)
+			}
+
+			require.NoError(t, Eventually(func() (bool, error) {
+				_, err := container.Task(ctx, nil)
+				if err == nil {
+					return false, nil
+				}
+				if errdefs.IsNotFound(err) {
+					return true, nil
+				}
+				return false, err
+			}, 100*time.Millisecond, 10*time.Second))
+			require.NoError(t, container.Delete(ctx, containerd.WithSnapshotCleanup))
+		}
+		return []upgradeVerifyCaseFunc{verify}, beforeUpgrade
+	}
+}
+
+func newUpgradeContainerdClient(t *testing.T, rSvc *remote.RuntimeService, namespace string) *containerd.Client {
+	t.Helper()
+
+	endpoint := criRuntimeInfo(t, rSvc)["containerdEndpoint"].(string)
+	client, err := containerd.New(
+		strings.TrimPrefix(endpoint, "unix://"),
+		containerd.WithDefaultNamespace(namespace))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	return client
+}

--- a/integration/release_upgrade_linux_test.go
+++ b/integration/release_upgrade_linux_test.go
@@ -71,6 +71,10 @@ func TestUpgrade(t *testing.T) {
 			t.Run("recover-images", runUpgradeTestCase(version, previousReleaseBinDir, shouldRecoverExistingImages))
 			t.Run("metrics", runUpgradeTestCase(version, previousReleaseBinDir, shouldParseMetricDataCorrectly))
 
+			t.Run("kill-shim-before-delete-task",
+				runUpgradeTestCase(version, previousReleaseBinDir,
+					shouldHandleShimExitStatusAfterUpgrade(previousReleaseBinDir)))
+
 			if version == "1.7" {
 				t.Run("recover-ungroupable-shim", runUpgradeTestCaseWithExistingConfig(version,
 					previousReleaseBinDir, true, shouldManipulateContainersInPodAfterUpgrade("runcv1")))
@@ -713,12 +717,16 @@ type shimConn struct {
 
 // buildShimClientFromBundle builds a shim client from the bundle directory of the container.
 func buildShimClientFromBundle(t *testing.T, rSvc *remote.RuntimeService, cid string) shimConn {
+	return buildShimClientFromNamespacedBundle(t, rSvc, "k8s.io", cid)
+}
+
+func buildShimClientFromNamespacedBundle(t *testing.T, rSvc *remote.RuntimeService, namespace, cid string) shimConn {
 	cfg := criRuntimeInfo(t, rSvc)
 
 	bundleDir := filepath.Join(
 		filepath.Dir(cfg["stateDir"].(string)),
 		"io.containerd.runtime.v2.task",
-		"k8s.io",
+		namespace,
 		cid,
 	)
 

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
@@ -1,0 +1,185 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package cmpopts provides common options for the cmp package.
+package cmpopts
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func equateAlways(_, _ interface{}) bool { return true }
+
+// EquateEmpty returns a [cmp.Comparer] option that determines all maps and slices
+// with a length of zero to be equal, regardless of whether they are nil.
+//
+// EquateEmpty can be used in conjunction with [SortSlices] and [SortMaps].
+func EquateEmpty() cmp.Option {
+	return cmp.FilterValues(isEmpty, cmp.Comparer(equateAlways))
+}
+
+func isEmpty(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Slice || vx.Kind() == reflect.Map) &&
+		(vx.Len() == 0 && vy.Len() == 0)
+}
+
+// EquateApprox returns a [cmp.Comparer] option that determines float32 or float64
+// values to be equal if they are within a relative fraction or absolute margin.
+// This option is not used when either x or y is NaN or infinite.
+//
+// The fraction determines that the difference of two values must be within the
+// smaller fraction of the two values, while the margin determines that the two
+// values must be within some absolute margin.
+// To express only a fraction or only a margin, use 0 for the other parameter.
+// The fraction and margin must be non-negative.
+//
+// The mathematical expression used is equivalent to:
+//
+//	|x-y| ≤ max(fraction*min(|x|, |y|), margin)
+//
+// EquateApprox can be used in conjunction with [EquateNaNs].
+func EquateApprox(fraction, margin float64) cmp.Option {
+	if margin < 0 || fraction < 0 || math.IsNaN(margin) || math.IsNaN(fraction) {
+		panic("margin or fraction must be a non-negative number")
+	}
+	a := approximator{fraction, margin}
+	return cmp.Options{
+		cmp.FilterValues(areRealF64s, cmp.Comparer(a.compareF64)),
+		cmp.FilterValues(areRealF32s, cmp.Comparer(a.compareF32)),
+	}
+}
+
+type approximator struct{ frac, marg float64 }
+
+func areRealF64s(x, y float64) bool {
+	return !math.IsNaN(x) && !math.IsNaN(y) && !math.IsInf(x, 0) && !math.IsInf(y, 0)
+}
+func areRealF32s(x, y float32) bool {
+	return areRealF64s(float64(x), float64(y))
+}
+func (a approximator) compareF64(x, y float64) bool {
+	relMarg := a.frac * math.Min(math.Abs(x), math.Abs(y))
+	return math.Abs(x-y) <= math.Max(a.marg, relMarg)
+}
+func (a approximator) compareF32(x, y float32) bool {
+	return a.compareF64(float64(x), float64(y))
+}
+
+// EquateNaNs returns a [cmp.Comparer] option that determines float32 and float64
+// NaN values to be equal.
+//
+// EquateNaNs can be used in conjunction with [EquateApprox].
+func EquateNaNs() cmp.Option {
+	return cmp.Options{
+		cmp.FilterValues(areNaNsF64s, cmp.Comparer(equateAlways)),
+		cmp.FilterValues(areNaNsF32s, cmp.Comparer(equateAlways)),
+	}
+}
+
+func areNaNsF64s(x, y float64) bool {
+	return math.IsNaN(x) && math.IsNaN(y)
+}
+func areNaNsF32s(x, y float32) bool {
+	return areNaNsF64s(float64(x), float64(y))
+}
+
+// EquateApproxTime returns a [cmp.Comparer] option that determines two non-zero
+// [time.Time] values to be equal if they are within some margin of one another.
+// If both times have a monotonic clock reading, then the monotonic time
+// difference will be used. The margin must be non-negative.
+func EquateApproxTime(margin time.Duration) cmp.Option {
+	if margin < 0 {
+		panic("margin must be a non-negative number")
+	}
+	a := timeApproximator{margin}
+	return cmp.FilterValues(areNonZeroTimes, cmp.Comparer(a.compare))
+}
+
+func areNonZeroTimes(x, y time.Time) bool {
+	return !x.IsZero() && !y.IsZero()
+}
+
+type timeApproximator struct {
+	margin time.Duration
+}
+
+func (a timeApproximator) compare(x, y time.Time) bool {
+	// Avoid subtracting times to avoid overflow when the
+	// difference is larger than the largest representable duration.
+	if x.After(y) {
+		// Ensure x is always before y
+		x, y = y, x
+	}
+	// We're within the margin if x+margin >= y.
+	// Note: time.Time doesn't have AfterOrEqual method hence the negation.
+	return !x.Add(a.margin).Before(y)
+}
+
+// AnyError is an error that matches any non-nil error.
+var AnyError anyError
+
+type anyError struct{}
+
+func (anyError) Error() string     { return "any error" }
+func (anyError) Is(err error) bool { return err != nil }
+
+// EquateErrors returns a [cmp.Comparer] option that determines errors to be equal
+// if [errors.Is] reports them to match. The [AnyError] error can be used to
+// match any non-nil error.
+func EquateErrors() cmp.Option {
+	return cmp.FilterValues(areConcreteErrors, cmp.Comparer(compareErrors))
+}
+
+// areConcreteErrors reports whether x and y are types that implement error.
+// The input types are deliberately of the interface{} type rather than the
+// error type so that we can handle situations where the current type is an
+// interface{}, but the underlying concrete types both happen to implement
+// the error interface.
+func areConcreteErrors(x, y interface{}) bool {
+	_, ok1 := x.(error)
+	_, ok2 := y.(error)
+	return ok1 && ok2
+}
+
+func compareErrors(x, y interface{}) bool {
+	xe := x.(error)
+	ye := y.(error)
+	return errors.Is(xe, ye) || errors.Is(ye, xe)
+}
+
+// EquateComparable returns a [cmp.Option] that determines equality
+// of comparable types by directly comparing them using the == operator in Go.
+// The types to compare are specified by passing a value of that type.
+// This option should only be used on types that are documented as being
+// safe for direct == comparison. For example, [net/netip.Addr] is documented
+// as being semantically safe to use with ==, while [time.Time] is documented
+// to discourage the use of == on time values.
+func EquateComparable(typs ...interface{}) cmp.Option {
+	types := make(typesFilter)
+	for _, typ := range typs {
+		switch t := reflect.TypeOf(typ); {
+		case !t.Comparable():
+			panic(fmt.Sprintf("%T is not a comparable Go type", typ))
+		case types[t]:
+			panic(fmt.Sprintf("%T is already specified", typ))
+		default:
+			types[t] = true
+		}
+	}
+	return cmp.FilterPath(types.filter, cmp.Comparer(equateAny))
+}
+
+type typesFilter map[reflect.Type]bool
+
+func (tf typesFilter) filter(p cmp.Path) bool { return tf[p.Last().Type()] }
+
+func equateAny(x, y interface{}) bool { return x == y }

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
@@ -1,0 +1,206 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// IgnoreFields returns an [cmp.Option] that ignores fields of the
+// given names on a single struct type. It respects the names of exported fields
+// that are forwarded due to struct embedding.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to ignore a
+// specific sub-field that is embedded or nested within the parent struct.
+func IgnoreFields(typ interface{}, names ...string) cmp.Option {
+	sf := newStructFilter(typ, names...)
+	return cmp.FilterPath(sf.filter, cmp.Ignore())
+}
+
+// IgnoreTypes returns an [cmp.Option] that ignores all values assignable to
+// certain types, which are specified by passing in a value of each type.
+func IgnoreTypes(typs ...interface{}) cmp.Option {
+	tf := newTypeFilter(typs...)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type typeFilter []reflect.Type
+
+func newTypeFilter(typs ...interface{}) (tf typeFilter) {
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil {
+			// This occurs if someone tries to pass in sync.Locker(nil)
+			panic("cannot determine type; consider using IgnoreInterfaces")
+		}
+		tf = append(tf, t)
+	}
+	return tf
+}
+func (tf typeFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreInterfaces returns an [cmp.Option] that ignores all values or references of
+// values assignable to certain interface types. These interfaces are specified
+// by passing in an anonymous struct with the interface types embedded in it.
+// For example, to ignore [sync.Locker], pass in struct{sync.Locker}{}.
+func IgnoreInterfaces(ifaces interface{}) cmp.Option {
+	tf := newIfaceFilter(ifaces)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type ifaceFilter []reflect.Type
+
+func newIfaceFilter(ifaces interface{}) (tf ifaceFilter) {
+	t := reflect.TypeOf(ifaces)
+	if ifaces == nil || t.Name() != "" || t.Kind() != reflect.Struct {
+		panic("input must be an anonymous struct")
+	}
+	for i := 0; i < t.NumField(); i++ {
+		fi := t.Field(i)
+		switch {
+		case !fi.Anonymous:
+			panic("struct cannot have named fields")
+		case fi.Type.Kind() != reflect.Interface:
+			panic("embedded field must be an interface type")
+		case fi.Type.NumMethod() == 0:
+			// This matches everything; why would you ever want this?
+			panic("cannot ignore empty interface")
+		default:
+			tf = append(tf, fi.Type)
+		}
+	}
+	return tf
+}
+func (tf ifaceFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+		if t.Kind() != reflect.Ptr && reflect.PtrTo(t).AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreUnexported returns an [cmp.Option] that only ignores the immediate unexported
+// fields of a struct, including anonymous fields of unexported types.
+// In particular, unexported fields within the struct's exported fields
+// of struct types, including anonymous fields, will not be ignored unless the
+// type of the field itself is also passed to IgnoreUnexported.
+//
+// Avoid ignoring unexported fields of a type which you do not control (i.e. a
+// type from another repository), as changes to the implementation of such types
+// may change how the comparison behaves. Prefer a custom [cmp.Comparer] instead.
+func IgnoreUnexported(typs ...interface{}) cmp.Option {
+	ux := newUnexportedFilter(typs...)
+	return cmp.FilterPath(ux.filter, cmp.Ignore())
+}
+
+type unexportedFilter struct{ m map[reflect.Type]bool }
+
+func newUnexportedFilter(typs ...interface{}) unexportedFilter {
+	ux := unexportedFilter{m: make(map[reflect.Type]bool)}
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil || t.Kind() != reflect.Struct {
+			panic(fmt.Sprintf("%T must be a non-pointer struct", typ))
+		}
+		ux.m[t] = true
+	}
+	return ux
+}
+func (xf unexportedFilter) filter(p cmp.Path) bool {
+	sf, ok := p.Index(-1).(cmp.StructField)
+	if !ok {
+		return false
+	}
+	return xf.m[p.Index(-2).Type()] && !isExported(sf.Name())
+}
+
+// isExported reports whether the identifier is exported.
+func isExported(id string) bool {
+	r, _ := utf8.DecodeRuneInString(id)
+	return unicode.IsUpper(r)
+}
+
+// IgnoreSliceElements returns an [cmp.Option] that ignores elements of []V.
+// The discard function must be of the form "func(T) bool" which is used to
+// ignore slice elements of type V, where V is assignable to T.
+// Elements are ignored if the function reports true.
+func IgnoreSliceElements(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.ValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		si, ok := p.Index(-1).(cmp.SliceIndex)
+		if !ok {
+			return false
+		}
+		if !si.Type().AssignableTo(vf.Type().In(0)) {
+			return false
+		}
+		vx, vy := si.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}
+
+// IgnoreMapEntries returns an [cmp.Option] that ignores entries of map[K]V.
+// The discard function must be of the form "func(T, R) bool" which is used to
+// ignore map entries of type K and V, where K and V are assignable to T and R.
+// Entries are ignored if the function reports true.
+func IgnoreMapEntries(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.KeyValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		mi, ok := p.Index(-1).(cmp.MapIndex)
+		if !ok {
+			return false
+		}
+		if !mi.Key().Type().AssignableTo(vf.Type().In(0)) || !mi.Type().AssignableTo(vf.Type().In(1)) {
+			return false
+		}
+		k := mi.Key()
+		vx, vy := mi.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{k, vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{k, vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
@@ -1,0 +1,171 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// SortSlices returns a [cmp.Transformer] option that sorts all []V.
+// The lessOrCompareFunc function must be either
+// a less function of the form "func(T, T) bool" or
+// a compare function of the format "func(T, T) int"
+// which is used to sort any slice with element type V that is assignable to T.
+//
+// A less function must be:
+//   - Deterministic: less(x, y) == less(x, y)
+//   - Irreflexive: !less(x, x)
+//   - Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//
+// A compare function must be:
+//   - Deterministic: compare(x, y) == compare(x, y)
+//   - Irreflexive: compare(x, x) == 0
+//   - Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//
+// The function does not have to be "total". That is, if x != y, but
+// less or compare report inequality, their relative order is maintained.
+//
+// SortSlices can be used in conjunction with [EquateEmpty].
+func SortSlices(lessOrCompareFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessOrCompareFunc)
+	if (!function.IsType(vf.Type(), function.Less) && !function.IsType(vf.Type(), function.Compare)) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less or compare function: %T", lessOrCompareFunc))
+	}
+	ss := sliceSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ss.filter, cmp.Transformer("cmpopts.SortSlices", ss.sort))
+}
+
+type sliceSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ss sliceSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	if !(x != nil && y != nil && vx.Type() == vy.Type()) ||
+		!(vx.Kind() == reflect.Slice && vx.Type().Elem().AssignableTo(ss.in)) ||
+		(vx.Len() <= 1 && vy.Len() <= 1) {
+		return false
+	}
+	// Check whether the slices are already sorted to avoid an infinite
+	// recursion cycle applying the same transform to itself.
+	ok1 := sort.SliceIsSorted(x, func(i, j int) bool { return ss.less(vx, i, j) })
+	ok2 := sort.SliceIsSorted(y, func(i, j int) bool { return ss.less(vy, i, j) })
+	return !ok1 || !ok2
+}
+func (ss sliceSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	dst := reflect.MakeSlice(src.Type(), src.Len(), src.Len())
+	for i := 0; i < src.Len(); i++ {
+		dst.Index(i).Set(src.Index(i))
+	}
+	sort.SliceStable(dst.Interface(), func(i, j int) bool { return ss.less(dst, i, j) })
+	ss.checkSort(dst)
+	return dst.Interface()
+}
+func (ss sliceSorter) checkSort(v reflect.Value) {
+	start := -1 // Start of a sequence of equal elements.
+	for i := 1; i < v.Len(); i++ {
+		if ss.less(v, i-1, i) {
+			// Check that first and last elements in v[start:i] are equal.
+			if start >= 0 && (ss.less(v, start, i-1) || ss.less(v, i-1, start)) {
+				panic(fmt.Sprintf("incomparable values detected: want equal elements: %v", v.Slice(start, i)))
+			}
+			start = -1
+		} else if start == -1 {
+			start = i
+		}
+	}
+}
+func (ss sliceSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i), v.Index(j)
+	vo := ss.fnc.Call([]reflect.Value{vx, vy})[0]
+	if vo.Kind() == reflect.Bool {
+		return vo.Bool()
+	} else {
+		return vo.Int() < 0
+	}
+}
+
+// SortMaps returns a [cmp.Transformer] option that flattens map[K]V types to be
+// a sorted []struct{K, V}. The lessOrCompareFunc function must be either
+// a less function of the form "func(T, T) bool" or
+// a compare function of the format "func(T, T) int"
+// which is used to sort any map with key K that is assignable to T.
+//
+// Flattening the map into a slice has the property that [cmp.Equal] is able to
+// use [cmp.Comparer] options on K or the K.Equal method if it exists.
+//
+// A less function must be:
+//   - Deterministic: less(x, y) == less(x, y)
+//   - Irreflexive: !less(x, x)
+//   - Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//   - Total: if x != y, then either less(x, y) or less(y, x)
+//
+// A compare function must be:
+//   - Deterministic: compare(x, y) == compare(x, y)
+//   - Irreflexive: compare(x, x) == 0
+//   - Transitive: if compare(x, y) < 0 and compare(y, z) < 0, then compare(x, z) < 0
+//   - Total: if x != y, then compare(x, y) != 0
+//
+// SortMaps can be used in conjunction with [EquateEmpty].
+func SortMaps(lessOrCompareFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessOrCompareFunc)
+	if (!function.IsType(vf.Type(), function.Less) && !function.IsType(vf.Type(), function.Compare)) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less or compare function: %T", lessOrCompareFunc))
+	}
+	ms := mapSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ms.filter, cmp.Transformer("cmpopts.SortMaps", ms.sort))
+}
+
+type mapSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ms mapSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Map && vx.Type().Key().AssignableTo(ms.in)) &&
+		(vx.Len() != 0 || vy.Len() != 0)
+}
+func (ms mapSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	outType := reflect.StructOf([]reflect.StructField{
+		{Name: "K", Type: src.Type().Key()},
+		{Name: "V", Type: src.Type().Elem()},
+	})
+	dst := reflect.MakeSlice(reflect.SliceOf(outType), src.Len(), src.Len())
+	for i, k := range src.MapKeys() {
+		v := reflect.New(outType).Elem()
+		v.Field(0).Set(k)
+		v.Field(1).Set(src.MapIndex(k))
+		dst.Index(i).Set(v)
+	}
+	sort.Slice(dst.Interface(), func(i, j int) bool { return ms.less(dst, i, j) })
+	ms.checkSort(dst)
+	return dst.Interface()
+}
+func (ms mapSorter) checkSort(v reflect.Value) {
+	for i := 1; i < v.Len(); i++ {
+		if !ms.less(v, i-1, i) {
+			panic(fmt.Sprintf("partial order detected: want %v < %v", v.Index(i-1), v.Index(i)))
+		}
+	}
+}
+func (ms mapSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i).Field(0), v.Index(j).Field(0)
+	vo := ms.fnc.Call([]reflect.Value{vx, vy})[0]
+	if vo.Kind() == reflect.Bool {
+		return vo.Bool()
+	} else {
+		return vo.Int() < 0
+	}
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
@@ -1,0 +1,189 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// filterField returns a new Option where opt is only evaluated on paths that
+// include a specific exported field on a single struct type.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to select a
+// specific sub-field that is embedded or nested within the parent struct.
+func filterField(typ interface{}, name string, opt cmp.Option) cmp.Option {
+	// TODO: This is currently unexported over concerns of how helper filters
+	// can be composed together easily.
+	// TODO: Add tests for FilterField.
+
+	sf := newStructFilter(typ, name)
+	return cmp.FilterPath(sf.filter, opt)
+}
+
+type structFilter struct {
+	t  reflect.Type // The root struct type to match on
+	ft fieldTree    // Tree of fields to match on
+}
+
+func newStructFilter(typ interface{}, names ...string) structFilter {
+	// TODO: Perhaps allow * as a special identifier to allow ignoring any
+	// number of path steps until the next field match?
+	// This could be useful when a concrete struct gets transformed into
+	// an anonymous struct where it is not possible to specify that by type,
+	// but the transformer happens to provide guarantees about the names of
+	// the transformed fields.
+
+	t := reflect.TypeOf(typ)
+	if t == nil || t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("%T must be a non-pointer struct", typ))
+	}
+	var ft fieldTree
+	for _, name := range names {
+		cname, err := canonicalName(t, name)
+		if err != nil {
+			panic(fmt.Sprintf("%s: %v", strings.Join(cname, "."), err))
+		}
+		ft.insert(cname)
+	}
+	return structFilter{t, ft}
+}
+
+func (sf structFilter) filter(p cmp.Path) bool {
+	for i, ps := range p {
+		if ps.Type().AssignableTo(sf.t) && sf.ft.matchPrefix(p[i+1:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldTree represents a set of dot-separated identifiers.
+//
+// For example, inserting the following selectors:
+//
+//	Foo
+//	Foo.Bar.Baz
+//	Foo.Buzz
+//	Nuka.Cola.Quantum
+//
+// Results in a tree of the form:
+//
+//	{sub: {
+//		"Foo": {ok: true, sub: {
+//			"Bar": {sub: {
+//				"Baz": {ok: true},
+//			}},
+//			"Buzz": {ok: true},
+//		}},
+//		"Nuka": {sub: {
+//			"Cola": {sub: {
+//				"Quantum": {ok: true},
+//			}},
+//		}},
+//	}}
+type fieldTree struct {
+	ok  bool                 // Whether this is a specified node
+	sub map[string]fieldTree // The sub-tree of fields under this node
+}
+
+// insert inserts a sequence of field accesses into the tree.
+func (ft *fieldTree) insert(cname []string) {
+	if ft.sub == nil {
+		ft.sub = make(map[string]fieldTree)
+	}
+	if len(cname) == 0 {
+		ft.ok = true
+		return
+	}
+	sub := ft.sub[cname[0]]
+	sub.insert(cname[1:])
+	ft.sub[cname[0]] = sub
+}
+
+// matchPrefix reports whether any selector in the fieldTree matches
+// the start of path p.
+func (ft fieldTree) matchPrefix(p cmp.Path) bool {
+	for _, ps := range p {
+		switch ps := ps.(type) {
+		case cmp.StructField:
+			ft = ft.sub[ps.Name()]
+			if ft.ok {
+				return true
+			}
+			if len(ft.sub) == 0 {
+				return false
+			}
+		case cmp.Indirect:
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// canonicalName returns a list of identifiers where any struct field access
+// through an embedded field is expanded to include the names of the embedded
+// types themselves.
+//
+// For example, suppose field "Foo" is not directly in the parent struct,
+// but actually from an embedded struct of type "Bar". Then, the canonical name
+// of "Foo" is actually "Bar.Foo".
+//
+// Suppose field "Foo" is not directly in the parent struct, but actually
+// a field in two different embedded structs of types "Bar" and "Baz".
+// Then the selector "Foo" causes a panic since it is ambiguous which one it
+// refers to. The user must specify either "Bar.Foo" or "Baz.Foo".
+func canonicalName(t reflect.Type, sel string) ([]string, error) {
+	var name string
+	sel = strings.TrimPrefix(sel, ".")
+	if sel == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+	if i := strings.IndexByte(sel, '.'); i < 0 {
+		name, sel = sel, ""
+	} else {
+		name, sel = sel[:i], sel[i:]
+	}
+
+	// Type must be a struct or pointer to struct.
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%v must be a struct", t)
+	}
+
+	// Find the canonical name for this current field name.
+	// If the field exists in an embedded struct, then it will be expanded.
+	sf, _ := t.FieldByName(name)
+	if !isExported(name) {
+		// Avoid using reflect.Type.FieldByName for unexported fields due to
+		// buggy behavior with regard to embeddeding and unexported fields.
+		// See https://golang.org/issue/4876 for details.
+		sf = reflect.StructField{}
+		for i := 0; i < t.NumField() && sf.Name == ""; i++ {
+			if t.Field(i).Name == name {
+				sf = t.Field(i)
+			}
+		}
+	}
+	if sf.Name == "" {
+		return []string{name}, fmt.Errorf("does not exist")
+	}
+	var ss []string
+	for i := range sf.Index {
+		ss = append(ss, t.FieldByIndex(sf.Index[:i+1]).Name)
+	}
+	if sel == "" {
+		return ss, nil
+	}
+	ssPost, err := canonicalName(sf.Type, sel)
+	return append(ss, ssPost...), err
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
@@ -1,0 +1,36 @@
+// Copyright 2018, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"github.com/google/go-cmp/cmp"
+)
+
+type xformFilter struct{ xform cmp.Option }
+
+func (xf xformFilter) filter(p cmp.Path) bool {
+	for _, ps := range p {
+		if t, ok := ps.(cmp.Transform); ok && t.Option() == xf.xform {
+			return false
+		}
+	}
+	return true
+}
+
+// AcyclicTransformer returns a [cmp.Transformer] with a filter applied that ensures
+// that the transformer cannot be recursively applied upon its own output.
+//
+// An example use case is a transformer that splits a string by lines:
+//
+//	AcyclicTransformer("SplitLines", func(s string) []string{
+//		return strings.Split(s, "\n")
+//	})
+//
+// Had this been an unfiltered [cmp.Transformer] instead, this would result in an
+// infinite cycle converting a string to []string to [][]string and so on.
+func AcyclicTransformer(name string, xformFunc interface{}) cmp.Option {
+	xf := xformFilter{cmp.Transformer(name, xformFunc)}
+	return cmp.FilterPath(xf.filter, xf.xform)
+}

--- a/vendor/google.golang.org/protobuf/internal/msgfmt/format.go
+++ b/vendor/google.golang.org/protobuf/internal/msgfmt/format.go
@@ -1,0 +1,261 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package msgfmt implements a text marshaler combining the desirable features
+// of both the JSON and proto text formats.
+// It is optimized for human readability and has no associated deserializer.
+package msgfmt
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/internal/detrand"
+	"google.golang.org/protobuf/internal/genid"
+	"google.golang.org/protobuf/internal/order"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// Format returns a formatted string for the message.
+func Format(m proto.Message) string {
+	return string(appendMessage(nil, m.ProtoReflect()))
+}
+
+// FormatValue returns a formatted string for an arbitrary value.
+func FormatValue(v protoreflect.Value, fd protoreflect.FieldDescriptor) string {
+	return string(appendValue(nil, v, fd))
+}
+
+func appendValue(b []byte, v protoreflect.Value, fd protoreflect.FieldDescriptor) []byte {
+	switch v := v.Interface().(type) {
+	case nil:
+		return append(b, "<invalid>"...)
+	case bool, int32, int64, uint32, uint64, float32, float64:
+		return append(b, fmt.Sprint(v)...)
+	case string:
+		return append(b, strconv.Quote(string(v))...)
+	case []byte:
+		return append(b, strconv.Quote(string(v))...)
+	case protoreflect.EnumNumber:
+		return appendEnum(b, v, fd)
+	case protoreflect.Message:
+		return appendMessage(b, v)
+	case protoreflect.List:
+		return appendList(b, v, fd)
+	case protoreflect.Map:
+		return appendMap(b, v, fd)
+	default:
+		panic(fmt.Sprintf("invalid type: %T", v))
+	}
+}
+
+func appendEnum(b []byte, v protoreflect.EnumNumber, fd protoreflect.FieldDescriptor) []byte {
+	if fd != nil {
+		if ev := fd.Enum().Values().ByNumber(v); ev != nil {
+			return append(b, ev.Name()...)
+		}
+	}
+	return strconv.AppendInt(b, int64(v), 10)
+}
+
+func appendMessage(b []byte, m protoreflect.Message) []byte {
+	if b2 := appendKnownMessage(b, m); b2 != nil {
+		return b2
+	}
+
+	b = append(b, '{')
+	order.RangeFields(m, order.IndexNameFieldOrder, func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		b = append(b, fd.TextName()...)
+		b = append(b, ':')
+		b = appendValue(b, v, fd)
+		b = append(b, delim()...)
+		return true
+	})
+	b = appendUnknown(b, m.GetUnknown())
+	b = bytes.TrimRight(b, delim())
+	b = append(b, '}')
+	return b
+}
+
+var protocmpMessageType = reflect.TypeOf(map[string]any(nil))
+
+func appendKnownMessage(b []byte, m protoreflect.Message) []byte {
+	md := m.Descriptor()
+	fds := md.Fields()
+	switch md.FullName() {
+	case genid.Any_message_fullname:
+		var msgVal protoreflect.Message
+		url := m.Get(fds.ByNumber(genid.Any_TypeUrl_field_number)).String()
+		if v := reflect.ValueOf(m); v.Type().ConvertibleTo(protocmpMessageType) {
+			// For protocmp.Message, directly obtain the sub-message value
+			// which is stored in structured form, rather than as raw bytes.
+			m2 := v.Convert(protocmpMessageType).Interface().(map[string]any)
+			v, ok := m2[string(genid.Any_Value_field_name)].(proto.Message)
+			if !ok {
+				return nil
+			}
+			msgVal = v.ProtoReflect()
+		} else {
+			val := m.Get(fds.ByNumber(genid.Any_Value_field_number)).Bytes()
+			mt, err := protoregistry.GlobalTypes.FindMessageByURL(url)
+			if err != nil {
+				return nil
+			}
+			msgVal = mt.New()
+			err = proto.UnmarshalOptions{AllowPartial: true}.Unmarshal(val, msgVal.Interface())
+			if err != nil {
+				return nil
+			}
+		}
+
+		b = append(b, '{')
+		b = append(b, "["+url+"]"...)
+		b = append(b, ':')
+		b = appendMessage(b, msgVal)
+		b = append(b, '}')
+		return b
+
+	case genid.Timestamp_message_fullname:
+		secs := m.Get(fds.ByNumber(genid.Timestamp_Seconds_field_number)).Int()
+		nanos := m.Get(fds.ByNumber(genid.Timestamp_Nanos_field_number)).Int()
+		if nanos < 0 || nanos >= 1e9 {
+			return nil
+		}
+		t := time.Unix(secs, nanos).UTC()
+		x := t.Format("2006-01-02T15:04:05.000000000") // RFC 3339
+		x = strings.TrimSuffix(x, "000")
+		x = strings.TrimSuffix(x, "000")
+		x = strings.TrimSuffix(x, ".000")
+		return append(b, x+"Z"...)
+
+	case genid.Duration_message_fullname:
+		sign := ""
+		secs := m.Get(fds.ByNumber(genid.Duration_Seconds_field_number)).Int()
+		nanos := m.Get(fds.ByNumber(genid.Duration_Nanos_field_number)).Int()
+		if nanos <= -1e9 || nanos >= 1e9 || (secs > 0 && nanos < 0) || (secs < 0 && nanos > 0) {
+			return nil
+		}
+		if secs < 0 || nanos < 0 {
+			sign, secs, nanos = "-", -1*secs, -1*nanos
+		}
+		x := fmt.Sprintf("%s%d.%09d", sign, secs, nanos)
+		x = strings.TrimSuffix(x, "000")
+		x = strings.TrimSuffix(x, "000")
+		x = strings.TrimSuffix(x, ".000")
+		return append(b, x+"s"...)
+
+	case genid.BoolValue_message_fullname,
+		genid.Int32Value_message_fullname,
+		genid.Int64Value_message_fullname,
+		genid.UInt32Value_message_fullname,
+		genid.UInt64Value_message_fullname,
+		genid.FloatValue_message_fullname,
+		genid.DoubleValue_message_fullname,
+		genid.StringValue_message_fullname,
+		genid.BytesValue_message_fullname:
+		fd := fds.ByNumber(genid.WrapperValue_Value_field_number)
+		return appendValue(b, m.Get(fd), fd)
+	}
+
+	return nil
+}
+
+func appendUnknown(b []byte, raw protoreflect.RawFields) []byte {
+	rs := make(map[protoreflect.FieldNumber][]protoreflect.RawFields)
+	for len(raw) > 0 {
+		num, _, n := protowire.ConsumeField(raw)
+		rs[num] = append(rs[num], raw[:n])
+		raw = raw[n:]
+	}
+
+	var ns []protoreflect.FieldNumber
+	for n := range rs {
+		ns = append(ns, n)
+	}
+	sort.Slice(ns, func(i, j int) bool { return ns[i] < ns[j] })
+
+	for _, n := range ns {
+		var leftBracket, rightBracket string
+		if len(rs[n]) > 1 {
+			leftBracket, rightBracket = "[", "]"
+		}
+
+		b = strconv.AppendInt(b, int64(n), 10)
+		b = append(b, ':')
+		b = append(b, leftBracket...)
+		for _, r := range rs[n] {
+			num, typ, n := protowire.ConsumeTag(r)
+			r = r[n:]
+			switch typ {
+			case protowire.VarintType:
+				v, _ := protowire.ConsumeVarint(r)
+				b = strconv.AppendInt(b, int64(v), 10)
+			case protowire.Fixed32Type:
+				v, _ := protowire.ConsumeFixed32(r)
+				b = append(b, fmt.Sprintf("0x%08x", v)...)
+			case protowire.Fixed64Type:
+				v, _ := protowire.ConsumeFixed64(r)
+				b = append(b, fmt.Sprintf("0x%016x", v)...)
+			case protowire.BytesType:
+				v, _ := protowire.ConsumeBytes(r)
+				b = strconv.AppendQuote(b, string(v))
+			case protowire.StartGroupType:
+				v, _ := protowire.ConsumeGroup(num, r)
+				b = append(b, '{')
+				b = appendUnknown(b, v)
+				b = bytes.TrimRight(b, delim())
+				b = append(b, '}')
+			default:
+				panic(fmt.Sprintf("invalid type: %v", typ))
+			}
+			b = append(b, delim()...)
+		}
+		b = bytes.TrimRight(b, delim())
+		b = append(b, rightBracket...)
+		b = append(b, delim()...)
+	}
+	return b
+}
+
+func appendList(b []byte, v protoreflect.List, fd protoreflect.FieldDescriptor) []byte {
+	b = append(b, '[')
+	for i := 0; i < v.Len(); i++ {
+		b = appendValue(b, v.Get(i), fd)
+		b = append(b, delim()...)
+	}
+	b = bytes.TrimRight(b, delim())
+	b = append(b, ']')
+	return b
+}
+
+func appendMap(b []byte, v protoreflect.Map, fd protoreflect.FieldDescriptor) []byte {
+	b = append(b, '{')
+	order.RangeEntries(v, order.GenericKeyOrder, func(k protoreflect.MapKey, v protoreflect.Value) bool {
+		b = appendValue(b, k.Value(), fd.MapKey())
+		b = append(b, ':')
+		b = appendValue(b, v, fd.MapValue())
+		b = append(b, delim()...)
+		return true
+	})
+	b = bytes.TrimRight(b, delim())
+	b = append(b, '}')
+	return b
+}
+
+func delim() string {
+	// Deliberately introduce instability into the message string to
+	// discourage users from depending on it.
+	if detrand.Bool() {
+		return "  "
+	}
+	return ", "
+}

--- a/vendor/google.golang.org/protobuf/testing/protocmp/reflect.go
+++ b/vendor/google.golang.org/protobuf/testing/protocmp/reflect.go
@@ -1,0 +1,258 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package protocmp
+
+import (
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/internal/genid"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/runtime/protoiface"
+)
+
+func reflectValueOf(v any) protoreflect.Value {
+	switch v := v.(type) {
+	case Enum:
+		return protoreflect.ValueOfEnum(v.Number())
+	case Message:
+		return protoreflect.ValueOfMessage(v.ProtoReflect())
+	case []byte:
+		return protoreflect.ValueOfBytes(v) // avoid overlap with reflect.Slice check below
+	default:
+		switch rv := reflect.ValueOf(v); {
+		case rv.Kind() == reflect.Slice:
+			return protoreflect.ValueOfList(reflectList{rv})
+		case rv.Kind() == reflect.Map:
+			return protoreflect.ValueOfMap(reflectMap{rv})
+		default:
+			return protoreflect.ValueOf(v)
+		}
+	}
+}
+
+type reflectMessage Message
+
+func (m reflectMessage) stringKey(fd protoreflect.FieldDescriptor) string {
+	if m.Descriptor() != fd.ContainingMessage() {
+		panic("mismatching containing message")
+	}
+	return fd.TextName()
+}
+
+func (m reflectMessage) Descriptor() protoreflect.MessageDescriptor {
+	return (Message)(m).Descriptor()
+}
+func (m reflectMessage) Type() protoreflect.MessageType {
+	return reflectMessageType{m.Descriptor()}
+}
+func (m reflectMessage) New() protoreflect.Message {
+	return m.Type().New()
+}
+func (m reflectMessage) Interface() protoreflect.ProtoMessage {
+	return Message(m)
+}
+func (m reflectMessage) Range(f func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool) {
+	// Range over populated known fields.
+	fds := m.Descriptor().Fields()
+	for i := 0; i < fds.Len(); i++ {
+		fd := fds.Get(i)
+		if m.Has(fd) && !f(fd, m.Get(fd)) {
+			return
+		}
+	}
+
+	// Range over populated extension fields.
+	for _, xd := range m[messageTypeKey].(messageMeta).xds {
+		if m.Has(xd) && !f(xd, m.Get(xd)) {
+			return
+		}
+	}
+}
+func (m reflectMessage) Has(fd protoreflect.FieldDescriptor) bool {
+	_, ok := m[m.stringKey(fd)]
+	return ok
+}
+func (m reflectMessage) Clear(protoreflect.FieldDescriptor) {
+	panic("invalid mutation of read-only message")
+}
+func (m reflectMessage) Get(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	v, ok := m[m.stringKey(fd)]
+	if !ok {
+		switch {
+		case fd.IsList():
+			return protoreflect.ValueOfList(reflectList{})
+		case fd.IsMap():
+			return protoreflect.ValueOfMap(reflectMap{})
+		case fd.Message() != nil:
+			return protoreflect.ValueOfMessage(reflectMessage{
+				messageTypeKey: messageMeta{md: fd.Message()},
+			})
+		default:
+			return fd.Default()
+		}
+	}
+
+	// The transformation may leave Any messages in structured form.
+	// If so, convert them back to a raw-encoded form.
+	if fd.FullName() == genid.Any_Value_field_fullname {
+		if m, ok := v.(Message); ok {
+			b, err := proto.MarshalOptions{Deterministic: true}.Marshal(m)
+			if err != nil {
+				panic("BUG: " + err.Error())
+			}
+			return protoreflect.ValueOfBytes(b)
+		}
+	}
+
+	return reflectValueOf(v)
+}
+func (m reflectMessage) Set(protoreflect.FieldDescriptor, protoreflect.Value) {
+	panic("invalid mutation of read-only message")
+}
+func (m reflectMessage) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	panic("invalid mutation of read-only message")
+}
+func (m reflectMessage) NewField(protoreflect.FieldDescriptor) protoreflect.Value {
+	panic("not implemented")
+}
+func (m reflectMessage) WhichOneof(od protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	if m.Descriptor().Oneofs().ByName(od.Name()) != od {
+		panic("oneof descriptor does not belong to this message")
+	}
+	fds := od.Fields()
+	for i := 0; i < fds.Len(); i++ {
+		fd := fds.Get(i)
+		if _, ok := m[m.stringKey(fd)]; ok {
+			return fd
+		}
+	}
+	return nil
+}
+func (m reflectMessage) GetUnknown() protoreflect.RawFields {
+	var nums []protoreflect.FieldNumber
+	for k := range m {
+		if len(strings.Trim(k, "0123456789")) == 0 {
+			n, _ := strconv.ParseUint(k, 10, 32)
+			nums = append(nums, protoreflect.FieldNumber(n))
+		}
+	}
+	sort.Slice(nums, func(i, j int) bool { return nums[i] < nums[j] })
+
+	var raw protoreflect.RawFields
+	for _, num := range nums {
+		b, _ := m[strconv.FormatUint(uint64(num), 10)].(protoreflect.RawFields)
+		raw = append(raw, b...)
+	}
+	return raw
+}
+func (m reflectMessage) SetUnknown(protoreflect.RawFields) {
+	panic("invalid mutation of read-only message")
+}
+func (m reflectMessage) IsValid() bool {
+	invalid, _ := m[messageInvalidKey].(bool)
+	return !invalid
+}
+func (m reflectMessage) ProtoMethods() *protoiface.Methods {
+	return nil
+}
+
+type reflectMessageType struct{ protoreflect.MessageDescriptor }
+
+func (t reflectMessageType) New() protoreflect.Message {
+	panic("not implemented")
+}
+func (t reflectMessageType) Zero() protoreflect.Message {
+	panic("not implemented")
+}
+func (t reflectMessageType) Descriptor() protoreflect.MessageDescriptor {
+	return t.MessageDescriptor
+}
+
+type reflectList struct{ v reflect.Value }
+
+func (ls reflectList) Len() int {
+	if !ls.IsValid() {
+		return 0
+	}
+	return ls.v.Len()
+}
+func (ls reflectList) Get(i int) protoreflect.Value {
+	return reflectValueOf(ls.v.Index(i).Interface())
+}
+func (ls reflectList) Set(int, protoreflect.Value) {
+	panic("invalid mutation of read-only list")
+}
+func (ls reflectList) Append(protoreflect.Value) {
+	panic("invalid mutation of read-only list")
+}
+func (ls reflectList) AppendMutable() protoreflect.Value {
+	panic("invalid mutation of read-only list")
+}
+func (ls reflectList) Truncate(int) {
+	panic("invalid mutation of read-only list")
+}
+func (ls reflectList) NewElement() protoreflect.Value {
+	panic("not implemented")
+}
+func (ls reflectList) IsValid() bool {
+	return ls.v.IsValid()
+}
+
+type reflectMap struct{ v reflect.Value }
+
+func (ms reflectMap) Len() int {
+	if !ms.IsValid() {
+		return 0
+	}
+	return ms.v.Len()
+}
+func (ms reflectMap) Range(f func(protoreflect.MapKey, protoreflect.Value) bool) {
+	if !ms.IsValid() {
+		return
+	}
+	ks := ms.v.MapKeys()
+	for _, k := range ks {
+		pk := reflectValueOf(k.Interface()).MapKey()
+		pv := reflectValueOf(ms.v.MapIndex(k).Interface())
+		if !f(pk, pv) {
+			return
+		}
+	}
+}
+func (ms reflectMap) Has(k protoreflect.MapKey) bool {
+	if !ms.IsValid() {
+		return false
+	}
+	return ms.v.MapIndex(reflect.ValueOf(k.Interface())).IsValid()
+}
+func (ms reflectMap) Clear(protoreflect.MapKey) {
+	panic("invalid mutation of read-only list")
+}
+func (ms reflectMap) Get(k protoreflect.MapKey) protoreflect.Value {
+	if !ms.IsValid() {
+		return protoreflect.Value{}
+	}
+	v := ms.v.MapIndex(reflect.ValueOf(k.Interface()))
+	if !v.IsValid() {
+		return protoreflect.Value{}
+	}
+	return reflectValueOf(v.Interface())
+}
+func (ms reflectMap) Set(protoreflect.MapKey, protoreflect.Value) {
+	panic("invalid mutation of read-only list")
+}
+func (ms reflectMap) Mutable(k protoreflect.MapKey) protoreflect.Value {
+	panic("invalid mutation of read-only list")
+}
+func (ms reflectMap) NewValue() protoreflect.Value {
+	panic("not implemented")
+}
+func (ms reflectMap) IsValid() bool {
+	return ms.v.IsValid()
+}

--- a/vendor/google.golang.org/protobuf/testing/protocmp/util.go
+++ b/vendor/google.golang.org/protobuf/testing/protocmp/util.go
@@ -1,0 +1,690 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package protocmp
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+var (
+	enumReflectType    = reflect.TypeOf(Enum{})
+	messageReflectType = reflect.TypeOf(Message{})
+)
+
+// FilterEnum filters opt to only be applicable on a standalone [Enum],
+// singular fields of enums, list fields of enums, or map fields of enum values,
+// where the enum is the same type as the specified enum.
+//
+// The Go type of the last path step may be an:
+//   - [Enum] for singular fields, elements of a repeated field,
+//     values of a map field, or standalone [Enum] values
+//   - [][Enum] for list fields
+//   - map[K][Enum] for map fields
+//   - any for a [Message] map entry value
+//
+// This must be used in conjunction with [Transform].
+func FilterEnum(enum protoreflect.Enum, opt cmp.Option) cmp.Option {
+	return FilterDescriptor(enum.Descriptor(), opt)
+}
+
+// FilterMessage filters opt to only be applicable on a standalone [Message] values,
+// singular fields of messages, list fields of messages, or map fields of
+// message values, where the message is the same type as the specified message.
+//
+// The Go type of the last path step may be an:
+//   - [Message] for singular fields, elements of a repeated field,
+//     values of a map field, or standalone [Message] values
+//   - [][Message] for list fields
+//   - map[K][Message] for map fields
+//   - any for a [Message] map entry value
+//
+// This must be used in conjunction with [Transform].
+func FilterMessage(message proto.Message, opt cmp.Option) cmp.Option {
+	return FilterDescriptor(message.ProtoReflect().Descriptor(), opt)
+}
+
+// FilterField filters opt to only be applicable on the specified field
+// in the message. It panics if a field of the given name does not exist.
+//
+// The Go type of the last path step may be an:
+//   - T for singular fields
+//   - []T for list fields
+//   - map[K]T for map fields
+//   - any for a [Message] map entry value
+//
+// This must be used in conjunction with [Transform].
+func FilterField(message proto.Message, name protoreflect.Name, opt cmp.Option) cmp.Option {
+	md := message.ProtoReflect().Descriptor()
+	return FilterDescriptor(mustFindFieldDescriptor(md, name), opt)
+}
+
+// FilterOneof filters opt to only be applicable on all fields within the
+// specified oneof in the message. It panics if a oneof of the given name
+// does not exist.
+//
+// The Go type of the last path step may be an:
+//   - T for singular fields
+//   - []T for list fields
+//   - map[K]T for map fields
+//   - any for a [Message] map entry value
+//
+// This must be used in conjunction with [Transform].
+func FilterOneof(message proto.Message, name protoreflect.Name, opt cmp.Option) cmp.Option {
+	md := message.ProtoReflect().Descriptor()
+	return FilterDescriptor(mustFindOneofDescriptor(md, name), opt)
+}
+
+// FilterDescriptor ignores the specified descriptor.
+//
+// The following descriptor types may be specified:
+//   - [protoreflect.EnumDescriptor]
+//   - [protoreflect.MessageDescriptor]
+//   - [protoreflect.FieldDescriptor]
+//   - [protoreflect.OneofDescriptor]
+//
+// For the behavior of each, see the corresponding filter function.
+// Since this filter accepts a [protoreflect.FieldDescriptor], it can be used
+// to also filter for extension fields as a [protoreflect.ExtensionDescriptor]
+// is just an alias to [protoreflect.FieldDescriptor].
+//
+// This must be used in conjunction with [Transform].
+func FilterDescriptor(desc protoreflect.Descriptor, opt cmp.Option) cmp.Option {
+	f := newNameFilters(desc)
+	return cmp.FilterPath(f.Filter, opt)
+}
+
+// IgnoreEnums ignores all enums of the specified types.
+// It is equivalent to FilterEnum(enum, cmp.Ignore()) for each enum.
+//
+// This must be used in conjunction with [Transform].
+func IgnoreEnums(enums ...protoreflect.Enum) cmp.Option {
+	var ds []protoreflect.Descriptor
+	for _, e := range enums {
+		ds = append(ds, e.Descriptor())
+	}
+	return IgnoreDescriptors(ds...)
+}
+
+// IgnoreMessages ignores all messages of the specified types.
+// It is equivalent to [FilterMessage](message, [cmp.Ignore]()) for each message.
+//
+// This must be used in conjunction with [Transform].
+func IgnoreMessages(messages ...proto.Message) cmp.Option {
+	var ds []protoreflect.Descriptor
+	for _, m := range messages {
+		ds = append(ds, m.ProtoReflect().Descriptor())
+	}
+	return IgnoreDescriptors(ds...)
+}
+
+// IgnoreFields ignores the specified fields in the specified message.
+// It is equivalent to [FilterField](message, name, [cmp.Ignore]()) for each field
+// in the message.
+//
+// This must be used in conjunction with [Transform].
+func IgnoreFields(message proto.Message, names ...protoreflect.Name) cmp.Option {
+	var ds []protoreflect.Descriptor
+	md := message.ProtoReflect().Descriptor()
+	for _, s := range names {
+		ds = append(ds, mustFindFieldDescriptor(md, s))
+	}
+	return IgnoreDescriptors(ds...)
+}
+
+// IgnoreOneofs ignores fields of the specified oneofs in the specified message.
+// It is equivalent to FilterOneof(message, name, cmp.Ignore()) for each oneof
+// in the message.
+//
+// This must be used in conjunction with [Transform].
+func IgnoreOneofs(message proto.Message, names ...protoreflect.Name) cmp.Option {
+	var ds []protoreflect.Descriptor
+	md := message.ProtoReflect().Descriptor()
+	for _, s := range names {
+		ds = append(ds, mustFindOneofDescriptor(md, s))
+	}
+	return IgnoreDescriptors(ds...)
+}
+
+// IgnoreDescriptors ignores the specified set of descriptors.
+// It is equivalent to [FilterDescriptor](desc, [cmp.Ignore]()) for each descriptor.
+//
+// This must be used in conjunction with [Transform].
+func IgnoreDescriptors(descs ...protoreflect.Descriptor) cmp.Option {
+	return cmp.FilterPath(newNameFilters(descs...).Filter, cmp.Ignore())
+}
+
+func mustFindFieldDescriptor(md protoreflect.MessageDescriptor, s protoreflect.Name) protoreflect.FieldDescriptor {
+	d := findDescriptor(md, s)
+	if fd, ok := d.(protoreflect.FieldDescriptor); ok && fd.TextName() == string(s) {
+		return fd
+	}
+
+	var suggestion string
+	switch d := d.(type) {
+	case protoreflect.FieldDescriptor:
+		suggestion = fmt.Sprintf("; consider specifying field %q instead", d.TextName())
+	case protoreflect.OneofDescriptor:
+		suggestion = fmt.Sprintf("; consider specifying oneof %q with IgnoreOneofs instead", d.Name())
+	}
+	panic(fmt.Sprintf("message %q has no field %q%s", md.FullName(), s, suggestion))
+}
+
+func mustFindOneofDescriptor(md protoreflect.MessageDescriptor, s protoreflect.Name) protoreflect.OneofDescriptor {
+	d := findDescriptor(md, s)
+	if od, ok := d.(protoreflect.OneofDescriptor); ok && d.Name() == s {
+		return od
+	}
+
+	var suggestion string
+	switch d := d.(type) {
+	case protoreflect.OneofDescriptor:
+		suggestion = fmt.Sprintf("; consider specifying oneof %q instead", d.Name())
+	case protoreflect.FieldDescriptor:
+		suggestion = fmt.Sprintf("; consider specifying field %q with IgnoreFields instead", d.TextName())
+	}
+	panic(fmt.Sprintf("message %q has no oneof %q%s", md.FullName(), s, suggestion))
+}
+
+func findDescriptor(md protoreflect.MessageDescriptor, s protoreflect.Name) protoreflect.Descriptor {
+	// Exact match.
+	if fd := md.Fields().ByTextName(string(s)); fd != nil {
+		return fd
+	}
+	if od := md.Oneofs().ByName(s); od != nil && !od.IsSynthetic() {
+		return od
+	}
+
+	// Best-effort match.
+	//
+	// It's a common user mistake to use the CamelCased field name as it appears
+	// in the generated Go struct. Instead of complaining that it doesn't exist,
+	// suggest the real protobuf name that the user may have desired.
+	normalize := func(s protoreflect.Name) string {
+		return strings.Replace(strings.ToLower(string(s)), "_", "", -1)
+	}
+	for i := 0; i < md.Fields().Len(); i++ {
+		if fd := md.Fields().Get(i); normalize(fd.Name()) == normalize(s) {
+			return fd
+		}
+	}
+	for i := 0; i < md.Oneofs().Len(); i++ {
+		if od := md.Oneofs().Get(i); normalize(od.Name()) == normalize(s) {
+			return od
+		}
+	}
+	return nil
+}
+
+type nameFilters struct {
+	names map[protoreflect.FullName]bool
+}
+
+func newNameFilters(descs ...protoreflect.Descriptor) *nameFilters {
+	f := &nameFilters{names: make(map[protoreflect.FullName]bool)}
+	for _, d := range descs {
+		switch d := d.(type) {
+		case protoreflect.EnumDescriptor:
+			f.names[d.FullName()] = true
+		case protoreflect.MessageDescriptor:
+			f.names[d.FullName()] = true
+		case protoreflect.FieldDescriptor:
+			f.names[d.FullName()] = true
+		case protoreflect.OneofDescriptor:
+			for i := 0; i < d.Fields().Len(); i++ {
+				f.names[d.Fields().Get(i).FullName()] = true
+			}
+		default:
+			panic("invalid descriptor type")
+		}
+	}
+	return f
+}
+
+func (f *nameFilters) Filter(p cmp.Path) bool {
+	vx, vy := p.Last().Values()
+	return (f.filterValue(vx) && f.filterValue(vy)) || f.filterFields(p)
+}
+
+func (f *nameFilters) filterFields(p cmp.Path) bool {
+	// Trim off trailing type-assertions so that the filter can match on the
+	// concrete value held within an interface value.
+	if _, ok := p.Last().(cmp.TypeAssertion); ok {
+		p = p[:len(p)-1]
+	}
+
+	// Filter for Message maps.
+	mi, ok := p.Index(-1).(cmp.MapIndex)
+	if !ok {
+		return false
+	}
+	ps := p.Index(-2)
+	if ps.Type() != messageReflectType {
+		return false
+	}
+
+	// Check field name.
+	vx, vy := ps.Values()
+	mx := vx.Interface().(Message)
+	my := vy.Interface().(Message)
+	k := mi.Key().String()
+	if f.filterFieldName(mx, k) && f.filterFieldName(my, k) {
+		return true
+	}
+
+	// Check field value.
+	vx, vy = mi.Values()
+	if f.filterFieldValue(vx) && f.filterFieldValue(vy) {
+		return true
+	}
+
+	return false
+}
+
+func (f *nameFilters) filterFieldName(m Message, k string) bool {
+	if _, ok := m[k]; !ok {
+		return true // treat missing fields as already filtered
+	}
+	var fd protoreflect.FieldDescriptor
+	switch mm := m[messageTypeKey].(messageMeta); {
+	case protoreflect.Name(k).IsValid():
+		fd = mm.md.Fields().ByTextName(k)
+	default:
+		fd = mm.xds[k]
+	}
+	if fd != nil {
+		return f.names[fd.FullName()]
+	}
+	return false
+}
+
+func (f *nameFilters) filterFieldValue(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true // implies missing slice element or map entry
+	}
+	v = v.Elem() // map entries are always populated values
+	switch t := v.Type(); {
+	case t == enumReflectType || t == messageReflectType:
+		// Check for singular message or enum field.
+		return f.filterValue(v)
+	case t.Kind() == reflect.Slice && (t.Elem() == enumReflectType || t.Elem() == messageReflectType):
+		// Check for list field of enum or message type.
+		return f.filterValue(v.Index(0))
+	case t.Kind() == reflect.Map && (t.Elem() == enumReflectType || t.Elem() == messageReflectType):
+		// Check for map field of enum or message type.
+		return f.filterValue(v.MapIndex(v.MapKeys()[0]))
+	}
+	return false
+}
+
+func (f *nameFilters) filterValue(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true // implies missing slice element or map entry
+	}
+	if !v.CanInterface() {
+		return false // implies unexported struct field
+	}
+	switch v := v.Interface().(type) {
+	case Enum:
+		return v.Descriptor() != nil && f.names[v.Descriptor().FullName()]
+	case Message:
+		return v.Descriptor() != nil && f.names[v.Descriptor().FullName()]
+	}
+	return false
+}
+
+// IgnoreDefaultScalars ignores singular scalars that are unpopulated or
+// explicitly set to the default value.
+// This option does not effect elements in a list or entries in a map.
+//
+// This must be used in conjunction with [Transform].
+func IgnoreDefaultScalars() cmp.Option {
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		// Filter for Message maps.
+		mi, ok := p.Index(-1).(cmp.MapIndex)
+		if !ok {
+			return false
+		}
+		ps := p.Index(-2)
+		if ps.Type() != messageReflectType {
+			return false
+		}
+
+		// Check whether both fields are default or unpopulated scalars.
+		vx, vy := ps.Values()
+		mx := vx.Interface().(Message)
+		my := vy.Interface().(Message)
+		k := mi.Key().String()
+		return isDefaultScalar(mx, k) && isDefaultScalar(my, k)
+	}, cmp.Ignore())
+}
+
+func isDefaultScalar(m Message, k string) bool {
+	if _, ok := m[k]; !ok {
+		return true
+	}
+
+	var fd protoreflect.FieldDescriptor
+	switch mm := m[messageTypeKey].(messageMeta); {
+	case protoreflect.Name(k).IsValid():
+		fd = mm.md.Fields().ByTextName(k)
+	default:
+		fd = mm.xds[k]
+	}
+	if fd == nil || !fd.Default().IsValid() {
+		return false
+	}
+	switch fd.Kind() {
+	case protoreflect.BytesKind:
+		v, ok := m[k].([]byte)
+		return ok && bytes.Equal(fd.Default().Bytes(), v)
+	case protoreflect.FloatKind:
+		v, ok := m[k].(float32)
+		return ok && equalFloat64(fd.Default().Float(), float64(v))
+	case protoreflect.DoubleKind:
+		v, ok := m[k].(float64)
+		return ok && equalFloat64(fd.Default().Float(), float64(v))
+	case protoreflect.EnumKind:
+		v, ok := m[k].(Enum)
+		return ok && fd.Default().Enum() == v.Number()
+	default:
+		return reflect.DeepEqual(fd.Default().Interface(), m[k])
+	}
+}
+
+func equalFloat64(x, y float64) bool {
+	return x == y || (math.IsNaN(x) && math.IsNaN(y))
+}
+
+// IgnoreEmptyMessages ignores messages that are empty or unpopulated.
+// It applies to standalone [Message] values, singular message fields,
+// list fields of messages, and map fields of message values.
+//
+// This must be used in conjunction with [Transform].
+func IgnoreEmptyMessages() cmp.Option {
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		vx, vy := p.Last().Values()
+		return (isEmptyMessage(vx) && isEmptyMessage(vy)) || isEmptyMessageFields(p)
+	}, cmp.Ignore())
+}
+
+func isEmptyMessageFields(p cmp.Path) bool {
+	// Filter for Message maps.
+	mi, ok := p.Index(-1).(cmp.MapIndex)
+	if !ok {
+		return false
+	}
+	ps := p.Index(-2)
+	if ps.Type() != messageReflectType {
+		return false
+	}
+
+	// Check field value.
+	vx, vy := mi.Values()
+	if isEmptyMessageFieldValue(vx) && isEmptyMessageFieldValue(vy) {
+		return true
+	}
+
+	return false
+}
+
+func isEmptyMessageFieldValue(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true // implies missing slice element or map entry
+	}
+	v = v.Elem() // map entries are always populated values
+	switch t := v.Type(); {
+	case t == messageReflectType:
+		// Check singular field for empty message.
+		if !isEmptyMessage(v) {
+			return false
+		}
+	case t.Kind() == reflect.Slice && t.Elem() == messageReflectType:
+		// Check list field for all empty message elements.
+		for i := 0; i < v.Len(); i++ {
+			if !isEmptyMessage(v.Index(i)) {
+				return false
+			}
+		}
+	case t.Kind() == reflect.Map && t.Elem() == messageReflectType:
+		// Check map field for all empty message values.
+		for _, k := range v.MapKeys() {
+			if !isEmptyMessage(v.MapIndex(k)) {
+				return false
+			}
+		}
+	default:
+		return false
+	}
+	return true
+}
+
+func isEmptyMessage(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true // implies missing slice element or map entry
+	}
+	if !v.CanInterface() {
+		return false // implies unexported struct field
+	}
+	if m, ok := v.Interface().(Message); ok {
+		for k := range m {
+			if k != messageTypeKey && k != messageInvalidKey {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// IgnoreUnknown ignores unknown fields in all messages.
+//
+// This must be used in conjunction with [Transform].
+func IgnoreUnknown() cmp.Option {
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		// Filter for Message maps.
+		mi, ok := p.Index(-1).(cmp.MapIndex)
+		if !ok {
+			return false
+		}
+		ps := p.Index(-2)
+		if ps.Type() != messageReflectType {
+			return false
+		}
+
+		// Filter for unknown fields (which always have a numeric map key).
+		return strings.Trim(mi.Key().String(), "0123456789") == ""
+	}, cmp.Ignore())
+}
+
+// SortRepeated sorts repeated fields of the specified element type.
+// The less function must be of the form "func(T, T) bool" where T is the
+// Go element type for the repeated field kind.
+//
+// The element type T can be one of the following:
+//   - Go type for a protobuf scalar kind except for an enum
+//     (i.e., bool, int32, int64, uint32, uint64, float32, float64, string, and []byte)
+//   - E where E is a concrete enum type that implements [protoreflect.Enum]
+//   - M where M is a concrete message type that implement [proto.Message]
+//
+// This option only applies to repeated fields within a protobuf message.
+// It does not operate on higher-order Go types that seem like a repeated field.
+// For example, a []T outside the context of a protobuf message will not be
+// handled by this option. To sort Go slices that are not repeated fields,
+// consider using [github.com/google/go-cmp/cmp/cmpopts.SortSlices] instead.
+//
+// The sorting of messages does not take into account ignored fields or oneofs
+// as a result of [IgnoreFields] or [IgnoreOneofs].
+//
+// This must be used in conjunction with [Transform].
+func SortRepeated(lessFunc any) cmp.Option {
+	t, ok := checkTTBFunc(lessFunc)
+	if !ok {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+
+	var opt cmp.Option
+	var sliceType reflect.Type
+	switch vf := reflect.ValueOf(lessFunc); {
+	case t.Implements(enumV2Type):
+		et := reflect.Zero(t).Interface().(protoreflect.Enum).Type()
+		lessFunc = func(x, y Enum) bool {
+			vx := reflect.ValueOf(et.New(x.Number()))
+			vy := reflect.ValueOf(et.New(y.Number()))
+			return vf.Call([]reflect.Value{vx, vy})[0].Bool()
+		}
+		opt = FilterDescriptor(et.Descriptor(), cmpopts.SortSlices(lessFunc))
+		sliceType = reflect.SliceOf(enumReflectType)
+	case t.Implements(messageV2Type):
+		mt := reflect.Zero(t).Interface().(protoreflect.ProtoMessage).ProtoReflect().Type()
+		lessFunc = func(x, y Message) bool {
+			mx := mt.New().Interface()
+			my := mt.New().Interface()
+			proto.Merge(mx, x)
+			proto.Merge(my, y)
+			vx := reflect.ValueOf(mx)
+			vy := reflect.ValueOf(my)
+			return vf.Call([]reflect.Value{vx, vy})[0].Bool()
+		}
+		opt = FilterDescriptor(mt.Descriptor(), cmpopts.SortSlices(lessFunc))
+		sliceType = reflect.SliceOf(messageReflectType)
+	default:
+		switch t {
+		case reflect.TypeOf(bool(false)):
+		case reflect.TypeOf(int32(0)):
+		case reflect.TypeOf(int64(0)):
+		case reflect.TypeOf(uint32(0)):
+		case reflect.TypeOf(uint64(0)):
+		case reflect.TypeOf(float32(0)):
+		case reflect.TypeOf(float64(0)):
+		case reflect.TypeOf(string("")):
+		case reflect.TypeOf([]byte(nil)):
+		default:
+			panic(fmt.Sprintf("invalid element type: %v", t))
+		}
+		opt = cmpopts.SortSlices(lessFunc)
+		sliceType = reflect.SliceOf(t)
+	}
+
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		// Filter to only apply to repeated fields within a message.
+		if t := p.Index(-1).Type(); t == nil || t != sliceType {
+			return false
+		}
+		if t := p.Index(-2).Type(); t == nil || t.Kind() != reflect.Interface {
+			return false
+		}
+		if t := p.Index(-3).Type(); t == nil || t != messageReflectType {
+			return false
+		}
+		return true
+	}, opt)
+}
+
+func checkTTBFunc(lessFunc any) (reflect.Type, bool) {
+	switch t := reflect.TypeOf(lessFunc); {
+	case t == nil:
+		return nil, false
+	case t.NumIn() != 2 || t.In(0) != t.In(1) || t.IsVariadic():
+		return nil, false
+	case t.NumOut() != 1 || t.Out(0) != reflect.TypeOf(false):
+		return nil, false
+	default:
+		return t.In(0), true
+	}
+}
+
+// SortRepeatedFields sorts the specified repeated fields.
+// Sorting a repeated field is useful for treating the list as a multiset
+// (i.e., a set where each value can appear multiple times).
+// It panics if the field does not exist or is not a repeated field.
+//
+// The sort ordering is as follows:
+//   - Booleans are sorted where false is sorted before true.
+//   - Integers are sorted in ascending order.
+//   - Floating-point numbers are sorted in ascending order according to
+//     the total ordering defined by IEEE-754 (section 5.10).
+//   - Strings and bytes are sorted lexicographically in ascending order.
+//   - [Enum] values are sorted in ascending order based on its numeric value.
+//   - [Message] values are sorted according to some arbitrary ordering
+//     which is undefined and may change in future implementations.
+//
+// The ordering chosen for repeated messages is unlikely to be aesthetically
+// preferred by humans. Consider using a custom sort function:
+//
+//	FilterField(m, "foo_field", SortRepeated(func(x, y *foopb.MyMessage) bool {
+//	    ... // user-provided definition for less
+//	}))
+//
+// The sorting of messages does not take into account ignored fields or oneofs
+// as a result of [IgnoreFields] or [IgnoreOneofs].
+//
+// This must be used in conjunction with [Transform].
+func SortRepeatedFields(message proto.Message, names ...protoreflect.Name) cmp.Option {
+	var opts cmp.Options
+	md := message.ProtoReflect().Descriptor()
+	for _, name := range names {
+		fd := mustFindFieldDescriptor(md, name)
+		if !fd.IsList() {
+			panic(fmt.Sprintf("message field %q is not repeated", fd.FullName()))
+		}
+
+		var lessFunc any
+		switch fd.Kind() {
+		case protoreflect.BoolKind:
+			lessFunc = func(x, y bool) bool { return !x && y }
+		case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+			lessFunc = func(x, y int32) bool { return x < y }
+		case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+			lessFunc = func(x, y int64) bool { return x < y }
+		case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+			lessFunc = func(x, y uint32) bool { return x < y }
+		case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+			lessFunc = func(x, y uint64) bool { return x < y }
+		case protoreflect.FloatKind:
+			lessFunc = lessF32
+		case protoreflect.DoubleKind:
+			lessFunc = lessF64
+		case protoreflect.StringKind:
+			lessFunc = func(x, y string) bool { return x < y }
+		case protoreflect.BytesKind:
+			lessFunc = func(x, y []byte) bool { return bytes.Compare(x, y) < 0 }
+		case protoreflect.EnumKind:
+			lessFunc = func(x, y Enum) bool { return x.Number() < y.Number() }
+		case protoreflect.MessageKind, protoreflect.GroupKind:
+			lessFunc = func(x, y Message) bool { return x.String() < y.String() }
+		default:
+			panic(fmt.Sprintf("invalid kind: %v", fd.Kind()))
+		}
+		opts = append(opts, FilterDescriptor(fd, cmpopts.SortSlices(lessFunc)))
+	}
+	return opts
+}
+
+func lessF32(x, y float32) bool {
+	// Bit-wise implementation of IEEE-754, section 5.10.
+	xi := int32(math.Float32bits(x))
+	yi := int32(math.Float32bits(y))
+	xi ^= int32(uint32(xi>>31) >> 1)
+	yi ^= int32(uint32(yi>>31) >> 1)
+	return xi < yi
+}
+func lessF64(x, y float64) bool {
+	// Bit-wise implementation of IEEE-754, section 5.10.
+	xi := int64(math.Float64bits(x))
+	yi := int64(math.Float64bits(y))
+	xi ^= int64(uint64(xi>>63) >> 1)
+	yi ^= int64(uint64(yi>>63) >> 1)
+	return xi < yi
+}

--- a/vendor/google.golang.org/protobuf/testing/protocmp/xform.go
+++ b/vendor/google.golang.org/protobuf/testing/protocmp/xform.go
@@ -1,0 +1,377 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package protocmp provides protobuf specific options for the
+// [github.com/google/go-cmp/cmp] package.
+//
+// The primary feature is the [Transform] option, which transform [proto.Message]
+// types into a [Message] map that is suitable for cmp to introspect upon.
+// All other options in this package must be used in conjunction with [Transform].
+package protocmp
+
+import (
+	"reflect"
+	"strconv"
+
+	"github.com/google/go-cmp/cmp"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/internal/genid"
+	"google.golang.org/protobuf/internal/msgfmt"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/runtime/protoiface"
+	"google.golang.org/protobuf/runtime/protoimpl"
+)
+
+var (
+	enumV2Type    = reflect.TypeOf((*protoreflect.Enum)(nil)).Elem()
+	messageV1Type = reflect.TypeOf((*protoiface.MessageV1)(nil)).Elem()
+	messageV2Type = reflect.TypeOf((*proto.Message)(nil)).Elem()
+)
+
+// Enum is a dynamic representation of a protocol buffer enum that is
+// suitable for [cmp.Equal] and [cmp.Diff] to compare upon.
+type Enum struct {
+	num protoreflect.EnumNumber
+	ed  protoreflect.EnumDescriptor
+}
+
+// Descriptor returns the enum descriptor.
+// It returns nil for a zero Enum value.
+func (e Enum) Descriptor() protoreflect.EnumDescriptor {
+	return e.ed
+}
+
+// Number returns the enum value as an integer.
+func (e Enum) Number() protoreflect.EnumNumber {
+	return e.num
+}
+
+// Equal reports whether e1 and e2 represent the same enum value.
+func (e1 Enum) Equal(e2 Enum) bool {
+	if e1.ed.FullName() != e2.ed.FullName() {
+		return false
+	}
+	return e1.num == e2.num
+}
+
+// String returns the name of the enum value if known (e.g., "ENUM_VALUE"),
+// otherwise it returns the formatted decimal enum number (e.g., "14").
+func (e Enum) String() string {
+	if ev := e.ed.Values().ByNumber(e.num); ev != nil {
+		return string(ev.Name())
+	}
+	return strconv.Itoa(int(e.num))
+}
+
+const (
+	// messageTypeKey indicates the protobuf message type.
+	// The value type is always messageMeta.
+	// From the public API, it presents itself as only the type, but the
+	// underlying data structure holds arbitrary metadata about the message.
+	messageTypeKey = "@type"
+
+	// messageInvalidKey indicates that the message is invalid.
+	// The value is always the boolean "true".
+	messageInvalidKey = "@invalid"
+)
+
+type messageMeta struct {
+	m   proto.Message
+	md  protoreflect.MessageDescriptor
+	xds map[string]protoreflect.ExtensionDescriptor
+}
+
+func (t messageMeta) String() string {
+	return string(t.md.FullName())
+}
+
+func (t1 messageMeta) Equal(t2 messageMeta) bool {
+	return t1.md.FullName() == t2.md.FullName()
+}
+
+// Message is a dynamic representation of a protocol buffer message that is
+// suitable for [cmp.Equal] and [cmp.Diff] to directly operate upon.
+//
+// Every populated known field (excluding extension fields) is stored in the map
+// with the key being the short name of the field (e.g., "field_name") and
+// the value determined by the kind and cardinality of the field.
+//
+// Singular scalars are represented by the same Go type as [protoreflect.Value],
+// singular messages are represented by the [Message] type,
+// singular enums are represented by the [Enum] type,
+// list fields are represented as a Go slice, and
+// map fields are represented as a Go map.
+//
+// Every populated extension field is stored in the map with the key being the
+// full name of the field surrounded by brackets (e.g., "[extension.full.name]")
+// and the value determined according to the same rules as known fields.
+//
+// Every unknown field is stored in the map with the key being the field number
+// encoded as a decimal string (e.g., "132") and the value being the raw bytes
+// of the encoded field (as the [protoreflect.RawFields] type).
+//
+// Message values must not be created by or mutated by users.
+type Message map[string]any
+
+// Unwrap returns the original message value.
+// It returns nil if this Message was not constructed from another message.
+func (m Message) Unwrap() proto.Message {
+	mm, _ := m[messageTypeKey].(messageMeta)
+	return mm.m
+}
+
+// Descriptor return the message descriptor.
+// It returns nil for a zero Message value.
+func (m Message) Descriptor() protoreflect.MessageDescriptor {
+	mm, _ := m[messageTypeKey].(messageMeta)
+	return mm.md
+}
+
+// ProtoReflect returns a reflective view of m.
+// It only implements the read-only operations of [protoreflect.Message].
+// Calling any mutating operations on m panics.
+func (m Message) ProtoReflect() protoreflect.Message {
+	return (reflectMessage)(m)
+}
+
+// ProtoMessage is a marker method from the legacy message interface.
+func (m Message) ProtoMessage() {}
+
+// Reset is the required Reset method from the legacy message interface.
+func (m Message) Reset() {
+	panic("invalid mutation of a read-only message")
+}
+
+// String returns a formatted string for the message.
+// It is intended for human debugging and has no guarantees about its
+// exact format or the stability of its output.
+func (m Message) String() string {
+	switch {
+	case m == nil:
+		return "<nil>"
+	case !m.ProtoReflect().IsValid():
+		return "<invalid>"
+	default:
+		return msgfmt.Format(m)
+	}
+}
+
+type transformer struct {
+	resolver protoregistry.MessageTypeResolver
+}
+
+func newTransformer(opts ...option) *transformer {
+	xf := &transformer{
+		resolver: protoregistry.GlobalTypes,
+	}
+	for _, opt := range opts {
+		opt(xf)
+	}
+	return xf
+}
+
+type option func(*transformer)
+
+// MessageTypeResolver overrides the resolver used for messages packed
+// inside Any. The default is protoregistry.GlobalTypes, which is
+// sufficient for all compiled-in Protobuf messages. Overriding the
+// resolver is useful in tests that dynamically create Protobuf
+// descriptors and messages, e.g. in proxies using dynamicpb.
+func MessageTypeResolver(r protoregistry.MessageTypeResolver) option {
+	return func(xf *transformer) {
+		xf.resolver = r
+	}
+}
+
+// Transform returns a [cmp.Option] that converts each [proto.Message] to a [Message].
+// The transformation does not mutate nor alias any converted messages.
+//
+// The google.protobuf.Any message is automatically unmarshaled such that the
+// "value" field is a [Message] representing the underlying message value
+// assuming it could be resolved and properly unmarshaled.
+//
+// This does not directly transform higher-order composite Go types.
+// For example, []*foopb.Message is not transformed into []Message,
+// but rather the individual message elements of the slice are transformed.
+func Transform(opts ...option) cmp.Option {
+	xf := newTransformer(opts...)
+
+	// addrType returns a pointer to t if t isn't a pointer or interface.
+	addrType := func(t reflect.Type) reflect.Type {
+		if k := t.Kind(); k == reflect.Interface || k == reflect.Ptr {
+			return t
+		}
+		return reflect.PtrTo(t)
+	}
+
+	// TODO: Should this transform protoreflect.Enum types to Enum as well?
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		ps := p.Last()
+		if isMessageType(addrType(ps.Type())) {
+			return true
+		}
+
+		// Check whether the concrete values of an interface both satisfy
+		// the Message interface.
+		if ps.Type().Kind() == reflect.Interface {
+			vx, vy := ps.Values()
+			if !vx.IsValid() || vx.IsNil() || !vy.IsValid() || vy.IsNil() {
+				return false
+			}
+			return isMessageType(addrType(vx.Elem().Type())) && isMessageType(addrType(vy.Elem().Type()))
+		}
+
+		return false
+	}, cmp.Transformer("protocmp.Transform", func(v any) Message {
+		// For user convenience, shallow copy the message value if necessary
+		// in order for it to implement the message interface.
+		if rv := reflect.ValueOf(v); rv.IsValid() && rv.Kind() != reflect.Ptr && !isMessageType(rv.Type()) {
+			pv := reflect.New(rv.Type())
+			pv.Elem().Set(rv)
+			v = pv.Interface()
+		}
+
+		m := protoimpl.X.MessageOf(v)
+		switch {
+		case m == nil:
+			return nil
+		case !m.IsValid():
+			return Message{messageTypeKey: messageMeta{m: m.Interface(), md: m.Descriptor()}, messageInvalidKey: true}
+		default:
+			return xf.transformMessage(m)
+		}
+	}))
+}
+
+func isMessageType(t reflect.Type) bool {
+	// Avoid transforming the Message itself.
+	if t == reflect.TypeOf(Message(nil)) || t == reflect.TypeOf((*Message)(nil)) {
+		return false
+	}
+	return t.Implements(messageV1Type) || t.Implements(messageV2Type)
+}
+
+func (xf *transformer) transformMessage(m protoreflect.Message) Message {
+	mx := Message{}
+	mt := messageMeta{m: m.Interface(), md: m.Descriptor(), xds: make(map[string]protoreflect.FieldDescriptor)}
+
+	// Handle known and extension fields.
+	m.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		s := fd.TextName()
+		if fd.IsExtension() {
+			mt.xds[s] = fd
+		}
+		switch {
+		case fd.IsList():
+			mx[s] = xf.transformList(fd, v.List())
+		case fd.IsMap():
+			mx[s] = xf.transformMap(fd, v.Map())
+		default:
+			mx[s] = xf.transformSingular(fd, v)
+		}
+		return true
+	})
+
+	// Handle unknown fields.
+	for b := m.GetUnknown(); len(b) > 0; {
+		num, _, n := protowire.ConsumeField(b)
+		s := strconv.Itoa(int(num))
+		b2, _ := mx[s].(protoreflect.RawFields)
+		mx[s] = append(b2, b[:n]...)
+		b = b[n:]
+	}
+
+	// Expand Any messages.
+	if mt.md.FullName() == genid.Any_message_fullname {
+		s, _ := mx[string(genid.Any_TypeUrl_field_name)].(string)
+		b, _ := mx[string(genid.Any_Value_field_name)].([]byte)
+		mt, err := xf.resolver.FindMessageByURL(s)
+		if mt != nil && err == nil {
+			m2 := mt.New()
+			err := proto.UnmarshalOptions{AllowPartial: true}.Unmarshal(b, m2.Interface())
+			if err == nil {
+				mx[string(genid.Any_Value_field_name)] = xf.transformMessage(m2)
+			}
+		}
+	}
+
+	mx[messageTypeKey] = mt
+	return mx
+}
+
+func (xf *transformer) transformList(fd protoreflect.FieldDescriptor, lv protoreflect.List) any {
+	t := protoKindToGoType(fd.Kind())
+	rv := reflect.MakeSlice(reflect.SliceOf(t), lv.Len(), lv.Len())
+	for i := 0; i < lv.Len(); i++ {
+		v := reflect.ValueOf(xf.transformSingular(fd, lv.Get(i)))
+		rv.Index(i).Set(v)
+	}
+	return rv.Interface()
+}
+
+func (xf *transformer) transformMap(fd protoreflect.FieldDescriptor, mv protoreflect.Map) any {
+	kfd := fd.MapKey()
+	vfd := fd.MapValue()
+	kt := protoKindToGoType(kfd.Kind())
+	vt := protoKindToGoType(vfd.Kind())
+	rv := reflect.MakeMapWithSize(reflect.MapOf(kt, vt), mv.Len())
+	mv.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
+		kv := reflect.ValueOf(xf.transformSingular(kfd, k.Value()))
+		vv := reflect.ValueOf(xf.transformSingular(vfd, v))
+		rv.SetMapIndex(kv, vv)
+		return true
+	})
+	return rv.Interface()
+}
+
+func (xf *transformer) transformSingular(fd protoreflect.FieldDescriptor, v protoreflect.Value) any {
+	switch fd.Kind() {
+	case protoreflect.EnumKind:
+		return Enum{num: v.Enum(), ed: fd.Enum()}
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return xf.transformMessage(v.Message())
+	case protoreflect.BytesKind:
+		// The protoreflect API does not specify whether an empty bytes is
+		// guaranteed to be nil or not. Always return non-nil bytes to avoid
+		// leaking information about the concrete proto.Message implementation.
+		if len(v.Bytes()) == 0 {
+			return []byte{}
+		}
+		return v.Bytes()
+	default:
+		return v.Interface()
+	}
+}
+
+func protoKindToGoType(k protoreflect.Kind) reflect.Type {
+	switch k {
+	case protoreflect.BoolKind:
+		return reflect.TypeOf(bool(false))
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return reflect.TypeOf(int32(0))
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return reflect.TypeOf(int64(0))
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return reflect.TypeOf(uint32(0))
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return reflect.TypeOf(uint64(0))
+	case protoreflect.FloatKind:
+		return reflect.TypeOf(float32(0))
+	case protoreflect.DoubleKind:
+		return reflect.TypeOf(float64(0))
+	case protoreflect.StringKind:
+		return reflect.TypeOf(string(""))
+	case protoreflect.BytesKind:
+		return reflect.TypeOf([]byte(nil))
+	case protoreflect.EnumKind:
+		return reflect.TypeOf(Enum{})
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return reflect.TypeOf(Message{})
+	default:
+		panic("invalid kind")
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -381,6 +381,7 @@ github.com/google/deck
 # github.com/google/go-cmp v0.7.0
 ## explicit; go 1.21
 github.com/google/go-cmp/cmp
+github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
@@ -860,6 +861,7 @@ google.golang.org/protobuf/internal/filetype
 google.golang.org/protobuf/internal/flags
 google.golang.org/protobuf/internal/genid
 google.golang.org/protobuf/internal/impl
+google.golang.org/protobuf/internal/msgfmt
 google.golang.org/protobuf/internal/order
 google.golang.org/protobuf/internal/pragma
 google.golang.org/protobuf/internal/protolazy
@@ -873,6 +875,7 @@ google.golang.org/protobuf/reflect/protoreflect
 google.golang.org/protobuf/reflect/protoregistry
 google.golang.org/protobuf/runtime/protoiface
 google.golang.org/protobuf/runtime/protoimpl
+google.golang.org/protobuf/testing/protocmp
 google.golang.org/protobuf/types/descriptorpb
 google.golang.org/protobuf/types/dynamicpb
 google.golang.org/protobuf/types/gofeaturespb


### PR DESCRIPTION
The task plugin may send duplicate task events to a subscriber. The second event is generated by the shim delete command and currently it doesn't know when container exited and what its exit code is. So, it always returns 137 as exit code. It may leave subscribers unsure which event they should trust (see https://github.com/containerd/containerd/issues/6429).

This patch stores exit status into bundle state dir. The bundle state dir is recommended to be tmpfs. Ideally, the write syscall won't take too long.

Follow-up: https://github.com/containerd/containerd/pull/14020

```release-note
Avoid inaccurate duplicate task exit events from shim delete by recording exit status in bundle
```
