### PR TITLE
metadata: guard sendLabelRefs against a nil bucket

### DIFF
--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -1109,7 +1109,7 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 // sendLabelRefs sends all snapshot and content references referred to by the labels in the bkt
 func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, cb labelRefCallbacks) error {
 	if bkt == nil {
-		return nil
+		return fmt.Errorf("nil label bucket in sendLabelRefs during GC")
 	}
 
 	lbkt := bkt.Bucket(bucketKeyObjectLabels)

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -1108,6 +1108,10 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 
 // sendLabelRefs sends all snapshot and content references referred to by the labels in the bkt
 func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, cb labelRefCallbacks) error {
+	if bkt == nil {
+		return nil
+	}
+
 	lbkt := bkt.Bucket(bucketKeyObjectLabels)
 	if lbkt != nil {
 		lc := lbkt.Cursor()

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -1109,7 +1109,7 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (any,
 // sendLabelRefs sends all snapshot and content references referred to by the labels in the bkt
 func (c *gcContext) sendLabelRefs(ns string, bkt *bolt.Bucket, cb labelRefCallbacks) error {
 	if bkt == nil {
-		return fmt.Errorf("nil label bucket in sendLabelRefs during GC")
+		return fmt.Errorf("sendLabelRefs: nil bucket (ns=%q)", ns)
 	}
 
 	lbkt := bkt.Bucket(bucketKeyObjectLabels)

--- a/core/metadata/gc_test.go
+++ b/core/metadata/gc_test.go
@@ -48,6 +48,20 @@ func TestResourceMax(t *testing.T) {
 	}
 }
 
+func TestSendLabelRefsNilBucket(t *testing.T) {
+	ctx := context.Background()
+	c := startGCContext(ctx, nil)
+
+	// A nil bucket (e.g. reached from an inconsistent metadata database) must
+	// be handled gracefully rather than panicking mid-transaction, which can
+	// leave the database unopenable on subsequent starts.
+	require.NotPanics(t, func() {
+		require.NoError(t, c.sendLabelRefs("ns", nil, labelRefCallbacks{
+			bref: func(gc.Node) {},
+		}))
+	})
+}
+
 func TestGCRoots(t *testing.T) {
 	db, err := newDatabase(t)
 	require.NoError(t, err)

--- a/core/metadata/gc_test.go
+++ b/core/metadata/gc_test.go
@@ -53,10 +53,10 @@ func TestSendLabelRefsNilBucket(t *testing.T) {
 	c := startGCContext(ctx, nil)
 
 	// A nil bucket (e.g. reached from an inconsistent metadata database) must
-	// be handled gracefully rather than panicking mid-transaction, which can
+	// fail the GC transaction rather than panicking mid-transaction, which can
 	// leave the database unopenable on subsequent starts.
 	require.NotPanics(t, func() {
-		require.NoError(t, c.sendLabelRefs("ns", nil, labelRefCallbacks{
+		require.Error(t, c.sendLabelRefs("ns", nil, labelRefCallbacks{
 			bref: func(gc.Node) {},
 		}))
 	})


### PR DESCRIPTION
## Description

`sendLabelRefs` dereferences the `*bolt.Bucket` passed to it without first checking for nil. When the metadata GC walks a namespace's buckets and a sub-bucket lookup returns nil (e.g. from an inconsistent or partially-written database), the call panics mid-transaction:

```
panic: runtime error: invalid memory address or nil pointer dereference
go.etcd.io/bbolt.(*Bucket).Bucket(0x0, ...)
github.com/containerd/containerd/v2/core/metadata.(*gcContext).sendLabelRefs(...)
    core/metadata/gc.go:1111
```

The SIGSEGV kills the daemon inside a bbolt `View`/transaction and can leave `io.containerd.metadata.v1.bolt/meta.db` with an inconsistent freelist, making it unopenable on every subsequent start (containerd crash-loops and the host's containers stay down until the DB is deleted).

This PR hardens `sendLabelRefs` to return early when the bucket is nil, so a GC pass that encounters unexpected metadata degrades gracefully instead of taking the daemon down.

## Changes

- Add a nil-bucket guard at the top of `sendLabelRefs`.
- Add a regression test `TestSendLabelRefsNilBucket` asserting a nil bucket is handled without panicking.

## Verification

- `gofmt` clean
- `go build ./core/metadata/` clean
- `go test ./core/metadata/ -count=1` green
- Confirmed the new test fails (panics) without the guard, and passes with it.

Fixes #14124

Signed-off-by: Shashank Varma <shashankvarma499@users.noreply.github.com>
