### PR TITLE
[release/1.7] core/unpack: fetch layers of every config-sharing manifest

### DIFF
--- a/images/imagetest/content.go
+++ b/images/imagetest/content.go
@@ -1,0 +1,276 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package imagetest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/images"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// Content represents a piece of image content in the content store along with
+// its relevant children and size.
+type Content struct {
+	Descriptor ocispec.Descriptor
+	Labels     map[string]string
+	Size       Size
+	Children   []Content
+}
+
+// ContentStore is a temporary content store which provides simple
+// helper functions for quickly altering content in the store.
+// Directly modifying the content store without using the helper functions
+// may result in out of sync test content values, be careful of this
+// when writing tests.
+type ContentStore struct {
+	content.Store
+
+	ctx context.Context
+	t   *testing.T
+}
+
+// NewContentStore creates a new content store in the testing's temporary directory
+func NewContentStore(ctx context.Context, t *testing.T) ContentStore {
+	cs, err := local.NewLabeledStore(t.TempDir(), newMemoryLabelStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ContentStore{
+		Store: cs,
+		ctx:   ctx,
+		t:     t,
+	}
+}
+
+// Index creates an index with the provided manifests and stores it
+// in the content store.
+func (tc ContentStore) Index(manifests ...Content) Content {
+	var index ocispec.Index
+	for _, m := range manifests {
+		index.Manifests = append(index.Manifests, m.Descriptor)
+	}
+
+	idx := tc.JSONObject(ocispec.MediaTypeImageIndex, index)
+	idx.Children = manifests
+	return idx
+
+}
+
+// Manifest creates a manifest with the given config and layers then
+// stores it in the content store.
+func (tc ContentStore) Manifest(config Content, layers ...Content) Content {
+	var manifest ocispec.Manifest
+	manifest.Config = config.Descriptor
+	for _, l := range layers {
+		manifest.Layers = append(manifest.Layers, l.Descriptor)
+	}
+	m := tc.JSONObject(ocispec.MediaTypeImageManifest, manifest)
+	m.Children = append(m.Children, config)
+	m.Children = append(m.Children, layers...)
+	return m
+}
+
+// Blob creates a generic blob with the given data and media type
+// and stores the data in the content store.
+func (tc ContentStore) Blob(mediaType string, data []byte) Content {
+	tc.t.Helper()
+
+	descriptor := ocispec.Descriptor{
+		MediaType: mediaType,
+		Digest:    digest.SHA256.FromBytes(data),
+		Size:      int64(len(data)),
+	}
+
+	ref := string(descriptor.Digest) // TODO: Add random component?
+	if err := content.WriteBlob(tc.ctx, tc.Store, ref, bytes.NewReader(data), descriptor); err != nil {
+		tc.t.Fatal(err)
+	}
+
+	return Content{
+		Descriptor: descriptor,
+		Size: Size{
+			Manifest: descriptor.Size,
+			Content:  descriptor.Size,
+		},
+	}
+
+}
+
+// RandomBlob creates a blob object in the content store with random data.
+func (tc ContentStore) RandomBlob(mediaType string, n int) Content {
+	tc.t.Helper()
+
+	data := make([]byte, int64(n))
+	rand.New(rand.NewSource(int64(n))).Read(data)
+
+	return tc.Blob(mediaType, data)
+}
+
+// JSONObject creates an object in the content store by first marshaling
+// to JSON and then storing the data.
+func (tc ContentStore) JSONObject(mediaType string, i interface{}) Content {
+	tc.t.Helper()
+
+	data, err := json.Marshal(i)
+	if err != nil {
+		tc.t.Fatal(err)
+	}
+
+	return tc.Blob(mediaType, data)
+}
+
+// Walk walks all the children of the provided content and calls the provided
+// function with the associated content store.
+// Walk can be used to update an object and reflect that change in the content
+// store.
+func (tc ContentStore) Walk(c Content, fn func(context.Context, *Content, content.Store) error) Content {
+	tc.t.Helper()
+
+	if err := fn(tc.ctx, &c, tc.Store); err != nil {
+		tc.t.Fatal(err)
+	}
+
+	if len(c.Children) > 0 {
+		children := make([]Content, len(c.Children))
+		for i, child := range c.Children {
+			children[i] = tc.Walk(child, fn)
+		}
+		c.Children = children
+	}
+
+	return c
+}
+
+// AddPlatform alters the content desciptor by setting the platform
+func AddPlatform(c Content, p ocispec.Platform) Content {
+	c.Descriptor.Platform = &p
+	return c
+}
+
+// LimitChildren limits the amount of children in the content.
+// This function is non-recursive and uses the natural ordering.
+func LimitChildren(c Content, limit int) Content {
+	if images.IsIndexType(c.Descriptor.MediaType) {
+		if len(c.Children) > limit {
+			c.Children = c.Children[0:limit]
+		}
+	}
+	return c
+}
+
+// ContentCreator is a simple interface for generating content for tests
+type ContentCreator func(ContentStore) Content
+
+// SimpleManifest generates a simple manifest with small config and random layer
+// The layer produced is not a valid compressed tar, do not unpack it.
+func SimpleManifest(layerSize int) ContentCreator {
+	return func(tc ContentStore) Content {
+		config := ocispec.ImageConfig{
+			Env: []string{"random"}, // TODO: Make random string
+		}
+		return tc.Manifest(
+			tc.JSONObject(ocispec.MediaTypeImageConfig, config),
+			tc.RandomBlob(ocispec.MediaTypeImageLayerGzip, layerSize))
+	}
+}
+
+// SimpleIndex generates a simple index with the number of simple
+// manifests specified.
+func SimpleIndex(manifests, layerSize int) ContentCreator {
+	manifestFn := SimpleManifest(layerSize)
+	return func(tc ContentStore) Content {
+		var m []Content
+		for i := 0; i < manifests; i++ {
+			m = append(m, manifestFn(tc))
+		}
+		return tc.Index(m...)
+	}
+}
+
+// StripLayers deletes all layer content from the content store
+// and updates the content size to 0.
+func StripLayers(cc ContentCreator) ContentCreator {
+	return func(tc ContentStore) Content {
+		return tc.Walk(cc(tc), func(ctx context.Context, c *Content, store content.Store) error {
+			if images.IsLayerType(c.Descriptor.MediaType) {
+				if err := store.Delete(tc.ctx, c.Descriptor.Digest); err != nil {
+					return err
+				}
+				c.Size.Content = 0
+			}
+			return nil
+		})
+
+	}
+}
+
+type memoryLabelStore struct {
+	l      sync.Mutex
+	labels map[digest.Digest]map[string]string
+}
+
+// newMemoryLabelStore creates an inmemory label store for testing
+func newMemoryLabelStore() local.LabelStore {
+	return &memoryLabelStore{
+		labels: map[digest.Digest]map[string]string{},
+	}
+}
+
+func (mls *memoryLabelStore) Get(d digest.Digest) (map[string]string, error) {
+	mls.l.Lock()
+	labels := mls.labels[d]
+	mls.l.Unlock()
+
+	return labels, nil
+}
+
+func (mls *memoryLabelStore) Set(d digest.Digest, labels map[string]string) error {
+	mls.l.Lock()
+	mls.labels[d] = labels
+	mls.l.Unlock()
+
+	return nil
+}
+
+func (mls *memoryLabelStore) Update(d digest.Digest, update map[string]string) (map[string]string, error) {
+	mls.l.Lock()
+	labels, ok := mls.labels[d]
+	if !ok {
+		labels = map[string]string{}
+	}
+	for k, v := range update {
+		if v == "" {
+			delete(labels, k)
+		} else {
+			labels[k] = v
+		}
+	}
+	mls.labels[d] = labels
+	mls.l.Unlock()
+
+	return labels, nil
+}

--- a/images/imagetest/size.go
+++ b/images/imagetest/size.go
@@ -1,0 +1,58 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package imagetest
+
+// Size represents the size of an object from different methods of counting, in bytes
+type Size struct {
+	// Manifest is the total Manifest reported size of current object and children
+	Manifest int64
+
+	// Content is the total of store Content of current object and children
+	Content int64
+
+	// Unpacked is the total size of Unpacked data for the given snapshotter
+	// The key is the snapshotter name
+	// The value is the usage reported by the snapshotter for the image
+	Unpacked map[string]int64
+
+	// Uncompressed is the total Uncompressed tar stream data (used for size estimate)
+	Uncompressed int64
+}
+
+// ContentSizeCalculator calculates a size property for the test content
+type ContentSizeCalculator func(Content) int64
+
+// SizeOfManifest recursively calculates the manifest reported size,
+// not accounting for duplicate entries.
+func SizeOfManifest(t Content) int64 {
+	accumulated := t.Size.Manifest
+	for _, child := range t.Children {
+		accumulated = accumulated + SizeOfManifest(child)
+	}
+	return accumulated
+}
+
+// SizeOfContent recursively calculates the size of all stored content
+// The calculation is a simple accumulation based on the structure,
+// duplicate blobs are not accounted for.
+func SizeOfContent(t Content) int64 {
+	accumulated := t.Size.Content
+	for _, child := range t.Children {
+		accumulated = accumulated + SizeOfContent(child)
+	}
+	return accumulated
+}

--- a/pkg/testutil/registry.go
+++ b/pkg/testutil/registry.go
@@ -1,0 +1,92 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ServeImage serves an image from a read-only HTTP registry listening on
+// localhost, and returns a reference to pull the image from.
+//
+// blobs must be keyed by digest and contain the manifest blob referenced by
+// target, along with the blobs it references, except for those already
+// present in the puller's content store. The registry is shut down when the
+// test completes.
+func ServeImage(t *testing.T, name, tag string, target ocispec.Descriptor, blobs map[digest.Digest][]byte) string {
+	manifestPath := "/v2/" + name + "/manifests/"
+	blobPath := "/v2/" + name + "/blobs/"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var b []byte
+		mediaType := "application/octet-stream"
+		switch {
+		case strings.HasPrefix(r.URL.Path, manifestPath):
+			// A manifest may be requested by the tag, by the target
+			// digest, or, for a multi-platform image, by the digest of
+			// a platform manifest.
+			dgst := target.Digest
+			if ref := strings.TrimPrefix(r.URL.Path, manifestPath); ref != tag {
+				var err error
+				if dgst, err = digest.Parse(ref); err != nil {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+			}
+			var ok bool
+			if b, ok = blobs[dgst]; !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if dgst == target.Digest {
+				mediaType = target.MediaType
+			}
+			w.Header().Set("Docker-Content-Digest", dgst.String())
+		case strings.HasPrefix(r.URL.Path, blobPath):
+			dgst, err := digest.Parse(strings.TrimPrefix(r.URL.Path, blobPath))
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			var ok bool
+			if b, ok = blobs[dgst]; !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", mediaType)
+		w.Header().Set("Content-Length", strconv.Itoa(len(b)))
+		if r.Method == http.MethodGet {
+			w.Write(b)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://") + "/" + name + ":" + tag
+}

--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -161,8 +161,18 @@ func NewUnpacker(ctx context.Context, cs content.Store, opts ...UnpackerOpt) (*U
 // process will be started in a goroutine.
 func (u *Unpacker) Unpack(h images.Handler) images.Handler {
 	var (
-		lock   sync.Mutex
-		layers = map[digest.Digest][]ocispec.Descriptor{}
+		lock sync.Mutex
+		// Maps a config's digest to the layer descriptors of each manifest
+		// that names it, one slice per manifest. Layers cannot be unpacked
+		// until the diffIDs are known from the config. Manifests can share a
+		// config (compression variants of one image have identical diffIDs
+		// and so identical configs), which is why one digest can hold the
+		// layers of several manifests.
+		queuedLayers = map[digest.Digest][][]ocispec.Descriptor{}
+		// Maps a config's digest to the layer descriptors selected for unpack.
+		// Once these layers are queued for fetch, the value is set to nil. The key
+		// remains to prevent scheduling another unpack.
+		unpackedLayers = map[digest.Digest][]ocispec.Descriptor{}
 	)
 	return images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		ctx, span := tracing.StartSpan(ctx, tracing.Name(unpackSpanPrefix, "UnpackHandler"))
@@ -197,20 +207,53 @@ func (u *Unpacker) Unpack(h images.Handler) images.Handler {
 				}
 			}
 
+			if len(manifestLayers) == 0 {
+				return nonLayers, nil
+			}
+
 			lock.Lock()
 			for _, nl := range nonLayers {
-				layers[nl.Digest] = manifestLayers
+				if images.IsConfigType(nl.MediaType) {
+					queuedLayers[nl.Digest] = append(queuedLayers[nl.Digest], manifestLayers)
+				}
 			}
 			lock.Unlock()
 
 			children = nonLayers
 		case images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
 			lock.Lock()
-			l := layers[desc.Digest]
+			queued := queuedLayers[desc.Digest]
+			delete(queuedLayers, desc.Digest)
+			// Because manifests that share the same config unpack to the same
+			// snapshot chain, we only need to unpack the layers for one
+			// manifest. The layers for any remaining manifests sharing that
+			// config are still fetched to ensure they make it in the content
+			// store.
+			var first []ocispec.Descriptor
+			unpacked, ok := unpackedLayers[desc.Digest]
+			if !ok && len(queued) > 0 {
+				first, queued = queued[0], queued[1:]
+				unpacked = first
+				unpackedLayers[desc.Digest] = first
+			}
+			// Unpack may skip fetching layers whose snapshots already exist.
+			// If another manifest shares this config, explicitly fetch the first
+			// manifest's layers too so every manifest's blobs reach the content
+			// store. For a config used by only one manifest, leave fetching to
+			// unpack.
+			if len(queued) > 0 && len(unpacked) > 0 {
+				queued = append(queued, unpacked)
+				unpackedLayers[desc.Digest] = nil
+			}
 			lock.Unlock()
-			if len(l) > 0 {
+			if len(first) > 0 {
 				u.eg.Go(func() error {
-					return u.unpack(h, desc, l)
+					return u.unpack(h, desc, first)
+				})
+			}
+			for _, layers := range queued {
+				u.eg.Go(func() error {
+					return u.fetch(u.ctx, h, layers, nil)
 				})
 			}
 		}

--- a/pkg/unpack/unpacker_test.go
+++ b/pkg/unpack/unpacker_test.go
@@ -1,0 +1,259 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package unpack
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/diff"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/images/imagetest"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/testutil"
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/platforms"
+)
+
+// failApplier fails the test if Apply is called.
+type failApplier struct{ t *testing.T }
+
+func (a failApplier) Apply(_ context.Context, desc ocispec.Descriptor, _ []mount.Mount, _ ...diff.ApplyOpt) (ocispec.Descriptor, error) {
+	a.t.Errorf("Apply must not be called for layer %s", desc.Digest)
+	return ocispec.Descriptor{}, nil
+}
+
+func layerDesc(id string) ocispec.Descriptor {
+	return ocispec.Descriptor{MediaType: ocispec.MediaTypeImageLayerGzip, Digest: digest.FromString(id), Size: 1}
+}
+
+func manifestDesc(id string) ocispec.Descriptor {
+	return ocispec.Descriptor{MediaType: ocispec.MediaTypeImageManifest, Digest: digest.FromString(id), Size: 1}
+}
+
+// alreadyExistsSnapshotter answers every Prepare with AlreadyExists and finds
+// the chain in Stat, so unpack skips each layer without fetching it.
+type alreadyExistsSnapshotter struct{ snapshots.Snapshotter }
+
+func (alreadyExistsSnapshotter) Prepare(context.Context, string, string, ...snapshots.Opt) ([]mount.Mount, error) {
+	return nil, errdefs.ErrAlreadyExists
+}
+
+func (alreadyExistsSnapshotter) Stat(_ context.Context, key string) (snapshots.Info, error) {
+	return snapshots.Info{Name: key}, nil
+}
+
+// TestUnpackConfigSharingManifests verifies that when several manifests share a
+// config, every manifest's layers are fetched even when the snapshots exist.
+// Only one unpack is scheduled per config. A lone manifest skips fetching
+// layers whose snapshots exist, and a manifest without layers is ignored.
+func TestUnpackConfigSharingManifests(t *testing.T) {
+	ctx := context.Background()
+	cs := imagetest.NewContentStore(ctx, t)
+
+	config := cs.JSONObject(ocispec.MediaTypeImageConfig, ocispec.Image{
+		Platform: ocispec.Platform{OS: "linux", Architecture: "amd64"},
+		RootFS:   ocispec.RootFS{Type: "layers", DiffIDs: []digest.Digest{digest.FromString("diff-0"), digest.FromString("diff-1")}},
+	}).Descriptor
+	manifestA, manifestB := manifestDesc("manifest-a"), manifestDesc("manifest-b")
+	layersA := []ocispec.Descriptor{layerDesc("a-0"), layerDesc("a-1")}
+	layersB := []ocispec.Descriptor{layerDesc("b-0"), layerDesc("b-1")}
+	sharedConfig := map[digest.Digest][]ocispec.Descriptor{
+		manifestA.Digest: append([]ocispec.Descriptor{config}, layersA...),
+		manifestB.Digest: append([]ocispec.Descriptor{config}, layersB...),
+	}
+
+	for _, tc := range []struct {
+		name        string
+		children    map[digest.Digest][]ocispec.Descriptor
+		order       []ocispec.Descriptor
+		wantFetched []ocispec.Descriptor
+		wantUnpacks int
+	}{
+		{
+			name:        "config after both manifests",
+			children:    sharedConfig,
+			order:       []ocispec.Descriptor{manifestA, manifestB, config, config},
+			wantFetched: slices.Concat([]ocispec.Descriptor{manifestA, manifestB, config}, layersA, layersB),
+			wantUnpacks: 1,
+		},
+		{
+			name:        "config between the manifests",
+			children:    sharedConfig,
+			order:       []ocispec.Descriptor{manifestA, config, manifestB, config},
+			wantFetched: slices.Concat([]ocispec.Descriptor{manifestA, manifestB, config}, layersA, layersB),
+			wantUnpacks: 1,
+		},
+		{
+			name:        "lone manifest with existing snapshots",
+			children:    sharedConfig,
+			order:       []ocispec.Descriptor{manifestA, config},
+			wantFetched: []ocispec.Descriptor{manifestA, config},
+			wantUnpacks: 1,
+		},
+		{
+			name:        "manifest without layers",
+			children:    map[digest.Digest][]ocispec.Descriptor{manifestA.Digest: {config}},
+			order:       []ocispec.Descriptor{manifestA, config},
+			wantFetched: []ocispec.Descriptor{manifestA, config},
+			wantUnpacks: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			fetched := map[digest.Digest]struct{}{}
+			h := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+				mu.Lock()
+				fetched[desc.Digest] = struct{}{}
+				mu.Unlock()
+				return tc.children[desc.Digest], nil
+			})
+
+			u, err := NewUnpacker(ctx, cs.Store, WithUnpackPlatform(Platform{
+				Snapshotter: alreadyExistsSnapshotter{},
+				Applier:     failApplier{t},
+			}))
+			require.NoError(t, err)
+
+			wrapped := u.Unpack(h)
+			for _, desc := range tc.order {
+				_, err := wrapped.Handle(ctx, desc)
+				require.NoError(t, err)
+			}
+			res, err := u.Wait()
+			require.NoError(t, err)
+
+			want := map[digest.Digest]struct{}{}
+			for _, desc := range tc.wantFetched {
+				want[desc.Digest] = struct{}{}
+			}
+			assert.Equal(t, want, fetched)
+			assert.Equal(t, tc.wantUnpacks, res.Unpacks)
+		})
+	}
+}
+
+// TestPullFetchesLayersOfEveryConfigSharingManifest verifies that a pull
+// through the real handler chain, from a local registry, fetches the layers
+// of every config-sharing manifest into the content store.
+func TestPullFetchesLayersOfEveryConfigSharingManifest(t *testing.T) {
+	ctx := context.Background()
+
+	imagePlatform := ocispec.Platform{OS: "linux", Architecture: "amd64"}
+
+	// One config, shared by both manifests. Both can share it because a config
+	// records each layer's uncompressed digest (diffID), which compression does
+	// not change.
+	config := mustMarshal(t, ocispec.Image{
+		Platform: imagePlatform,
+		RootFS:   ocispec.RootFS{Type: "layers", DiffIDs: []digest.Digest{digest.FromString("diff-0")}},
+	})
+	configDesc := blobDesc(ocispec.MediaTypeImageConfig, config)
+
+	layerA := []byte("layer-a-compressed-bytes")
+	layerB := []byte("layer-b-compressed-bytes")
+	layerADesc := blobDesc(ocispec.MediaTypeImageLayerGzip, layerA)
+	layerBDesc := blobDesc(ocispec.MediaTypeImageLayerGzip, layerB)
+
+	manifestA := mustMarshal(t, ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{layerADesc},
+	})
+	manifestB := mustMarshal(t, ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{layerBDesc},
+	})
+	manifestADesc := blobDesc(ocispec.MediaTypeImageManifest, manifestA)
+	manifestADesc.Platform = &imagePlatform
+	manifestBDesc := blobDesc(ocispec.MediaTypeImageManifest, manifestB)
+	manifestBDesc.Platform = &imagePlatform
+
+	index := mustMarshal(t, ocispec.Index{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{manifestADesc, manifestBDesc},
+	})
+	indexDesc := blobDesc(ocispec.MediaTypeImageIndex, index)
+
+	ref := testutil.ServeImage(t, "img", "latest", indexDesc, map[digest.Digest][]byte{
+		indexDesc.Digest:     index,
+		manifestADesc.Digest: manifestA,
+		manifestBDesc.Digest: manifestB,
+		configDesc.Digest:    config,
+		layerADesc.Digest:    layerA,
+		layerBDesc.Digest:    layerB,
+	})
+
+	store := imagetest.NewContentStore(ctx, t).Store
+
+	// NewResolver uses plain HTTP for localhost, where the registry listens,
+	// so no hosts configuration is needed.
+	resolver := docker.NewResolver(docker.ResolverOptions{})
+	_, resolved, err := resolver.Resolve(ctx, ref)
+	require.NoError(t, err)
+	fetcher, err := resolver.Fetcher(ctx, ref)
+	require.NoError(t, err)
+
+	// Assemble the same handler chain a transfer-service pull uses.
+	children := images.FilterPlatforms(images.ChildrenHandler(store), platforms.Only(imagePlatform))
+	handler := images.Handlers(remotes.FetchHandler(store, fetcher), children)
+
+	u, err := NewUnpacker(ctx, store, WithUnpackPlatform(Platform{
+		// No image matches, so unpack fetches every layer instead of applying
+		// it, and no real snapshotter is needed.
+		Platform:    platforms.OnlyStrict(platforms.MustParse("linux/arm64")),
+		Snapshotter: alreadyExistsSnapshotter{},
+		Applier:     failApplier{t},
+	}))
+	require.NoError(t, err)
+
+	require.NoError(t, images.Dispatch(ctx, u.Unpack(handler), nil, resolved))
+	_, err = u.Wait()
+	require.NoError(t, err)
+
+	_, err = store.Info(ctx, layerADesc.Digest)
+	require.NoError(t, err, "layer of the first config-sharing manifest should be present, but is not")
+	_, err = store.Info(ctx, layerBDesc.Digest)
+	require.NoError(t, err, "layer of the second config-sharing manifest should be present, but is not")
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+func blobDesc(mediaType string, body []byte) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: mediaType,
+		Digest:    digest.FromBytes(body),
+		Size:      int64(len(body)),
+	}
+}


