### PR TITLE
cri: purge stale image references and handle missing content in Store.Update

### DIFF
--- a/internal/cri/store/image/image.go
+++ b/internal/cri/store/image/image.go
@@ -97,22 +97,93 @@ func NewStore(img Getter, provider content.InfoReaderProvider, platform platform
 
 // Update updates cache for a reference.
 func (s *Store) Update(ctx context.Context, ref string) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	i, err := s.images.Get(ctx, ref)
-	if err != nil && !errdefs.IsNotFound(err) {
-		return fmt.Errorf("get image from containerd: %w", err)
+	var (
+		i   images.Image
+		err error
+	)
+	if s.images != nil {
+		i, err = s.images.Get(ctx, ref)
+		if err != nil && !errdefs.IsNotFound(err) {
+			return fmt.Errorf("get image from containerd: %w", err)
+		}
+	} else {
+		err = errdefs.ErrNotFound
 	}
 
 	var img *Image
 	if err == nil {
 		img, err = s.getImage(ctx, i)
 		if err != nil {
-			return fmt.Errorf("get image info from containerd: %w", err)
+			if errdefs.IsNotFound(err) {
+				img = nil
+			} else {
+				return fmt.Errorf("get image info from containerd: %w", err)
+			}
 		}
 	}
-	return s.update(ref, img)
+
+	var (
+		remainingToCheck []string
+		oldID            string
+	)
+
+	s.lock.Lock()
+	var oldExist bool
+	oldID, oldExist = s.refCache[ref]
+	if img == nil {
+		if oldExist {
+			s.store.delete(oldID, ref)
+			delete(s.refCache, ref)
+			if cached, err := s.store.get(oldID); err == nil {
+				remainingToCheck = append(remainingToCheck, cached.References...)
+			}
+		}
+	} else {
+		if err := s.update(ref, img); err != nil {
+			s.lock.Unlock()
+			return err
+		}
+	}
+	s.lock.Unlock()
+
+	if len(remainingToCheck) > 0 && s.images != nil {
+		missingRefs := make(map[string]bool)
+		var checkErr error
+
+		for _, r := range remainingToCheck {
+			_, err := s.images.Get(ctx, r)
+			if err == nil {
+				continue
+			}
+			if errdefs.IsNotFound(err) {
+				missingRefs[r] = true
+			} else {
+				checkErr = err
+				break
+			}
+		}
+
+		if checkErr != nil {
+			return fmt.Errorf("check remaining image references: %w", checkErr)
+		}
+
+		if len(missingRefs) > 0 {
+			s.lock.Lock()
+			for _, r := range remainingToCheck {
+				if !missingRefs[r] {
+					continue
+				}
+				if currID, ok := s.refCache[r]; !ok || currID != oldID {
+					continue
+				}
+				s.store.delete(oldID, r)
+				delete(s.refCache, r)
+			}
+			s.lock.Unlock()
+		}
+	}
+
+	return nil
 }
 
 // update updates the internal cache. img == nil means that

--- a/internal/cri/store/image/image_test.go
+++ b/internal/cri/store/image/image_test.go
@@ -17,13 +17,20 @@
 package image
 
 import (
+	"context"
+	"errors"
 	"sort"
 	"strings"
 	"testing"
 
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
 
+	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/go-digest/digestset"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	assertlib "github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -315,4 +322,151 @@ func TestImageStore(t *testing.T) {
 			}
 		})
 	}
