### PR TITLE
DNM: testing golangci-lint for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/install-go
-      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee  # v9.2.1
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        env:
+          GOOS: windows
         with:
           version: v2.13.2
           skip-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,11 @@ jobs:
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         env:
           GOOS: windows
+          GL_DEBUG: loader,env
         with:
           version: v2.13.2
           skip-cache: true
-          args: --timeout=8m
+          args: --timeout=8m -v
 
   #
   # Project checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,8 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/install-go
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
-        env:
-          GOOS: windows
-          GL_DEBUG: loader,env
         with:
-          version: v2.13.2
+          version: v2.13.1
           skip-cache: true
           args: --timeout=8m -v
 


### PR DESCRIPTION
I got some linting failures, some of which legit(?) when running with GOOS=windows on macOS, but CI didn't show these;

```
INFO [runner] linters took 12.613851s with stages: goanalysis_metalinter: 12.60222975s
cmd/containerd/command/service_windows.go:214:3: SA4023(related information): the lhs of the comparison is the 3rd return value of this function call (staticcheck)
		r, _, err := allocConsole.Call()
		^
cmd/containerd/command/service_windows.go:215:16: SA4023: this comparison is always true (staticcheck)
		if r == 0 && err != nil {
		             ^
pkg/archive/tar.go:422:42: SA4023: this comparison is always true (staticcheck)
			if err := setxattr(path, key, value); err != nil {
			                                      ^
pkg/oci/spec_opts.go:1523:3: SA4023(related information): the lhs of the comparison is the 2nd return value of this function call (staticcheck)
		dev, err := DeviceFromPath(path)
		^
pkg/oci/spec_opts.go:1524:6: SA4023: this comparison is always true (staticcheck)
		if err != nil {
		   ^
5 issues:
* staticcheck: 5
```