### PR TITLE
unpack: Add opt-in fetching for existing snapshots

### DIFF
--- a/client/image.go
+++ b/client/image.go
@@ -261,6 +261,8 @@ type UnpackConfig struct {
 	DuplicationSuppressor kmutex.KeyedLocker
 	// Limiter is used to limit concurrent unpacks
 	Limiter *semaphore.Weighted
+	// FetchAllContent fetches layers during Pull even if their snapshots exist.
+	FetchAllContent bool
 }
 
 // UnpackOpt provides configuration for unpack
@@ -294,6 +296,17 @@ func WithUnpackApplyOpts(opts ...diff.ApplyOpt) UnpackOpt {
 func WithUnpackLimiter(limiter *semaphore.Weighted) UnpackOpt {
 	return func(ctx context.Context, uc *UnpackConfig) error {
 		uc.Limiter = limiter
+		return nil
+	}
+}
+
+// WithUnpackFetchAllContent fetches layers during Pull even if their snapshots
+// already exist, without changing the selected platforms.
+// Use it with WithPullUnpack and WithUnpackOpts.
+// It has no effect on Image.Unpack, which does not fetch content.
+func WithUnpackFetchAllContent() UnpackOpt {
+	return func(ctx context.Context, uc *UnpackConfig) error {
+		uc.FetchAllContent = true
 		return nil
 	}
 }

--- a/client/pull.go
+++ b/client/pull.go
@@ -125,6 +125,9 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 			SnapshotterCapabilities: snCapabilities,
 		}
 		uopts := []unpack.UnpackerOpt{unpack.WithUnpackPlatform(platform)}
+		if uconfig.FetchAllContent {
+			uopts = append(uopts, unpack.WithFetchAllContent())
+		}
 		if uconfig.DuplicationSuppressor != nil {
 			uopts = append(uopts, unpack.WithDuplicationSuppressor(uconfig.DuplicationSuppressor))
 		}

