### PR TITLE
cri: split tag+digest references when listing images

### DIFF
--- a/internal/cri/util/references.go
+++ b/internal/cri/util/references.go
@@ -30,10 +30,18 @@ func ParseImageReferences(refs []string) ([]string, []string) {
 		if err != nil {
 			continue
 		}
-		if _, ok := parsed.(reference.Canonical); ok {
-			digests = append(digests, parsed.String())
-		} else if _, ok := parsed.(reference.Tagged); ok {
-			tags = append(tags, parsed.String())
+		named, isNamed := parsed.(reference.Named)
+		if !isNamed {
+			continue
+		}
+		// A reference may carry both a tag and a digest (e.g. "ubuntu:16.04@sha256:...").
+		// Split it into its tag and digest components so the tag is not lost when the
+		// digest is reported.
+		if tagged, ok := parsed.(reference.Tagged); ok {
+			tags = append(tags, named.Name()+":"+tagged.Tag())
+		}
+		if canonical, ok := parsed.(reference.Canonical); ok {
+			digests = append(digests, named.Name()+"@"+canonical.Digest().String())
 		}
 	}
 	return tags, digests

--- a/internal/cri/util/references_test.go
+++ b/internal/cri/util/references_test.go
@@ -41,6 +41,21 @@ func TestParseImageReferences(t *testing.T) {
 	assert.Equal(t, expectedDigests, digests)
 }
 
+func TestParseImageReferencesTagAndDigest(t *testing.T) {
+	refs := []string{
+		"docker.io/library/ubuntu:16.04@sha256:1f1a2d56de1d604801a9671f301190704c25d604a416f59e03c04f5c6ffee0d6",
+	}
+	expectedTags := []string{
+		"docker.io/library/ubuntu:16.04",
+	}
+	expectedDigests := []string{
+		"docker.io/library/ubuntu@sha256:1f1a2d56de1d604801a9671f301190704c25d604a416f59e03c04f5c6ffee0d6",
+	}
+	tags, digests := ParseImageReferences(refs)
+	assert.Equal(t, expectedTags, tags)
+	assert.Equal(t, expectedDigests, digests)
+}
+
 func TestGetRepoDigestAndTag(t *testing.T) {
 	digest := digest.Digest("sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582")
 	for _, test := range []struct {


### PR DESCRIPTION
## Description

`ParseImageReferences` classifies any reference that carries a digest as a `Canonical` reference and reports its full `String()` verbatim, only falling back to the `Tagged` branch when there is no digest. A reference that carries *both* a tag and a digest (for example `docker.io/library/ubuntu:16.04@sha256:...`) is therefore placed entirely in the digest list, with the tag embedded inside the digest string, and is never surfaced as a `RepoTag`.

When such an image is pulled into the `k8s.io` namespace (e.g. `ctr -n k8s.io image pull docker.io/library/ubuntu:16.04@sha256:...`), `crictl images` consequently reports it with a `<none>` tag instead of `16.04`.

This change splits a tag+digest reference into its two components, so both the tag and the digest are reported, matching how the tag and digest are stored separately when the image is pulled without a combined reference.

## Changes

- `ParseImageReferences` now extracts the tag (as `name:tag`) and digest (as `name@digest`) independently rather than relying on a single `String()` that conflates the two.
- Add `TestParseImageReferencesTagAndDigest` covering the combined-reference case.

## Verification

- `gofmt` clean
- `go test ./internal/cri/util/` green (including the new test)
- `go test ./internal/cri/server/images/` green
- `go vet ./internal/cri/util/` clean

Fixes #13969

Signed-off-by: Shashank Varma <324153016+shashankvarma499@users.noreply.github.com>
