### PR TITLE
runtime/v2: re-resolve stale shim binary path on shim load

### DIFF
--- a/core/runtime/v2/shim_load.go
+++ b/core/runtime/v2/shim_load.go
@@ -158,7 +158,7 @@ func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle) error {
 		runtime = container.Runtime.Name
 	}
 
-	runtime, err := m.resolveRuntimePath(runtime)
+	runtime, err := m.resolveRuntimeWithFallback(ctx, runtime, id)
 	if err != nil {
 		bundle.Delete()
 
@@ -223,6 +223,42 @@ func shouldCleanupShim(sgetErr, pidErr error, pInfo []runtimeapi.ProcessInfo) bo
 	return errors.Is(sgetErr, errdefs.ErrNotFound) &&
 		(errors.Is(pidErr, errdefs.ErrNotFound) ||
 			(pidErr == nil && len(pInfo) == 0))
+}
+
+// resolveRuntimeWithFallback resolves the shim binary path for runtime. If
+// runtime is a pinned absolute path that no longer resolves (e.g. an update
+// moved or replaced the binary that the path was resolved to at task start), it
+// falls back to re-resolving from the runtime name recorded in metadata for id,
+// which stays valid across such moves. If the fallback also fails, the original
+// resolution error is returned.
+func (m *ShimManager) resolveRuntimeWithFallback(ctx context.Context, runtime, id string) (string, error) {
+	resolved, err := m.resolveRuntimePath(runtime)
+	if err == nil {
+		return resolved, nil
+	}
+	if name := m.runtimeName(ctx, id); name != "" && name != runtime {
+		if r, rerr := m.resolveRuntimePath(name); rerr == nil {
+			log.G(ctx).WithField("id", id).WithField("runtime", name).
+				Info("pinned shim binary path is stale; re-resolved from runtime name")
+			return r, nil
+		}
+	}
+	return "", err
+}
+
+// runtimeName returns the runtime name recorded for id in metadata, trying the
+// container store first and the sandbox store second (a shim bundle is one or
+// the other). It returns "" if neither has a record.
+func (m *ShimManager) runtimeName(ctx context.Context, id string) string {
+	if c, err := m.containers.Get(ctx, id); err == nil {
+		return c.Runtime.Name
+	} else if !errdefs.IsNotFound(err) {
+		log.G(ctx).WithError(err).Errorf("loading container %s for runtime name", id)
+	}
+	if sb, err := m.sandboxStore.Get(ctx, id); err == nil {
+		return sb.Runtime.Name
+	}
+	return ""
 }
 
 func loadShimTask(ctx context.Context, bundle *Bundle, onClose func()) (_ *shimTask, retErr error) {

--- a/core/runtime/v2/shim_load_test.go
+++ b/core/runtime/v2/shim_load_test.go
@@ -19,13 +19,176 @@ package v2
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/containerd/errdefs"
 	"github.com/stretchr/testify/require"
 
+	"github.com/containerd/containerd/v2/core/containers"
 	runtimeapi "github.com/containerd/containerd/v2/core/runtime"
+	"github.com/containerd/containerd/v2/core/sandbox"
+	shimbinary "github.com/containerd/containerd/v2/pkg/shim"
 )