+}
+
+type fakeGetter struct {
+	imgs map[string]images.Image
+	errs map[string]error
+}
+
+func (f *fakeGetter) Get(ctx context.Context, name string) (images.Image, error) {
+	if f.errs != nil {
+		if err, ok := f.errs[name]; ok {
+			return images.Image{}, err
+		}
+	}
+	img, ok := f.imgs[name]
+	if !ok {
+		return images.Image{}, errdefs.ErrNotFound
+	}
+	return img, nil
+}
+
+type fakeContentProvider struct {
+	err error
+}
+
+func (f *fakeContentProvider) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	if f.err != nil {
+		return content.Info{}, f.err
+	}
+	return content.Info{}, errdefs.ErrNotFound
+}
+
+func (f *fakeContentProvider) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return nil, errdefs.ErrNotFound
+}
+
+func TestStoreUpdateMissingContent(t *testing.T) {
+	assert := assertlib.New(t)
+	ctx := context.Background()
+	imgID := "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	ref := "containerd.io/ref-missing-content"
+
+	getter := &fakeGetter{
+		imgs: map[string]images.Image{
+			ref: {
+				Name: ref,
+				Target: ocispec.Descriptor{
+					Digest: digest.Digest(imgID),
+				},
+			},
+		},
+	}
+	provider := &fakeContentProvider{err: errdefs.ErrNotFound}
+
+	s := NewStore(getter, provider, platforms.Default())
+	// Pre-populate store cache with image
+	s.refCache[ref] = imgID
+	assert.NoError(s.store.add(Image{
+		ID:         imgID,
+		References: []string{ref},
+	}))
+
+	// Verify image exists in cache before Update
+	_, err := s.Get(imgID)
+	assert.NoError(err)
+
+	// Update should catch missing content (ErrNotFound from getImage) and purge ref from cache
+	err = s.Update(ctx, ref)
+	assert.NoError(err)
+
+	// Image should no longer exist in cache
+	_, err = s.Get(imgID)
+	assert.Equal(errdefs.ErrNotFound, err)
+	_, err = s.Resolve(ref)
+	assert.Equal(errdefs.ErrNotFound, err)
+}
+
+func TestStoreUpdateStaleReferences(t *testing.T) {
+	assert := assertlib.New(t)
+	ctx := context.Background()
+	imgID := "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	ref1 := "containerd.io/primary"
+	ref2 := "containerd.io/extra@sha256:1123456789abcdef"
+
+	// containerd store has NO images left (both ref1 and ref2 were deleted outside CRI)
+	getter := &fakeGetter{
+		imgs: map[string]images.Image{},
+	}
+	provider := &fakeContentProvider{}
+
+	s := NewStore(getter, provider, platforms.Default())
+	// Cache contains image with BOTH references
+	s.refCache[ref1] = imgID
+	s.refCache[ref2] = imgID
+	assert.NoError(s.store.add(Image{
+		ID:         imgID,
+		References: []string{ref1, ref2},
+	}))
+
+	// Update called for ref1
+	err := s.Update(ctx, ref1)
+	assert.NoError(err)
+
+	// Since ref2 is ALSO deleted from containerd, s.Update should clean up all stale references and remove imgID
+	_, err = s.Get(imgID)
+	assert.Equal(errdefs.ErrNotFound, err)
+	_, err = s.Resolve(ref1)
+	assert.Equal(errdefs.ErrNotFound, err)
+	_, err = s.Resolve(ref2)
+	assert.Equal(errdefs.ErrNotFound, err)
+}
+
+func TestStoreUpdateTransientError(t *testing.T) {
+	assert := assertlib.New(t)
+	ctx := context.Background()
+	imgID := "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	ref1 := "containerd.io/primary"
+	ref2 := "containerd.io/extra@sha256:1123456789abcdef"
+
+	transientErr := errors.New("transient database connection error")
+	getter := &fakeGetter{
+		imgs: map[string]images.Image{},
+		errs: map[string]error{
+			ref2: transientErr,
+		},
+	}
+	provider := &fakeContentProvider{}
+
+	s := NewStore(getter, provider, platforms.Default())
+	s.refCache[ref1] = imgID
+	s.refCache[ref2] = imgID
+	assert.NoError(s.store.add(Image{
+		ID:         imgID,
+		References: []string{ref1, ref2},
+	}))
+
+	// Update called for ref1 (which was deleted), but checking ref2 returns a transient error
+	err := s.Update(ctx, ref1)
+	assert.Error(err)
+	assert.True(errors.Is(err, transientErr) || strings.Contains(err.Error(), transientErr.Error()))
+
+	// ref2 was NOT confirmed missing due to the transient error, so ref2 must NOT be purged from cache
+	resolvedID, err := s.Resolve(ref2)
+	assert.NoError(err)
+	assert.Equal(imgID, resolvedID)
 }


### PR DESCRIPTION
### What this PR does / why we need it

When an image is imported via `ctr image import --index-name foo data.tar`, containerd creates a primary index reference (`foo`) and extra reference(s) (e.g. `import-<date>@sha256:...`) tied via `containerd.io/gc.bref.image = "foo"`.

When `ctr image rm foo` is executed, containerd's metadata store and GC delete `foo` and its extra references. However, CRI's `imagestore.Store` remained stuck with stale entries because:

1. `Store.Update` held `s.lock.Lock()` during content fetching (`s.getImage`), causing unnecessary lock contention.
2. `s.getImage` erroring on missing content (e.g., `errdefs.ErrNotFound`) was propagated as an error rather than clearing `img`, leaving deleted images in CRI's in-memory store.
3. Deleting an index reference only deleted that single reference from the cached `Image.References` slice without validating if the remaining extra references still existed in containerd.

This PR fixes these issues by:
- Reducing lock contention by executing containerd I/O (`s.images.Get` and `s.getImage`) outside `s.lock.Lock()`.
- Handling `errdefs.IsNotFound(err)` from `s.getImage` to set `img = nil`, properly purging missing content references from cache.
- Accessing the store safely via `s.store.get(oldID)` instead of accessing `s.store.images` directly under `s.lock`.
- Checking remaining image references outside the lock using `s.images.Get(ctx, r)` and only purging references when positively confirmed missing (`errdefs.IsNotFound`), safely ignoring transient errors.

Fixes: #14080

### Which issue(s) this PR fixes
Fixes #14080

### Special notes for your reviewer
- Added comprehensive unit tests in `internal/cri/store/image/image_test.go` covering missing content, stale index references, and transient error safety.
