### PR TITLE
remotes/docker: fall back to direct upload on 403 Forbidden mount

### DIFF
--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -218,8 +218,8 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 			}
 			if resp != nil {
 				switch resp.StatusCode {
-				case http.StatusUnauthorized:
-					log.G(ctx).Debugf("failed to mount from repository %s, not authorized", fromRepo)
+				case http.StatusUnauthorized, http.StatusForbidden:
+					log.G(ctx).Debugf("failed to mount from repository %s, not authorized (status %d)", fromRepo, resp.StatusCode)
 
 					resp.Body.Close()
 					resp = nil

--- a/core/remotes/docker/pusher_test.go
+++ b/core/remotes/docker/pusher_test.go
@@ -279,6 +279,19 @@ func TestPusherInvalidAuthorizationOnMount(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "Registry returns 403 Forbidden on mount",
+			setup: func(t *testing.T, p *dockerPusher, reg *uploadableMockRegistry, triggered func()) {
+				reg.defaultHandlerFunc = func(w http.ResponseWriter, r *http.Request) bool {
+					if isCrossRepoMount(r) {
+						triggered()
+						w.WriteHeader(http.StatusForbidden)
+						return true
+					}
+					return false
+				}
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #14086

### Problem
When pushing an image where containerd attempts a cross-repository blob mount, some registries return `403 Forbidden` (instead of `401 Unauthorized`) when the authenticated user does not have read access to the mount source repository.

In `core/remotes/docker/pusher.go`, containerd only treated `401 Unauthorized` as a recoverable condition. Consequently, a `403 Forbidden` response on the mount attempt was unhandled, causing containerd to skip the fallback and fail the entire push with an unexpected response error (`unexpected status from POST request ...: 403 Forbidden`).

### Solution
Include `http.StatusForbidden` alongside `http.StatusUnauthorized` in the status switch when handling the cross-repository mount response in `pusher.go`. This allows containerd to cleanly close the response, reset `resp = nil`, and fall back to direct blob upload as expected.

### Testing
- Added unit test case `Registry returns 403 Forbidden on mount` to `TestPusherInvalidAuthorizationOnMount` in `core/remotes/docker/pusher_test.go`.
- Verified test fails before the fix (returns `403 Forbidden` error) and passes cleanly after the fix.
- All tests in `core/remotes/docker` pass cleanly.

Signed-off-by: Soumyajit Ghosh <jobsoumyajit6124@gmail.com>