### PR DESCRIPTION
An index can carry more than one manifest that shares a config. A config lists uncompressed layer digests, so packaging the same layers with different compression (which `podman manifest push --add-compression` does) produces manifests with identical configs and the same config digest.

Right now, when the unpacker visits a manifest, it stores its layers in a map keyed by its config's digest, so they can be unpacked later once the config descriptor is visited. Because that map holds only one manifest's layers per digest, when more than one manifest shares a config, only the last visited manifest's layers are stored (and unpacked), and the others' layers are never fetched. Image pulls still report success, but a later export or push of the image fails with NotFound.

Fix this by changing the map to store the layers for all manifests pointing at a specific config (instead of just one manifest). This means manifests sharing the same config result in more than one set of layers being stored for the same config digest. Because manifests that share a config unpack to the same snapshot chain, we only need to unpack the first manifest's layers, and fetch the others (so their blobs reach the content store). Unpack skips fetching a layer whose snapshot already exists, so once a second manifest shares the config, the first manifest's layers are also fetched explicitly; a config named by a single manifest keeps that skip. Note that for indexes with more than one config-sharing manifest, this will now result in additional download time and storage for those layers.

Don't store anything for a manifest with no layers; an empty slice reaching the unpack would fail the pull.

(cherry picked from commit 3c5d9fefd84498de699fdc2f57c6682fe4599d00)

Apply the fix under `pkg/unpack` using the release branch's config types. Include the registry test helper needed by the regression tests.

Assisted-by: Claude Code