--- a/core/unpack/fetch_all_test.go
+++ b/core/unpack/fetch_all_test.go
@@ -1,0 +1,187 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package unpack_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/diff"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/images/imagetest"
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/unpack"
+	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnpackFetchesExistingSnapshots(t *testing.T) {
+	t.Parallel()
+	for _, fetchAll := range []bool{false, true} {
+		for _, existing := range []int{0, 1, 2} {
+			t.Run(fmt.Sprintf("fetchAll=%t/existing=%d", fetchAll, existing), func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+				defer cancel()
+				store, config, layers, blobs := unpackFixture(t, ctx)
+				sn := &testSnapshotter{existing: make(map[string]bool)}
+				chain := make([]digest.Digest, len(layers))
+				for j, layer := range layers {
+					chain[j] = layer.Digest
+					if j < existing {
+						sn.existing[identity.ChainID(chain[:j+1]).String()] = true
+					}
+				}
+				secondFetch := make(chan struct{})
+				firstApplied := make(chan struct{})
+				var applied atomic.Int32
+				applier := testApplier(func(ctx context.Context, desc ocispec.Descriptor) (ocispec.Descriptor, error) {
+					if desc.Digest == layers[0].Digest {
+						// The second download cannot finish until the first layer is
+						// applied. A download-all-first implementation deadlocks here.
+						select {
+						case <-secondFetch:
+						case <-ctx.Done():
+							return ocispec.Descriptor{}, ctx.Err()
+						}
+						close(firstApplied)
+					}
+					b, err := content.ReadBlob(ctx, store.Store, desc)
+					if err != nil {
+						return ocispec.Descriptor{}, err
+					}
+					applied.Add(1)
+					return ocispec.Descriptor{Digest: digest.FromBytes(b)}, nil
+				})
+				opts := []unpack.UnpackerOpt{unpack.WithUnpackPlatform(unpack.Platform{SnapshotterKey: "test", Snapshotter: sn, Applier: applier})}
+				if fetchAll {
+					opts = append(opts, unpack.WithFetchAllContent())
+				}
+				u, err := unpack.NewUnpacker(ctx, store.Store, opts...)
+				require.NoError(t, err)
+				h := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+					if desc.Digest == layers[1].Digest {
+						close(secondFetch)
+						if existing == 0 {
+							select {
+							case <-firstApplied:
+							case <-ctx.Done():
+								return nil, ctx.Err()
+							}
+						}
+					}
+					if b, ok := blobs[desc.Digest]; ok {
+						return nil, content.WriteBlob(ctx, store.Store, desc.Digest.String(), bytes.NewReader(b), desc)
+					}
+					return images.Children(ctx, store.Store, desc)
+				})
+				manifest := store.JSONObject(ocispec.MediaTypeImageManifest, ocispec.Manifest{Config: config, Layers: layers}).Descriptor
+				require.NoError(t, images.Dispatch(ctx, u.Unpack(h), nil, manifest))
+				_, err = u.Wait()
+				require.NoError(t, err)
+				assert.Equal(t, int32(len(layers)-existing), applied.Load())
+				for j, layer := range layers {
+					b, err := content.ReadBlob(ctx, store.Store, layer)
+					if !fetchAll && j < existing {
+						assert.Truef(t, cerrdefs.IsNotFound(err), "default behavior should not fetch existing snapshots: %v", err)
+						continue
+					}
+					require.NoError(t, err)
+					assert.Equal(t, layer.Digest, digest.FromBytes(b))
+				}
+			})
+		}
+	}
+}
+
+func unpackFixture(t *testing.T, ctx context.Context) (imagetest.ContentStore, ocispec.Descriptor, []ocispec.Descriptor, map[digest.Digest][]byte) {
+	t.Helper()
+	store := imagetest.NewContentStore(ctx, t)
+	var layers []ocispec.Descriptor
+	var diffIDs []digest.Digest
+	blobs := make(map[digest.Digest][]byte)
+	for _, b := range [][]byte{[]byte("first layer"), []byte("second layer")} {
+		d := digest.FromBytes(b)
+		layers = append(layers, ocispec.Descriptor{MediaType: ocispec.MediaTypeImageLayer, Digest: d, Size: int64(len(b))})
+		diffIDs = append(diffIDs, d)
+		blobs[d] = b
+	}
+	config := store.JSONObject(ocispec.MediaTypeImageConfig, ocispec.Image{
+		Platform: platforms.DefaultSpec(),
+		RootFS:   ocispec.RootFS{Type: "layers", DiffIDs: diffIDs},
+	}).Descriptor
+	return store, config, layers, blobs
+}
+
+type testApplier func(context.Context, ocispec.Descriptor) (ocispec.Descriptor, error)
+
+func (a testApplier) Apply(ctx context.Context, desc ocispec.Descriptor, _ []mount.Mount, _ ...diff.ApplyOpt) (ocispec.Descriptor, error) {
+	return a(ctx, desc)
+}
+
+type testSnapshotter struct {
+	snapshots.Snapshotter
+	mu       sync.Mutex
+	existing map[string]bool
+}
+
+func (s *testSnapshotter) Prepare(_ context.Context, _, _ string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	var info snapshots.Info
+	for _, opt := range opts {
+		if err := opt(&info); err != nil {
+			return nil, err
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.existing[info.Labels[snapshots.LabelSnapshotRef]] {
+		return nil, cerrdefs.ErrAlreadyExists
+	}
+	return nil, nil
+}
+
+func (s *testSnapshotter) Stat(_ context.Context, key string) (snapshots.Info, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.existing[key] {
+		return snapshots.Info{Name: key}, nil
+	}
+	return snapshots.Info{}, cerrdefs.ErrNotFound
+}
+
+func (s *testSnapshotter) Commit(_ context.Context, name, _ string, _ ...snapshots.Opt) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.existing[name] = true
+	return nil
+}
+
+func (s *testSnapshotter) Remove(context.Context, string) error {
+	return nil
+}

--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -61,7 +61,8 @@ type Result struct {
 type unpackerConfig struct {
 	platforms []*Platform
 
-	content content.Store
+	content  content.Store
+	fetchAll bool
 
 	limiter               Limiter
 	duplicationSuppressor KeyedLocker
@@ -144,6 +145,16 @@ func WithDuplicationSuppressor(d KeyedLocker) UnpackerOpt {
 		c.duplicationSuppressor = d
 		return nil
 	})
+}
+
+// WithFetchAllContent fetches all layers supplied to the unpacker, including
+// layers whose snapshots already exist.
+// It does not change the caller's platform selection.
+func WithFetchAllContent() UnpackerOpt {
+	return func(c *unpackerConfig) error {
+		c.fetchAll = true
+		return nil
+	}
 }
 
 func WithUnpackLimiter(l Limiter) UnpackerOpt {
@@ -354,15 +365,41 @@ func (u *Unpacker) unpack(
 
 		fetchOffset int
 		fetchC      []chan struct{}
-		fetchErr    []chan error
+		fetchDone   chan struct{}
+		fetchErr    error
 
 		parallel = u.supportParallel(unpack)
 	)
 
-	// If there is an early return, ensure any ongoing
-	// fetches get their context cancelled
+	// Cancel outstanding fetches on return, joining them for fetch-all callers.
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	defer func() {
+		cancel()
+		if u.fetchAll && fetchDone != nil {
+			<-fetchDone
+		}
+	}()
+
+	startFetch := func(i int) {
+		if fetchDone != nil {
+			return
+		}
+		fetchOffset = i
+		fetchC = make([]chan struct{}, len(layers)-i)
+		for j := range fetchC {
+			fetchC[j] = make(chan struct{})
+		}
+		fetchDone = make(chan struct{})
+		go func() {
+			fetchErr = u.fetch(ctx, h, layers[i:], fetchC)
+			close(fetchDone)
+		}()
+	}
+	if u.fetchAll {
+		// Retained snapshots do not imply that their compressed blobs survived GC.
+		// Each extraction still waits only for its own layer's download.
+		startFetch(0)
+	}
 
 	// pre-calculate chain ids for each layer
 	chainIDs := make([]digest.Digest, len(diffIDs))
@@ -424,7 +461,7 @@ func (u *Unpacker) unpack(
 						// Try again, this should be rare, log it
 						log.G(ctx).WithField("key", key).WithField("chainid", chainID).Debug("extraction snapshot already exists, chain id not found")
 					} else {
-						log.G(ctx).Debugf("snapshot %s with chainID %s already exists skip fetch blob %q ", snInfo.Name, chainID, desc.Digest)
+						log.G(ctx).Debugf("snapshot %s with chainID %s already exists, skip extraction of blob %q", snInfo.Name, chainID, desc.Digest)
 						// no need to handle, snapshot now found with chain id
 						return nil, nil
 					}
@@ -441,7 +478,7 @@ func (u *Unpacker) unpack(
 
 		if isStaged(mounts) {
 			// The snapshotter staged the layer content into the active snapshot
-			// as read-only (e.g. a layer content cache hit). Skip fetch+apply,
+			// as read-only (e.g. a layer content cache hit). Skip apply,
 			// but still commit it below (which applies the parent).
 			staged = true
 		}
@@ -455,7 +492,7 @@ func (u *Unpacker) unpack(
 
 		// commitF is the bottom half shared by normal and staged layers: it rebases
 		// in the real parent (parallel mode) and commits the snapshot. Staged layers
-		// have no fetched content, so they skip the post-apply uncompressed label.
+		// skip apply's digest verification, so they cannot set the uncompressed label.
 		commitF := func(shouldAbort bool) error {
 			defer unlock()
 			if shouldAbort {
@@ -475,7 +512,7 @@ func (u *Unpacker) unpack(
 			}
 
 			if staged {
-				// No layer was fetched, so there is no content to label.
+				// Apply did not verify the uncompressed digest, even if fetched.
 				return nil
 			}
 
@@ -494,8 +531,8 @@ func (u *Unpacker) unpack(
 		}
 
 		if staged {
-			// Content is already staged in the active snapshot; there is nothing to
-			// fetch or apply. Emit a status that runs commitF in the (serialized)
+			// Content is already staged in the active snapshot; no apply is needed.
+			// Downloads may still be running. Run commitF in the (serialized)
 			// bottom half so the parent is rebased in and the chain is linked.
 			resCh := make(chan *unpackStatus, 1)
 			resCh <- &unpackStatus{
@@ -508,25 +545,7 @@ func (u *Unpacker) unpack(
 			return resCh, nil
 		}
 
-		if fetchErr == nil {
-			fetchOffset = i
-			n := len(layers) - fetchOffset
-			fetchErr = make([]chan error, n)
-			fetchC = make([]chan struct{}, n)
-			for i := range n {
-				fetchC[i] = make(chan struct{})
-				fetchErr[i] = make(chan error, 1)
-			}
-			go func(i int) {
-				err := u.fetch(ctx, h, layers[i:], fetchC)
-				if err != nil {
-					for _, fc := range fetchErr {
-						fc <- err
-						close(fc)
-					}
-				}
-			}(i)
-		}
+		startFetch(i)
 
 		if err = u.acquire(ctx, u.unpackLimiter); err != nil {
 			cleanup.Do(ctx, abort)
@@ -549,18 +568,15 @@ func (u *Unpacker) unpack(
 
 			select {
 			case <-ctx.Done():
-				cleanup.Do(ctx, abort)
 				status.err = ctx.Err()
+			case <-fetchDone:
+				status.err = fetchErr
+			case <-fetchC[i-fetchOffset]:
+			}
+			if status.err != nil {
+				cleanup.Do(ctx, abort)
 				resCh <- status
 				return
-			case err := <-fetchErr[i-fetchOffset]:
-				if err != nil {
-					cleanup.Do(ctx, abort)
-					status.err = err
-					resCh <- status
-					return
-				}
-			case <-fetchC[i-fetchOffset]:
 			}
 
 			// In case of parallel unpack, the parent snapshot isn't provided to the snapshotter.
@@ -667,6 +683,15 @@ func (u *Unpacker) unpack(
 		errs = errors.Join(errs, topErr)
 		if errs != nil {
 			return errs
+		}
+	}
+
+	// In fetch-all mode, existing snapshots have no extraction waiting for downloads.
+	// Include those downloads and their errors in the unpack result.
+	if u.fetchAll && fetchDone != nil {
+		<-fetchDone
+		if fetchErr != nil {
+			return fetchErr
 		}
 	}
 

--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -31,7 +31,55 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
 )
+
+func TestPullFetchAllContent(t *testing.T) {
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	client, err := newClient(t, address)
+	require.NoError(t, err)
+	defer client.Close()
+
+	imageName := imagelist.Get(imagelist.Pause)
+	image, err := client.Pull(ctx, imageName, WithPullUnpack, WithPullSnapshotter(testSnapshotter))
+	require.NoError(t, err)
+	defer client.ImageService().Delete(ctx, imageName, images.SynchronousDelete())
+
+	cs := client.ContentStore()
+	manifest, err := images.Manifest(ctx, cs, image.Target(), platforms.Default())
+	require.NoError(t, err)
+	require.NotEmpty(t, manifest.Layers)
+	layer := manifest.Layers[0]
+	_, err = cs.Info(ctx, layer.Digest)
+	require.NoError(t, err)
+
+	// Keep subsequent pulls on the same image even if the tag changes.
+	ref := imageName + "@" + image.Target().Digest.String()
+	defer client.ImageService().Delete(ctx, ref, images.SynchronousDelete())
+
+	require.NoError(t, cs.Delete(ctx, layer.Digest))
+	_, err = cs.Info(ctx, layer.Digest)
+	require.True(t, errdefs.IsNotFound(err), "layer should be missing: %v", err)
+	unpacked, err := image.IsUnpacked(ctx, testSnapshotter)
+	require.NoError(t, err)
+	require.True(t, unpacked, "deleting the blob must leave the snapshot intact")
+
+	_, err = client.Pull(ctx, ref, WithPullUnpack, WithPullSnapshotter(testSnapshotter))
+	require.NoError(t, err)
+	_, err = cs.Info(ctx, layer.Digest)
+	require.True(t, errdefs.IsNotFound(err), "default pull should leave the layer missing: %v", err)
+
+	_, err = client.Pull(ctx, ref,
+		WithPullUnpack,
+		WithPullSnapshotter(testSnapshotter),
+		WithUnpackOpts([]UnpackOpt{WithUnpackFetchAllContent()}),
+	)
+	require.NoError(t, err)
+	_, err = cs.Info(ctx, layer.Digest)
+	require.NoError(t, err, "fetch-all pull should restore the layer")
+}
 
 func TestImageIsUnpacked(t *testing.T) {
 	imageName := imagelist.Get(imagelist.Pause)


### PR DESCRIPTION
- fix: https://github.com/containerd/containerd/issues/8973

Resurrect the client changes from https://github.com/containerd/containerd/pull/11841

Retained snapshots can outlive layer blobs removed by garbage collection. Pull with unpack then skips downloads, leaving images that cannot be saved, exported, or pushed.

Add `unpack.WithFetchAllContent` and `client.WithUnpackFetchAllContent` to fetch all selected layers even when snapshots exist. Wait for these downloads before publishing success, without changing the default policy.

```release-note
Add client options to fetch all layer content during unpack even when snapshots exist
```
