### PR TITLE
integration/client: fix TestContainerExecLargeOutputWithTTY

### DIFF
--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -1977,6 +1977,8 @@ func TestContainerExecLargeOutputWithTTY(t *testing.T) {
 		if code != 0 {
 			t.Errorf("expected exec exit code 0 but received %d", code)
 		}
+		// Wait for all output to be copied before Delete cancels the IO.
+		process.IO().Wait()
 		if _, err := process.Delete(ctx); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Wait for IO copying to complete before deleting the exec process. Delete cancels outstanding IO operations, which can truncate the output.

```
=== NAME  TestContainerExecLargeOutputWithTTY
    container_test.go:1990: process output does not end with "999999 1000000" at iteration 1, here are the last 20 characters of the output:

         "1150 991151 991152 9"
--- FAIL: TestContainerExecLargeOutputWithTTY (2.00s)
```

In a follow-up, we should add comment for Delete API and document that the caller should take responsibility to drain IO before Delete.