### PR TITLE
vendor: github.com/moby/sys/userns v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/moby/sys/signal v0.7.1
 	github.com/moby/sys/symlink v0.3.0
 	github.com/moby/sys/user v0.4.1
-	github.com/moby/sys/userns v0.2.0
+	github.com/moby/sys/userns v0.2.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/moby/sys/symlink v0.3.0 h1:GZX89mEZ9u53f97npBy4Rc3vJKj7JBDj/PN2I22GrN
 github.com/moby/sys/symlink v0.3.0/go.mod h1:3eNdhduHmYPcgsJtZXW1W4XUJdZGBIkttZ8xKqPUJq0=
 github.com/moby/sys/user v0.4.1 h1:RgjRlaDKi/Xmyrz4t8lyzXT6v2ooFeO/7xtchmhVWE0=
 github.com/moby/sys/user v0.4.1/go.mod h1:E9QsW5WRe1kUAf7kW8hXKwu1uhsZEAdPLYHYSDudF4Y=
-github.com/moby/sys/userns v0.2.0 h1:nEtDtp7NCV/6dutSklNe8FrENPwFdc4mXnZqC/JWgXM=
-github.com/moby/sys/userns v0.2.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
+github.com/moby/sys/userns v0.2.1 h1:4OvdM7BcPkASbuouHsbW3aeMJSFlYDldBRnXVZhaRk8=
+github.com/moby/sys/userns v0.2.1/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/vendor/github.com/moby/sys/userns/userns_linux.go
+++ b/vendor/github.com/moby/sys/userns/userns_linux.go
@@ -2,6 +2,7 @@ package userns
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -23,7 +24,16 @@ var inUserNS = sync.OnceValue(runningInUserNS)
 func runningInUserNS() bool {
 	var st syscall.Stat_t
 	if err := syscall.Stat("/proc/self/ns/user", &st); err == nil {
-		return st.Ino != procUserInitIno
+		// The kernel's initial user namespace inode is definitive when it
+		// matches. OpenVZ virtualizes namespace inode numbers, so a mismatch
+		// must fall back to uid_map-based detection there.
+		if st.Ino == procUserInitIno {
+			return false
+		}
+		if runningInOpenVZ() {
+			return runningInUserNSFromUIDMap()
+		}
+		return true
 	} else if !os.IsNotExist(err) {
 		// As long as /proc/self/ns/user exists, we are on a modern kernel.
 		// Other errors indicate an unexpected procfs state, where assuming the
@@ -35,6 +45,10 @@ func runningInUserNS() bool {
 	// through procfs at /proc/self/ns/user.
 	// TODO: Remove this fallback once Linux kernels older than 3.8 are no
 	// longer supported.
+	return runningInUserNSFromUIDMap()
+}
+
+func runningInUserNSFromUIDMap() bool {
 	file, err := os.Open("/proc/self/uid_map")
 	if err != nil {
 		// This kernel-provided file only exists if user namespaces are supported.
@@ -68,4 +82,20 @@ func uidMapInUserNS(uidMap string) bool {
 	// the initial user namespace shows 0 0 4294967295.
 	initNS := a == 0 && b == 0 && c == 4294967295
 	return !initNS
+}
+
+// runningInOpenVZ reports whether the process is running inside an OpenVZ
+// container.
+//
+// OpenVZ exposes /proc/vz both on the host and inside containers, while
+// /proc/bc is only exposed on the host. This follows systemd's OpenVZ
+// detection:
+// https://github.com/systemd/systemd/blob/v261.2/src/basic/virt.c#L642-L653
+func runningInOpenVZ() bool {
+	var st syscall.Stat_t
+	if err := syscall.Stat("/proc/vz", &st); err != nil {
+		return false
+	}
+	err := syscall.Stat("/proc/bc", &st)
+	return errors.Is(err, syscall.ENOENT)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -461,7 +461,7 @@ github.com/moby/sys/symlink
 # github.com/moby/sys/user v0.4.1
 ## explicit; go 1.18
 github.com/moby/sys/user
-# github.com/moby/sys/userns v0.2.0
+# github.com/moby/sys/userns v0.2.1
 ## explicit; go 1.21
 github.com/moby/sys/userns
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd


### PR DESCRIPTION
userns: fix user-namespace detection on OpenVZ, where namespace inode numbers are virtualized.

full diff: https://github.com/moby/sys/compare/userns/v0.2.0...userns/v0.2.1