+
+// fakeContainerStore stubs containers.Store; only Get is used by the code under
+// test. The embedded nil interface panics if any other method is called.
+type fakeContainerStore struct {
+	containers.Store
+	container containers.Container
+	err       error
+}
+
+func (f fakeContainerStore) Get(context.Context, string) (containers.Container, error) {
+	return f.container, f.err
+}
+
+// fakeSandboxStore stubs sandbox.Store; only Get is used by the code under test.
+type fakeSandboxStore struct {
+	sandbox.Store
+	sandbox sandbox.Sandbox
+	err     error
+}
+
+func (f fakeSandboxStore) Get(context.Context, string) (sandbox.Sandbox, error) {
+	return f.sandbox, f.err
+}
+
+func container(name string) containers.Container {
+	return containers.Container{Runtime: containers.RuntimeInfo{Name: name}}
+}
+
+func sbox(name string) sandbox.Sandbox {
+	return sandbox.Sandbox{Runtime: sandbox.RuntimeOpts{Name: name}}
+}
+
+func TestRuntimeName(t *testing.T) {
+	otherErr := errors.New("some other error")
+
+	testCases := []struct {
+		Name       string
+		Containers containers.Store
+		Sandboxes  sandbox.Store
+		Expected   string
+	}{
+		{
+			Name:       "container record wins",
+			Containers: fakeContainerStore{container: container("io.containerd.runc.v2")},
+			Sandboxes:  fakeSandboxStore{sandbox: sbox("io.containerd.other.v1")},
+			Expected:   "io.containerd.runc.v2",
+		},
+		{
+			Name:       "falls back to sandbox when no container",
+			Containers: fakeContainerStore{err: errdefs.ErrNotFound},
+			Sandboxes:  fakeSandboxStore{sandbox: sbox("io.containerd.runc.v2")},
+			Expected:   "io.containerd.runc.v2",
+		},
+		{
+			Name:       "empty when neither store has a record",
+			Containers: fakeContainerStore{err: errdefs.ErrNotFound},
+			Sandboxes:  fakeSandboxStore{err: errdefs.ErrNotFound},
+			Expected:   "",
+		},
+		{
+			// A non-NotFound container error is logged but still falls through
+			// to the sandbox store.
+			Name:       "container error still tries sandbox",
+			Containers: fakeContainerStore{err: otherErr},
+			Sandboxes:  fakeSandboxStore{sandbox: sbox("io.containerd.runc.v2")},
+			Expected:   "io.containerd.runc.v2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			m := &ShimManager{containers: tc.Containers, sandboxStore: tc.Sandboxes}
+			require.Equal(t, tc.Expected, m.runtimeName(context.Background(), "id"))
+		})
+	}
+}
+
+func TestResolveRuntimeWithFallback(t *testing.T) {
+	const (
+		stalePath   = "/nonexistent/stale/containerd-shim-runc-v2"
+		runtimeName = "io.containerd.runc.v2"
+		validPath   = "/usr/local/bin/containerd-shim-runc-v2"
+	)
+
+	testCases := []struct {
+		Name        string
+		Runtime     string
+		RealFile    bool // create Runtime as a real file so os.Stat succeeds
+		Containers  containers.Store
+		Sandboxes   sandbox.Store
+		Cache       map[string]string
+		Expected    string
+		ExpectError bool
+	}{
+		{
+			// Pinned path still resolves: no metadata lookup, returned as-is.
+			Name:     "pinned path still valid",
+			RealFile: true,
+		},
+		{
+			// Pinned path is stale but the runtime name in metadata re-resolves.
+			Name:       "stale path re-resolved from runtime name",
+			Runtime:    stalePath,
+			Containers: fakeContainerStore{container: container(runtimeName)},
+			Sandboxes:  fakeSandboxStore{err: errdefs.ErrNotFound},
+			Cache:      map[string]string{shimbinary.BinaryName(runtimeName): validPath},
+			Expected:   validPath,
+		},
+		{
+			// Stale path with a sandbox record instead of a container.
+			Name:       "stale path re-resolved from sandbox runtime name",
+			Runtime:    stalePath,
+			Containers: fakeContainerStore{err: errdefs.ErrNotFound},
+			Sandboxes:  fakeSandboxStore{sandbox: sbox(runtimeName)},
+			Cache:      map[string]string{shimbinary.BinaryName(runtimeName): validPath},
+			Expected:   validPath,
+		},
+		{
+			// Stale path and no metadata: original resolution error propagates.
+			Name:        "stale path with no metadata errors",
+			Runtime:     stalePath,
+			Containers:  fakeContainerStore{err: errdefs.ErrNotFound},
+			Sandboxes:   fakeSandboxStore{err: errdefs.ErrNotFound},
+			ExpectError: true,
+		},
+		{
+			// Metadata name equals the (stale) runtime: the guard skips a
+			// pointless retry and the original error propagates.
+			Name:        "stale path equal to metadata name errors",
+			Runtime:     stalePath,
+			Containers:  fakeContainerStore{container: container(stalePath)},
+			Sandboxes:   fakeSandboxStore{err: errdefs.ErrNotFound},
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			m := &ShimManager{containers: tc.Containers, sandboxStore: tc.Sandboxes}
+			for name, path := range tc.Cache {
+				m.runtimePaths.Store(name, path)
+			}
+			runtime, expected := tc.Runtime, tc.Expected
+			if tc.RealFile {
+				runtime = filepath.Join(t.TempDir(), "containerd-shim-runc-v2")
+				require.NoError(t, os.WriteFile(runtime, nil, 0o755))
+				expected = runtime
+			}
+			got, err := m.resolveRuntimeWithFallback(context.Background(), runtime, "id")
+			if tc.ExpectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, expected, got)
+		})
+	}
+}
 
 func TestShouldCleanupShim(t *testing.T) {
 	otherErr := errors.New("some other error")


### PR DESCRIPTION
**What**

On load, `loadShim` resolves the pinned `shim-binary-path` with `os.Stat`. If a Docker/containerd update moved or replaced that binary, the stat fails, the bundle is deleted, and the still-running shim is leaked.

This falls back to re-resolving from the runtime name recorded in metadata (container store, then sandbox store), which stays valid across such moves. The bundle is only deleted when that fallback also fails, so there's no behaviour change when the binary is genuinely gone.

**How**

- Extracted the resolution + fallback into `ShimManager.resolveRuntimeWithFallback`, and the metadata lookup into `runtimeName`.
- Fallback triggers only when the primary resolve fails and the metadata name differs from the pinned path.

**Tests**

- `TestResolveRuntimeWithFallback`: valid pinned path returned as-is; stale path re-resolved from container and from sandbox names; no metadata and `name == runtime` both propagate the original error.
- `TestRuntimeName`: container precedence, sandbox fallback, neither present, non-NotFound container error still tries sandbox.
